### PR TITLE
fix(proxy): preserve explicit null embedding fields

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4460,7 +4460,7 @@ async def _source_embeddings_response(
         request_model=model,
         request_service_tier=None,
     )
-    outbound = payload.model_dump(exclude_none=True)
+    outbound = payload.model_dump(exclude_unset=True)
     outbound["model"] = model
     try:
         result = await forward_source_embeddings(source, outbound)

--- a/openspec/changes/preserve-embedding-explicit-null-fields/.openspec.yaml
+++ b/openspec/changes/preserve-embedding-explicit-null-fields/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/preserve-embedding-explicit-null-fields/design.md
+++ b/openspec/changes/preserve-embedding-explicit-null-fields/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`V1EmbeddingsRequest` validates `model` and `input` while allowing arbitrary compatible extras. Pydantic retains both extra values and their presence, but `_source_embeddings_response` currently serializes with `exclude_none=True`, which converts every explicit null into omission before the forwarding adapter receives the payload. The forwarding adapter sends its input dictionary unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the client's distinction between an omitted embedding extra and an explicitly supplied null.
+- Keep non-null extras, source routing, reservation settlement, and request-log metadata unchanged.
+- Prove behavior through the real ASGI route and an inert captured source.
+
+**Non-Goals:**
+
+- Change serialization for any endpoint other than source-routed `/v1/embeddings`.
+- Change model-source selection, authentication, usage accounting, logging, or error handling.
+- Add a compatibility shim, setting, dependency, migration, or dashboard behavior.
+
+## Decisions
+
+- Serialize the embeddings request with Pydantic presence semantics (`exclude_unset=True`). This omits values absent from the inbound model while retaining explicit null and non-null values. Using a manual field-set reconstruction would duplicate behavior Pydantic already guarantees; removing all exclusion would be broader than the required presence contract.
+- Add three route-level source-capture cases: explicit null, omitted extras, and non-null extras. The existing settled limited-key case remains the non-null control and continues asserting reservation-derived token accounting and request-log source metadata.
+- Sync the stable requirement into `openspec/specs/model-source-routing/spec.md` because the owning capability was introduced by the still-active `add-model-source-embeddings` change and has not yet been materialized under main specs.
+
+## Risks / Trade-offs
+
+- **[Risk] A serializer change could accidentally emit absent optional fields.** → Mitigation: captured-source omitted control asserts binary key absence.
+- **[Risk] Payload correctness coverage could hide accounting regressions.** → Mitigation: retain and extend the existing limited-key settlement and request-log assertions.
+- **[Risk] A shared serializer change could affect unrelated routes.** → Mitigation: change only the single embeddings outbound serialization call.

--- a/openspec/changes/preserve-embedding-explicit-null-fields/proposal.md
+++ b/openspec/changes/preserve-embedding-explicit-null-fields/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Source-routed `/v1/embeddings` requests currently serialize with `exclude_none=True`, so explicitly supplied null extras disappear before forwarding even though the model-source contract requires extras beyond `model` and `input` to pass through verbatim. Compatible sources that distinguish an omitted key from an explicit null therefore receive a client-different payload.
+
+## What Changes
+
+- Preserve explicitly supplied null embedding extras when forwarding to a model source.
+- Continue omitting fields the client did not send and preserving non-null extras unchanged.
+- Lock the behavior at the real ASGI route and captured-source boundary while retaining reservation settlement and request-log assertions.
+- Sync the stable embeddings forwarding requirement into the owning main specification.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `model-source-routing`: Clarify that verbatim embeddings forwarding distinguishes explicitly supplied null fields from omitted fields.
+
+## Impact
+
+The change is limited to `/v1/embeddings` request serialization in `app/modules/proxy/api.py`, focused model-source routing integration coverage, and the `model-source-routing` OpenSpec contract. It adds no setting, dependency, migration, authentication behavior, or dashboard surface.

