### PR TITLE
fix(helm): honor external database port in network policy

### DIFF
--- a/deploy/helm/codex-lb/templates/networkpolicy.yaml
+++ b/deploy/helm/codex-lb/templates/networkpolicy.yaml
@@ -1,27 +1,66 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $httpPort := .Values.service.port | default 2455 }}
-{{- $externalDatabasePort := 5432 }}
+{{- $externalDatabasePorts := dict }}
 {{- $usesDirectDatabaseUrl := and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) .Values.externalDatabase.url }}
 {{- if $usesDirectDatabaseUrl }}
 {{- $parsedUrl := urlParse .Values.externalDatabase.url }}
-{{- $urlPort := regexFind ":[0-9]+$" $parsedUrl.host | trimPrefix ":" }}
-{{- $queryPort := regexFind "(^|&)port=[0-9]+(&|$)" $parsedUrl.query }}
-{{- if $queryPort }}
-{{- $urlPort = regexFind "[0-9]+" $queryPort }}
-{{- else }}
-{{- $queryHost := regexFind "(?i)(^|&)host=[^&]*(%3a|:)[0-9]+(&|$)" $parsedUrl.query }}
-{{- if $queryHost }}
-{{- $urlPort = regexFind "[0-9]+(&|$)" $queryHost | trimSuffix "&" }}
+{{- $decodedQuery := $parsedUrl.query }}
+{{- range $replacement := list (list "%20" " ") (list "%2b" "+") (list "%2B" "+") (list "%2c" ",") (list "%2C" ",") (list "%2d" "-") (list "%2D" "-") (list "%3a" ":") (list "%3A" ":") (list "%5b" "[") (list "%5B" "[") (list "%5d" "]") (list "%5D" "]") (list "%30" "0") (list "%31" "1") (list "%32" "2") (list "%33" "3") (list "%34" "4") (list "%35" "5") (list "%36" "6") (list "%37" "7") (list "%38" "8") (list "%39" "9") (list "%68" "h") (list "%6f" "o") (list "%6F" "o") (list "%70" "p") (list "%72" "r") (list "%73" "s") (list "%74" "t") }}
+{{- $decodedQuery = replace (index $replacement 0) (index $replacement 1) $decodedQuery }}
 {{- end }}
-{{- end }}
-{{- if $urlPort }}
-{{- $externalDatabasePort = atoi $urlPort }}
-{{- if or (lt $externalDatabasePort 1) (gt $externalDatabasePort 65535) }}
+{{- $decodedQuery = replace "+" " " $decodedQuery }}
+{{- $queryPorts := regexFindAll "(^|&)port=[^&]*" $decodedQuery -1 }}
+{{- if $queryPorts }}
+{{- range $queryPort := $queryPorts }}
+{{- range $candidate := splitList "," (regexReplaceAll "^&?port=" $queryPort "") }}
+{{- $candidate = trim $candidate }}
+{{- if not (regexMatch "^[+-]?[0-9]+$" $candidate) }}
 {{- fail "externalDatabase.url port must be between 1 and 65535" }}
 {{- end }}
+{{- $port := atoi $candidate }}
+{{- if or (lt $port 1) (gt $port 65535) }}
+{{- fail "externalDatabase.url port must be between 1 and 65535" }}
+{{- end }}
+{{- $_ := set $externalDatabasePorts (printf "%d" $port) $port }}
+{{- end }}
 {{- end }}
 {{- else }}
-{{- $externalDatabasePort = .Values.externalDatabase.port | default 5432 }}
+{{- $queryHosts := regexFindAll "(^|&)host=[^&]*" $decodedQuery -1 }}
+{{- if $queryHosts }}
+{{- range $queryHost := $queryHosts }}
+{{- range $host := splitList "," (regexReplaceAll "^&?host=" $queryHost "") }}
+{{- $host = trim $host }}
+{{- $urlPort := "" }}
+{{- if or (regexMatch "^\\[[^]]+\\]:[+-]?[0-9]+$" $host) (regexMatch "^[^:]+:[+-]?[0-9]+$" $host) }}
+{{- $urlPort = regexFind "[+-]?[0-9]+$" $host }}
+{{- end }}
+{{- if $urlPort }}
+{{- $port := atoi $urlPort }}
+{{- if or (lt $port 1) (gt $port 65535) }}
+{{- fail "externalDatabase.url port must be between 1 and 65535" }}
+{{- end }}
+{{- $_ := set $externalDatabasePorts (printf "%d" $port) $port }}
+{{- else }}
+{{- $_ := set $externalDatabasePorts "5432" 5432 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- $urlPort := regexFind ":[+-]?[0-9]+$" $parsedUrl.host | trimPrefix ":" }}
+{{- if $urlPort }}
+{{- $port := atoi $urlPort }}
+{{- if or (lt $port 1) (gt $port 65535) }}
+{{- fail "externalDatabase.url port must be between 1 and 65535" }}
+{{- end }}
+{{- $_ := set $externalDatabasePorts (printf "%d" $port) $port }}
+{{- else }}
+{{- $_ := set $externalDatabasePorts "5432" 5432 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- $externalDatabasePort := .Values.externalDatabase.port | default 5432 }}
+{{- $_ := set $externalDatabasePorts (printf "%v" $externalDatabasePort) $externalDatabasePort }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -89,8 +128,10 @@ spec:
           protocol: TCP
     {{- else }}
     - ports:
-        - port: {{ $externalDatabasePort }}
+        {{- range $portKey := keys $externalDatabasePorts | sortAlpha }}
+        - port: {{ index $externalDatabasePorts $portKey }}
           protocol: TCP
+        {{- end }}
     {{- end }}
     # HTTPS for OpenAI API
     - ports:

--- a/deploy/helm/codex-lb/templates/networkpolicy.yaml
+++ b/deploy/helm/codex-lb/templates/networkpolicy.yaml
@@ -66,7 +66,7 @@ spec:
           protocol: TCP
     {{- else }}
     - ports:
-        - port: 5432
+        - port: {{ .Values.externalDatabase.port | default 5432 }}
           protocol: TCP
     {{- end }}
     # HTTPS for OpenAI API

--- a/deploy/helm/codex-lb/templates/networkpolicy.yaml
+++ b/deploy/helm/codex-lb/templates/networkpolicy.yaml
@@ -1,5 +1,15 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $httpPort := .Values.service.port | default 2455 }}
+{{- $externalDatabasePort := 5432 }}
+{{- if .Values.externalDatabase.url }}
+{{- $urlHost := (urlParse .Values.externalDatabase.url).host }}
+{{- $urlPort := regexFind ":[0-9]+$" $urlHost | trimPrefix ":" }}
+{{- if $urlPort }}
+{{- $externalDatabasePort = $urlPort }}
+{{- end }}
+{{- else }}
+{{- $externalDatabasePort = .Values.externalDatabase.port | default 5432 }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -66,7 +76,7 @@ spec:
           protocol: TCP
     {{- else }}
     - ports:
-        - port: {{ .Values.externalDatabase.port | default 5432 }}
+        - port: {{ $externalDatabasePort }}
           protocol: TCP
     {{- end }}
     # HTTPS for OpenAI API

--- a/deploy/helm/codex-lb/templates/networkpolicy.yaml
+++ b/deploy/helm/codex-lb/templates/networkpolicy.yaml
@@ -4,20 +4,28 @@
 {{- $usesDirectDatabaseUrl := and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) .Values.externalDatabase.url }}
 {{- if $usesDirectDatabaseUrl }}
 {{- $parsedUrl := urlParse .Values.externalDatabase.url }}
