### PR TITLE
feat(telemetry): report consent state and send a decision-time opt-out signal

### DIFF
--- a/app/modules/telemetry/api.py
+++ b/app/modules/telemetry/api.py
@@ -60,18 +60,21 @@ async def update_telemetry_consent(
     previous = await store.resolve()
     consent = await store.set_decision(payload.enabled)
     if previous.active and not consent.active:
-        identity = await store.get_or_create_identity()
-        task = asyncio.create_task(
-            TelemetrySender().send_opt_out(
-                identity,
-                app_version=__version__,
-                deployment_mode=deployment_method(),
-                os_arch=f"{platform.system().lower()}/{platform.machine().lower()}",
-            ),
-            name="anonymous-telemetry-opt-out",
-        )
-        _OPT_OUT_TASKS.add(task)
-        task.add_done_callback(_handle_opt_out_task_done)
+        try:
+            identity = await store.get_or_create_identity()
+            task = asyncio.create_task(
+                TelemetrySender().send_opt_out(
+                    identity,
+                    app_version=__version__,
+                    deployment_mode=deployment_method(),
+                    os_arch=f"{platform.system().lower()}/{platform.machine().lower()}",
+                ),
+                name="anonymous-telemetry-opt-out",
+            )
+            _OPT_OUT_TASKS.add(task)
+            task.add_done_callback(_handle_opt_out_task_done)
+        except Exception as exc:
+            logger.debug("Unable to schedule anonymous telemetry opt-out", exc_info=exc)
     return await _response(session, store, consent, include_preview=False)
 
 

--- a/app/modules/telemetry/api.py
+++ b/app/modules/telemetry/api.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import platform
+
 from fastapi import APIRouter, Body, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import __version__
 from app.core.auth.dependencies import (
     require_dashboard_write_access,
     set_dashboard_error_format,
@@ -16,7 +21,12 @@ from app.modules.telemetry.schemas import (
     TelemetrySnapshotEnvelope,
     build_snapshot_envelope,
 )
-from app.modules.telemetry.snapshot import TelemetrySnapshotBuilder
+from app.modules.telemetry.sender import TelemetrySender
+from app.modules.telemetry.snapshot import TelemetrySnapshotBuilder, deployment_method
+
+logger = logging.getLogger(__name__)
+
+_OPT_OUT_TASKS: set[asyncio.Task[None]] = set()
 
 router = APIRouter(
     prefix="/api/settings",
@@ -47,7 +57,21 @@ async def update_telemetry_consent(
     session: AsyncSession = Depends(get_session),
 ) -> TelemetryConsentResponse:
     store = TelemetryConsentStore(session)
+    previous = await store.resolve()
     consent = await store.set_decision(payload.enabled)
+    if previous.active and not consent.active:
+        identity = await store.get_or_create_identity()
+        task = asyncio.create_task(
+            TelemetrySender().send_opt_out(
+                identity,
+                app_version=__version__,
+                deployment_mode=deployment_method(),
+                os_arch=f"{platform.system().lower()}/{platform.machine().lower()}",
+            ),
+            name="anonymous-telemetry-opt-out",
+        )
+        _OPT_OUT_TASKS.add(task)
+        task.add_done_callback(_handle_opt_out_task_done)
     return await _response(session, store, consent, include_preview=False)
 
 
@@ -61,7 +85,11 @@ async def _response(
     preview: TelemetrySnapshotEnvelope | None = None
     if include_preview:
         identity = await store.get_or_create_identity()
-        snapshot = await TelemetrySnapshotBuilder(session).build(identity.instance_id)
+        snapshot_consent = "enabled" if consent.state == "disabled" else consent.state
+        snapshot = await TelemetrySnapshotBuilder(session).build(
+            identity.instance_id,
+            consent=snapshot_consent,
+        )
         preview = build_snapshot_envelope(snapshot)
     return TelemetryConsentResponse(
         state=consent.state,
@@ -69,3 +97,16 @@ async def _response(
         active=consent.active,
         preview=preview,
     )
+
+
+def _handle_opt_out_task_done(task: asyncio.Task[None]) -> None:
+    try:
+        if task.cancelled():
+            return
+        if exc := task.exception():
+            logger.debug(
+                "Anonymous telemetry opt-out background task failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+    finally:
+        _OPT_OUT_TASKS.discard(task)

--- a/app/modules/telemetry/scheduler.py
+++ b/app/modules/telemetry/scheduler.py
@@ -83,8 +83,12 @@ class TelemetryScheduler:
                         )
                     if not consent.active:
                         return
+                    assert consent.state != "disabled"
                     identity = await store.get_or_create_identity()
-                    snapshot = await TelemetrySnapshotBuilder(session).build(identity.instance_id)
+                    snapshot = await TelemetrySnapshotBuilder(session).build(
+                        identity.instance_id,
+                        consent=consent.state,
+                    )
                 await self.sender.send_snapshot(snapshot)
             except Exception as exc:
                 logger.debug("Anonymous telemetry scheduler tick failed", exc_info=exc)

--- a/app/modules/telemetry/schemas.py
+++ b/app/modules/telemetry/schemas.py
@@ -5,13 +5,16 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+DeploymentMethod = Literal["docker", "k8s", "pip", "bare"]
+ActiveConsentState = Literal["undecided", "enabled"]
+
 
 class TelemetryModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
 class DeploymentSnapshot(TelemetryModel):
-    method: Literal["docker", "k8s", "pip", "bare"]
+    method: DeploymentMethod
     db_backend: Literal["sqlite", "postgres"]
     db_size_bucket: Literal["unknown", "<100MB", "100MB-1GB", "1-5GB", "5-10GB", "10-50GB", "50GB+"]
     replicas: int = Field(ge=1)
@@ -97,7 +100,7 @@ class FeaturesSnapshot(TelemetryModel):
 
 class TelemetrySnapshot(TelemetryModel):
     schema_version: Literal[1] = 1
-    consent: Literal["undecided", "enabled"]
+    consent: ActiveConsentState
     instance_id: str
     version: str
     python: str
@@ -113,7 +116,7 @@ class TelemetrySnapshot(TelemetryModel):
 class TelemetryRegistration(TelemetryModel):
     app_name: Literal["codex-lb"] = "codex-lb"
     app_version: str
-    deployment_mode: Literal["docker", "k8s", "pip", "bare"]
+    deployment_mode: DeploymentMethod
     environment: str = ""
     instance_id: str
     os_arch: str

--- a/app/modules/telemetry/schemas.py
+++ b/app/modules/telemetry/schemas.py
@@ -97,6 +97,7 @@ class FeaturesSnapshot(TelemetryModel):
 
 class TelemetrySnapshot(TelemetryModel):
     schema_version: Literal[1] = 1
+    consent: Literal["undecided", "enabled"]
     instance_id: str
     version: str
     python: str
@@ -121,6 +122,13 @@ class TelemetryRegistration(TelemetryModel):
 
 class TelemetryActivation(TelemetryModel):
     action: Literal["activate"] = "activate"
+
+
+class TelemetryOptOut(TelemetryModel):
+    app_version: str
+    event: Literal["optout"] = "optout"
+    instance_id: str
+    occurred_at: str
 
 
 class TelemetrySnapshotEnvelope(TelemetryModel):

--- a/app/modules/telemetry/sender.py
+++ b/app/modules/telemetry/sender.py
@@ -115,6 +115,19 @@ class TelemetrySender:
         )
 
         envelope = build_snapshot_envelope(snapshot)
+        try:
+            active, current_identity = await self._context_provider()
+            identity_matches = (
+                current_identity is not None
+                and current_identity.instance_id == identity.instance_id
+                and current_identity.public_key_hex == identity.public_key_hex
+            )
+        except Exception as exc:
+            logger.debug("Anonymous telemetry consent re-check failed", exc_info=exc)
+            return
+        if not active or not identity_matches:
+            return
+
         await self._post_signed(session, "/v1/snapshot", _json_bytes(envelope), identity, accepted={200, 202})
 
     async def _transmit_opt_out_once(

--- a/app/modules/telemetry/sender.py
+++ b/app/modules/telemetry/sender.py
@@ -4,15 +4,18 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from typing import Literal
 
 import aiohttp
 
 from app.core.config.settings import get_settings
+from app.core.utils.time import utcnow
 from app.db.session import get_background_session
 from app.modules.telemetry.consent import TelemetryConsentStore, TelemetryIdentity
 from app.modules.telemetry.schemas import (
     TelemetryActivation,
     TelemetryModel,
+    TelemetryOptOut,
     TelemetryRegistration,
     TelemetrySnapshot,
     build_snapshot_envelope,
@@ -52,20 +55,44 @@ class TelemetrySender:
             async with asyncio.timeout(_TIMEOUT_SECONDS):
                 timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
                 async with aiohttp.ClientSession(timeout=timeout, trust_env=False) as session:
-                    await self._send_with_retry(session, snapshot, identity)
+                    await self._send_with_retry(lambda: self._transmit_once(session, snapshot, identity))
         except Exception as exc:
             logger.debug("Anonymous telemetry transmission failed", exc_info=exc)
 
-    async def _send_with_retry(
+    async def send_opt_out(
         self,
-        session: aiohttp.ClientSession,
-        snapshot: TelemetrySnapshot,
         identity: TelemetryIdentity,
+        *,
+        app_version: str,
+        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        os_arch: str,
     ) -> None:
+        try:
+            event = TelemetryOptOut(
+                app_version=app_version,
+                instance_id=identity.instance_id,
+                occurred_at=f"{utcnow().isoformat()}Z",
+            )
+            async with asyncio.timeout(_TIMEOUT_SECONDS):
+                timeout = aiohttp.ClientTimeout(total=_TIMEOUT_SECONDS)
+                async with aiohttp.ClientSession(timeout=timeout, trust_env=False) as session:
+                    await self._send_with_retry(
+                        lambda: self._transmit_opt_out_once(
+                            session,
+                            event,
+                            identity,
+                            deployment_mode=deployment_mode,
+                            os_arch=os_arch,
+                        )
+                    )
+        except Exception as exc:
+            logger.debug("Anonymous telemetry opt-out transmission failed", exc_info=exc)
+
+    async def _send_with_retry(self, operation: Callable[[], Awaitable[None]]) -> None:
         last_error: Exception | None = None
         for attempt in range(_MAX_ATTEMPTS):
             try:
-                await self._transmit_once(session, snapshot, identity)
+                await operation()
                 return
             except Exception as exc:
                 last_error = exc
@@ -79,22 +106,58 @@ class TelemetrySender:
         snapshot: TelemetrySnapshot,
         identity: TelemetryIdentity,
     ) -> None:
-        if self._activated_instance_id != identity.instance_id:
-            registration = TelemetryRegistration(
-                app_version=snapshot.version,
-                deployment_mode=snapshot.deploy.method,
-                instance_id=identity.instance_id,
-                os_arch=f"{snapshot.os}/{snapshot.arch}",
-                public_key=identity.public_key_hex,
-            )
-            await self._post(session, "/v1/register", _json_bytes(registration), accepted={200, 201})
-
-            activation = TelemetryActivation()
-            await self._post_signed(session, "/v1/activate", _json_bytes(activation), identity, accepted={200})
-            self._activated_instance_id = identity.instance_id
+        await self._ensure_activated(
+            session,
+            identity,
+            app_version=snapshot.version,
+            deployment_mode=snapshot.deploy.method,
+            os_arch=f"{snapshot.os}/{snapshot.arch}",
+        )
 
         envelope = build_snapshot_envelope(snapshot)
         await self._post_signed(session, "/v1/snapshot", _json_bytes(envelope), identity, accepted={200, 202})
+
+    async def _transmit_opt_out_once(
+        self,
+        session: aiohttp.ClientSession,
+        event: TelemetryOptOut,
+        identity: TelemetryIdentity,
+        *,
+        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        os_arch: str,
+    ) -> None:
+        await self._ensure_activated(
+            session,
+            identity,
+            app_version=event.app_version,
+            deployment_mode=deployment_mode,
+            os_arch=os_arch,
+        )
+        await self._post_signed(session, "/v1/optout", _json_bytes(event), identity, accepted={200})
+
+    async def _ensure_activated(
+        self,
+        session: aiohttp.ClientSession,
+        identity: TelemetryIdentity,
+        *,
+        app_version: str,
+        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        os_arch: str,
+    ) -> None:
+        if self._activated_instance_id == identity.instance_id:
+            return
+        registration = TelemetryRegistration(
+            app_version=app_version,
+            deployment_mode=deployment_mode,
+            instance_id=identity.instance_id,
+            os_arch=os_arch,
+            public_key=identity.public_key_hex,
+        )
+        await self._post(session, "/v1/register", _json_bytes(registration), accepted={200, 201})
+
+        activation = TelemetryActivation()
+        await self._post_signed(session, "/v1/activate", _json_bytes(activation), identity, accepted={200})
+        self._activated_instance_id = identity.instance_id
 
     async def _post_signed(
         self,

--- a/app/modules/telemetry/sender.py
+++ b/app/modules/telemetry/sender.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Literal
 
 import aiohttp
 
@@ -13,6 +12,7 @@ from app.core.utils.time import utcnow
 from app.db.session import get_background_session
 from app.modules.telemetry.consent import TelemetryConsentStore, TelemetryIdentity
 from app.modules.telemetry.schemas import (
+    DeploymentMethod,
     TelemetryActivation,
     TelemetryModel,
     TelemetryOptOut,
@@ -64,7 +64,7 @@ class TelemetrySender:
         identity: TelemetryIdentity,
         *,
         app_version: str,
-        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        deployment_mode: DeploymentMethod,
         os_arch: str,
     ) -> None:
         try:
@@ -123,7 +123,7 @@ class TelemetrySender:
         event: TelemetryOptOut,
         identity: TelemetryIdentity,
         *,
-        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        deployment_mode: DeploymentMethod,
         os_arch: str,
     ) -> None:
         await self._ensure_activated(
@@ -141,7 +141,7 @@ class TelemetrySender:
         identity: TelemetryIdentity,
         *,
         app_version: str,
-        deployment_mode: Literal["docker", "k8s", "pip", "bare"],
+        deployment_mode: DeploymentMethod,
         os_arch: str,
     ) -> None:
         if self._activated_instance_id == identity.instance_id:

--- a/app/modules/telemetry/snapshot.py
+++ b/app/modules/telemetry/snapshot.py
@@ -39,6 +39,8 @@ from app.modules.settings.repository import SettingsRepository
 from app.modules.telemetry.clients import ClientCount, catalog_model_name, client_shares
 from app.modules.telemetry.schemas import (
     AccountsSnapshot,
+    ActiveConsentState,
+    DeploymentMethod,
     DeploymentSnapshot,
     FeaturesSnapshot,
     ModelUsageSnapshot,
@@ -159,7 +161,7 @@ class TelemetrySnapshotBuilder:
         self,
         instance_id: str,
         *,
-        consent: Literal["undecided", "enabled"],
+        consent: ActiveConsentState,
     ) -> TelemetrySnapshot:
         now = utcnow()
         start = now - timedelta(days=7)
@@ -468,7 +470,7 @@ def _canonical_routing_policy(raw_policy: str | None) -> str:
     return normalized if normalized in _ROUTING_POLICIES else "other"
 
 
-def deployment_method() -> Literal["docker", "k8s", "pip", "bare"]:
+def deployment_method() -> DeploymentMethod:
     if os.environ.get("KUBERNETES_SERVICE_HOST") or Path("/var/run/secrets/kubernetes.io/serviceaccount").exists():
         return "k8s"
     if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():

--- a/app/modules/telemetry/snapshot.py
+++ b/app/modules/telemetry/snapshot.py
@@ -155,7 +155,12 @@ class TelemetrySnapshotBuilder:
         self._session = session
         self._settings = settings or get_settings()
 
-    async def build(self, instance_id: str) -> TelemetrySnapshot:
+    async def build(
+        self,
+        instance_id: str,
+        *,
+        consent: Literal["undecided", "enabled"],
+    ) -> TelemetrySnapshot:
         now = utcnow()
         start = now - timedelta(days=7)
         reports = ReportsRepository(self._session)
@@ -180,7 +185,7 @@ class TelemetrySnapshotBuilder:
         top_errors = await self._top_upstream_errors(conditions)
         feature_counts = await self._feature_counts(conditions)
 
-        method = _deployment_method()
+        method = deployment_method()
         db_backend = "postgres" if self._session.get_bind().dialect.name == "postgresql" else "sqlite"
         plan_mix = PlanMixSnapshot(
             plus=count_bucket(plan_counts.get("plus", 0)),
@@ -189,6 +194,7 @@ class TelemetrySnapshotBuilder:
             free=count_bucket(plan_counts.get("free", 0)),
         )
         return TelemetrySnapshot(
+            consent=consent,
             instance_id=instance_id,
             version=__version__,
             python=f"{platform.python_version_tuple()[0]}.{platform.python_version_tuple()[1]}",
@@ -462,7 +468,7 @@ def _canonical_routing_policy(raw_policy: str | None) -> str:
     return normalized if normalized in _ROUTING_POLICIES else "other"
 
 
-def _deployment_method() -> Literal["docker", "k8s", "pip", "bare"]:
+def deployment_method() -> Literal["docker", "k8s", "pip", "bare"]:
     if os.environ.get("KUBERNETES_SERVICE_HOST") or Path("/var/run/secrets/kubernetes.io/serviceaccount").exists():
         return "k8s"
     if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,8 +19,8 @@ view it later from Settings. The signed snapshot body has three fields:
 
 The versioned `metrics` schema contains only these fields:
 
-- `schema_version`, random `instance_id`, codex-lb `version`, Python version, OS, architecture,
-  and process uptime
+- `schema_version`, active `consent` (`undecided` or `enabled`), random `instance_id`, codex-lb
+  `version`, Python version, OS, architecture, and process uptime
 - `deploy`: deployment method, database backend and size bucket, replica count, and whether
   trusted reverse-proxy headers are enabled
 - `accounts`: bucketed pool and plan counts, whether workspace accounts exist, routing policy,
@@ -52,7 +52,31 @@ CODEX_LB_TELEMETRY_ENABLED=false
 ```
 
 An environment value overrides the saved dashboard setting. When telemetry resolves to
-disabled, codex-lb opens no connection to the telemetry endpoint.
+disabled, codex-lb opens no connection to the telemetry endpoint. The environment kill switch
+is always completely silent.
+
+When a dashboard decision changes telemetry from active to inactive, codex-lb makes one final
+signed request to `POST /v1/optout` so aggregate opt-out counts remain accurate. If the instance
+has not contacted the collector in this process, it first performs the normal registration and
+activation. Re-enabling and later disabling from the dashboard sends one new notice for that new
+transition. Repeating an already-disabled decision sends nothing.
+
+The opt-out request uses the same `X-Instance-ID` and Ed25519 `X-Signature` headers as a snapshot.
+Its canonical JSON body is:
+
+```json
+{
+  "app_version": "<codex-lb version>",
+  "event": "optout",
+  "instance_id": "<random UUIDv4>",
+  "occurred_at": "<current ISO 8601 UTC time>"
+}
+```
+
+This single decision-time notice is the only exception to disabled telemetry silence. It is
+sent only for a dashboard-driven active-to-inactive transition; setting
+`CODEX_LB_TELEMETRY_ENABLED=false`, or changing a saved decision while either environment
+override value controls telemetry, never sends it.
 
 ## Retention and failures
 
@@ -61,7 +85,8 @@ codex-lb does not keep a separate local telemetry history and does not queue a f
 collector's server-side retention duration is not currently specified; assume transmitted
 snapshots remain stored until a published retention policy or explicit deletion.
 
-Endpoint failures use a bounded timeout, are logged only at debug level, and never interrupt
-proxy traffic.
+Snapshot and opt-out endpoint failures use a five-second total timeout, retry no more than once,
+are logged only at debug level, and never interrupt proxy traffic or change the dashboard
+settings response.
 
 *Source of truth: [telemetry OpenSpec capability](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/telemetry)*

--- a/frontend/src/features/settings/components/settings-skeleton.tsx
+++ b/frontend/src/features/settings/components/settings-skeleton.tsx
@@ -135,6 +135,7 @@ export function SettingsSkeleton() {
             </div>
             <Skeleton className="h-5 w-9 rounded-full" />
           </div>
+          <Skeleton className="h-3 w-96 max-w-full" />
           <div className="flex items-center justify-between rounded-lg border p-3">
             <div className="space-y-1">
               <Skeleton className="h-3.5 w-24" />

--- a/frontend/src/features/settings/components/telemetry-consent-dialog.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-consent-dialog.test.tsx
@@ -32,6 +32,12 @@ describe("TelemetryConsentDialog", () => {
     expect(within(dialog).getByText(/"timestamp": "2026-08-06T00:00:00Z"/)).toBeInTheDocument();
     expect(within(dialog).getByText(/"metrics": \{/)).toBeInTheDocument();
     expect(within(dialog).getByText(/"schema_version": 1/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/"consent": "undecided"/)).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.",
+      ),
+    ).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "Keep enabled" })).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "Disable telemetry" })).toBeInTheDocument();
     expect(

--- a/frontend/src/features/settings/components/telemetry-consent-dialog.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-consent-dialog.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { TelemetryConsentDialog } from "@/features/settings/components/telemetry-consent-dialog";
+import i18n from "@/i18n";
 import { createTelemetryConsent, createTelemetrySnapshotEnvelope } from "@/test/mocks/factories";
 import { server } from "@/test/mocks/server";
 import { renderWithProviders } from "@/test/utils";
@@ -34,9 +35,7 @@ describe("TelemetryConsentDialog", () => {
     expect(within(dialog).getByText(/"schema_version": 1/)).toBeInTheDocument();
     expect(within(dialog).getByText(/"consent": "undecided"/)).toBeInTheDocument();
     expect(
-      within(dialog).getByText(
-        "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.",
-      ),
+      within(dialog).getByText(i18n.t("settings.telemetry.optOutNotice")),
     ).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "Keep enabled" })).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: "Disable telemetry" })).toBeInTheDocument();

--- a/frontend/src/features/settings/components/telemetry-consent-dialog.tsx
+++ b/frontend/src/features/settings/components/telemetry-consent-dialog.tsx
@@ -17,6 +17,8 @@ import { useTelemetryConsent } from "@/features/settings/hooks/use-settings";
 // Same published page the backend startup notice points operators to
 // (TELEMETRY_FIELDS_DOCUMENTATION in app/modules/telemetry/scheduler.py).
 const TELEMETRY_DOCS_URL = "https://soju06.github.io/codex-lb/telemetry/";
+const OPT_OUT_NOTICE =
+  "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.";
 
 export function TelemetryConsentDialog() {
   const { t } = useTranslation();
@@ -60,6 +62,7 @@ export function TelemetryConsentDialog() {
           <p className="text-sm text-muted-foreground">
             {t("settings.telemetry.consentDialog.categories")}
           </p>
+          <p className="text-sm text-muted-foreground">{OPT_OUT_NOTICE}</p>
           <p className="text-sm font-medium">{t("settings.telemetry.consentDialog.payloadLabel")}</p>
           <TelemetryPayloadPreview preview={preview} />
           <p className="text-sm">

--- a/frontend/src/features/settings/components/telemetry-consent-dialog.tsx
+++ b/frontend/src/features/settings/components/telemetry-consent-dialog.tsx
@@ -17,8 +17,6 @@ import { useTelemetryConsent } from "@/features/settings/hooks/use-settings";
 // Same published page the backend startup notice points operators to
 // (TELEMETRY_FIELDS_DOCUMENTATION in app/modules/telemetry/scheduler.py).
 const TELEMETRY_DOCS_URL = "https://soju06.github.io/codex-lb/telemetry/";
-const OPT_OUT_NOTICE =
-  "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.";
 
 export function TelemetryConsentDialog() {
   const { t } = useTranslation();
@@ -62,7 +60,7 @@ export function TelemetryConsentDialog() {
           <p className="text-sm text-muted-foreground">
             {t("settings.telemetry.consentDialog.categories")}
           </p>
-          <p className="text-sm text-muted-foreground">{OPT_OUT_NOTICE}</p>
+          <p className="text-sm text-muted-foreground">{t("settings.telemetry.optOutNotice")}</p>
           <p className="text-sm font-medium">{t("settings.telemetry.consentDialog.payloadLabel")}</p>
           <TelemetryPayloadPreview preview={preview} />
           <p className="text-sm">

--- a/frontend/src/features/settings/components/telemetry-settings.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.test.tsx
@@ -27,6 +27,11 @@ describe("TelemetrySettings", () => {
     const toggle = await screen.findByRole("switch", { name: "Enable anonymous telemetry" });
     await waitFor(() => expect(toggle).toBeChecked());
     expect(toggle).toBeEnabled();
+    expect(
+      screen.getByText(
+        "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.",
+      ),
+    ).toBeInTheDocument();
 
     await user.click(toggle);
 
@@ -86,6 +91,7 @@ describe("TelemetrySettings", () => {
 
     const dialog = await screen.findByRole("dialog", { name: "Collected telemetry data" });
     expect(within(dialog).getByText(/"schema_version": 1/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/"consent": "undecided"/)).toBeInTheDocument();
     expect(within(dialog).getByText(/"timestamp": "2026-08-06T00:00:00Z"/)).toBeInTheDocument();
     expect(
       telemetryRequests.filter((url) => url.searchParams.get("include_preview") === "true"),

--- a/frontend/src/features/settings/components/telemetry-settings.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { TelemetrySettings } from "@/features/settings/components/telemetry-settings";
+import i18n from "@/i18n";
 import { createTelemetryConsent, createTelemetrySnapshotEnvelope } from "@/test/mocks/factories";
 import { server } from "@/test/mocks/server";
 import { renderWithProviders } from "@/test/utils";
@@ -27,11 +28,7 @@ describe("TelemetrySettings", () => {
     const toggle = await screen.findByRole("switch", { name: "Enable anonymous telemetry" });
     await waitFor(() => expect(toggle).toBeChecked());
     expect(toggle).toBeEnabled();
-    expect(
-      screen.getByText(
-        "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText(i18n.t("settings.telemetry.optOutNotice"))).toBeInTheDocument();
 
     await user.click(toggle);
 

--- a/frontend/src/features/settings/components/telemetry-settings.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.tsx
@@ -21,9 +21,6 @@ export type TelemetrySettingsProps = {
   disabled: boolean;
 };
 
-const OPT_OUT_NOTICE =
-  "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.";
-
 export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
   const { t } = useTranslation();
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -58,7 +55,7 @@ export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
           />
         </div>
 
-        <p className="text-xs text-muted-foreground">{OPT_OUT_NOTICE}</p>
+        <p className="text-xs text-muted-foreground">{t("settings.telemetry.optOutNotice")}</p>
 
         {envControlled ? (
           <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs font-medium text-foreground">

--- a/frontend/src/features/settings/components/telemetry-settings.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.tsx
@@ -21,6 +21,9 @@ export type TelemetrySettingsProps = {
   disabled: boolean;
 };
 
+const OPT_OUT_NOTICE =
+  "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.";
+
 export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
   const { t } = useTranslation();
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -54,6 +57,8 @@ export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
             onCheckedChange={(checked) => updateTelemetryConsentMutation.mutate({ enabled: checked })}
           />
         </div>
+
+        <p className="text-xs text-muted-foreground">{OPT_OUT_NOTICE}</p>
 
         {envControlled ? (
           <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs font-medium text-foreground">

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -436,6 +436,7 @@ const TelemetryFeaturesSnapshotSchema = z.strictObject({
 
 export const TelemetrySnapshotSchema = z.strictObject({
   schema_version: z.literal(1),
+  consent: z.enum(["undecided", "enabled"]),
   instance_id: z.string(),
   version: z.string(),
   python: z.string(),

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1293,6 +1293,7 @@
   "settings.telemetry.description": "Share anonymous usage statistics to help improve codex-lb.",
   "settings.telemetry.toggleAria": "Enable anonymous telemetry",
   "settings.telemetry.envNotice": "Telemetry is controlled by the CODEX_LB_TELEMETRY_ENABLED environment variable. Unset it to manage this setting from the dashboard.",
+  "settings.telemetry.optOutNotice": "Disabling from the dashboard sends one anonymous opt-out notice to keep aggregate counts accurate.",
   "settings.telemetry.collectedData.label": "Collected data",
   "settings.telemetry.collectedData.description": "Review the exact anonymous payload this instance would send.",
   "settings.telemetry.collectedData.view": "View collected data",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1293,6 +1293,7 @@
   "settings.telemetry.description": "익명 사용 통계를 공유해 codex-lb 개선에 도움을 줍니다.",
   "settings.telemetry.toggleAria": "익명 텔레메트리 사용",
   "settings.telemetry.envNotice": "텔레메트리는 CODEX_LB_TELEMETRY_ENABLED 환경 변수로 제어되고 있습니다. 대시보드에서 이 설정을 관리하려면 해당 변수를 해제하세요.",
+  "settings.telemetry.optOutNotice": "대시보드에서 텔레메트리를 비활성화하면 집계 수치의 정확성을 유지하기 위해 익명 비활성화 알림을 한 번 전송합니다.",
   "settings.telemetry.collectedData.label": "수집 데이터",
   "settings.telemetry.collectedData.description": "이 인스턴스가 전송할 익명 payload 원문을 확인할 수 있습니다.",
   "settings.telemetry.collectedData.view": "수집 데이터 보기",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1293,6 +1293,7 @@
   "settings.telemetry.description": "分享匿名使用统计，帮助改进 codex-lb。",
   "settings.telemetry.toggleAria": "启用匿名遥测",
   "settings.telemetry.envNotice": "遥测当前由 CODEX_LB_TELEMETRY_ENABLED 环境变量控制。如需在仪表盘中管理此设置，请取消设置该变量。",
+  "settings.telemetry.optOutNotice": "从仪表盘中禁用遥测时，系统会发送一次匿名的选择退出通知，以确保汇总计数准确。",
   "settings.telemetry.collectedData.label": "收集的数据",
   "settings.telemetry.collectedData.description": "查看此实例将发送的匿名数据的完整内容。",
   "settings.telemetry.collectedData.view": "查看收集的数据",

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -550,6 +550,7 @@ export function createTelemetrySnapshotEnvelope(): TelemetrySnapshotEnvelope {
 		timestamp: "2026-08-06T00:00:00Z",
 		metrics: {
 			schema_version: 1,
+			consent: "undecided",
 			instance_id: "00000000-0000-4000-8000-000000000000",
 			version: "1.23.0",
 			python: "3.13",

--- a/openspec/changes/add-telemetry-optout-signal/.openspec.yaml
+++ b/openspec/changes/add-telemetry-optout-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/add-telemetry-optout-signal/design.md
+++ b/openspec/changes/add-telemetry-optout-signal/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Snapshot transmission currently resolves consent before building the payload and uses an
+instance identity to register, activate, sign, and post through an isolated HTTP client. The
+settings PUT persists dashboard decisions through a request-scoped database session. See
+`proposal.md` for motivation and `specs/telemetry/spec.md` for the changed contract.
+
+The opt-out signal is unusual because its triggering decision has already made consent inactive.
+It therefore cannot depend on the normal consent-gated sender context, and its asynchronous work
+cannot retain request-scoped database or HTTP resources.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve one authoritative consent resolution for each snapshot and preview.
+- Emit an opt-out only from a dashboard-driven effective active-to-inactive transition.
+- Keep the settings response independent from all collector network activity.
+- Preserve canonical serialization, signing, bounded retries, and debug-only failure handling.
+
+**Non-Goals:**
+
+- No new setting, scheduler cadence, collector implementation, or database migration.
+- No historical opt-out backfill or notification when the environment kill switch disables
+  telemetry.
+- No delivery guarantee beyond the existing bounded best-effort telemetry discipline.
+
+## Decisions
+
+### Pass resolved consent into snapshot construction
+
+The scheduler and preview API will pass their already-resolved active consent state into the
+snapshot builder. This keeps the envelope deterministic and prevents a second resolution from
+observing a different state. Resolving consent again inside the builder was rejected because it
+would duplicate policy and could disagree with the caller's send decision.
+
+### Detect the effective transition around persistence
+
+The PUT handler will resolve consent before persisting the decision and again afterward. It will
+schedule an opt-out only when the first resolution is active and the second is inactive. This
+naturally excludes disabled-to-disabled writes and both environment override values, while
+allowing a later re-enable/re-disable cycle to produce a new event. Comparing only persisted
+values was rejected because it would incorrectly notify while an environment override controls
+effective behavior.
+
+### Give the background task explicit immutable inputs
+
+Before scheduling, the handler will obtain the instance identity and gather the version and
+platform fields needed for registration and activation. The sender will then open and close its
+own HTTP client, lazily register and activate, and post the signed canonical opt-out body. A
+module-owned task set will retain a strong reference until completion. Reusing the request's
+database session or the consent-gated sender context was rejected because those resources and
+policy no longer match the task's lifetime.
+
+### Reuse the sender's bounded delivery discipline
+
+Opt-out delivery will share the snapshot path's five-second total timeout, at-most-one retry,
+canonical JSON, signing, accepted-status handling, and debug-only exception isolation. The
+event body is:
+
+```json
+{"app_version":"1.2.3","event":"optout","instance_id":"550e8400-e29b-41d4-a716-446655440000","occurred_at":"2026-08-20T12:00:00+00:00"}
+```
+
+The route order for an uninitialized process is registration, activation, then opt-out. Waiting
+for network completion in the API handler was rejected because collector latency must not affect
+the operator's settings response.
+
+## Risks / Trade-offs
+
+- **Process exit can cancel the best-effort task** → Server-side idempotency and per-transition
+  scheduling make retries safe, while avoiding shutdown delay or API coupling.
+- **Concurrent duplicate dashboard requests can each observe a transition** → Persisted state
+  serialization and transition tests constrain ordinary request behavior; the collector remains
+  idempotent for rare delivery duplication.
+- **Registration or activation outage prevents the event** → The sender swallows the bounded
+  failure at debug level, matching snapshot availability and privacy behavior.
+- **A future snapshot caller could pass disabled consent** → The type narrows the payload to the
+  two wire-valid states, and callers only build while resolved consent is active.
+
+## Migration Plan
+
+Deploy the additive client contract together with collector support for `/v1/optout`. Existing
+instances require no data migration. Rollback removes the new snapshot field and notification;
+the collector's idempotent endpoint can remain deployed without affecting older clients.

--- a/openspec/changes/add-telemetry-optout-signal/proposal.md
+++ b/openspec/changes/add-telemetry-optout-signal/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Telemetry currently becomes silent when an operator disables it, so the collector cannot
+distinguish an explicit rejection from an instance that stopped running. The wire contract also
+needs the effective persisted consent state on snapshots so aggregate interpretation stays
+accurate without weakening the environment kill switch.
+
+## What Changes
+
+- Add the active consent state (`undecided` or `enabled`) to every snapshot payload.
+- Send one final signed opt-out notification for each dashboard-driven transition from active
+  telemetry to inactive telemetry.
+- Preserve absolute silence for the `CODEX_LB_TELEMETRY_ENABLED=false` environment path and
+  isolate opt-out transmission failures from the settings API response.
+- Explain the additive wire behavior in the telemetry settings UI and published telemetry docs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `telemetry`: Extend the outbound allowlist and consent behavior with snapshot consent and the
+  decision-time opt-out notification.
+
+## Impact
+
+- Telemetry schemas, snapshot construction, scheduler and preview callers, sender, and settings
+  API transition handling.
+- Telemetry unit tests and wire-contract allowlists.
+- Dashboard telemetry consent copy and component tests.
+- Published telemetry payload documentation.

--- a/openspec/changes/add-telemetry-optout-signal/specs/telemetry/spec.md
+++ b/openspec/changes/add-telemetry-optout-signal/specs/telemetry/spec.md
@@ -64,4 +64,3 @@ MUST remain completely silent.
 - **WHEN** telemetry is disabled and the service runs through startup and a 24-hour scheduler
   cycle outside the dashboard decision-time transition
 - **THEN** no connection attempt to the telemetry endpoint is made
-

--- a/openspec/changes/add-telemetry-optout-signal/specs/telemetry/spec.md
+++ b/openspec/changes/add-telemetry-optout-signal/specs/telemetry/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Snapshot payload declares active consent
+
+Every snapshot payload MUST include a top-level `consent` field whose value is the resolved
+persisted consent state `undecided` or `enabled`; `disabled` MUST NOT appear because snapshots
+are not transmitted while telemetry is inactive.
+
+#### Scenario: Undecided snapshot declares consent
+
+- **WHEN** telemetry is active under the default undecided consent state
+- **THEN** the transmitted snapshot and exact payload preview contain `consent: "undecided"`
+
+#### Scenario: Enabled snapshot declares consent
+
+- **WHEN** telemetry is active under persisted enabled consent
+- **THEN** the transmitted snapshot and exact payload preview contain `consent: "enabled"`
+
+### Requirement: Dashboard opt-out notification
+
+The service MUST send one final signed `POST /v1/optout` notification for each
+dashboard-driven effective consent transition from active to inactive, and MUST complete any
+required instance registration and activation before sending that notification. The notification
+MUST use the telemetry instance identity and snapshot signing scheme, MUST be isolated from the
+settings API response, and MUST NOT be sent for an environment-controlled consent path.
+
+#### Scenario: Opt-out fires exactly once per transition
+
+- **WHEN** dashboard consent transitions from undecided or enabled active telemetry to disabled
+  inactive telemetry without an environment override
+- **THEN** exactly one opt-out notification is attempted for that transition before telemetry
+  becomes silent
+
+#### Scenario: Environment kill switch stays silent
+
+- **WHEN** `CODEX_LB_TELEMETRY_ENABLED=false` makes telemetry inactive or a dashboard decision
+  is persisted while consent is controlled by either environment override value
+- **THEN** no opt-out notification or other telemetry network request is attempted
+
+#### Scenario: Opt-out failure is isolated
+
+- **WHEN** registration, activation, or opt-out transmission fails
+- **THEN** the failure uses a total timeout of no more than five seconds, retries no more than
+  once, is logged only at debug level, does not raise to the caller, and does not delay or alter
+  the successful settings API response
+
+#### Scenario: A later transition may notify again
+
+- **WHEN** an operator re-enables telemetry and later disables it again through the dashboard
+  without an environment override
+- **THEN** the later active-to-inactive transition attempts exactly one new opt-out notification
+
+## MODIFIED Requirements
+
+### Requirement: Disabled means zero telemetry traffic
+
+Except for the single decision-time opt-out notification on a dashboard-driven active-to-inactive
+transition, when resolved consent is `disabled` the service MUST NOT open any network connection
+to the telemetry endpoint. The environment kill-switch path MUST NOT receive this exception and
+MUST remain completely silent.
+
+#### Scenario: No connection attempts when disabled
+
+- **WHEN** telemetry is disabled and the service runs through startup and a 24-hour scheduler
+  cycle outside the dashboard decision-time transition
+- **THEN** no connection attempt to the telemetry endpoint is made
+

--- a/openspec/changes/add-telemetry-optout-signal/tasks.md
+++ b/openspec/changes/add-telemetry-optout-signal/tasks.md
@@ -1,0 +1,22 @@
+## 1. Snapshot Consent Contract
+
+- [ ] 1.1 Add the active consent literal to snapshot schemas and introduce the typed opt-out event schema
+- [ ] 1.2 Require callers to pass resolved consent into snapshot construction and expose it in sender and preview envelopes
+- [ ] 1.3 Update schema allowlist and builder, scheduler, and preview regression tests for the consent field
+
+## 2. Opt-Out Delivery
+
+- [ ] 2.1 Implement signed canonical opt-out delivery with lazy registration, activation, bounded retry, and debug-only failure isolation
+- [ ] 2.2 Detect dashboard effective active-to-inactive transitions and schedule one resource-owning background send
+- [ ] 2.3 Add sender and settings API tests for successful delivery, retry/failure isolation, repeated transitions, no-op decisions, and both environment overrides
+- [ ] 2.4 Preserve transport-level zero-call coverage for disabled scheduler and sender paths
+
+## 3. Operator Communication
+
+- [ ] 3.1 Add neutral opt-out notice copy to the telemetry consent dialog and settings components with co-located test coverage
+- [ ] 3.2 Document the snapshot consent field, opt-out wire payload, transition behavior, and environment-path silence
+
+## 4. Verification
+
+- [ ] 4.1 Validate the OpenSpec change and run focused backend and frontend tests
+- [ ] 4.2 Run the full unit suite, lint, and type-check gates and confirm the final diff stays within the approved scope

--- a/openspec/changes/add-telemetry-optout-signal/tasks.md
+++ b/openspec/changes/add-telemetry-optout-signal/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Snapshot Consent Contract
 
-- [ ] 1.1 Add the active consent literal to snapshot schemas and introduce the typed opt-out event schema
-- [ ] 1.2 Require callers to pass resolved consent into snapshot construction and expose it in sender and preview envelopes
-- [ ] 1.3 Update schema allowlist and builder, scheduler, and preview regression tests for the consent field
+- [x] 1.1 Add the active consent literal to snapshot schemas and introduce the typed opt-out event schema
+- [x] 1.2 Require callers to pass resolved consent into snapshot construction and expose it in sender and preview envelopes
+- [x] 1.3 Update schema allowlist and builder, scheduler, and preview regression tests for the consent field
 
 ## 2. Opt-Out Delivery
 
-- [ ] 2.1 Implement signed canonical opt-out delivery with lazy registration, activation, bounded retry, and debug-only failure isolation
-- [ ] 2.2 Detect dashboard effective active-to-inactive transitions and schedule one resource-owning background send
-- [ ] 2.3 Add sender and settings API tests for successful delivery, retry/failure isolation, repeated transitions, no-op decisions, and both environment overrides
-- [ ] 2.4 Preserve transport-level zero-call coverage for disabled scheduler and sender paths
+- [x] 2.1 Implement signed canonical opt-out delivery with lazy registration, activation, bounded retry, and debug-only failure isolation
+- [x] 2.2 Detect dashboard effective active-to-inactive transitions and schedule one resource-owning background send
+- [x] 2.3 Add sender and settings API tests for successful delivery, retry/failure isolation, repeated transitions, no-op decisions, and both environment overrides
+- [x] 2.4 Preserve transport-level zero-call coverage for disabled scheduler and sender paths
 
 ## 3. Operator Communication
 
-- [ ] 3.1 Add neutral opt-out notice copy to the telemetry consent dialog and settings components with co-located test coverage
-- [ ] 3.2 Document the snapshot consent field, opt-out wire payload, transition behavior, and environment-path silence
+- [x] 3.1 Add neutral opt-out notice copy to the telemetry consent dialog and settings components with co-located test coverage
+- [x] 3.2 Document the snapshot consent field, opt-out wire payload, transition behavior, and environment-path silence
 
 ## 4. Verification
 
-- [ ] 4.1 Validate the OpenSpec change and run focused backend and frontend tests
-- [ ] 4.2 Run the full unit suite, lint, and type-check gates and confirm the final diff stays within the approved scope
+- [x] 4.1 Validate the OpenSpec change and run focused backend and frontend tests
+- [x] 4.2 Run the full unit suite, lint, and type-check gates and confirm the final diff stays within the approved scope

--- a/tests/unit/test_telemetry_api.py
+++ b/tests/unit/test_telemetry_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import Mock
+import asyncio
+import logging
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -9,8 +11,21 @@ from app.core.config.settings import get_settings
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def opt_out_sender(monkeypatch):
+    sender = Mock()
+    sender.send_opt_out = AsyncMock()
+    factory = Mock(return_value=sender)
+    monkeypatch.setattr("app.modules.telemetry.api.TelemetrySender", factory)
+    return sender
+
+
 @pytest.mark.asyncio
-async def test_consent_api_get_preview_and_put_persists_without_restart(async_client, monkeypatch) -> None:
+async def test_consent_api_get_preview_and_put_persists_without_restart(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+) -> None:
     monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
     get_settings.cache_clear()
 
@@ -22,6 +37,7 @@ async def test_consent_api_get_preview_and_put_persists_without_restart(async_cl
     assert initial["active"] is True
     assert set(initial["preview"]) == {"instance_id", "metrics", "timestamp"}
     assert initial["preview"]["metrics"]["schema_version"] == 1
+    assert initial["preview"]["metrics"]["consent"] == "undecided"
     assert initial["preview"]["instance_id"] == initial["preview"]["metrics"]["instance_id"]
 
     response = await async_client.put("/api/settings/telemetry", json={"enabled": False})
@@ -31,6 +47,8 @@ async def test_consent_api_get_preview_and_put_persists_without_restart(async_cl
     assert disabled["source"] == "persisted"
     assert disabled["active"] is False
     assert disabled["preview"] is None
+    await asyncio.sleep(0)
+    opt_out_sender.send_opt_out.assert_awaited_once()
 
     builder = Mock(side_effect=AssertionError("decided consent must not build a preview"))
     monkeypatch.setattr("app.modules.telemetry.api.TelemetrySnapshotBuilder", builder)
@@ -42,7 +60,10 @@ async def test_consent_api_get_preview_and_put_persists_without_restart(async_cl
 
 
 @pytest.mark.asyncio
-async def test_consent_api_builds_decided_preview_only_when_requested(async_client, monkeypatch) -> None:
+async def test_consent_api_builds_decided_preview_only_when_requested(
+    async_client,
+    monkeypatch,
+) -> None:
     monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
     get_settings.cache_clear()
     await async_client.put("/api/settings/telemetry", json={"enabled": False})
@@ -53,6 +74,7 @@ async def test_consent_api_builds_decided_preview_only_when_requested(async_clie
     payload = response.json()
     assert payload["state"] == "disabled"
     assert payload["preview"]["instance_id"] == payload["preview"]["metrics"]["instance_id"]
+    assert payload["preview"]["metrics"]["consent"] == "enabled"
 
 
 @pytest.mark.asyncio
@@ -71,3 +93,115 @@ async def test_consent_api_env_override_wins_and_suppresses_undecided_state(asyn
     assert payload["active"] is True
     assert payload["preview"] is None
     builder.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_active_to_inactive_transitions_each_send_exactly_once(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
+    get_settings.cache_clear()
+
+    first = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+    assert first.status_code == 200
+    await asyncio.sleep(0)
+    assert opt_out_sender.send_opt_out.await_count == 1
+
+    repeated = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+    assert repeated.status_code == 200
+    await asyncio.sleep(0)
+    assert opt_out_sender.send_opt_out.await_count == 1
+
+    enabled = await async_client.put("/api/settings/telemetry", json={"enabled": True})
+    assert enabled.status_code == 200
+    await asyncio.sleep(0)
+    assert opt_out_sender.send_opt_out.await_count == 1
+
+    second = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+    assert second.status_code == 200
+    await asyncio.sleep(0)
+    assert opt_out_sender.send_opt_out.await_count == 2
+
+    call = opt_out_sender.send_opt_out.await_args_list[-1]
+    assert call.args[0].instance_id
+    assert call.kwargs["app_version"]
+    assert call.kwargs["deployment_mode"] in {"docker", "k8s", "pip", "bare"}
+    assert "/" in call.kwargs["os_arch"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("env_value", "enabled", "expected_active"),
+    [("true", False, True), ("false", True, False)],
+)
+async def test_environment_controlled_put_never_sends_opt_out(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+    env_value: str,
+    enabled: bool,
+    expected_active: bool,
+) -> None:
+    monkeypatch.setenv("CODEX_LB_TELEMETRY_ENABLED", env_value)
+    get_settings.cache_clear()
+
+    response = await async_client.put("/api/settings/telemetry", json={"enabled": enabled})
+
+    assert response.status_code == 200
+    assert response.json()["source"] == "env"
+    assert response.json()["active"] is expected_active
+    await asyncio.sleep(0)
+    opt_out_sender.send_opt_out.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_opt_out_background_send_does_not_block_settings_response(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
+    get_settings.cache_clear()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_send(*args, **kwargs) -> None:
+        del args, kwargs
+        started.set()
+        await release.wait()
+
+    opt_out_sender.send_opt_out.side_effect = blocked_send
+
+    response = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+
+    assert response.status_code == 200
+    await asyncio.wait_for(started.wait(), timeout=1)
+    from app.modules.telemetry import api as telemetry_api
+
+    assert telemetry_api._OPT_OUT_TASKS
+    release.set()
+    await asyncio.gather(*tuple(telemetry_api._OPT_OUT_TASKS))
+    await asyncio.sleep(0)
+    assert not telemetry_api._OPT_OUT_TASKS
+
+
+@pytest.mark.asyncio
+async def test_unexpected_opt_out_task_failure_is_debug_only_and_does_not_change_response(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+    caplog,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
+    get_settings.cache_clear()
+    opt_out_sender.send_opt_out.side_effect = RuntimeError("unexpected sender failure")
+
+    with caplog.at_level(logging.DEBUG, logger="app.modules.telemetry.api"):
+        response = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+        await asyncio.sleep(0)
+
+    assert response.status_code == 200
+    assert caplog.records
+    assert all(record.levelno == logging.DEBUG for record in caplog.records)

--- a/tests/unit/test_telemetry_api.py
+++ b/tests/unit/test_telemetry_api.py
@@ -188,6 +188,37 @@ async def test_opt_out_background_send_does_not_block_settings_response(
 
 
 @pytest.mark.asyncio
+async def test_opt_out_identity_failure_is_debug_only_and_preserves_disabled_state(
+    async_client,
+    monkeypatch,
+    opt_out_sender,
+    caplog,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
+    get_settings.cache_clear()
+
+    async def fail_identity(_store) -> None:
+        raise RuntimeError("identity decryption failed")
+
+    monkeypatch.setattr(
+        "app.modules.telemetry.api.TelemetryConsentStore.get_or_create_identity",
+        fail_identity,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="app.modules.telemetry.api"):
+        response = await async_client.put("/api/settings/telemetry", json={"enabled": False})
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "disabled"
+    persisted = await async_client.get("/api/settings/telemetry")
+    assert persisted.status_code == 200
+    assert persisted.json()["state"] == "disabled"
+    opt_out_sender.send_opt_out.assert_not_awaited()
+    assert "Unable to schedule anonymous telemetry opt-out" in caplog.messages
+    assert all(record.levelno == logging.DEBUG for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_unexpected_opt_out_task_failure_is_debug_only_and_does_not_change_response(
     async_client,
     monkeypatch,

--- a/tests/unit/test_telemetry_consent.py
+++ b/tests/unit/test_telemetry_consent.py
@@ -88,6 +88,22 @@ async def test_disabled_scheduler_tick_makes_zero_sender_calls(db_setup, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_enabled_scheduler_snapshot_declares_enabled_consent(db_setup, monkeypatch) -> None:
+    del db_setup
+    monkeypatch.delenv("CODEX_LB_TELEMETRY_ENABLED", raising=False)
+    get_settings.cache_clear()
+    async with SessionLocal() as session:
+        store = TelemetryConsentStore(session)
+        await store.set_decision(True)
+
+    sender = AsyncMock()
+    await TelemetryScheduler(sender=sender)._tick()
+
+    sender.send_snapshot.assert_awaited_once()
+    assert sender.send_snapshot.await_args.args[0].consent == "enabled"
+
+
+@pytest.mark.asyncio
 async def test_non_leader_scheduler_tick_builds_and_transmits_nothing(monkeypatch) -> None:
     import app.modules.telemetry.scheduler as scheduler_module
 
@@ -144,6 +160,7 @@ async def test_scheduler_sends_startup_and_interval_snapshots_with_one_undecided
         await scheduler.stop()
 
     assert sender.send_snapshot.await_count >= 2
+    assert all(call.args[0].consent == "undecided" for call in sender.send_snapshot.await_args_list)
     notices = [
         record.getMessage() for record in caplog.records if "Anonymous telemetry is active" in record.getMessage()
     ]

--- a/tests/unit/test_telemetry_sender.py
+++ b/tests/unit/test_telemetry_sender.py
@@ -139,11 +139,97 @@ async def test_sender_disabled_guard_does_not_construct_http_client(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_opt_out_registers_activates_and_posts_exact_signed_canonical_body(monkeypatch) -> None:
+async def test_sender_aborts_snapshot_when_consent_becomes_inactive_before_post(monkeypatch) -> None:
+    snapshot = _snapshot()
+    identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
+    context_provider = AsyncMock(side_effect=[(True, identity), (False, None)])
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+
+    await TelemetrySender(
+        "https://telemetry.example",
+        context_provider=context_provider,
+    ).send_snapshot(snapshot)
+
+    assert [request[0] for request in session.requests] == [
+        "https://telemetry.example/v1/register",
+        "https://telemetry.example/v1/activate",
+    ]
+    assert context_provider.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sender_posts_snapshot_once_when_consent_stays_active(monkeypatch) -> None:
+    snapshot = _snapshot()
+    identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
+    context_provider = AsyncMock(return_value=(True, identity))
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+
+    await TelemetrySender(
+        "https://telemetry.example",
+        context_provider=context_provider,
+    ).send_snapshot(snapshot)
+
+    assert [request[0] for request in session.requests] == [
+        "https://telemetry.example/v1/register",
+        "https://telemetry.example/v1/activate",
+        "https://telemetry.example/v1/snapshot",
+    ]
+    assert context_provider.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sender_aborts_snapshot_when_identity_changes_before_post(monkeypatch) -> None:
+    snapshot = _snapshot()
+    identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
+    replacement_identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
+    context_provider = AsyncMock(side_effect=[(True, identity), (True, replacement_identity)])
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+
+    await TelemetrySender(
+        "https://telemetry.example",
+        context_provider=context_provider,
+    ).send_snapshot(snapshot)
+
+    assert [request[0] for request in session.requests] == [
+        "https://telemetry.example/v1/register",
+        "https://telemetry.example/v1/activate",
+    ]
+    assert context_provider.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_sender_aborts_snapshot_when_consent_recheck_fails(monkeypatch, caplog) -> None:
+    snapshot = _snapshot()
+    identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
+    context_provider = AsyncMock(side_effect=[(True, identity), OSError("database unavailable")])
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+
+    with caplog.at_level(logging.DEBUG, logger="app.modules.telemetry.sender"):
+        await TelemetrySender(
+            "https://telemetry.example",
+            context_provider=context_provider,
+        ).send_snapshot(snapshot)
+
+    assert [request[0] for request in session.requests] == [
+        "https://telemetry.example/v1/register",
+        "https://telemetry.example/v1/activate",
+    ]
+    assert context_provider.await_count == 2
+    assert [record.message for record in caplog.records] == ["Anonymous telemetry consent re-check failed"]
+
+
+@pytest.mark.asyncio
+async def test_opt_out_with_inactive_consent_registers_activates_and_posts_exact_signed_canonical_body(
+    monkeypatch,
+) -> None:
     identity = TelemetryIdentity("00000000-0000-4000-8000-000000000004", Ed25519PrivateKey.generate())
     session = _FakeClientSession()
     client_session = Mock(return_value=session)
-    context_provider = AsyncMock(side_effect=AssertionError("opt-out must not resolve inactive consent"))
+    context_provider = AsyncMock(return_value=(False, None))
     monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", client_session)
     monkeypatch.setattr("app.modules.telemetry.sender.utcnow", lambda: datetime(2026, 8, 20, 12, 0, 0))
 
@@ -220,7 +306,7 @@ async def test_opt_out_failure_is_swallowed_and_logged_at_debug(monkeypatch, cap
 async def test_sender_uses_canonical_shm_paths_and_valid_ed25519_signature() -> None:
     snapshot = _snapshot()
     identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
-    sender = TelemetrySender()
+    sender = TelemetrySender(context_provider=AsyncMock(return_value=(True, identity)))
     sender._post = AsyncMock()
     sender._post_signed = AsyncMock()
     session = Mock()
@@ -272,7 +358,7 @@ async def test_preview_and_sender_snapshot_envelopes_have_identical_key_structur
     snapshot = _snapshot()
     identity = TelemetryIdentity(snapshot.instance_id, Ed25519PrivateKey.generate())
     preview = build_snapshot_envelope(snapshot)
-    sender = TelemetrySender()
+    sender = TelemetrySender(context_provider=AsyncMock(return_value=(True, identity)))
     sender._post = AsyncMock()
     sender._post_signed = AsyncMock()
 

--- a/tests/unit/test_telemetry_sender.py
+++ b/tests/unit/test_telemetry_sender.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -14,9 +15,38 @@ from app.modules.telemetry.sender import TelemetrySender
 pytestmark = pytest.mark.unit
 
 
+class _FakeResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    async def read(self) -> bytes:
+        return b""
+
+
+class _FakeClientSession:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, bytes, dict[str, str]]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    def post(self, url: str, *, data: bytes, headers: dict[str, str]) -> _FakeResponse:
+        self.requests.append((url, data, headers))
+        return _FakeResponse()
+
+
 def _snapshot() -> TelemetrySnapshot:
     return TelemetrySnapshot.model_validate(
         {
+            "consent": "enabled",
             "instance_id": "00000000-0000-4000-8000-000000000004",
             "version": "1.0.0",
             "python": "3.13",
@@ -106,6 +136,84 @@ async def test_sender_disabled_guard_does_not_construct_http_client(monkeypatch)
     await TelemetrySender(context_provider=context_provider).send_snapshot(_snapshot())
 
     client_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_opt_out_registers_activates_and_posts_exact_signed_canonical_body(monkeypatch) -> None:
+    identity = TelemetryIdentity("00000000-0000-4000-8000-000000000004", Ed25519PrivateKey.generate())
+    session = _FakeClientSession()
+    client_session = Mock(return_value=session)
+    context_provider = AsyncMock(side_effect=AssertionError("opt-out must not resolve inactive consent"))
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", client_session)
+    monkeypatch.setattr("app.modules.telemetry.sender.utcnow", lambda: datetime(2026, 8, 20, 12, 0, 0))
+
+    await TelemetrySender(
+        "https://telemetry.example",
+        context_provider=context_provider,
+    ).send_opt_out(
+        identity,
+        app_version="1.24.0",
+        deployment_mode="docker",
+        os_arch="linux/x86_64",
+    )
+
+    assert [request[0] for request in session.requests] == [
+        "https://telemetry.example/v1/register",
+        "https://telemetry.example/v1/activate",
+        "https://telemetry.example/v1/optout",
+    ]
+    expected_body = (
+        b'{"app_version":"1.24.0","event":"optout",'
+        b'"instance_id":"00000000-0000-4000-8000-000000000004",'
+        b'"occurred_at":"2026-08-20T12:00:00Z"}'
+    )
+    _, body, headers = session.requests[-1]
+    assert body == expected_body
+    assert headers["X-Instance-ID"] == identity.instance_id
+    identity.private_key.public_key().verify(bytes.fromhex(headers["X-Signature"]), body)
+    context_provider.assert_not_awaited()
+    client_session.assert_called_once()
+    assert client_session.call_args.kwargs["timeout"].total == 5.0
+    assert client_session.call_args.kwargs["trust_env"] is False
+
+
+@pytest.mark.asyncio
+async def test_opt_out_retries_once_then_succeeds(monkeypatch) -> None:
+    identity = TelemetryIdentity("00000000-0000-4000-8000-000000000004", Ed25519PrivateKey.generate())
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+    sender = TelemetrySender()
+    sender._transmit_opt_out_once = AsyncMock(side_effect=[OSError("transient"), None])
+
+    await sender.send_opt_out(
+        identity,
+        app_version="1.24.0",
+        deployment_mode="bare",
+        os_arch="linux/x86_64",
+    )
+
+    assert sender._transmit_opt_out_once.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_opt_out_failure_is_swallowed_and_logged_at_debug(monkeypatch, caplog) -> None:
+    identity = TelemetryIdentity("00000000-0000-4000-8000-000000000004", Ed25519PrivateKey.generate())
+    session = _FakeClientSession()
+    monkeypatch.setattr("app.modules.telemetry.sender.aiohttp.ClientSession", Mock(return_value=session))
+    sender = TelemetrySender()
+    sender._transmit_opt_out_once = AsyncMock(side_effect=OSError("collector unavailable"))
+
+    with caplog.at_level(logging.DEBUG, logger="app.modules.telemetry.sender"):
+        await sender.send_opt_out(
+            identity,
+            app_version="1.24.0",
+            deployment_mode="bare",
+            os_arch="linux/x86_64",
+        )
+
+    assert sender._transmit_opt_out_once.await_count == 2
+    assert caplog.records
+    assert all(record.levelno == logging.DEBUG for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_telemetry_snapshot.py
+++ b/tests/unit/test_telemetry_snapshot.py
@@ -19,7 +19,12 @@ from app.modules.telemetry.clients import (
     client_family,
     client_shares,
 )
-from app.modules.telemetry.schemas import TelemetryActivation, TelemetryRegistration, build_snapshot_envelope
+from app.modules.telemetry.schemas import (
+    TelemetryActivation,
+    TelemetryOptOut,
+    TelemetryRegistration,
+    build_snapshot_envelope,
+)
 from app.modules.telemetry.snapshot import (
     _ROUTING_POLICIES,
     TelemetrySnapshotBuilder,
@@ -79,11 +84,16 @@ async def test_snapshot_serialized_field_set_matches_documented_schema(async_ses
     async_session.add(_request_log("schema", model="gpt-5.4", useragent_group="codex_exec"))
     await async_session.commit()
 
-    snapshot = await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000001")
+    snapshot = await TelemetrySnapshotBuilder(async_session).build(
+        "00000000-0000-4000-8000-000000000001",
+        consent="undecided",
+    )
     payload = snapshot.model_dump()
 
+    assert payload["consent"] == "undecided"
     assert set(payload) == {
         "schema_version",
+        "consent",
         "instance_id",
         "version",
         "python",
@@ -157,6 +167,11 @@ async def test_snapshot_serialized_field_set_matches_documented_schema(async_ses
         public_key="00",
     ).model_dump(mode="json")
     activation = TelemetryActivation().model_dump(mode="json")
+    opt_out = TelemetryOptOut(
+        app_version=snapshot.version,
+        instance_id=snapshot.instance_id,
+        occurred_at="2026-08-20T12:00:00Z",
+    ).model_dump(mode="json")
     envelope = build_snapshot_envelope(snapshot).model_dump(mode="json")
     assert set(registration) == {
         "app_name",
@@ -168,6 +183,7 @@ async def test_snapshot_serialized_field_set_matches_documented_schema(async_ses
         "public_key",
     }
     assert set(activation) == {"action"}
+    assert set(opt_out) == {"app_version", "event", "instance_id", "occurred_at"}
     assert set(envelope) == {"instance_id", "metrics", "timestamp"}
 
 
@@ -228,7 +244,13 @@ async def test_model_catalog_filter_merges_custom_models_and_scopes_reasoning(
     )
     await async_session.commit()
 
-    payload = (await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000002")).model_dump()
+    payload = (
+        await TelemetrySnapshotBuilder(async_session).build(
+            "00000000-0000-4000-8000-000000000002",
+            consent="enabled",
+        )
+    ).model_dump()
+    assert payload["consent"] == "enabled"
     models = {model["name"]: model for model in payload["usage_7d"]["models"]}
 
     assert set(models) == {"gpt-5.4", "other"}
@@ -264,7 +286,10 @@ async def test_request_kind_mix_fails_honest_without_persisted_route_family(asyn
     )
     await async_session.commit()
 
-    payload = await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000005")
+    payload = await TelemetrySnapshotBuilder(async_session).build(
+        "00000000-0000-4000-8000-000000000005",
+        consent="undecided",
+    )
 
     assert payload.usage_7d.request_kinds.model_dump() == {
         "responses": 0.0,
@@ -411,7 +436,10 @@ async def test_privacy_quick_check_identifying_values_never_serialize(async_sess
     await async_session.commit()
 
     serialized = (
-        await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000003")
+        await TelemetrySnapshotBuilder(async_session).build(
+            "00000000-0000-4000-8000-000000000003",
+            consent="undecided",
+        )
     ).model_dump_json()
 
     for private_value in (
@@ -466,7 +494,10 @@ async def test_success_rate_excludes_cancelled_terminals(async_session: AsyncSes
     )
     await async_session.commit()
 
-    snapshot = await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000004")
+    snapshot = await TelemetrySnapshotBuilder(async_session).build(
+        "00000000-0000-4000-8000-000000000004",
+        consent="undecided",
+    )
 
     # 1 success out of 4 requests: cancellations are neither successes nor
     # errors, so they must not inflate the numerator.
@@ -496,7 +527,10 @@ async def test_top_upstream_errors_exclude_cancelled_terminals(async_session: As
     )
     await async_session.commit()
 
-    snapshot = await TelemetrySnapshotBuilder(async_session).build("00000000-0000-4000-8000-000000000005")
+    snapshot = await TelemetrySnapshotBuilder(async_session).build(
+        "00000000-0000-4000-8000-000000000005",
+        consent="undecided",
+    )
 
     # High-volume disconnects (status='cancelled' with a retained
     # client_disconnected code) must not displace genuine upstream failures.


### PR DESCRIPTION
## Summary

Telemetry goes silent when an operator disables it, so the collector cannot tell an explicit
rejection apart from an instance that simply stopped running. This adds two additive signals so
aggregate interpretation is honest, without weakening the environment kill switch.

- Snapshots carry the effective consent state (`undecided` | `enabled`).
- One signed opt-out notification is sent per dashboard-driven active → inactive transition,
  then the instance goes silent as before.

Measured motivation (production collector, 2026-08-20): of 1,175 registered instances, 1,072
(93.5%) sent exactly one snapshot at `uptime_hours=0` and 982 never had an account or a request.
Rejection was indistinguishable from a throwaway boot. The collector side of this work
(`engaged_7d` metric, `POST /v1/optout`) is already deployed.

## Wire contract

`POST {telemetry_endpoint}/v1/optout`, same Ed25519 signing scheme as `/v1/snapshot` (raw
signature over exact canonical-JSON body bytes, `X-Instance-ID` + `X-Signature`).

```json
{"app_version":"1.24.0","event":"optout","instance_id":"<uuid4>","occurred_at":"<ISO8601 UTC>"}
```

Accepted status `200`; the collector is idempotent (first opt-out timestamp is retained). The
sender lazily registers and activates first, because an instance may have never sent a snapshot.

## Behavior

| Transition | Opt-out sent |
|---|---|
| `undecided` → `disabled` via dashboard PUT | yes, once |
| `enabled` → `disabled` via dashboard PUT | yes, once |
| `disabled` → `disabled` | no |
| `CODEX_LB_TELEMETRY_ENABLED=false` (env path) | **never** |

The env kill switch stays absolutely silent: effective consent never transitions on that path,
so no code path can reach the notification. Transmission reuses the snapshot sender's failure
isolation (5s bounded timeout, at most one retry, DEBUG-only logging) and runs as a background
task, so the settings API response is never blocked or failed by it. A later snapshot re-enables
an instance collector-side, so re-enabling telemetry works without special handling.

## OpenSpec

`openspec/changes/add-telemetry-optout-signal/` — two ADDED requirements (snapshot consent
field, decision-time notification) and one MODIFIED requirement ("Disabled means zero telemetry
traffic", whole-requirement replacement carving out exactly this single event and explicitly
excluding the env path). `openspec validate add-telemetry-optout-signal` → valid.

## Simplicity gates (PRINCIPLES.md P1-P5)

- **P1 zero-config**: no new settings. `CODEX_LB_*` surface is unchanged, `.env.example`
  untouched, no new README sections. Behavior is fully determined by the existing tri-state
  consent and the existing kill switch.
- **P2**: no new `Settings` field, so no `MAX_SETTINGS_FIELDS` bump and no
  why-not-a-default justification is owed.
- Feature documentation goes to `docs/telemetry.md`, which already links its owning
  `openspec/specs/telemetry/` entry.
- Dashboard-visible copy change: before/after screenshots below.

## Verification

| Gate | Result |
|---|---|
| `uv run pytest tests/unit -q` (full, unfiltered) | 6324 passed, 3 skipped |
| `make lint` | ruff check + format clean |
| `uv run ty check` | All checks passed (`uv.lock` unchanged) |
| `uv run openspec validate add-telemetry-optout-signal` | is valid |
| Frontend vitest (telemetry dialog / settings / integration) | 3 files, 14 tests passed |

Cross-repo live E2E against the collector running the deployed code (local `wrangler dev` + D1):
the real `TelemetrySender` performed register → activate → snapshot(with `consent`) → opt-out,
and the collector row showed `status='opted_out'`, `snapshot_count=1`, `has_usage=1`,
`last_consent='undecided'`, `opted_out_at` set. Signature verification passed server-side, so
the canonical-JSON byte contract holds across Python and Workers.

## Screenshots

### One-time consent dialog

| Before (`main`) | After |
|---|---|
| ![before dialog](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-screenshots/telemetry-optout/before-dialog.png) | ![after dialog](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-screenshots/telemetry-optout/after-dialog.png) |

### Settings → Anonymous telemetry

| Before (`main`) | After |
|---|---|
| ![before settings](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-screenshots/telemetry-optout/before-settings.png) | ![after settings](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-screenshots/telemetry-optout/after-settings.png) |

The after shots add one sentence and, in the dialog's live payload preview, the new
`"consent": "undecided"` field. No layout or control changes.

## Known gaps (deferred, tracked in #1844)

Three adversarial review rounds ran on this branch. Everything actionable was fixed; the residual
items below were deliberately accepted rather than fixed here.

| Item | Why deferred |
|---|---|
| TOCTOU between the pre-POST consent re-check and the snapshot write | The re-check narrows the window to the gap between two adjacent statements on a once-per-24h tick. Closing it properly needs a fence with ordering authority (collector-side re-activation rule or a consent generation counter), which is a separate change on both sides. |
| Settings preview shows `consent: "enabled"` for a persisted-`undecided` instance under `CODEX_LB_TELEMETRY_ENABLED=false` | Preview-only inaccuracy in one override combination; no effect on transmitted payloads. |
| `TelemetryOptOut.occurred_at` typed as `str` rather than `datetime` | Hardening, not a live defect: `utcnow()` returns naive UTC so the emitted `Z` suffix is correct today. |
| No operation/phase/instance context in retry logs; no opt-out scheduling lifecycle record | Adding observability around an anonymous rejection event pulls against the feature's privacy posture. Revisit when the collector reports non-zero `opt_outs`. |

Fixed during review: opt-out identity failures no longer break the settings response (they are
isolated and logged at DEBUG); the consent notice is localized through `t(...)` in en/ko/zh-CN
instead of two hard-coded English literals; the settings skeleton regained parity with the new
notice row; the snapshot sender re-checks consent and identity before the final POST; the
deployment-method and active-consent literals are single-sourced as schema-owned aliases.

## Notes

This measures rejections from deployment forward only; operators who already disabled telemetry
before this ships cannot be counted retroactively.