--- a/openspec/changes/preserve-embedding-explicit-null-fields/specs/model-source-routing/spec.md
+++ b/openspec/changes/preserve-embedding-explicit-null-fields/specs/model-source-routing/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Embeddings source forwarding preserves field presence
+
+For source-routed `POST /v1/embeddings` requests, the system MUST preserve both the values and presence of fields beyond the validated `model` and `input` fields. A field explicitly supplied as null MUST be forwarded as null, a field omitted by the client MUST remain absent, and a non-null field MUST be forwarded unchanged. This forwarding behavior MUST NOT change reservation settlement or request-log metadata.
+
+#### Scenario: explicit null extras remain present
+
+- **WHEN** a client supplies `dimensions: null` and `user: null` in a source-routed embeddings request
+- **THEN** the compatible source receives both keys with null values
+
+#### Scenario: omitted extras remain absent
+
+- **WHEN** a client omits `dimensions` and `user` from a source-routed embeddings request
+- **THEN** the compatible source payload does not contain either key
+
+#### Scenario: non-null extras and accounting remain unchanged
+
+- **WHEN** a client supplies non-null embedding extras through a limited API key
+- **THEN** the compatible source receives those values unchanged
+- **AND** the reservation settles from reported usage
+- **AND** the successful request log retains its model-source metadata and token counts

--- a/openspec/changes/preserve-embedding-explicit-null-fields/tasks.md
+++ b/openspec/changes/preserve-embedding-explicit-null-fields/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add the exact ASGI source-capture regression for explicitly supplied null `dimensions` and `user` fields and confirm it fails because the captured payload omits those keys.
+- [x] 1.2 Add an omitted-fields control that proves unsent extras remain absent.
+- [x] 1.3 Extend the existing non-null embeddings settlement test to prove extra values, reservation settlement, and request-log metadata remain unchanged.
+
+## 2. Serialization Fix
+
+- [x] 2.1 Change only source-routed embeddings serialization to omit unset fields while preserving explicit null values.
+- [x] 2.2 Run the explicit-null regression and omitted/non-null accounting controls to green.
+
+## 3. Contract and Verification
+
+- [x] 3.1 Sync the stable embeddings field-presence and accounting requirement into the owning `model-source-routing` main spec.
+- [x] 3.2 Run focused model-source routing, forwarding, and request-log tests plus relevant Ruff and type checks.
+- [x] 3.3 Run strict OpenSpec validation and verify the implementation against all change artifacts.

--- a/openspec/specs/model-source-routing/context.md
+++ b/openspec/specs/model-source-routing/context.md
@@ -1,0 +1,13 @@
+# Model Source Routing — Context
+
+## Purpose
+
+Capability-based routing and accounting for OpenAI-compatible model sources,
+including field-preserving embeddings forwarding.
+
+This capability keeps source selection separate from subscription-account
+routing: embeddings traffic is served only by sources that declare the
+embeddings capability, while Responses/chat/audio continue to use their own
+capability gates. Field presence (including explicit nulls) is preserved on
+embeddings forwards so compatible sources see the same payload shape the
+client sent.

