### PR TITLE
fix(proxy): bound HTTP bridge live event queue

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -221,6 +221,9 @@ logger = logging.getLogger("app.modules.proxy.service")
 
 _HTTP_BRIDGE_CLEAN_CLOSE_RETRY_MAX_COUNT = 1
 _HTTP_BRIDGE_CLEAN_CLOSE_RETRY_JITTER_MAX_SECONDS = 2.0
+# A local startup failure must enqueue its terminal frame and end marker before
+# the downstream consumer loop starts; the third unread live event backpressures.
+_HTTP_BRIDGE_LIVE_EVENT_QUEUE_MAX_SIZE = 2
 
 _REQUEST_TRANSPORT_HTTP = "http"
 _WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE = "account_auth_invalidated"
@@ -230,6 +233,39 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
     "security work. codex-lb is continuing with normal account selection; the upstream request may still fail until "
     "an account with Trusted Access for Cyber is marked as security-work-authorized."
 )
+
+
+class _HTTPBridgeLiveEventQueue(asyncio.Queue[str | None]):
+    """Finite live queue whose blocked producer exits when downstream detaches."""
+
+    def __init__(self, *, maxsize: int, revoked: asyncio.Event) -> None:
+        super().__init__(maxsize=maxsize)
+        self._revoked = revoked
+
+    async def put(self, item: str | None) -> None:
+        if self._revoked.is_set():
+            return
+        try:
+            self.put_nowait(item)
+        except asyncio.QueueFull:
+            put_task = asyncio.create_task(
+                super().put(item),
+                name="http-bridge-event-put",
+            )
+            revoke_task = asyncio.create_task(
+                self._revoked.wait(),
+                name="http-bridge-event-revoke",
+            )
+            tasks = (put_task, revoke_task)
+            try:
+                done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                if put_task in done:
+                    put_task.result()
+            finally:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -657,6 +693,7 @@ class _HTTPBridgeRequestSubmitMixin:
         request_kind = (
             "normal" if connection_request_kind == "prewarm" and not generate_false_prewarm else header_request_kind
         )
+        event_queue_revoked = asyncio.Event()
         request_state = _WebSocketRequestState(
             request_id=resolved_request_id,
             request_log_id=request_log_id,
@@ -668,7 +705,15 @@ class _HTTPBridgeRequestSubmitMixin:
             started_at=_service_time().monotonic(),
             requested_service_tier=forwarded_service_tier,
             awaiting_response_created=True,
-            event_queue=asyncio.Queue() if attach_event_queue else None,
+            event_queue=(
+                _HTTPBridgeLiveEventQueue(
+                    maxsize=_HTTP_BRIDGE_LIVE_EVENT_QUEUE_MAX_SIZE,
+                    revoked=event_queue_revoked,
+                )
+                if attach_event_queue
+                else None
+            ),
+            event_queue_revoked=event_queue_revoked,
             transport=transport,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             api_key=api_key,
@@ -1301,9 +1346,11 @@ class _HTTPBridgeRequestSubmitMixin:
                             request_state.operation_id = operation.operation_id
                             request_state.operation_fingerprint = operation_fingerprint
                             request_state.operation_registered = True
+                            replay_queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=len(replay_events) + 1)
+                            request_state.event_queue = replay_queue
                             for replay_event in replay_events:
-                                await request_state.event_queue.put(replay_event)
-                            await request_state.event_queue.put(None)
+                                replay_queue.put_nowait(replay_event)
+                            replay_queue.put_nowait(None)
                             return
                 if recovery_attempt_consumed:
                     raise ProxyResponseError(
@@ -2615,6 +2662,7 @@ class _HTTPBridgeRequestSubmitMixin:
             # completed handler that wins first keeps its local queue reference;
             # a detach that wins first leaves no queue for that handler to claim.
             request_state.event_queue = None
+            request_state.event_queue_revoked.set()
         await _release_websocket_response_create_gate(request_state, session.response_create_gate)
         if not detached:
             if request_state.operation_replay:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -4054,6 +4054,7 @@ class _HTTPBridgeStreamingMixin:
                         # prevents a later completion from claiming an
                         # orphaned downstream consumer.
                         request_state.event_queue = None
+                        request_state.event_queue_revoked.set()
 
                 if completed_delivery_owns_queue and not completed_delivery_suppression_logged:
                     logger.info(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3854,6 +3854,12 @@ class _HTTPBridgeStreamingMixin:
                 )
             )
 