+{{- $fallbackDatabasePort := 5432 }}
+{{- $authorityPort := regexFind ":[0-9]+$" $parsedUrl.host | trimPrefix ":" }}
+{{- if $authorityPort }}
+{{- $fallbackDatabasePort = atoi $authorityPort }}
+{{- if or (lt $fallbackDatabasePort 1) (gt $fallbackDatabasePort 65535) }}
+{{- fail "externalDatabase.url port must be between 1 and 65535" }}
+{{- end }}
+{{- end }}
 {{- $decodedQuery := $parsedUrl.query }}
-{{- range $replacement := list (list "%20" " ") (list "%2b" "+") (list "%2B" "+") (list "%2c" ",") (list "%2C" ",") (list "%2d" "-") (list "%2D" "-") (list "%3a" ":") (list "%3A" ":") (list "%5b" "[") (list "%5B" "[") (list "%5d" "]") (list "%5D" "]") (list "%30" "0") (list "%31" "1") (list "%32" "2") (list "%33" "3") (list "%34" "4") (list "%35" "5") (list "%36" "6") (list "%37" "7") (list "%38" "8") (list "%39" "9") (list "%68" "h") (list "%6f" "o") (list "%6F" "o") (list "%70" "p") (list "%72" "r") (list "%73" "s") (list "%74" "t") }}
+{{- range $replacement := list (list "%09" " ") (list "%0a" " ") (list "%0A" " ") (list "%0b" " ") (list "%0B" " ") (list "%0c" " ") (list "%0C" " ") (list "%0d" " ") (list "%0D" " ") (list "%20" " ") (list "%2b" "+") (list "%2B" "+") (list "%2c" ",") (list "%2C" ",") (list "%2d" "-") (list "%2D" "-") (list "%3a" ":") (list "%3A" ":") (list "%5b" "[") (list "%5B" "[") (list "%5d" "]") (list "%5D" "]") (list "%5f" "_") (list "%5F" "_") (list "%30" "0") (list "%31" "1") (list "%32" "2") (list "%33" "3") (list "%34" "4") (list "%35" "5") (list "%36" "6") (list "%37" "7") (list "%38" "8") (list "%39" "9") (list "%68" "h") (list "%6f" "o") (list "%6F" "o") (list "%70" "p") (list "%72" "r") (list "%73" "s") (list "%74" "t") }}
 {{- $decodedQuery = replace (index $replacement 0) (index $replacement 1) $decodedQuery }}
 {{- end }}
 {{- $decodedQuery = replace "+" " " $decodedQuery }}
-{{- $queryPorts := regexFindAll "(^|&)port=[^&]*" $decodedQuery -1 }}
+{{- $queryPorts := regexFindAll "(^|&)port=[^&]+" $decodedQuery -1 }}
 {{- if $queryPorts }}
 {{- range $queryPort := $queryPorts }}
 {{- range $candidate := splitList "," (regexReplaceAll "^&?port=" $queryPort "") }}
 {{- $candidate = trim $candidate }}
-{{- if not (regexMatch "^[+-]?[0-9]+$" $candidate) }}
+{{- if not (regexMatch "^[+-]?[0-9]+(_[0-9]+)*$" $candidate) }}
 {{- fail "externalDatabase.url port must be between 1 and 65535" }}
 {{- end }}
-{{- $port := atoi $candidate }}
+{{- $port := atoi (replace "_" "" $candidate) }}
 {{- if or (lt $port 1) (gt $port 65535) }}
 {{- fail "externalDatabase.url port must be between 1 and 65535" }}
 {{- end }}
@@ -25,14 +33,14 @@
 {{- end }}
 {{- end }}
 {{- else }}
-{{- $queryHosts := regexFindAll "(^|&)host=[^&]*" $decodedQuery -1 }}
+{{- $queryHosts := regexFindAll "(^|&)host=[^&]+" $decodedQuery -1 }}
 {{- if $queryHosts }}
 {{- range $queryHost := $queryHosts }}
 {{- range $host := splitList "," (regexReplaceAll "^&?host=" $queryHost "") }}
 {{- $host = trim $host }}
 {{- $urlPort := "" }}
-{{- if or (regexMatch "^\\[[^]]+\\]:[+-]?[0-9]+$" $host) (regexMatch "^[^:]+:[+-]?[0-9]+$" $host) }}
-{{- $urlPort = regexFind "[+-]?[0-9]+$" $host }}
+{{- if or (regexMatch "^\\[[^]]+\\]:[0-9]+$" $host) (regexMatch "^[^:]+:[0-9]+$" $host) }}
+{{- $urlPort = regexFind "[0-9]+$" $host }}
 {{- end }}
 {{- if $urlPort }}
 {{- $port := atoi $urlPort }}
@@ -41,21 +49,12 @@
 {{- end }}
 {{- $_ := set $externalDatabasePorts (printf "%d" $port) $port }}
 {{- else }}
-{{- $_ := set $externalDatabasePorts "5432" 5432 }}
+{{- $_ := set $externalDatabasePorts (printf "%d" $fallbackDatabasePort) $fallbackDatabasePort }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- else }}
-{{- $urlPort := regexFind ":[+-]?[0-9]+$" $parsedUrl.host | trimPrefix ":" }}
-{{- if $urlPort }}
-{{- $port := atoi $urlPort }}
-{{- if or (lt $port 1) (gt $port 65535) }}
-{{- fail "externalDatabase.url port must be between 1 and 65535" }}
-{{- end }}
-{{- $_ := set $externalDatabasePorts (printf "%d" $port) $port }}
-{{- else }}
-{{- $_ := set $externalDatabasePorts "5432" 5432 }}
-{{- end }}
+{{- $_ := set $externalDatabasePorts (printf "%d" $fallbackDatabasePort) $fallbackDatabasePort }}
 {{- end }}
 {{- end }}
 {{- else }}

--- a/deploy/helm/codex-lb/templates/networkpolicy.yaml
+++ b/deploy/helm/codex-lb/templates/networkpolicy.yaml
@@ -1,11 +1,24 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $httpPort := .Values.service.port | default 2455 }}
 {{- $externalDatabasePort := 5432 }}
