### PR TITLE
test(oauth): make test_oauth_flow order-independent by fencing the shared OAuth store

### DIFF
--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -43,6 +43,50 @@ def _oauth_flow_schema(db_setup):
     del db_setup
 
 
+async def _drain_global_oauth_store() -> None:
+    """Reset the module-global OAuth store AND await its tasks to completion.
+
+    ``_OAUTH_STORE.reset()`` cancels poll tasks but does not await them, so a
+    cancelled (or still-pending) device poller can keep running into the next
+    test on the shared session loop -- exchanging the device code against
+    whatever ``exchange_device_token`` is monkeypatched to at that moment (or
+    the real network client) and committing slot/status writes to the next
+    test's freshly reset database (issue #1794, same family as #1755). Awaiting
+    every task here guarantees nothing owned by the store crosses a test
+    boundary, and retrieves cancelled tasks' exceptions so they cannot surface
+    as unrelated "Task exception was never retrieved" noise in a later test.
+    """
+
+    store = oauth_module._OAUTH_STORE
+    async with store.lock:
+        tasks = [
+            flow.poll_task for flow in store._flows.values() if flow.poll_task is not None and not flow.poll_task.done()
+        ]
+        stop_task = store._callback_server_stop_task
+        if stop_task is not None and not stop_task.done():
+            tasks.append(stop_task)
+    await store.reset()
+    for task in tasks:
+        task.cancel()
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await task
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_global_oauth_store():
+    """Fence ``oauth_module._OAUTH_STORE`` at BOTH edges of every test.
+
+    The per-test ``_OAUTH_STORE.reset()`` calls this fixture replaces only ran
+    at each test's start, so whichever test happened to run next inherited the
+    previous test's live poll tasks for its whole fixture setup -- the
+    order-dependent "different victim per run" flake of issue #1794.
+    """
+
+    await _drain_global_oauth_store()
+    yield
+    await _drain_global_oauth_store()
+
+
 def _encode_jwt(payload: dict) -> str:
     raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     body = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
@@ -104,7 +148,6 @@ async def test_manual_callback_api_preserves_oauth_error():
 
 @pytest.mark.asyncio
 async def test_manual_callback_service_sanitizes_unexpected_exception(monkeypatch, caplog):
-    await oauth_module._OAUTH_STORE.reset()
     caplog.set_level(logging.ERROR, logger=oauth_module.logger.name)
     # Persist the flow durably (real flows are written to the shared DB at start)
     # so the reconciliation gate keeps it rather than dropping it as stale.