+        async def detach_downstream_request() -> None:
+            with anyio.CancelScope(shield=True):
+                await self._detach_http_bridge_request(session, request_state=request_state)
+                session.last_used_at = _service_time().monotonic()
+                await self._maybe_release_idle_http_bridge_session_lease(session)
+
         while True:
             budget_terminal_event = await operation_fenced_request_budget_terminal_event()
             if budget_terminal_event is not None:
@@ -3949,10 +3955,17 @@ class _HTTPBridgeStreamingMixin:
                 # injected previous_response_id and its continuity anchor.
                 text_data = request_state.request_text or text_data
                 continue
+            except BaseException:
+                await detach_downstream_request()
+                raise
             break
         event_queue = request_state.event_queue
         assert event_queue is not None
-        initial_retry_cooldown_seconds = await self._http_bridge_precreated_retry_cooldown_seconds(session)
+        try:
+            initial_retry_cooldown_seconds = await self._http_bridge_precreated_retry_cooldown_seconds(session)
+        except BaseException:
+            await detach_downstream_request()
+            raise
         if (
             initial_retry_cooldown_seconds > 0
             and session.key.strength == "hard"
@@ -4488,7 +4501,4 @@ class _HTTPBridgeStreamingMixin:
                 yield event_block
                 yielded_any = True
         finally:
-            with anyio.CancelScope(shield=True):
-                await self._detach_http_bridge_request(session, request_state=request_state)
-                session.last_used_at = _service_time().monotonic()
-                await self._maybe_release_idle_http_bridge_session_lease(session)
+            await detach_downstream_request()

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -939,6 +939,7 @@ class _WebSocketRequestState:
     response_id: str | None = None
     awaiting_response_created: bool = False
     event_queue: asyncio.Queue[str | None] | None = None
+    event_queue_revoked: asyncio.Event = field(default_factory=asyncio.Event)
     transport: str = _REQUEST_TRANSPORT_WEBSOCKET
     upstream_transport: str | None = _REQUEST_TRANSPORT_WEBSOCKET
     enforce_openai_sdk_contract: bool = True

--- a/openspec/changes/bound-http-bridge-event-queue/.openspec.yaml
+++ b/openspec/changes/bound-http-bridge-event-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/bound-http-bridge-event-queue/design.md
+++ b/openspec/changes/bound-http-bridge-event-queue/design.md
@@ -1,0 +1,37 @@
+## Context
+
+HTTP-bridge request preparation currently attaches `asyncio.Queue(maxsize=0)` to every live downstream stream. The upstream reader awaits each `put`, but an unbounded queue makes that await non-blocking regardless of downstream pace. The same request state also carries terminal events and byte-bounded durable transcript replay, and downstream detachment revokes the mutable queue while the shared upstream reader continues draining the request to terminal settlement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound unread live events per HTTP-bridge request and propagate pressure through the existing awaited upstream-reader enqueue.
+- Preserve event order, terminal/end-of-stream delivery, reservation and request-log settlement, durable spool/replay, and shared-reader cleanup.
+- Make paused, resumed, paced, and detached-consumer behavior deterministic in focused integration coverage.
+
+**Non-Goals:**
+
+- Add an operator setting or reuse the request-admission queue limit for a different unit.
+- Change bridge admission, wire events, durable spool byte limits, retry/failover, or account selection.
+- Refactor the broader HTTP-bridge lifecycle.
+
+## Decisions
+
+1. **Use a two-event internal live queue.** Request preparation will construct the live queue with capacity for exactly a terminal frame plus its end-of-stream marker. Local startup failures enqueue that pair before the downstream consumer loop begins, so a capacity of one would deadlock submission. The third unread live event blocks the producer; a larger arbitrary count would multiply the existing 16 MiB per-event ceiling without a contract-derived benefit. This is internal flow control rather than an operator policy, so no setting is added.
+
+2. **Make queue revocation unblock a pressured producer.** A request-scoped event will signal that downstream ownership was revoked. Enqueue uses `put_nowait` on the fast path and races only a full-queue `put` against revocation. Detachment signals revocation before continuing terminal drain, so a disconnected consumer cannot strand the shared upstream reader or an enqueue task. Terminal settlement and durable persistence continue even when downstream delivery is skipped.
+3. **Size completed durable replay to its already-loaded transcript.** Durable replay is byte-bounded before retrieval and is loaded before the live consumer loop starts. When replay is selected, replace the live queue with a finite queue sized exactly for the retrieved events plus end-of-stream, then enqueue synchronously. This avoids startup deadlock without turning live buffering back into an unbounded queue.
+4. **Keep terminal ordering unchanged.** Existing producer call sites retain their event-then-end-marker order. The enqueue helper changes waiting behavior only; it does not reorder, drop while attached, alter spool persistence, or transfer settlement ownership.
+
+Alternatives rejected:
+
+- Reusing `http_responses_session_bridge_queue_limit`: it counts admitted requests, not event memory, and would couple unrelated units.
+- Reusing durable spool pending-event settings: they govern asynchronous database batching, not downstream live delivery.
+- An unbounded queue plus metrics or dropping: neither applies backpressure nor preserves complete Responses streams.
+- Replacing the queue with a new channel abstraction: broader than required and riskier across the mature terminal/replay paths.
+
+## Risks / Trade-offs
+
+- **[Head-of-line pressure on the shared upstream socket]** → The response-create gate already serializes active turns; pressure is intentional and bounded to the slow downstream that owns the active response.
+- **[Disconnect while a producer awaits capacity]** → Queue revocation wins the enqueue race and all spawned wait tasks are cancelled and awaited.

--- a/openspec/changes/bound-http-bridge-event-queue/proposal.md
+++ b/openspec/changes/bound-http-bridge-event-queue/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+An admitted HTTP-bridge Responses stream currently stores upstream events in an unbounded in-memory queue. A paused or slow downstream SSE consumer therefore lets an otherwise bounded request retain every unread event and can exhaust proxy-worker memory.
+
+## What Changes
+
+- Bound each HTTP-bridge request's live downstream event queue with an internal capacity.
+- Make the existing awaited producer enqueue apply backpressure when that queue is full.
+- Preserve ordered event delivery, terminal settlement, durable spool/replay, disconnect cleanup, and paced-consumer behavior.
+- Add deterministic integration coverage for paused, resumed, and paced consumers without adding a user setting.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require bounded live HTTP-bridge event buffering and producer backpressure while preserving delivery and lifecycle contracts.
+
+## Impact
+
+- Affected code: HTTP-bridge request preparation in `app/modules/proxy/_service/http_bridge/request_submit.py`.
+- Affected tests: focused HTTP-bridge integration coverage in `tests/integration/test_http_responses_bridge.py`.
+- Affected contract: `openspec/specs/responses-api-compat/spec.md` through a change delta.
+- No API, setting, dependency, migration, dashboard, wire-format, or durable-storage change.

--- a/openspec/changes/bound-http-bridge-event-queue/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-http-bridge-event-queue/specs/responses-api-compat/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge live event buffering is bounded
+
+Each admitted HTTP-bridge Responses request MUST use a finite-capacity in-memory queue for live upstream events. When an attached downstream SSE consumer does not keep pace and that queue reaches capacity, the upstream relay MUST wait for downstream capacity before enqueueing another live event. The relay MUST preserve event order and MUST NOT drop attached-consumer events to relieve pressure.
+
+Downstream detachment or cancellation MUST release any relay wait on that request's full queue so the shared upstream reader and its enqueue tasks do not leak. Revocation of downstream delivery MUST NOT prevent terminal persistence, reservation settlement, request logging, or request/session cleanup.
+
+Completed durable transcript replay MUST remain byte-bounded by the durable spool contract and MUST use finite startup buffering that can hold the selected replay plus its end marker without waiting for a consumer that has not started yet.
+
+#### Scenario: Paused consumer backpressures the live relay
+
+- **GIVEN** an HTTP-bridge request with an attached downstream SSE consumer
+- **WHEN** the consumer pauses long enough for the live event queue to reach capacity
+- **THEN** the next live upstream enqueue waits without growing the queue beyond its finite capacity
+- **AND** resuming the consumer delivers every event in order through the terminal event and end marker
+
+#### Scenario: Paced consumer preserves delivery
+
+- **GIVEN** an HTTP-bridge request whose downstream consumer keeps pace with upstream events
+- **WHEN** ordinary and terminal Responses events are relayed
+- **THEN** every event is delivered in upstream order
+- **AND** reservation settlement, request logging, and request/session cleanup complete under their existing ownership rules
+
+#### Scenario: Detached consumer releases a blocked producer
+
+- **GIVEN** an HTTP-bridge live event enqueue is waiting because its downstream queue is full
+- **WHEN** the downstream stream disconnects or is cancelled
+- **THEN** the waiting enqueue and every enqueue-owned task terminate without requiring another consumer read
+- **AND** terminal persistence, durable spool state, request logging, reservation settlement, and bridge cleanup remain able to complete
+
+#### Scenario: Durable replay starts without a live consumer
+
+- **GIVEN** a completed durable operation has a replayable byte-bounded event transcript
+- **WHEN** HTTP-bridge submission selects that replay before the downstream consumer loop starts
+- **THEN** the finite replay queue accepts the selected transcript and end marker without deadlock
+- **AND** the downstream consumer receives the complete replay in order

--- a/openspec/changes/bound-http-bridge-event-queue/tasks.md
+++ b/openspec/changes/bound-http-bridge-event-queue/tasks.md
@@ -24,4 +24,4 @@
 
 - [x] 3.3 Run an actual-path async surface driver and record bounded-pressure plus resumed-delivery output
 
-- [ ] 3.4 Review the committed diff for disconnect/cancellation, task ownership, terminal settlement, durable spool/replay, and async task leaks
+- [x] 3.4 Review the committed diff for disconnect/cancellation, task ownership, terminal settlement, durable spool/replay, and async task leaks

--- a/openspec/changes/bound-http-bridge-event-queue/tasks.md
+++ b/openspec/changes/bound-http-bridge-event-queue/tasks.md
@@ -1,0 +1,27 @@
+## 1. Regression
+
+- [x] 1.1 Add `test_http_bridge_live_event_queue_applies_backpressure` through actual request preparation and upstream event relay
+
+- [x] 1.2 Capture deterministic RED showing the unbounded queue lets a paused-consumer producer complete, while the paced control remains ordered
+
+
+## 2. Bounded delivery
+
+- [x] 2.1 Construct live HTTP-bridge event queues with the two-event terminal-safe internal capacity
+
+- [x] 2.2 Release full-queue producer waits on downstream detachment without changing persistence or terminal settlement ownership
+
+- [x] 2.3 Preserve completed durable replay with finite transcript-sized startup buffering
+
+- [x] 2.4 Prove resumed and paced delivery order, terminal end marker, disconnect cancellation, settlement, and task cleanup
+
+
+## 3. Verification
+
+- [x] 3.1 Run the exact regression, focused bridge lifecycle tests, and relevant broader proxy tests
+
+- [x] 3.2 Run changed-file diagnostics, Ruff, type checks, and strict OpenSpec validation
+
+- [x] 3.3 Run an actual-path async surface driver and record bounded-pressure plus resumed-delivery output
+
+- [ ] 3.4 Review the committed diff for disconnect/cancellation, task ownership, terminal settlement, durable spool/replay, and async task leaks

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -24,6 +24,7 @@ import app.modules.proxy.load_balancer as load_balancer_module
 import app.modules.proxy.service as proxy_module
 from app.core.config.settings import Settings
 from app.core.openai.model_registry import ModelRegistry
+from app.core.types import JsonValue
 from app.core.utils.request_id import (
     reset_request_id,
     reset_request_scope_id,
@@ -15066,6 +15067,183 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
     assert session.closed is True
     assert session.upstream_control.retire_after_drain is True
     assert fake_upstream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_live_event_queue_applies_backpressure(
+    async_client,
+    app_instance,
+) -> None:
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_event_backpressure",
+        "http-bridge-event-backpressure@example.com",
+    )
+    account = await _get_account(account_id)
+    service = get_proxy_service_for_app(app_instance)
+    payload = proxy_module.ResponsesRequest(
+        model="gpt-5.4",
+        instructions="Return exactly OK.",
+        input="event-backpressure",
+        prompt_cache_key="event-backpressure",
+    )
+
+    def prepare_request(suffix: str) -> tuple[proxy_module._WebSocketRequestState, proxy_module._HTTPBridgeSession]:
+        request_state, _ = service._prepare_http_bridge_request(
+            payload,
+            {},
+            api_key=None,
+            api_key_reservation=None,
+            request_id=f"req_event_backpressure_{suffix}",
+        )
+        request_state.skip_request_log = True
+        session = _make_dummy_bridge_session(
+            proxy_module._HTTPBridgeSessionKey("prompt_cache", f"event-backpressure-{suffix}", None)
+        )
+        session.account = account
+        session.pending_requests.append(request_state)
+        session.queued_request_count = 1
+        return request_state, session
+
+    def response_events(response_id: str) -> list[dict[str, JsonValue]]:
+        events: list[dict[str, JsonValue]] = [
+            {
+                "type": "response.created",
+                "response": {"id": response_id, "object": "response", "status": "in_progress"},
+            }
+        ]
+        for index in range(4):
+            events.append(
+                {
+                    "type": "response.output_text.delta",
+                    "response_id": response_id,
+                    "delta": str(index),
+                }
+            )
+        events.append(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "object": "response",
+                    "status": "completed",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 4,
+                        "output_tokens": 4,
+                        "total_tokens": 8,
+                        "input_tokens_details": {"cached_tokens": 0},
+                        "output_tokens_details": {"reasoning_tokens": 0},
+                    },
+                },
+            }
+        )
+        return events
+
+    paced_state, paced_session = prepare_request("paced")
+    paced_queue = paced_state.event_queue
+    assert paced_queue is not None
+    paced_types: list[str] = []
+    paced_max_qsize = 0
+    for event in response_events("resp_event_backpressure_paced")[:-1]:
+        await service._process_http_bridge_upstream_text(
+            paced_session,
+            json.dumps(event, separators=(",", ":")),
+        )
+        paced_max_qsize = max(paced_max_qsize, paced_queue.qsize())
+        event_block = paced_queue.get_nowait()
+        assert event_block is not None
+        event_payload = proxy_module.parse_sse_data_json(event_block)
+        assert event_payload is not None
+        paced_types.append(cast(str, event_payload["type"]))
+
+    slow_state, slow_session = prepare_request("slow")
+    slow_queue = slow_state.event_queue
+    assert slow_queue is not None
+    slow_events = response_events("resp_event_backpressure_slow")
+    queue_full = asyncio.Event()
+    blocked_enqueue_started = asyncio.Event()
+    producer_done = asyncio.Event()
+
+    async def relay_slow_events() -> None:
+        for index, event in enumerate(slow_events):
+            if index == slow_queue.maxsize:
+                blocked_enqueue_started.set()
+            await service._process_http_bridge_upstream_text(
+                slow_session,
+                json.dumps(event, separators=(",", ":")),
+            )
+            if slow_queue.full():
+                queue_full.set()
+        producer_done.set()
+
+    producer_task = asyncio.create_task(relay_slow_events())
+    if slow_queue.maxsize == 0:
+        await _wait_for_event(producer_done)
+        assert slow_queue.maxsize > 0, (
+            "prepared HTTP bridge live queue is unbounded: "
+            f"producer_completed={producer_task.done()} qsize={slow_queue.qsize()}"
+        )
+    await _wait_for_event(queue_full)
+    await _wait_for_event(blocked_enqueue_started)
+    assert producer_task.done() is False
+    assert slow_queue.qsize() == slow_queue.maxsize
+
+    delivered_types: list[str] = []
+    while True:
+        event_block = await asyncio.wait_for(slow_queue.get(), timeout=_TEST_SYNC_TIMEOUT_SECONDS)
+        if event_block is None:
+            break
+        event_payload = proxy_module.parse_sse_data_json(event_block)
+        assert event_payload is not None
+        delivered_types.append(cast(str, event_payload["type"]))
+    await _wait_for_event(producer_done)
+    await asyncio.wait_for(producer_task, timeout=_TEST_SYNC_TIMEOUT_SECONDS)
+
+    assert paced_types == [event["type"] for event in slow_events[:-1]]
+    assert paced_max_qsize <= max(1, paced_queue.maxsize)
+    assert delivered_types == [event["type"] for event in slow_events]
+    assert slow_queue.empty()
+    assert not slow_session.pending_requests
+    assert slow_session.queued_request_count == 0
+    assert slow_state.api_key_reservation is None
+
+    detached_state, detached_session = prepare_request("detached")
+    detached_queue = detached_state.event_queue
+    assert detached_queue is not None
+    detached_queue_full = asyncio.Event()
+    detached_blocked_enqueue_started = asyncio.Event()
+    detached_producer_done = asyncio.Event()
+
+    async def relay_detached_events() -> None:
+        for index, event in enumerate(response_events("resp_event_backpressure_detached")):
+            if index == detached_queue.maxsize:
+                detached_blocked_enqueue_started.set()
+            await service._process_http_bridge_upstream_text(
+                detached_session,
+                json.dumps(event, separators=(",", ":")),
+            )
+            if detached_queue.full():
+                detached_queue_full.set()
+        detached_producer_done.set()
+
+    detached_producer_task = asyncio.create_task(relay_detached_events())
+    await _wait_for_event(detached_queue_full)
+    await _wait_for_event(detached_blocked_enqueue_started)
+    assert detached_queue.full()
+    assert detached_producer_task.done() is False
+
+    await service._detach_http_bridge_request(detached_session, request_state=detached_state)
+    await _wait_for_event(detached_producer_done)
+    await asyncio.wait_for(detached_producer_task, timeout=_TEST_SYNC_TIMEOUT_SECONDS)
+
+    assert detached_state.event_queue is None
+    assert not detached_session.pending_requests
+    assert detached_session.queued_request_count == 0
+    assert detached_state.api_key_reservation is None
+    assert not [
+        task for task in asyncio.all_tasks() if task.get_name() in {"http-bridge-event-put", "http-bridge-event-revoke"}
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -193,6 +193,103 @@ async def test_http_bridge_event_put_stops_when_queue_is_revoked() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_cancellation_before_consumer_loop_revokes_full_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="cancel-before-consumer")
+    revoked = asyncio.Event()
+    event_queue = http_bridge_request_submit_module._HTTPBridgeLiveEventQueue(maxsize=2, revoked=revoked)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-cancel-before-consumer",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=event_queue,
+        event_queue_revoked=revoked,
+        transport="http",
+    )
+    producer_started = asyncio.Event()
+    producer_released = asyncio.Event()
+    cooldown_entered = asyncio.Event()
+    producer_task: asyncio.Task[None] | None = None
+
+    async def produce_after_capacity() -> None:
+        producer_started.set()
+        await event_queue.put("third")
+        producer_released.set()
+
+    async def submit_request(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        nonlocal producer_task
+        del text_data, queue_limit
+        async with target_session.pending_lock:
+            target_session.pending_requests.append(request_state)
+            target_session.queued_request_count += 1
+        event_queue.put_nowait("first")
+        event_queue.put_nowait("second")
+        producer_task = asyncio.create_task(produce_after_capacity(), name="test-http-bridge-blocked-producer")
+        await producer_started.wait()
+        assert not producer_task.done()
+
+    async def hold_precreated_cooldown(target_session: proxy_service._HTTPBridgeSession) -> float:
+        del target_session
+        cooldown_entered.set()
+        await asyncio.Event().wait()
+        return 0.0
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit_request)
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", hold_precreated_cooldown)
+    stream = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data="{}",
+        queue_limit=8,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    consumer_task = asyncio.create_task(anext(stream))
+
+    try:
+        await asyncio.wait_for(cooldown_entered.wait(), timeout=1.0)
+        consumer_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(consumer_task, timeout=1.0)
+        await asyncio.wait_for(producer_released.wait(), timeout=1.0)
+        await stream.aclose()
+
+        assert revoked.is_set()
+        assert request_state.event_queue is None
+        assert request_state.draining_until_terminal is True
+        assert request_state not in session.pending_requests
+        assert session.queued_request_count == 0
+        assert session.upstream_control.reconnect_requested is True
+        assert session.upstream_control.retire_after_drain is True
+        assert session.upstream_close_attempted is True
+        assert [event_queue.get_nowait(), event_queue.get_nowait()] == ["first", "second"]
+        assert event_queue.empty()
+        assert producer_task is not None and producer_task.done()
+        assert not [
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name() in {"http-bridge-event-put", "http-bridge-event-revoke"}
+        ]
+    finally:
+        consumer_task.cancel()
+        if producer_task is not None:
+            producer_task.cancel()
+            await asyncio.gather(producer_task, return_exceptions=True)
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_durable_replay_uses_finite_transcript_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -162,6 +162,99 @@ def _without_installation_metadata(text: str) -> dict[str, Any]:
     return payload
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_event_put_delivers_after_capacity_frees() -> None:
+    revoked = asyncio.Event()
+    event_queue = http_bridge_request_submit_module._HTTPBridgeLiveEventQueue(maxsize=1, revoked=revoked)
+    event_queue.put_nowait("first")
+
+    put_task = asyncio.create_task(event_queue.put("second"))
+    first = event_queue.get_nowait()
+    await put_task
+
+    assert first == "first"
+    assert event_queue.get_nowait() == "second"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_event_put_stops_when_queue_is_revoked() -> None:
+    revoked = asyncio.Event()
+    event_queue = http_bridge_request_submit_module._HTTPBridgeLiveEventQueue(maxsize=1, revoked=revoked)
+    event_queue.put_nowait("first")
+    revoked.set()
+
+    await event_queue.put("second")
+
+    assert event_queue.get_nowait() == "first"
+    assert event_queue.empty()
+    assert not [
+        task for task in asyncio.all_tasks() if task.get_name() in {"http-bridge-event-put", "http-bridge-event-revoke"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_durable_replay_uses_finite_transcript_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="finite-replay")
+    session.durable_session_id = "durable-finite-replay"
+    session.durable_owner_epoch = 3
+    live_queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=1)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-finite-replay",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp-parent",
+        event_queue=live_queue,
+        request_text='{"type":"response.create","previous_response_id":"resp-parent"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    operation = SimpleNamespace(
+        created=False,
+        operation_id="operation-finite-replay",
+        state="completed",
+        response_id="resp-replay",
+        event_spool_complete=True,
+    )
+    replay_events = ["data: first\n\n", "data: second\n\n"]
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            get_operation_by_fingerprint=AsyncMock(return_value=operation),
+            get_operation=AsyncMock(return_value=operation),
+            record_operation=AsyncMock(return_value=operation),
+            get_operation_events=AsyncMock(return_value=replay_events),
+        ),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-finite-replay"),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", AsyncMock(return_value=True))
+
+    await service._submit_http_bridge_request_with_handoff(
+        session,
+        request_state=request_state,
+        text_data=request_state.request_text or "{}",
+        queue_limit=8,
+        request_scope_id="scope-finite-replay",
+        owned_unanchored_handoff=False,
+    )
+
+    replay_queue = request_state.event_queue
+    assert replay_queue is not None
+    assert replay_queue is not live_queue
+    assert replay_queue.maxsize == len(replay_events) + 1
+    assert [replay_queue.get_nowait() for _ in range(replay_queue.qsize())] == [*replay_events, None]
+    assert request_state.operation_replay is True
+
+
 def test_http_bridge_operation_metadata_is_stable_and_non_destructive() -> None:
     payload = {"type": "response.create", "previous_response_id": "resp_parent", "input": "continue"}
     text = json.dumps(payload)