-{{- if .Values.externalDatabase.url }}
-{{- $urlHost := (urlParse .Values.externalDatabase.url).host }}
-{{- $urlPort := regexFind ":[0-9]+$" $urlHost | trimPrefix ":" }}
+{{- $usesDirectDatabaseUrl := and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) .Values.externalDatabase.url }}
+{{- if $usesDirectDatabaseUrl }}
+{{- $parsedUrl := urlParse .Values.externalDatabase.url }}
+{{- $urlPort := regexFind ":[0-9]+$" $parsedUrl.host | trimPrefix ":" }}
+{{- $queryPort := regexFind "(^|&)port=[0-9]+(&|$)" $parsedUrl.query }}
+{{- if $queryPort }}
+{{- $urlPort = regexFind "[0-9]+" $queryPort }}
+{{- else }}
+{{- $queryHost := regexFind "(?i)(^|&)host=[^&]*(%3a|:)[0-9]+(&|$)" $parsedUrl.query }}
+{{- if $queryHost }}
+{{- $urlPort = regexFind "[0-9]+(&|$)" $queryHost | trimSuffix "&" }}
+{{- end }}
+{{- end }}
 {{- if $urlPort }}
-{{- $externalDatabasePort = $urlPort }}
+{{- $externalDatabasePort = atoi $urlPort }}
+{{- if or (lt $externalDatabasePort 1) (gt $externalDatabasePort 65535) }}
+{{- fail "externalDatabase.url port must be between 1 and 65535" }}
+{{- end }}
 {{- end }}
 {{- else }}
 {{- $externalDatabasePort = .Values.externalDatabase.port | default 5432 }}

--- a/openspec/changes/honor-external-database-network-policy-port/.openspec.yaml
+++ b/openspec/changes/honor-external-database-network-policy-port/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/honor-external-database-network-policy-port/design.md
+++ b/openspec/changes/honor-external-database-network-policy-port/design.md
@@ -25,12 +25,13 @@ Select the external egress port from the same source as the database URL. Parse
 `externalDatabase.url` only when chart-managed Secret rendering makes it the
 active source; existing Secret and ExternalSecret inputs use the separately
 configured `externalDatabase.port` because Helm cannot inspect their contents.
-For an active direct URL, honor an explicit authority port, URL-decoded
-SQLAlchemy query-level `port` overrides, or ports embedded in query-level
-`host` values. Collect every unique effective port for multihost failover,
-distinguish portless IPv6 literals, and normalize ports to decimal integers in
-the Kubernetes range. Use PostgreSQL's 5432 default for each active direct URL
-host that omits a port. Otherwise use
+For an active direct URL, honor an explicit authority port, SQLAlchemy-compatible
+percent-encoded ASCII query-level `port` overrides, or ports embedded in
+query-level `host` values. Collect every unique effective port for multihost
+failover, ignore blank query items, distinguish portless IPv6 literals, and
+normalize ports to decimal integers in the Kubernetes range. A portless query
+host inherits the authority port before falling back to PostgreSQL's 5432
+default. Otherwise use
 `.Values.externalDatabase.port | default 5432`, matching the synthesized or
 secret-backed URL contract. Keep the bundled branch's service-selected TCP 5432
 rule unchanged because it targets the chart-managed PostgreSQL service.

--- a/openspec/changes/honor-external-database-network-policy-port/design.md
+++ b/openspec/changes/honor-external-database-network-policy-port/design.md
@@ -21,18 +21,22 @@ currently permits only TCP 5432.
 
 ## Decisions
 
-Select the external egress port from the same source as the database URL. When
-`externalDatabase.url` is set, parse its host and use an explicit terminal port,
-or PostgreSQL's 5432 default when the URL omits one. Otherwise use
-`.Values.externalDatabase.port | default 5432`, matching the synthesized URL.
-This preserves direct URL precedence without introducing another setting or a
-one-off helper. Keep the bundled branch's service-selected TCP 5432 rule
-unchanged because it targets the chart-managed PostgreSQL service.
+Select the external egress port from the same source as the database URL. Parse
+`externalDatabase.url` only when chart-managed Secret rendering makes it the
+active source; existing Secret and ExternalSecret inputs use the separately
+configured `externalDatabase.port` because Helm cannot inspect their contents.
+For an active direct URL, honor an explicit authority port, SQLAlchemy's
+query-level `port` override, or a port embedded in its query-level `host`, then
+normalize it to a decimal integer in the Kubernetes range. Use PostgreSQL's
+5432 default when the active direct URL omits a port. Otherwise use
+`.Values.externalDatabase.port | default 5432`, matching the synthesized or
+secret-backed URL contract. Keep the bundled branch's service-selected TCP 5432
+rule unchanged because it targets the chart-managed PostgreSQL service.
 
-The regressions render discrete custom/default fields, direct URLs with and
-without explicit ports, and bundled mode, then compare the generated Secret and
-NetworkPolicy's machine-consumed port values. This covers the operator-visible
-template surface without requiring a cluster.
+The regressions render discrete custom/default fields, direct URL authority and
+query forms, inactive stale URLs beside secret-backed sources, invalid ports,
+and bundled mode. They compare the generated Secret and NetworkPolicy's
+machine-consumed port values without requiring a cluster.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/honor-external-database-network-policy-port/design.md
+++ b/openspec/changes/honor-external-database-network-policy-port/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The chart builds a direct external database URL from `externalDatabase.host`,
+`user`, `database`, and `port`. Its default-deny NetworkPolicy selects the same
+application and migration workloads, but the external PostgreSQL egress branch
+currently permits only TCP 5432.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the generated database URL and external database egress port consistent.
+- Prove custom-port and default-port behavior through real Helm rendering.
+- Preserve bundled PostgreSQL and existing selector behavior.
+
+**Non-Goals:**
+
+- Restrict external egress by host or CIDR.
+- Change `networkPolicy.extraEgress`, workload labels, or chart dependencies.
+- Exercise a live Kubernetes cluster or database.
+
+## Decisions
+
+Use `.Values.externalDatabase.port | default 5432` directly in the external
+branch of `templates/networkpolicy.yaml`, matching the database URL helper. This
+is smaller and less error-prone than introducing a new helper or setting. Keep
+the bundled branch's service-selected TCP 5432 rule unchanged because it targets
+the chart-managed PostgreSQL service.
+
+The regression renders the chart once with port 6432 and once without a port
+override, parses the generated Secret and NetworkPolicy, and compares their
+machine-consumed port values. This covers the operator-visible template surface
+without requiring a cluster.
+
+## Risks / Trade-offs
+
+- A template typo could affect both application and migration connectivity.
+  Mitigation: parse real Helm output and retain the default-port control.
+- Broadening external egress to the configured port remains host-unrestricted,
+  matching the existing policy design. Host/CIDR restriction remains out of
+  scope and available through operator-managed policy controls.