--- a/openspec/specs/model-source-routing/spec.md
+++ b/openspec/specs/model-source-routing/spec.md
@@ -1,0 +1,142 @@
+# Model Source Routing Specification
+
+## Purpose
+
+Define capability-based routing and accounting for OpenAI-compatible model sources, including field-preserving embeddings forwarding.
+
+## Requirements
+
+### Requirement: Model sources declare an embeddings capability
+
+Each model source MUST carry a persisted `supports_embeddings` boolean
+capability flag. The flag MUST default to disabled, so a source created or
+migrated without an explicit value MUST NOT be treated as embeddings-capable.
+The model-source create, read, and update contracts MUST expose the flag, and
+the stored value MUST survive a round trip through those contracts.
+
+#### Scenario: existing sources default to disabled
+
+- **GIVEN** a model source row that predates the embeddings capability
+- **WHEN** the schema migration runs
+- **THEN** the source reports `supports_embeddings` as disabled
+- **AND** its existing chat-completions, responses, and audio-transcription
+  routing is unchanged
+
+#### Scenario: capability round-trips through the API
+
+- **WHEN** a client creates or updates a model source with the embeddings
+  capability enabled
+- **THEN** reading the source back reports the capability as enabled
+
+#### Scenario: omitted capability parses as disabled
+
+- **WHEN** a model-source payload omits `supports_embeddings`
+- **THEN** it parses as disabled rather than failing validation
+
+### Requirement: Embeddings route only to capable model sources
+
+The system SHALL expose `POST /v1/embeddings` and MUST serve it only from an
+enabled model source of kind `openai_compatible` that declares the embeddings
+capability and has the requested model enabled. Embeddings requests MUST NOT
+fall back to subscription-backed accounts. When the caller presents an API key
+restricted to a set of sources, selection MUST stay inside that set. Beyond
+the validated `model` and `input` fields, the request payload MUST be
+forwarded to the source verbatim.
+
+#### Scenario: capable source serves the request
+
+- **GIVEN** an enabled model source declaring the embeddings capability with
+  the requested model enabled
+- **WHEN** a client posts to `/v1/embeddings`
+- **THEN** the proxy forwards the payload to that source's `/embeddings`
+  endpoint and returns the upstream JSON response
+
+#### Scenario: no capable source is a model error
+
+- **GIVEN** no enabled model source declares the embeddings capability for
+  the requested model
+- **WHEN** a client posts to `/v1/embeddings`
+- **THEN** the proxy returns 404 with an OpenAI-format error envelope using
+  code `model_not_found`
+- **AND** the request is not routed to a subscription-backed account
+
+#### Scenario: source-restricted API key cannot escape its set
+
+- **GIVEN** an API key restricted to a set of model sources
+- **WHEN** the only embeddings-capable source for the model is outside that
+  set
+- **THEN** the proxy returns `model_not_found`
+
+### Requirement: Embeddings requests are accounted like other source routes
+
+Embeddings responses MUST be inspected for prompt and total token usage. When
+the caller's API key requires usage for settlement and the source response
+reports none, the proxy MUST fail closed with `usage_unavailable` rather than
+serving unmetered traffic. Every embeddings attempt that is dispatched to a
+model source MUST produce a request-log entry, with `success` on a forwarded
+response and `error` on a forwarding, usage, or settlement failure. That entry
+MUST carry the upstream status code when a source returned an HTTP response,
+and MUST record the upstream status as absent when the attempt failed before
+any response was received. A request rejected before source selection succeeds
+is not a dispatched attempt: it MUST NOT produce a request-log entry, because
+no source was contacted and no reservation was consumed.
+
+#### Scenario: missing usage fails closed for a limited key
+
+- **GIVEN** an API key whose reservation requires reported usage
+- **WHEN** the model source returns an embeddings response without a usage
+  object
+- **THEN** the proxy returns an error envelope using code `usage_unavailable`
+- **AND** records an error request log
+
+#### Scenario: forwarding error propagates the upstream status
+
+- **WHEN** the model source returns an error status for an embeddings request
+- **THEN** the proxy returns an OpenAI-format error envelope with that status
+- **AND** records an error request log carrying the upstream status code
+
+#### Scenario: transport failure records an attempt without an upstream status
+
+- **WHEN** the request to the model source fails before any HTTP response is
+  received
+- **THEN** the proxy records an error request log for the attempt with no
+  upstream status code
+
+#### Scenario: unroutable model is not a logged attempt
+
+- **GIVEN** no enabled model source declares the embeddings capability for
+  the requested model
+- **WHEN** a client posts to `/v1/embeddings`
+- **THEN** the proxy returns the `model_not_found` envelope without writing a
+  request-log entry
+- **AND** no reservation is consumed for the rejected request
+
+### Requirement: Embeddings source forwarding preserves field presence
+
+For source-routed `POST /v1/embeddings` requests, the system MUST preserve both
+the values and presence of fields beyond the validated `model` and `input`
+fields. A field explicitly supplied as null MUST be forwarded as null, a field
+omitted by the client MUST remain absent, and a non-null field MUST be forwarded
+unchanged. This forwarding behavior MUST NOT change reservation settlement or
+request-log metadata.
+
+#### Scenario: explicit null extras remain present
+
+- **WHEN** a client supplies `dimensions: null` and `user: null` in a
+  source-routed embeddings request
+- **THEN** the compatible source receives both keys with null values
+
+#### Scenario: omitted extras remain absent
+
+- **WHEN** a client omits `dimensions` and `user` from a source-routed
+  embeddings request
+- **THEN** the compatible source payload does not contain either key
+
+#### Scenario: non-null extras and accounting remain unchanged
+
+- **WHEN** a client supplies non-null embedding extras through a limited API
+  key
+- **THEN** the compatible source receives those values unchanged
+- **AND** the reservation settles from reported usage
+- **AND** the successful request log retains its model-source metadata and
+  token counts