@@ -162,8 +205,6 @@ def test_oauth_error_html_escapes_message():
 
 @pytest.mark.asyncio
 async def test_device_oauth_flow_creates_account(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     email = "device@example.com"
     raw_account_id = "acc_device"
 
@@ -220,7 +261,6 @@ async def test_device_oauth_flow_creates_account(async_client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_starting_new_device_flow_cancels_previous_pending_poll(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
     issued = 0
     first_poll_started = asyncio.Event()
     first_poll_cancelled = asyncio.Event()
@@ -276,8 +316,6 @@ async def test_starting_new_device_flow_cancels_previous_pending_poll(async_clie
     await asyncio.wait_for(first_poll_cancelled.wait(), timeout=1)
     assert first_task.cancelled()
 
-    await oauth_module._OAUTH_STORE.reset()
-
 
 @pytest.mark.asyncio
 async def test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity(
@@ -298,8 +336,6 @@ async def test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity
     ChatGPT identity, so a refresh-token-revoked account picks up the
     new tokens onto its historical row instead of forking a duplicate.
     """
-
-    await oauth_module._OAUTH_STORE.reset()
 
     settings = await async_client.put(
         "/api/settings",
@@ -352,6 +388,7 @@ async def test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity
         start = await async_client.post("/api/oauth/start", json={"forceMethod": "device"})
         assert start.status_code == 200
         assert start.json()["method"] == "device"
+        flow_id = start.json()["flowId"]
 
         complete = await async_client.post("/api/oauth/complete", json={})
         assert complete.status_code == 200
@@ -359,9 +396,13 @@ async def test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity
 
         await asyncio.sleep(0)
 
+        # Poll THIS flow's status (like the dashboard does): the flowId-less
+        # endpoint reads the store's "latest flow" pointer, which a finishing
+        # neighbor poller's cleanup can re-latch to its own already-successful
+        # flow -- reporting success before this flow's poller persisted.
         payload = None
         for _ in range(20):
-            status = await async_client.get("/api/oauth/status")
+            status = await async_client.get("/api/oauth/status", params={"flowId": flow_id})
             assert status.status_code == 200
             payload = status.json()
             if payload["status"] == "success":
@@ -388,8 +429,6 @@ async def test_device_oauth_flow_heals_deactivated_account_when_import_without_o
     async_client,
     monkeypatch,
 ):
-    await oauth_module._OAUTH_STORE.reset()
-
     settings = await async_client.put(
         "/api/settings",
         json={
@@ -834,8 +873,6 @@ async def test_device_oauth_flow_keeps_same_email_distinct_upstream_identities_i
     async_client,
     monkeypatch,
 ):
-    await oauth_module._OAUTH_STORE.reset()
-
     enable_separate = await async_client.put(
         "/api/settings",
         json={
@@ -901,6 +938,7 @@ async def test_device_oauth_flow_keeps_same_email_distinct_upstream_identities_i
         start = await async_client.post("/api/oauth/start", json={"forceMethod": "device"})
         assert start.status_code == 200
         assert start.json()["method"] == "device"
+        flow_id = start.json()["flowId"]
 
         complete = await async_client.post("/api/oauth/complete", json={})
         assert complete.status_code == 200
@@ -908,9 +946,11 @@ async def test_device_oauth_flow_keeps_same_email_distinct_upstream_identities_i
 
         await asyncio.sleep(0)
 
+        # Poll THIS flow's status; see the reauth test above for why the
+        # flowId-less "latest flow" endpoint is racy across sequential flows.
         payload: dict[str, str | None] | None = None
         for _ in range(20):
-            status = await async_client.get("/api/oauth/status")
+            status = await async_client.get("/api/oauth/status", params={"flowId": flow_id})
             assert status.status_code == 200
             payload = status.json()
             if payload["status"] in {"success", "error"}:
@@ -949,8 +989,6 @@ async def test_device_oauth_flow_keeps_same_email_distinct_upstream_identities_i
 
 @pytest.mark.asyncio
 async def test_oauth_start_with_existing_account_marks_success(async_client):
-    await oauth_module._OAUTH_STORE.reset()
-
     encryptor = TokenEncryptor()
     account = Account(
         id="acc_existing",
@@ -978,8 +1016,6 @@ async def test_oauth_start_with_existing_account_marks_success(async_client):
 
 @pytest.mark.asyncio
 async def test_oauth_start_with_existing_account_clears_stale_flows(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1025,8 +1061,6 @@ async def test_oauth_start_with_existing_account_clears_stale_flows(async_client
 
 @pytest.mark.asyncio
 async def test_terminal_oauth_flows_are_bounded_outside_full_reset():
-    await oauth_module._OAUTH_STORE.reset()
-
     retained_limit = oauth_module._MAX_RETAINED_TERMINAL_OAUTH_FLOWS
 
     async with oauth_module._OAUTH_STORE.lock:
@@ -1056,8 +1090,6 @@ async def test_terminal_oauth_flows_are_bounded_outside_full_reset():
 
 @pytest.mark.asyncio
 async def test_expired_pending_browser_oauth_flows_are_pruned():
-    await oauth_module._OAUTH_STORE.reset()
-
     now = time.time()
     async with oauth_module._OAUTH_STORE.lock:
         expired = oauth_module.OAuthState(
@@ -1087,8 +1119,6 @@ async def test_expired_pending_browser_oauth_flows_are_pruned():
 
 @pytest.mark.asyncio
 async def test_only_expired_pending_browser_flow_no_longer_keeps_callback_server_alive():
-    await oauth_module._OAUTH_STORE.reset()
-
     async with oauth_module._OAUTH_STORE.lock:
         flow = oauth_module.OAuthState(
             flow_id="expired-flow",
@@ -1107,7 +1137,6 @@ async def test_only_expired_pending_browser_flow_no_longer_keeps_callback_server
 
 @pytest.mark.asyncio
 async def test_callback_server_remains_reserved_until_stop_completes():
-    await oauth_module._OAUTH_STORE.reset()
     stop_started = asyncio.Event()
     release_stop = asyncio.Event()
 
@@ -1133,8 +1162,6 @@ async def test_callback_server_remains_reserved_until_stop_completes():
 
 @pytest.mark.asyncio
 async def test_oauth_start_falls_back_to_device_on_os_error(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_browser_flow(self):
         raise OSError("no port")
 
@@ -1147,8 +1174,15 @@ async def test_oauth_start_falls_back_to_device_on_os_error(async_client, monkey
             expires_in_seconds=30,
         )
 
+    # Park the spawned device poller instead of letting it hit the REAL token
+    # exchange client (this test only asserts the browser->device fallback);
+    # the autouse store fence cancels and awaits it at teardown.
+    async def fake_exchange_device_token(**_):
+        await asyncio.Event().wait()
+
     monkeypatch.setattr(oauth_module.OauthService, "_start_browser_flow", fake_browser_flow)
     monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
 
     start = await async_client.post("/api/oauth/start", json={})
     assert start.status_code == 200
@@ -1159,8 +1193,6 @@ async def test_oauth_start_falls_back_to_device_on_os_error(async_client, monkey
 
 @pytest.mark.asyncio
 async def test_device_oauth_flow_reports_proxy_route_errors(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_oauth_route(*_args, **_kwargs):
         raise UpstreamProxyRouteError("default_pool_unconfigured", account_id=None)
 
@@ -1174,8 +1206,6 @@ async def test_device_oauth_flow_reports_proxy_route_errors(async_client, monkey
 
 @pytest.mark.asyncio
 async def test_manual_callback_returns_success_and_creates_account(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1227,8 +1257,6 @@ async def test_manual_callback_returns_success_and_creates_account(async_client,
 
 @pytest.mark.asyncio
 async def test_manual_callback_returns_error_message_for_invalid_state(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1262,8 +1290,6 @@ async def test_manual_callback_returns_error_message_for_invalid_state(async_cli
 
 @pytest.mark.asyncio
 async def test_oauth_status_binds_camel_case_flow_id(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1309,8 +1335,6 @@ async def test_oauth_status_binds_camel_case_flow_id(async_client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_manual_callback_error_resolves_state_before_marking_flow_failed(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1377,7 +1401,6 @@ async def test_manual_callback_error_resolves_state_before_marking_flow_failed(a
 
 @pytest.mark.asyncio
 async def test_unknown_flow_error_does_not_mutate_latest_oauth_status():
-    await oauth_module._OAUTH_STORE.reset()
     async with SessionLocal() as session:
         service = oauth_module.OauthService(AccountsRepository(session))
 
@@ -1407,7 +1430,6 @@ async def test_unknown_flow_error_does_not_mutate_latest_oauth_status():
 
 @pytest.mark.asyncio
 async def test_missing_flow_error_does_not_mutate_latest_oauth_status():
-    await oauth_module._OAUTH_STORE.reset()
     async with SessionLocal() as session:
         service = oauth_module.OauthService(AccountsRepository(session))
 
@@ -1437,8 +1459,6 @@ async def test_missing_flow_error_does_not_mutate_latest_oauth_status():
 
 @pytest.mark.asyncio
 async def test_manual_callback_unknown_state_does_not_mutate_latest_flow(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1467,8 +1487,6 @@ async def test_manual_callback_unknown_state_does_not_mutate_latest_flow(async_c
 
 @pytest.mark.asyncio
 async def test_concurrent_browser_oauth_flows_keep_callbacks_isolated(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -1547,7 +1565,6 @@ async def test_concurrent_browser_oauth_flows_keep_callbacks_isolated(async_clie
 
 @pytest.mark.asyncio
 async def test_callback_server_idle_stop_releases_store_lock_before_cleanup():
-    await oauth_module._OAUTH_STORE.reset()
     async with SessionLocal() as session:
         service = oauth_module.OauthService(AccountsRepository(session))
 
@@ -1575,8 +1592,6 @@ async def test_callback_server_idle_stop_releases_store_lock_before_cleanup():
 
 @pytest.mark.asyncio
 async def test_existing_account_cleanup_releases_store_lock_before_callback_server_stop():
-    await oauth_module._OAUTH_STORE.reset()
-
     class ExistingAccountRepo:
         async def list_accounts(self):
             return [object()]
@@ -1607,7 +1622,6 @@ async def test_existing_account_cleanup_releases_store_lock_before_callback_serv
 
 @pytest.mark.asyncio
 async def test_new_browser_flow_waits_for_stopping_callback_server_before_reusing_slot(monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
     stop_started = asyncio.Event()
     release_stop = asyncio.Event()
     started_servers: list[object] = []
@@ -1653,8 +1667,6 @@ async def test_new_browser_flow_waits_for_stopping_callback_server_before_reusin
 
 @pytest.mark.asyncio
 async def test_manual_callback_idempotent_success_requires_requested_flow(async_client, monkeypatch):
-    await oauth_module._OAUTH_STORE.reset()
-
     async def fake_callback_server_start(self) -> None:
         return None
 
@@ -2059,7 +2071,6 @@ async def test_device_complete_ack_stays_pending_when_own_poller_already_succeed
     and must NOT spawn a second poll of the consumed device code.
     """
 
-    await oauth_module._OAUTH_STORE.reset()
     async with SessionLocal() as session:
         service = oauth_module.OauthService(AccountsRepository(session))
 


### PR DESCRIPTION
## Summary

`tests/integration/test_oauth_flow.py` was order-dependent within the file with a different victim per run (#1794). Root cause: the module-global `oauth_module._OAUTH_STORE` carries **live poll tasks across test boundaries** on the shared session loop.

### Leaked state, precisely

1. **Cross-test poller leak.** Tests only called `_OAUTH_STORE.reset()` at their *start*, and `reset()` cancels poll tasks **without awaiting them** — so whichever test ran next inherited the previous test's still-running device poller through its entire fixture setup (DB drop/recreate, lifespan startup) and body.
2. **Real network + DB writes from the leaked poller.** `test_oauth_start_falls_back_to_device_on_os_error` never patched `exchange_device_token`, so its leaked poller performed a **real token-exchange HTTP call** and then slot/status writes (`consume_device_slot` commit, `set_status`) against a *later test's* freshly reset database — the timing of the upstream response picks the victim, which is why the victim differs per run (in CI it landed on the victim's first `PUT /api/settings`).
3. **"Latest flow" pointer clobber.** The multi-flow device tests polled `GET /api/oauth/status` without `flowId`, which reads the store's *latest-flow* pointer. A finishing poller's cleanup (`_poll_device_tokens` `finally`: `set_latest_flow_locked`) re-latches that pointer to its own already-successful flow after a newer flow was remembered, so the poll loop reported success before the current flow's poller persisted — observed as `planType 'plus' != 'team'`. This one reproduces even in isolation on a fast loop (Python 3.14: 4/20 runs).

### Fix (test-only)

- Autouse `_isolate_global_oauth_store` fixture fences the global store at **both edges** of every test: reset + cancel **and await** every task the store owns (poll tasks + callback-server stop task), so nothing crosses a test boundary and cancelled tasks' exceptions are retrieved instead of surfacing as `Task exception was never retrieved` noise in a later test. Same treatment as the live-usage ingestor fence from #1755. The 28 per-test `reset()` calls are replaced by the fixture.
- `test_oauth_start_falls_back_to_device_on_os_error` parks `exchange_device_token` on an `Event` (the test only asserts the browser→device fallback); the fence cancels the poller at teardown. No more real network from tests.
- The two multi-flow tests pin their status polls to each flow's own `flowId` (matching how the dashboard polls), removing the ambiguous latest-pointer observation.

## Evidence

RED (unmodified `origin/main` @ d148dd9a4):

```
# pair ordering — fails ~10-20% of runs
uv run --frozen pytest \
  tests/integration/test_oauth_flow.py::test_oauth_start_falls_back_to_device_on_os_error \
  tests/integration/test_oauth_flow.py::test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity
# -> AssertionError: assert 'plus' == 'team'   (3 failures across ~30 repeats)
# leaked-poller proof: a probe test run right after the fallback test observes the
# previous test's flow still registered in _OAUTH_STORE._flows with a live
# _poll_device_tokens task, which then dies with
# aiohttp ClientConnectionError('Connector is closed.') inside the NEXT test.

# victim alone (latest-pointer race): 4/20 failed
uv run --frozen pytest tests/integration/test_oauth_flow.py::test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity
```

GREEN (this branch):

- pair ordering: **0/20 failed**
- victim alone: **0/20 failed**
- whole file: **5x 58 passed**, plus **3 randomized whole-file orderings** (seeded shuffles) all green
- `uv run pytest tests/unit -q`: **6369 passed, 3 skipped**
- `uv run ruff check .`: clean

Test-only change; no openspec delta needed.

Fixes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth device-flow test isolation and cleanup.
  * Fixed status checks to consistently track the correct authentication flow.
  * Stabilized browser-to-device fallback behavior during authentication testing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->