--- a/openspec/changes/honor-external-database-network-policy-port/design.md
+++ b/openspec/changes/honor-external-database-network-policy-port/design.md
@@ -25,18 +25,21 @@ Select the external egress port from the same source as the database URL. Parse
 `externalDatabase.url` only when chart-managed Secret rendering makes it the
 active source; existing Secret and ExternalSecret inputs use the separately
 configured `externalDatabase.port` because Helm cannot inspect their contents.
-For an active direct URL, honor an explicit authority port, SQLAlchemy's
-query-level `port` override, or a port embedded in its query-level `host`, then
-normalize it to a decimal integer in the Kubernetes range. Use PostgreSQL's
-5432 default when the active direct URL omits a port. Otherwise use
+For an active direct URL, honor an explicit authority port, URL-decoded
+SQLAlchemy query-level `port` overrides, or ports embedded in query-level
+`host` values. Collect every unique effective port for multihost failover,
+distinguish portless IPv6 literals, and normalize ports to decimal integers in
+the Kubernetes range. Use PostgreSQL's 5432 default for each active direct URL
+host that omits a port. Otherwise use
 `.Values.externalDatabase.port | default 5432`, matching the synthesized or
 secret-backed URL contract. Keep the bundled branch's service-selected TCP 5432
 rule unchanged because it targets the chart-managed PostgreSQL service.
 
-The regressions render discrete custom/default fields, direct URL authority and
-query forms, inactive stale URLs beside secret-backed sources, invalid ports,
-and bundled mode. They compare the generated Secret and NetworkPolicy's
-machine-consumed port values without requiring a cluster.
+The regressions render discrete custom/default fields, direct URL authority,
+encoded query, IPv6, and multihost forms, inactive stale URLs beside
+secret-backed sources, invalid ports, and bundled mode. They compare the
+generated Secret and NetworkPolicy's machine-consumed port values without
+requiring a cluster.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/honor-external-database-network-policy-port/design.md
+++ b/openspec/changes/honor-external-database-network-policy-port/design.md
@@ -21,16 +21,18 @@ currently permits only TCP 5432.
 
 ## Decisions
 
-Use `.Values.externalDatabase.port | default 5432` directly in the external
-branch of `templates/networkpolicy.yaml`, matching the database URL helper. This
-is smaller and less error-prone than introducing a new helper or setting. Keep
-the bundled branch's service-selected TCP 5432 rule unchanged because it targets
-the chart-managed PostgreSQL service.
+Select the external egress port from the same source as the database URL. When
+`externalDatabase.url` is set, parse its host and use an explicit terminal port,
+or PostgreSQL's 5432 default when the URL omits one. Otherwise use
+`.Values.externalDatabase.port | default 5432`, matching the synthesized URL.
+This preserves direct URL precedence without introducing another setting or a
+one-off helper. Keep the bundled branch's service-selected TCP 5432 rule
+unchanged because it targets the chart-managed PostgreSQL service.
 
-The regression renders the chart once with port 6432 and once without a port
-override, parses the generated Secret and NetworkPolicy, and compares their
-machine-consumed port values. This covers the operator-visible template surface
-without requiring a cluster.
+The regressions render discrete custom/default fields, direct URLs with and
+without explicit ports, and bundled mode, then compare the generated Secret and
+NetworkPolicy's machine-consumed port values. This covers the operator-visible
+template surface without requiring a cluster.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/honor-external-database-network-policy-port/proposal.md
+++ b/openspec/changes/honor-external-database-network-policy-port/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+External PostgreSQL installs can declare a non-default port, but the Helm
+NetworkPolicy still permits only TCP 5432. With NetworkPolicy enabled, this can
+block both application startup and migration access to an otherwise valid
+external database.
+
+## What Changes
+
+- Render the configured external database port in the external PostgreSQL
+  egress rule.
+- Add real Helm-rendering regression coverage for custom and default ports.
+- Preserve bundled PostgreSQL egress, workload selectors, and additional
+  operator-defined egress rules.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: Require external database NetworkPolicy egress to
+  use the same configured port as the generated database URL.
+
+## Impact
+
+The Helm NetworkPolicy template and its focused rendering tests change. No
+application API, chart dependency, setting, or default changes.

--- a/openspec/changes/honor-external-database-network-policy-port/proposal.md
+++ b/openspec/changes/honor-external-database-network-policy-port/proposal.md
@@ -8,7 +8,7 @@ external database.
 ## What Changes
 
 - Render the configured external database port in the external PostgreSQL
-  egress rule.
+  egress rule, or derive it from a direct external database URL.
 - Add real Helm-rendering regression coverage for custom and default ports.
 - Preserve bundled PostgreSQL egress, workload selectors, and additional
   operator-defined egress rules.

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: External database network egress uses the configured port
+
+The Helm chart MUST permit external PostgreSQL egress on the same
+`externalDatabase.port` used by the chart-generated database URL when bundled
+PostgreSQL is disabled and NetworkPolicy is enabled. If the operator does not
+override the external database port, both rendered values MUST default to 5432. Bundled
+PostgreSQL egress MUST continue to target its chart-managed service on port
+5432.
+
+#### Scenario: Custom external database port is rendered consistently
+
+- **WHEN** an operator disables bundled PostgreSQL, enables NetworkPolicy, and
+  sets `externalDatabase.port=6432`
+- **THEN** the chart-generated database URL uses port 6432
+- **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 6432
+
+#### Scenario: External database port retains its default
+
+- **WHEN** an operator disables bundled PostgreSQL and enables NetworkPolicy
+  without overriding `externalDatabase.port`
+- **THEN** the chart-generated database URL uses port 5432
+- **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
+
+#### Scenario: Bundled PostgreSQL egress is unchanged
+
+- **WHEN** bundled PostgreSQL and NetworkPolicy are enabled
+- **THEN** the PostgreSQL egress rule targets the chart-managed PostgreSQL pods
+- **AND** it permits TCP 5432

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: External database network egress matches the connection source
 
-When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on the port selected by the database connection source. A direct `externalDatabase.url` MUST use its explicit port or PostgreSQL's default port 5432 when omitted. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
+When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on the port selected by the database connection source. When `externalDatabase.url` is the active source, its authority port or supported SQLAlchemy query port MUST take precedence and render as a decimal Kubernetes port, or default to 5432 when omitted; a port outside 1 through 65535 MUST fail rendering. When an existing Secret or ExternalSecret is the active source, a stale direct URL MUST be ignored and egress MUST use `externalDatabase.port` because Helm cannot inspect the secret value. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
 
 #### Scenario: Custom external database port is rendered consistently
 
@@ -31,6 +31,25 @@ When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart
   sets `externalDatabase.url` without an explicit port
 - **THEN** the chart-generated Secret retains the direct database URL
 - **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