--- a/openspec/specs/model-source-routing/spec.md
+++ b/openspec/specs/model-source-routing/spec.md
@@ -1,9 +1,5 @@
 # Model Source Routing Specification
 
-## Purpose
-
-Define capability-based routing and accounting for OpenAI-compatible model sources, including field-preserving embeddings forwarding.
-
 ## Requirements
 
 ### Requirement: Model sources declare an embeddings capability

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -128,6 +128,17 @@ async def source_upstream() -> AsyncIterator[Callable[[_UpstreamHandler], Awaita
         await runner.cleanup()
 
 
+def _embedding_success_response(model: str) -> web.Response:
+    return web.json_response(
+        {
+            "object": "list",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
+            "model": model,
+            "usage": {"prompt_tokens": 21, "total_tokens": 21},
+        }
+    )
+
+
 @pytest.mark.asyncio
 async def test_source_audio_transcription_routes_multipart_and_settles_usage(
     async_client,
@@ -3303,25 +3314,82 @@ async def test_codex_responses_payload_restores_declared_minimal_effort(async_cl
 
 
 @pytest.mark.asyncio
+async def test_source_embeddings_routes_explicit_null_fields(async_client, source_upstream) -> None:
+    captured: dict[str, object] = {}
+    model = "explicit-null-embedder"
+
+    async def embed(request: web.Request) -> web.Response:
+        captured.update(await request.json())
+        return _embedding_success_response(model)
+
+    base_url = await source_upstream(embed)
+    await _create_model_source(
+        async_client,
+        name="explicit-null-embedder",
+        model=model,
+        base_url=base_url,
+        supports_embeddings=True,
+    )
+
+    response = await async_client.post(
+        "/v1/embeddings",
+        json={
+            "model": model,
+            "input": "hello",
+            "dimensions": None,
+            "user": None,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "model": model,
+        "input": "hello",
+        "dimensions": None,
+        "user": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_source_embeddings_omits_unsent_fields(async_client, source_upstream) -> None:
+    captured: dict[str, object] = {}
+    model = "omitted-fields-embedder"
+
+    async def embed(request: web.Request) -> web.Response:
+        captured.update(await request.json())
+        return _embedding_success_response(model)
+
+    base_url = await source_upstream(embed)
+    await _create_model_source(
+        async_client,
+        name="omitted-fields-embedder",
+        model=model,
+        base_url=base_url,
+        supports_embeddings=True,
+    )
+
+    response = await async_client.post(
+        "/v1/embeddings",
+        json={"model": model, "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {"model": model, "input": "hello"}
+
+
+@pytest.mark.asyncio
 async def test_source_embeddings_routes_payload_and_settles_usage(async_client, source_upstream) -> None:
     await _enable_api_key_auth(async_client)
     captured: dict[str, object] = {}
+    model = "all-minilm:latest"
 
     async def embed(request: web.Request) -> web.Response:
         captured["path"] = request.path
         captured["authorization"] = request.headers.get("authorization")
         captured["payload"] = await request.json()
-        return web.json_response(
-            {
-                "object": "list",
-                "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}],
-                "model": "all-minilm:latest",
-                "usage": {"prompt_tokens": 21, "total_tokens": 21},
-            }
-        )
+        return _embedding_success_response(model)
 
     base_url = await source_upstream(embed)
-    model = "all-minilm:latest"
     source_id = await _create_model_source(
         async_client,
         name="embedder",
@@ -3342,11 +3410,18 @@ async def test_source_embeddings_routes_payload_and_settles_usage(async_client, 
     )
     assert created.status_code == 200
     key = created.json()["key"]
+    key_id = created.json()["id"]
 
     response = await async_client.post(
         "/v1/embeddings",
         headers={"Authorization": f"Bearer {key}"},
-        json={"model": model, "input": ["hello", "world"], "encoding_format": "float"},
+        json={
+            "model": model,
+            "input": ["hello", "world"],
+            "encoding_format": "float",
+            "dimensions": 384,
+            "user": "client-1",
+        },
     )
 
     assert response.status_code == 200
@@ -3360,9 +3435,19 @@ async def test_source_embeddings_routes_payload_and_settles_usage(async_client, 
         "model": model,
         "input": ["hello", "world"],
         "encoding_format": "float",
+        "dimensions": 384,
+        "user": "client-1",
     }
 
     async with SessionLocal() as session:
+        limits = await ApiKeysRepository(session).get_limits_by_key(key_id)
+        assert len(limits) == 1
+        assert limits[0].current_value == 21
+        reservations = await session.execute(
+            select(ApiKeyUsageReservation).where(ApiKeyUsageReservation.status == "reserved")
+        )
+        assert reservations.scalars().all() == []
+
         result = await session.execute(select(RequestLog).where(RequestLog.model == model))
         log = result.scalar_one()
         assert log.account_id is None


### PR DESCRIPTION
## Summary

Source-routed `/v1/embeddings` stripped explicitly supplied null extras because its outbound Pydantic serialization excluded every `None` value. This preserves client field presence at the compatible-source boundary: explicit nulls remain null, omitted extras remain absent, and non-null extras remain unchanged.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: none; discovered by route-level regression analysis.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches an upstream-compatible request shape and preserves the client payload's field-presence semantics

Change directory: `openspec/changes/preserve-embedding-explicit-null-fields/`

## Changes

- Serialize only source-routed embeddings with `exclude_unset=True` instead of dropping all null values.
- Add real ASGI source-capture coverage for explicit-null and omitted extras.
- Extend the non-null control to prove API-key reservation settlement and request-log metadata/token counts.
- Sync the stable embeddings routing and field-presence contract to the owning main spec.

## Simplicity

- [x] No new setting, required setup step, README section, `.env.example` entry, dashboard navigation, dependency, or migration
- [x] Existing behavior remains zero-config

## Test plan

- RED: exact explicit-null ASGI test returned HTTP 200 while the captured source payload lacked `dimensions` and `user`.
- GREEN: explicit-null, omitted, and non-null settlement controls: 3 passed.
- Focused model-source routing, forwarding, and request-log suite: 119 passed.
- `ruff check` and `ruff format --check` on changed Python files: passed.
- `ty check` with the existing virtual environment on changed Python files: passed.
- Strict validation of `model-source-routing` and this OpenSpec change: passed.
- Repository-wide `openspec validate --specs --strict` was also run; this new owning spec passes, while eight unrelated pre-existing specs remain strict-invalid.
- Independent committed-diff review: no actionable findings.

## Observable proof

For a request containing `dimensions: null` and `user: null`, the inert compatible source now captures those keys with null values. The omitted control captures neither key, and the non-null control captures `dimensions: 384` and `user: "client-1"` while settling 21 tokens and writing the successful `model_source` request log.

## Related work

- #1776 introduced model-source embeddings and its verbatim-forwarding/accounting contract; this PR is a focused correction to explicit-null presence semantics.
- One bounded issue search and one PR search for the defect terms found no duplicate or in-progress correction.

## Intentionally not run locally

- Full local CI was not run; required GitHub CI is the integration gate. The focused product seam, formatting, type, and scoped strict OpenSpec checks above were run locally.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Added tests covering the externally failing ASGI route.
- [x] Relevant local checks passed.
- [x] OpenSpec change is complete and scoped validation is clean.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` was not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source-routed embedding requests now preserve explicitly provided `null` fields.
  * Unprovided fields continue to be omitted, while non-null values are forwarded unchanged.
  * Embedding usage accounting, reservation cleanup, request logging, and API-key limits remain consistent.

* **Tests**
  * Added coverage for null, omitted, and non-null embedding fields.
  * Verified forwarding of additional parameters and successful usage settlement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->