### PR DESCRIPTION
## Summary

Bounds each admitted HTTP Responses bridge's live upstream-event queue so a paused SSE consumer backpressures the shared relay instead of allowing unbounded per-request memory growth. Downstream cancellation revokes blocked queue producers while preserving terminal persistence, settlement, logging, replay, and cleanup ownership.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None found. Related continuity work: #232 (merged; contextual, not overlapping).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent SSE framing and ordering

Change directory: `openspec/changes/bound-http-bridge-event-queue/`

## Changes

- Use a two-event finite live queue: enough for terminal event plus end marker before consumption starts, while the next unread event applies backpressure.
- Revoke blocked queue puts when the downstream detaches, including cancellation before the consumer loop begins, without changing shared-reader drain or settlement ownership.
- Keep completed durable replay finite with transcript-sized startup capacity.
- Add deterministic paused, resumed, paced, detached, startup-cancelled, and durable-replay regressions.

## Simplicity

- [x] Works with zero config and adds no setting
- [x] No new required setup step
- New setting(s): None
- [x] README, environment example, and dashboard navigation are unchanged

## Test plan

```text
10 focused queue and bridge lifecycle tests: passed
Responses integration suite: 65 passed
Responses API contract suite: 65 passed
Full bridge unit module: 637 passed; 1 unrelated existing fixture failure because file_account_pins was absent
Ruff check and format check on changed Python files: passed
ty check on changed Python files: passed
OpenSpec strict validation for bound-http-bridge-event-queue: passed
Actual-path async surface proof: bounded at maxsize=2, paused producer blocked, resumed terminal/EOS delivery remained ordered, and detach released the producer without queue-task leaks
```

Global strict spec validation was also attempted; it reports eight existing repository spec failures outside this change. The change-specific strict validation is clean. The all-files local CI hook was intentionally not run; Sensitive-path focused tests, lint, formatting, type checks, diagnostics, OpenSpec validation, and committed-diff review were run instead.

## Output

The regression drives request preparation through upstream event relay. With consumption paused, the queue remains at two events and the producer blocks; after consumption resumes, all events arrive in order through the terminal event and end marker. Cancelling before the consumer loop revokes the full queue and terminates producer-owned put/revoke tasks.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related work was checked and documented above.
- [x] Added tests covering the change.
- [ ] Ran the all-files local CI hook (focused Sensitive-path verification used instead; details above).
- [x] Change-specific strict OpenSpec validation and verification are clean.
- [x] Simplicity gates reviewed; no setting, default, README, environment, or navigation change.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP bridge event delivery for slow or paused consumers by applying bounded buffering and backpressure.
  * Prevented event producers from remaining blocked when a downstream request disconnects or is cancelled.
  * Preserved event ordering, terminal responses, durable replay, and cleanup during disconnects and retries.

* **Tests**
  * Added coverage for backpressure, cancellation, queue revocation, cleanup, and durable event replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->