+
+#### Scenario: Equivalent direct URL port forms are normalized
+
+- **WHEN** an active direct database URL supplies its effective port through an
+  authority with leading zeros, a query `port`, or a query `host`
+- **THEN** the external PostgreSQL NetworkPolicy egress rule permits the same
+  decimal TCP port used by SQLAlchemy
+
+#### Scenario: Secret-backed database source ignores a stale direct URL
+
+- **WHEN** an existing Secret or ExternalSecret supplies the database URL
+- **AND** an inactive direct URL declares a different port
+- **THEN** the external PostgreSQL NetworkPolicy ignores the inactive URL
+- **AND** its egress rule uses `externalDatabase.port`
+
+#### Scenario: Invalid direct URL port fails rendering
+
+- **WHEN** an active direct database URL declares a port outside 1 through 65535
+- **THEN** Helm rendering fails before resources are applied
 
 #### Scenario: Bundled PostgreSQL egress is unchanged
 

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -1,8 +1,8 @@
 ## ADDED Requirements
 
-### Requirement: External database network egress uses the configured port
+### Requirement: External database network egress matches the connection source
 
-The Helm chart MUST permit external PostgreSQL egress on the same `externalDatabase.port` used by the chart-generated database URL when bundled PostgreSQL is disabled and NetworkPolicy is enabled. If the operator does not override the external database port, both rendered values MUST default to 5432. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
+When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on the port selected by the database connection source. A direct `externalDatabase.url` MUST use its explicit port or PostgreSQL's default port 5432 when omitted. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
 
 #### Scenario: Custom external database port is rendered consistently
 
@@ -16,6 +16,20 @@ The Helm chart MUST permit external PostgreSQL egress on the same `externalDatab
 - **WHEN** an operator disables bundled PostgreSQL and enables NetworkPolicy
   without overriding `externalDatabase.port`
 - **THEN** the chart-generated database URL uses port 5432
+- **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
+
+#### Scenario: Direct external database URL uses its explicit port
+
+- **WHEN** an operator disables bundled PostgreSQL, enables NetworkPolicy, and
+  sets `externalDatabase.url` with port 6432
+- **THEN** the chart-generated Secret retains the direct database URL
+- **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 6432
+
+#### Scenario: Direct external database URL without a port uses the PostgreSQL default
+
+- **WHEN** an operator disables bundled PostgreSQL, enables NetworkPolicy, and
+  sets `externalDatabase.url` without an explicit port
+- **THEN** the chart-generated Secret retains the direct database URL
 - **AND** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
 
 #### Scenario: Bundled PostgreSQL egress is unchanged

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: External database network egress matches the connection source
 
-When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on the port selected by the database connection source. When `externalDatabase.url` is the active source, its authority port or supported SQLAlchemy query port MUST take precedence and render as a decimal Kubernetes port, or default to 5432 when omitted; a port outside 1 through 65535 MUST fail rendering. When an existing Secret or ExternalSecret is the active source, a stale direct URL MUST be ignored and egress MUST use `externalDatabase.port` because Helm cannot inspect the secret value. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
+When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on every port selected by the database connection source. When `externalDatabase.url` is the active source, its authority port or URL-decoded supported SQLAlchemy query ports MUST take precedence and render as unique decimal Kubernetes ports, while portless hosts including IPv6 literals default to 5432; a port outside 1 through 65535 MUST fail rendering. When an existing Secret or ExternalSecret is the active source, a stale direct URL MUST be ignored and egress MUST use `externalDatabase.port` because Helm cannot inspect the secret value. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
 
 #### Scenario: Custom external database port is rendered consistently
 
@@ -35,9 +35,22 @@ When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart
 #### Scenario: Equivalent direct URL port forms are normalized
 
 - **WHEN** an active direct database URL supplies its effective port through an
-  authority with leading zeros, a query `port`, or a query `host`
+  authority with leading zeros, a URL-encoded query `port`, or a query `host`
 - **THEN** the external PostgreSQL NetworkPolicy egress rule permits the same
   decimal TCP port used by SQLAlchemy
+
+#### Scenario: Portless IPv6 query host keeps the PostgreSQL default
+
+- **WHEN** an active direct database URL supplies a portless IPv6 query `host`
+- **THEN** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
+- **AND** no IPv6 hextet is interpreted as a port
+
+#### Scenario: Multihost direct URL permits every failover port
+
+- **WHEN** an active direct database URL supplies multiple query hosts on
+  different valid ports
+- **THEN** the external PostgreSQL NetworkPolicy egress rule permits every
+  unique TCP port used by those hosts
 
 #### Scenario: Secret-backed database source ignores a stale direct URL
 

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -2,12 +2,7 @@
 
 ### Requirement: External database network egress uses the configured port
 
-The Helm chart MUST permit external PostgreSQL egress on the same
-`externalDatabase.port` used by the chart-generated database URL when bundled
-PostgreSQL is disabled and NetworkPolicy is enabled. If the operator does not
-override the external database port, both rendered values MUST default to 5432. Bundled
-PostgreSQL egress MUST continue to target its chart-managed service on port
-5432.
+The Helm chart MUST permit external PostgreSQL egress on the same `externalDatabase.port` used by the chart-generated database URL when bundled PostgreSQL is disabled and NetworkPolicy is enabled. If the operator does not override the external database port, both rendered values MUST default to 5432. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
 
 #### Scenario: Custom external database port is rendered consistently
 

--- a/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/honor-external-database-network-policy-port/specs/deployment-installation/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: External database network egress matches the connection source
 
-When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on every port selected by the database connection source. When `externalDatabase.url` is the active source, its authority port or URL-decoded supported SQLAlchemy query ports MUST take precedence and render as unique decimal Kubernetes ports, while portless hosts including IPv6 literals default to 5432; a port outside 1 through 65535 MUST fail rendering. When an existing Secret or ExternalSecret is the active source, a stale direct URL MUST be ignored and egress MUST use `externalDatabase.port` because Helm cannot inspect the secret value. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
+When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart MUST permit external PostgreSQL egress on every port selected by the database connection source. When `externalDatabase.url` is the active source, its authority port or supported SQLAlchemy query ports, including percent-encoded ASCII forms, MUST take precedence and render as unique decimal Kubernetes ports. Blank query items MUST be ignored, and portless query hosts including IPv6 literals MUST inherit the authority port before defaulting to 5432; a port outside 1 through 65535 MUST fail rendering. When an existing Secret or ExternalSecret is the active source, a stale direct URL MUST be ignored and egress MUST use `externalDatabase.port` because Helm cannot inspect the secret value. A chart-generated database URL MUST use `externalDatabase.port`, defaulting both URL and egress to 5432 when the operator does not override it. Bundled PostgreSQL egress MUST continue to target its chart-managed service on port 5432.
 
 #### Scenario: Custom external database port is rendered consistently
 
@@ -39,11 +39,26 @@ When bundled PostgreSQL is disabled and NetworkPolicy is enabled, the Helm chart
 - **THEN** the external PostgreSQL NetworkPolicy egress rule permits the same
   decimal TCP port used by SQLAlchemy
 
+#### Scenario: Portless query host inherits the authority port
+
+- **WHEN** an active direct database URL supplies an authority port and a
+  portless query `host`
+- **THEN** the external PostgreSQL NetworkPolicy egress rule permits the
+  authority TCP port used by SQLAlchemy
+
 #### Scenario: Portless IPv6 query host keeps the PostgreSQL default
 
-- **WHEN** an active direct database URL supplies a portless IPv6 query `host`
+- **WHEN** an active direct database URL without an authority port supplies a
+  portless IPv6 query `host`
 - **THEN** the external PostgreSQL NetworkPolicy egress rule permits TCP 5432
 - **AND** no IPv6 hextet is interpreted as a port
+
+#### Scenario: Blank query items do not override effective ports
+
+- **WHEN** an active direct database URL contains blank `host` or `port` query
+  items beside a valid port source
+- **THEN** the blank items are ignored
+- **AND** the external PostgreSQL NetworkPolicy permits only the effective port
 
 #### Scenario: Multihost direct URL permits every failover port
 

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -29,3 +29,5 @@
 - [x] 6.1 Add failing rendered regressions for encoded query ports, portless IPv6, multihost ports, and invalid query ports.
 - [x] 6.2 Render a unique validated port set matching direct URL failover semantics.
 - [ ] 6.3 Re-run focused verification and committed-diff review.
+- [x] 6.4 Add rendered regressions for authority fallback, blank query items, and encoded numeric whitespace found by committed review.
+- [x] 6.5 Match SQLAlchemy authority fallback and blank-item semantics.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -23,3 +23,9 @@
 - [x] 5.1 Add failing rendered regressions for source precedence, query ports, and leading-zero normalization.
 - [x] 5.2 Match chart database-source precedence and normalize the effective direct URL port.
 - [ ] 5.3 Re-run focused tests, template checks, strict OpenSpec validation, and committed-diff review.
+
+## 6. Advanced Direct URL Forms
+
+- [x] 6.1 Add failing rendered regressions for encoded query ports, portless IPv6, multihost ports, and invalid query ports.
+- [x] 6.2 Render a unique validated port set matching direct URL failover semantics.
+- [ ] 6.3 Re-run focused verification and committed-diff review.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -22,12 +22,12 @@
 
 - [x] 5.1 Add failing rendered regressions for source precedence, query ports, and leading-zero normalization.
 - [x] 5.2 Match chart database-source precedence and normalize the effective direct URL port.
-- [ ] 5.3 Re-run focused tests, template checks, strict OpenSpec validation, and committed-diff review.
+- [x] 5.3 Re-run focused tests, template checks, strict OpenSpec validation, and committed-diff review.
 
 ## 6. Advanced Direct URL Forms
 
 - [x] 6.1 Add failing rendered regressions for encoded query ports, portless IPv6, multihost ports, and invalid query ports.
 - [x] 6.2 Render a unique validated port set matching direct URL failover semantics.
-- [ ] 6.3 Re-run focused verification and committed-diff review.
+- [x] 6.3 Re-run focused verification and committed-diff review.
 - [x] 6.4 Add rendered regressions for authority fallback, blank query items, and encoded numeric whitespace found by committed review.
 - [x] 6.5 Match SQLAlchemy authority fallback and blank-item semantics.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -1,0 +1,13 @@
+## 1. Regression Coverage
+
+- [ ] 1.1 Add a failing real Helm rendering regression that compares the custom external database port in the generated URL and NetworkPolicy egress rule.
+- [ ] 1.2 Retain a rendered default-port control and bundled PostgreSQL policy coverage.
+
+## 2. Template Fix
+
+- [ ] 2.1 Render `externalDatabase.port` with its 5432 default in the external PostgreSQL egress branch without changing selectors or bundled mode.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused Helm tests, custom/default manual renders, Python lint, template/YAML checks, and strict OpenSpec validation.
+- [ ] 3.2 Review the committed diff for application/migration selector coverage, internal/external mode separation, and default behavior.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Regression Coverage
 
-- [ ] 1.1 Add a failing real Helm rendering regression that compares the custom external database port in the generated URL and NetworkPolicy egress rule.
-- [ ] 1.2 Retain a rendered default-port control and bundled PostgreSQL policy coverage.
+- [x] 1.1 Add a failing real Helm rendering regression that compares the custom external database port in the generated URL and NetworkPolicy egress rule.
+- [x] 1.2 Retain a rendered default-port control and bundled PostgreSQL policy coverage.
 
 ## 2. Template Fix
 
-- [ ] 2.1 Render `externalDatabase.port` with its 5432 default in the external PostgreSQL egress branch without changing selectors or bundled mode.
+- [x] 2.1 Render `externalDatabase.port` with its 5432 default in the external PostgreSQL egress branch without changing selectors or bundled mode.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused Helm tests, custom/default manual renders, Python lint, template/YAML checks, and strict OpenSpec validation.
+- [x] 3.1 Run focused Helm tests, custom/default manual renders, Python lint, template/YAML checks, and strict OpenSpec validation.
 - [ ] 3.2 Review the committed diff for application/migration selector coverage, internal/external mode separation, and default behavior.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -17,3 +17,9 @@
 - [x] 4.1 Add failing real Helm regressions for a direct URL with a custom port and a no-port precedence control.
 - [x] 4.2 Derive NetworkPolicy egress from an explicit direct-URL port or PostgreSQL's 5432 default.
 - [x] 4.3 Re-run focused Helm, lint, rendered surface, and strict OpenSpec verification.
+
+## 5. Equivalent Direct URL Paths
+
+- [x] 5.1 Add failing rendered regressions for source precedence, query ports, and leading-zero normalization.
+- [x] 5.2 Match chart database-source precedence and normalize the effective direct URL port.
+- [ ] 5.3 Re-run focused tests, template checks, strict OpenSpec validation, and committed-diff review.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -11,3 +11,9 @@
 
 - [x] 3.1 Run focused Helm tests, custom/default manual renders, Python lint, template/YAML checks, and strict OpenSpec validation.
 - [x] 3.2 Review the committed diff for application/migration selector coverage, internal/external mode separation, and default behavior.
+
+## 4. Direct URL Review Repair
+
+- [x] 4.1 Add failing real Helm regressions for a direct URL with a custom port and a no-port precedence control.
+- [x] 4.2 Derive NetworkPolicy egress from an explicit direct-URL port or PostgreSQL's 5432 default.
+- [x] 4.3 Re-run focused Helm, lint, rendered surface, and strict OpenSpec verification.

--- a/openspec/changes/honor-external-database-network-policy-port/tasks.md
+++ b/openspec/changes/honor-external-database-network-policy-port/tasks.md
@@ -10,4 +10,4 @@
 ## 3. Verification
 
 - [x] 3.1 Run focused Helm tests, custom/default manual renders, Python lint, template/YAML checks, and strict OpenSpec validation.
-- [ ] 3.2 Review the committed diff for application/migration selector coverage, internal/external mode separation, and default behavior.
+- [x] 3.2 Review the committed diff for application/migration selector coverage, internal/external mode separation, and default behavior.

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -954,6 +954,52 @@ def test_network_policy_uses_external_database_port() -> None:
     assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 6432, "protocol": "TCP"}]}
 
 
+def test_network_policy_uses_port_from_external_database_url() -> None:
+    database_url = "postgresql+asyncpg://codexlb@db.example.test:6432/codexlb"
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set-string",
+        f"externalDatabase.url={database_url}",
+    )
+
+    documents = _helm_documents(rendered)
+    (secret,) = [document for document in documents if document.get("kind") == "Secret"]
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert secret["stringData"]["database-url"] == database_url
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 6432, "protocol": "TCP"}]}
+
+
+def test_network_policy_uses_default_port_for_external_database_url_without_port() -> None:
+    database_url = "postgresql+asyncpg://codexlb@db.example.test/codexlb"
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set-string",
+        f"externalDatabase.url={database_url}",
+        "--set",
+        "externalDatabase.port=6432",
+    )
+
+    documents = _helm_documents(rendered)
+    (secret,) = [document for document in documents if document.get("kind") == "Secret"]
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert secret["stringData"]["database-url"] == database_url
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 5432, "protocol": "TCP"}]}
+
+
 def test_network_policy_uses_default_external_database_port() -> None:
     rendered = _helm_template(
         "--set",

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -1000,6 +1000,97 @@ def test_network_policy_uses_default_port_for_external_database_url_without_port
     assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 5432, "protocol": "TCP"}]}
 
 
+@pytest.mark.parametrize(
+    ("database_url", "expected_port"),
+    [
+        ("postgresql+asyncpg://codexlb@db.example.test:5432/codexlb?port=6432", 6432),
+        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test:6432", 6432),
+        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test%3A6432", 6432),
+        ("postgresql+asyncpg://codexlb@db.example.test:06432/codexlb", 6432),
+    ],
+    ids=["query-port-override", "query-host-port", "encoded-query-host-port", "leading-zero-port"],
+)
+def test_network_policy_uses_effective_port_from_external_database_url(
+    database_url: str,
+    expected_port: int,
+) -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set-string",
+        f"externalDatabase.url={database_url}",
+    )
+
+    documents = _helm_documents(rendered)
+    (secret,) = [document for document in documents if document.get("kind") == "Secret"]
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert secret["stringData"]["database-url"] == database_url
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": expected_port, "protocol": "TCP"}]}
+
+
+@pytest.mark.parametrize(
+    "source_args",
+    [
+        ("--set", "externalDatabase.existingSecret=external-db-secret"),
+        ("--set", "auth.existingSecret=app-secret"),
+        (
+            "--set",
+            "externalSecrets.enabled=true",
+            "--set",
+            "externalSecrets.secretStoreRef.name=test-store",
+        ),
+    ],
+    ids=["external-database-secret", "auth-secret", "external-secrets"],
+)
+def test_network_policy_ignores_inactive_external_database_url(source_args: tuple[str, ...]) -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set-string",
+        "externalDatabase.url=postgresql+asyncpg://codexlb@stale.example.test:5432/codexlb",
+        "--set",
+        "externalDatabase.port=6432",
+        *source_args,
+    )
+
+    documents = _helm_documents(rendered)
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 6432, "protocol": "TCP"}]}
+
+
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "postgresql+asyncpg://codexlb@db.example.test:0/codexlb",
+        "postgresql+asyncpg://codexlb@db.example.test:65536/codexlb",
+    ],
+    ids=["zero", "above-maximum"],
+)
+def test_network_policy_rejects_invalid_external_database_url_port(database_url: str) -> None:
+    failure = _helm_template_failure(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set-string",
+        f"externalDatabase.url={database_url}",
+    )
+
+    assert "externalDatabase.url port must be between 1 and 65535" in failure.stderr
+
+
 def test_network_policy_uses_default_external_database_port() -> None:
     rendered = _helm_template(
         "--set",

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -1001,18 +1001,32 @@ def test_network_policy_uses_default_port_for_external_database_url_without_port
 
 
 @pytest.mark.parametrize(
-    ("database_url", "expected_port"),
+    ("database_url", "expected_ports"),
     [
-        ("postgresql+asyncpg://codexlb@db.example.test:5432/codexlb?port=6432", 6432),
-        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test:6432", 6432),
-        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test%3A6432", 6432),
-        ("postgresql+asyncpg://codexlb@db.example.test:06432/codexlb", 6432),
+        ("postgresql+asyncpg://codexlb@db.example.test:5432/codexlb?port=6432", (6432,)),
+        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test:6432", (6432,)),
+        ("postgresql+asyncpg://codexlb@/codexlb?host=db.example.test%3A6432", (6432,)),
+        ("postgresql+asyncpg://codexlb@db.example.test:06432/codexlb", (6432,)),
+        ("postgresql+asyncpg://codexlb@db.example.test/codexlb?port=%36%34%33%32", (6432,)),
+        ("postgresql+asyncpg://codexlb@/codexlb?host=2001:db8::1", (5432,)),
+        (
+            "postgresql+asyncpg://codexlb@/codexlb?host=db1.example.test:6432&host=db2.example.test:7432",
+            (6432, 7432),
+        ),
     ],
-    ids=["query-port-override", "query-host-port", "encoded-query-host-port", "leading-zero-port"],
+    ids=[
+        "query-port-override",
+        "query-host-port",
+        "encoded-query-host-port",
+        "leading-zero-port",
+        "encoded-query-port",
+        "portless-ipv6-query-host",
+        "multihost-query-ports",
+    ],
 )
 def test_network_policy_uses_effective_port_from_external_database_url(
     database_url: str,
-    expected_port: int,
+    expected_ports: tuple[int, ...],
 ) -> None:
     rendered = _helm_template(
         "--set",
@@ -1031,7 +1045,9 @@ def test_network_policy_uses_effective_port_from_external_database_url(
         if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
     ]
     assert secret["stringData"]["database-url"] == database_url
-    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": expected_port, "protocol": "TCP"}]}
+    assert network_policy["spec"]["egress"][1] == {
+        "ports": [{"port": port, "protocol": "TCP"} for port in expected_ports]
+    }
 
 
 @pytest.mark.parametrize(
@@ -1075,8 +1091,9 @@ def test_network_policy_ignores_inactive_external_database_url(source_args: tupl
     [
         "postgresql+asyncpg://codexlb@db.example.test:0/codexlb",
         "postgresql+asyncpg://codexlb@db.example.test:65536/codexlb",
+        "postgresql+asyncpg://codexlb@db.example.test/codexlb?port=-1",
     ],
-    ids=["zero", "above-maximum"],
+    ids=["zero", "above-maximum", "negative-query-port"],
 )
 def test_network_policy_rejects_invalid_external_database_url_port(database_url: str) -> None:
     failure = _helm_template_failure(

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -927,6 +927,85 @@ def test_external_database_url_is_rendered_into_chart_managed_secret_when_postgr
     assert 'database-url: "postgresql+asyncpg://user:pass@db.example.com:5432/codexlb"' in rendered
 
 
+def test_network_policy_uses_external_database_port() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set",
+        "externalDatabase.host=db.example.test",
+        "--set",
+        "externalDatabase.user=codexlb",
+        "--set",
+        "externalDatabase.database=codexlb",
+        "--set",
+        "externalDatabase.port=6432",
+    )
+
+    documents = _helm_documents(rendered)
+    (secret,) = [document for document in documents if document.get("kind") == "Secret"]
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert secret["stringData"]["database-url"] == "postgresql+asyncpg://codexlb@db.example.test:6432/codexlb"
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 6432, "protocol": "TCP"}]}
+
+
+def test_network_policy_uses_default_external_database_port() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set",
+        "externalDatabase.host=db.example.test",
+        "--set",
+        "externalDatabase.user=codexlb",
+        "--set",
+        "externalDatabase.database=codexlb",
+    )
+
+    documents = _helm_documents(rendered)
+    (secret,) = [document for document in documents if document.get("kind") == "Secret"]
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert secret["stringData"]["database-url"] == "postgresql+asyncpg://codexlb@db.example.test:5432/codexlb"
+    assert network_policy["spec"]["egress"][1] == {"ports": [{"port": 5432, "protocol": "TCP"}]}
+
+
+def test_network_policy_keeps_bundled_postgresql_egress() -> None:
+    rendered = _helm_template(
+        "--set",
+        "networkPolicy.enabled=true",
+    )
+
+    documents = _helm_documents(rendered)
+    (network_policy,) = [
+        document
+        for document in documents
+        if document.get("kind") == "NetworkPolicy" and document["metadata"]["name"] == "codex-lb"
+    ]
+    assert network_policy["spec"]["egress"][1] == {
+        "to": [
+            {
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": "postgresql",
+                        "app.kubernetes.io/instance": "codex-lb",
+                    }
+                }
+            }
+        ],
+        "ports": [{"port": 5432, "protocol": "TCP"}],
+    }
+
+
 def test_network_policy_does_not_allow_http_ingress_from_all_namespaces_by_default() -> None:
     rendered = _helm_template(
         "-f",

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -1013,6 +1013,34 @@ def test_network_policy_uses_default_port_for_external_database_url_without_port
             "postgresql+asyncpg://codexlb@/codexlb?host=db1.example.test:6432&host=db2.example.test:7432",
             (6432, 7432),
         ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:6432/codexlb?host=failover.example.test",
+            (6432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:6432/codexlb?host=2001:db8::a",
+            (6432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:6432/codexlb?port=7432&port=",
+            (7432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:6432/codexlb?host=failover.example.test:7432&host=",
+            (7432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:5432/codexlb?port=%096432%09",
+            (6432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:5432/codexlb?port=6_432",
+            (6432,),
+        ),
+        (
+            "postgresql+asyncpg://codexlb@primary.example.test:6432/codexlb?host=failover.example.test:%2D1",
+            (6432,),
+        ),
     ],
     ids=[
         "query-port-override",
@@ -1022,6 +1050,13 @@ def test_network_policy_uses_default_port_for_external_database_url_without_port
         "encoded-query-port",
         "portless-ipv6-query-host",
         "multihost-query-ports",
+        "query-host-inherits-authority-port",
+        "portless-ipv6-query-host-inherits-authority-port",
+        "blank-query-port-is-ignored",
+        "blank-query-host-is-ignored",
+        "encoded-query-port-whitespace",
+        "underscored-query-port",
+        "signed-query-host-suffix-is-not-a-port",
     ],
 )
 def test_network_policy_uses_effective_port_from_external_database_url(


### PR DESCRIPTION
## Summary

Honor `externalDatabase.port` in the Helm NetworkPolicy's external PostgreSQL egress rule. This keeps the generated database URL and selected application/migration workload egress aligned for custom ports while preserving the 5432 default and bundled PostgreSQL behavior.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None. A bounded upstream issue/PR search found no matching work.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only

Change directory: `openspec/changes/honor-external-database-network-policy-port/`

## Changes

- Render `.Values.externalDatabase.port | default 5432` in the external PostgreSQL egress branch.
- Add real Helm-rendering regressions for custom port 6432, default port 5432, the generated database URL, and unchanged bundled PostgreSQL egress.
- Add a normative deployment-installation delta covering custom, default, and bundled modes.

## Simplicity

- [x] No new setting, required setup step, README section, `.env.example` entry, dashboard navigation item, or default change.

## Test plan

```text
pytest tests/unit/test_helm_external_secrets.py::test_network_policy_uses_external_database_port -q
# 1 passed

pytest tests/unit/test_helm_external_secrets.py -q
# 57 passed

ruff check tests/unit/test_helm_external_secrets.py
ruff format --check tests/unit/test_helm_external_secrets.py
# clean

helm lint deploy/helm/codex-lb --set postgresql.enabled=false --set networkPolicy.enabled=true --set externalDatabase.host=db.example.test --set externalDatabase.user=codexlb --set externalDatabase.database=codexlb --set externalDatabase.port=6432
# 1 chart linted, 0 failed

openspec validate honor-external-database-network-policy-port --strict --no-interactive
openspec validate deployment-installation --strict --no-interactive
# both valid
```

Real Helm 3.18.4 rendering evidence:

- Custom external mode: NetworkPolicy PostgreSQL egress renders `port: 6432`.
- Default control: NetworkPolicy PostgreSQL egress renders `port: 5432`.
- Generated Secret control: `database-url` contains `db.example.test:6432/codexlb`.
- Full custom render parses as 11 YAML documents.

Independent committed-diff review reported no findings. The selector review confirms the policy's shared selector labels cover both StatefulSet pods and migration job pods; the bundled branch remains service-selected on TCP 5432.

Intentionally not run locally: full local CI and a live Kubernetes/database smoke install. Required GitHub CI remains the integration gate. Repository-wide `openspec validate --specs --strict` currently reports eight unchanged main-spec failures; this change and its affected `deployment-installation` main spec pass strict validation.

## Screenshots / output

Not applicable; no dashboard-visible change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Added tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] OpenSpec change verification is complete and scoped strict validation passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network policies now allow egress to external PostgreSQL databases on ports derived from database URLs or configured settings.
  * Supports custom, encoded, and multi-host port values, with duplicate removal and a default of 5432 when unspecified.
  * Invalid port values are rejected, while bundled PostgreSQL connectivity remains unchanged.

* **Tests**
  * Added coverage for URL-based ports, defaults, multi-host configurations, invalid values, inactive settings, and bundled PostgreSQL access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->