### PR TITLE
fix(http-bridge): classify recovery error frames and poison same-anchor eventless failures

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -2770,7 +2770,15 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     error = payload.get("error")
     if not isinstance(error, dict):
         return False
-    code = error.get("code")
+    code_value = error.get("code")
+    raw_code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else None
+    type_value = error.get("type")
+    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else None
+    # Normalize like the websocket rewrite path (#1818): upstream frames may
+    # carry the classifiable code only in ``type`` (or omit both code and
+    # param on the terse previous-response rejection), and a raw read would
+    # misclassify them into the ambiguous transport class below (issue #1830).
+    code = _normalize_error_code(raw_code, error_type)
     if code in {
         "bridge_owner_unreachable",
         "bridge_previous_response_not_found",

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -95,6 +95,9 @@ from app.modules.proxy._service.http_bridge.helpers import (
 from app.modules.proxy._service.http_bridge.quarantine import (
     _record_http_bridge_quarantine_wedged_pending,
 )
+from app.modules.proxy._service.http_bridge.retry_circuit import (
+    _http_bridge_anchor_poison_detail,
+)
 from app.modules.proxy._service.http_bridge.service_stubs import (
     _call_with_supported_optional_kwargs,
     _classify_upstream_close,
@@ -123,6 +126,9 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _websocket_auth_failure_permanent_code,
     _websocket_auth_failure_requires_reauth,
     _websocket_request_text_is_account_neutral_fresh_replay,
+)
+from app.modules.proxy._service.http_bridge.upstream_events import (
+    _abandon_durable_http_bridge_continuity,
 )
 from app.modules.proxy._service.observability import (
     _hash_identifier as _hash_identifier,
@@ -2846,11 +2852,27 @@ class _HTTPBridgeRequestSubmitMixin:
         # that handoff, genuine pre-response failures disappear from circuit
         # accounting while idle closes and request failures look identical.
         if retired_request_count > 0 and response_events_seen == 0:
-            await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+            consecutive_failures = await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
                 session,
                 detail=retry_circuit_detail or detail,
                 selection=retry_circuit_attempt_selection,
             )
+            poison_detail = _http_bridge_anchor_poison_detail(retry_circuit_detail or detail)
+            if (
+                poison_detail is not None
+                and consecutive_failures is not None
+                and consecutive_failures
+                >= _service_get_settings().http_responses_session_bridge_anchor_poison_failure_threshold
+            ):
+                # Consecutive eventless failures on one bridge key are
+                # same-anchor failures (the anchor only advances on a
+                # completed response, which resets the circuit). Clear the
+                # poisoned durable anchor while this session still owns the
+                # lease so the next attempt is not re-anchored into the same
+                # failure. Without this, only the admission-waiter reader
+                # path could ever poison an anchor, and an anchored session
+                # failing without waiters cooled down forever (issue #1830).
+                await _abandon_durable_http_bridge_continuity(self, session, detail=poison_detail)
         session.closed = True
         async with self._http_bridge_lock:
             # Bounded close may return while resource finalization is still

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2872,7 +2872,21 @@ class _HTTPBridgeRequestSubmitMixin:
                 # failure. Without this, only the admission-waiter reader
                 # path could ever poison an anchor, and an anchored session
                 # failing without waiters cooled down forever (issue #1830).
-                await _abandon_durable_http_bridge_continuity(self, session, detail=poison_detail)
+                durable_cleared = await _abandon_durable_http_bridge_continuity(self, session, detail=poison_detail)
+                if not durable_cleared and session.durable_session_id is not None:
+                    # Keep failed waiterless clears visible in the same
+                    # poison-clear telemetry the admission-waiter path emits;
+                    # the next threshold failure re-attempts the clear.
+                    _log_http_bridge_event(
+                        "durable_anchor_poison_clear_failed",
+                        session.key,
+                        account_id=session.account.id,
+                        model=session.request_model,
+                        pending_count=retired_request_count,
+                        detail=poison_detail,
+                        cache_key_family=session.key.affinity_kind,
+                        model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                    )
         session.closed = True
         async with self._http_bridge_lock:
             # Bounded close may return while resource finalization is still

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -38,6 +38,24 @@ _HTTP_BRIDGE_RETRY_CIRCUIT_DETAIL_ALIASES = {
     "missing_response_created_timeout": "stream_idle_timeout",
     "response_create_gate_timeout_stuck_pending": "stream_idle_timeout",
 }
+_HTTP_BRIDGE_ANCHOR_POISON_DETAILS = {
+    "stream_idle_timeout": "repeated_zero_event_idle_timeout",
+    "stream_incomplete": "repeated_zero_event_stream_incomplete",
+}
+
+
+def _http_bridge_anchor_poison_detail(detail: str | None) -> str | None:
+    """Map an eventless retry-circuit failure class to its anchor-poison detail.
+
+    Consecutive eventless failures on one bridge key are same-anchor failures:
+    the durable anchor only advances on a completed response, which resets the
+    circuit. Both ambiguous transport classes therefore count toward anchor
+    poison (issue #1830); ``clean_close`` never does.
+    """
+    if detail is None:
+        return None
+    aliased = _HTTP_BRIDGE_RETRY_CIRCUIT_DETAIL_ALIASES.get(detail, detail)
+    return _HTTP_BRIDGE_ANCHOR_POISON_DETAILS.get(aliased)
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -75,6 +75,9 @@ from app.modules.proxy._service.http_bridge.quarantine import (
     _record_http_bridge_quarantine_eventless_timeout,
     _record_http_bridge_quarantine_wedged_pending,
 )
+from app.modules.proxy._service.http_bridge.retry_circuit import (
+    _http_bridge_anchor_poison_detail,
+)
 from app.modules.proxy._service.http_bridge.service_stubs import (
     _assign_websocket_response_id,
     _await_cancelled_task,
@@ -963,6 +966,8 @@ async def _clear_durable_http_bridge_response_anchor(
 async def _abandon_durable_http_bridge_continuity(
     service: Any,
     session: "_HTTPBridgeSession",
+    *,
+    detail: str = "repeated_zero_event_idle_timeout",
 ) -> bool:
     """Clear durable continuity before retiring a repeatedly poisoned bridge.
 
@@ -999,7 +1004,7 @@ async def _abandon_durable_http_bridge_continuity(
         session.key,
         account_id=session.account.id,
         model=session.request_model,
-        detail="repeated_zero_event_idle_timeout",
+        detail=detail,
         cache_key_family=session.key.affinity_kind,
         model_class=_extract_model_class(session.request_model) if session.request_model else None,
     )
@@ -1159,7 +1164,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                     ),
                 )
         finally:
-            poison_after_deferred_failures = False
+            poison_detail: str | None = None
             if session.admission_waiter_count > 0 and not force_retire:
                 retry_circuit_detail = None
                 if close_classification == "clean":
@@ -1179,19 +1184,21 @@ class _HTTPBridgeUpstreamEventsMixin:
                         detail=retry_circuit_detail,
                         selection=retry_circuit_attempt_selection,
                     )
-                    poison_after_deferred_failures = bool(
-                        retry_circuit_detail == "stream_idle_timeout"
+                    poison_candidate_detail = _http_bridge_anchor_poison_detail(retry_circuit_detail)
+                    if (
+                        poison_candidate_detail is not None
                         and observed_response_events == 0
                         and consecutive_failures is not None
                         and consecutive_failures
                         >= _service_get_settings().http_responses_session_bridge_anchor_poison_failure_threshold
-                    )
-                if poison_after_deferred_failures:
-                    durable_cleared = await _abandon_durable_http_bridge_continuity(self, session)
+                    ):
+                        poison_detail = poison_candidate_detail
+                if poison_detail is not None:
+                    durable_cleared = await _abandon_durable_http_bridge_continuity(self, session, detail=poison_detail)
                     if durable_cleared:
                         await self._retire_stale_pending_http_bridge_session(
                             session,
-                            detail="repeated_zero_event_idle_timeout",
+                            detail=poison_detail,
                             response_events_seen=observed_response_events,
                             **retry_circuit_attempt_kwargs,
                         )
@@ -1203,7 +1210,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             account_id=session.account.id,
                             model=session.request_model,
                             pending_count=session.admission_waiter_count,
-                            detail="repeated_zero_event_idle_timeout",
+                            detail=poison_detail,
                             cache_key_family=session.key.affinity_kind,
                             model_class=_extract_model_class(session.request_model) if session.request_model else None,
                         )

--- a/openspec/changes/classify-bridge-recovery-error-frames/.openspec.yaml
+++ b/openspec/changes/classify-bridge-recovery-error-frames/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/classify-bridge-recovery-error-frames/proposal.md
+++ b/openspec/changes/classify-bridge-recovery-error-frames/proposal.md
@@ -1,0 +1,29 @@
+# Classify Bridge Recovery Error Frames
+
+## Why
+
+The HTTP responses session bridge can wedge a session permanently (issue #1830). After one genuine mid-turn interruption the bridge rebinds to its stored durable anchor and re-injects it on every attempt. When upstream rejects that anchor with a classifiable previous-response error, two gaps keep the session unrecoverable:
+
+1. The bridge-local recovery gate reads raw error codes without the normalization the WebSocket path gained in the `classify-invalid-previous-response-id` change (#1818): a frame that carries its classifiable code only in `type`, or the terse parameterless ``Invalid `previous_response_id`.`` shape, falls through to the ambiguous-transport class instead of previous-response recovery.
+2. Anchor poisoning only counts `stream_idle_timeout` failures, and only on the reader path when admission waiters exist. The wedge observed in production fails eventlessly with `stream_incomplete` (the bridge's masked form of an upstream previous-response rejection), so the retry circuit opens and cools down forever while `http_responses_session_bridge_anchor_poison_failure_threshold` never fires. Operators had to wipe the `http_bridge_*` tables to free sessions.
+
+## What Changes
+
+- Route the bridge-local previous-response recovery gate through the same error-code normalization as the WebSocket rewrite path (code falls back to `type`; the terse parameterless invalid-previous-response shape classifies as a continuity miss).
+- Count both ambiguous eventless transport classes — `stream_incomplete` and `stream_idle_timeout` (with its aliased diagnostics) — toward anchor poison, so consecutive same-anchor failures self-heal even when the frame is genuinely unclassifiable. `clean_close` still never poisons.
+- Evaluate anchor poison at the shared retirement boundary as well, so a wedged anchored session that fails without admission waiters also clears its poisoned durable anchor once the threshold is reached.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Normalize error frames at the bridge-local recovery gate and widen anchor poisoning to all consecutive eventless same-anchor failures, including the waiterless retirement path.
+
+## Impact
+
+- HTTP bridge recovery gate (`app/modules/proxy/_service/http_bridge/helpers.py`), anchor-poison accounting (`app/modules/proxy/_service/http_bridge/upstream_events.py`, `app/modules/proxy/_service/http_bridge/request_submit.py`, `app/modules/proxy/_service/http_bridge/retry_circuit.py`).
+- No API, schema, migration, dependency, configuration, or dashboard changes; the existing poison threshold setting and its default of seven are unchanged.

--- a/openspec/changes/classify-bridge-recovery-error-frames/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-bridge-recovery-error-frames/specs/responses-api-compat/spec.md
@@ -1,0 +1,74 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Bridge-local previous-response recovery classifies normalized error frames
+
+When the HTTP bridge evaluates whether a failed anchored request may enter bridge-local previous-response recovery, it MUST classify the error frame with the same normalization as the WebSocket rewrite path: a missing or empty `code` MUST fall back to the error `type` before classification, and the parameterless ``Invalid `previous_response_id`.`` invalid-request shape MUST classify as a previous-response continuity miss. A classifiable previous-response rejection MUST route into previous-response recovery and MUST NOT be treated as an ambiguous transport failure that only feeds the retry-circuit cooldown.
+
+#### Scenario: Terse parameterless rejection enters local recovery
+
+- **GIVEN** an anchored HTTP bridge request fails with `type = "invalid_request_error"`, no `code`, no `param`, and the message ``Invalid `previous_response_id`.``
+- **WHEN** the bridge evaluates bridge-local previous-response recovery for that failure
+- **THEN** the failure classifies as a previous-response continuity miss
+- **AND** the bridge attempts previous-response recovery instead of the ambiguous-transport path
+
+#### Scenario: Code carried only in the error type classifies
+
+- **GIVEN** an anchored HTTP bridge request fails with no `code` and `type = "previous_response_not_found"`
+- **WHEN** the bridge evaluates bridge-local previous-response recovery for that failure
+- **THEN** the failure enters previous-response recovery instead of the ambiguous-transport class
+
+#### Scenario: Unrelated errors keep their classification
+
+- **WHEN** a failed anchored request carries an error whose normalized code, param, and message do not match a previous-response continuity miss
+- **THEN** the bridge MUST NOT classify it as a previous-response continuity miss
+
+## MODIFIED Requirements
+
+### Requirement: Repeated zero-event idle failures poison dead anchors
+
+For hard HTTP bridge keys, repeated zero-event failures MUST use the existing durable retry-circuit counter to identify an anchor that should no longer remain addressable; the counter resets on a completed response, so a run of consecutive failures proves the anchor never advanced. Both ambiguous eventless transport classes — `stream_idle_timeout` (including its aliased diagnostics) and `stream_incomplete` — MUST be able to trigger anchor poisoning at the threshold; a `clean_close` outcome MUST NOT itself trigger anchor poisoning. When an eligible eventless failure reaches the configured poison threshold for the same hard bridge key, the proxy MUST abandon durable continuity for that session and retire the bridge even when admission waiters exist, and the shared retirement boundary MUST clear the poisoned durable anchor even when no admission waiter exists, while the session still owns its durable lease. If the clear cannot be confirmed on the waiterless retirement path, the proxy MUST re-attempt it when a later eligible eventless failure at or above the threshold retires the session. The default threshold MUST be no greater than seven failures.
+
+#### Scenario: Admission waiters cannot defer anchor poisoning forever
+
+- **GIVEN** a hard durable bridge key has admission waiters
+- **AND** repeated zero-event idle failures for that same key reach the poison
+  threshold
+- **WHEN** the reader failure path would normally defer retirement for the
+  admission waiter
+- **THEN** the proxy clears the durable continuity anchors
+- **AND** retires the session despite the admission waiter
+- **AND** the next attach starts from fresh durable state rather than the
+  poisoned previous-response anchor
+
+#### Scenario: Repeated eventless stream_incomplete failures poison the anchor
+
+- **GIVEN** a hard durable bridge key has a stored durable anchor
+- **AND** every anchored attempt fails eventlessly with `stream_incomplete` (for example a masked upstream previous-response rejection)
+- **WHEN** consecutive failures for that key reach the poison threshold
+- **THEN** the proxy clears the durable continuity anchors under the session's owner epoch
+- **AND** the next attach starts from fresh durable state instead of looping through retry-circuit cooldown
+
+#### Scenario: Waiterless retirement poisons the anchor at the threshold
+
+- **GIVEN** a hard durable bridge key fails eventlessly with no admission waiters
+- **WHEN** the shared retirement boundary records the eventless failure that reaches the poison threshold
+- **THEN** the proxy clears the durable continuity anchors before releasing the durable lease
+
+#### Scenario: Failed waiterless clear is re-attempted on the next threshold failure
+
+- **GIVEN** the waiterless retirement path reached the poison threshold but the durable continuity clear could not be confirmed
+- **WHEN** the next eligible eventless failure for the same key retires the session
+- **THEN** the proxy re-attempts the durable continuity clear under the new session's owner epoch
+
+#### Scenario: Clean closes never trigger anchor poisoning
+
+- **WHEN** a `clean_close` retry-circuit outcome is recorded for a hard bridge key, at any consecutive-failure count
+- **THEN** that outcome does not clear the durable continuity anchors
+
+#### Scenario: Lease liveness comparison is timezone-safe
+- **GIVEN** a durable bridge session whose `lease_expires_at` was read from a `timestamptz` column (offset-aware) on PostgreSQL
+- **WHEN** the dead-owner classifier evaluates lease liveness against the application's naive-UTC clock
+- **THEN** both timestamps MUST be normalized to naive UTC before comparison
+- **AND** the anchored-lookup path MUST NOT raise on mixed-awareness datetimes

--- a/openspec/changes/classify-bridge-recovery-error-frames/tasks.md
+++ b/openspec/changes/classify-bridge-recovery-error-frames/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## 1. Regression Coverage
+
+- [x] 1.1 Add gate regressions for the terse parameterless ``Invalid `previous_response_id`.`` frame and a frame carrying the classifiable code only in `type`, verifying both misclassify (no recovery) before the fix.
+- [x] 1.2 Add anchor-poison regressions: consecutive eventless `stream_incomplete` reader failures with an admission waiter, and consecutive eventless failures through the shared retirement boundary without waiters, verifying neither poisons the anchor before the fix.
+
+## 2. Classifier Routing
+
+- [x] 2.1 Normalize the error code (falling back to `type`) in the bridge-local previous-response recovery gate before all classification checks, matching the WebSocket rewrite path from `classify-invalid-previous-response-id`.
+
+## 3. Anchor Poison Counting
+
+- [x] 3.1 Map both ambiguous eventless retry-circuit classes (`stream_incomplete`, `stream_idle_timeout` and its aliases) to anchor-poison details; keep `clean_close` excluded.
+- [x] 3.2 Widen the deferred reader-path poison branch to both classes and thread the poison detail into the poisoned-anchor observability events.
+- [x] 3.3 Evaluate the poison threshold at the shared retirement boundary and clear the poisoned durable anchor while the session still owns its durable lease.
+
+## 4. Verification
+
+- [x] 4.1 Run the touched bridge unit and integration suites, ruff, and type checks.
+- [x] 4.2 Run strict OpenSpec validation for this change and review the final diff for unrelated changes.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -27263,7 +27263,7 @@ async def test_http_bridge_eventless_pending_retirement_records_one_retry_circui
         pending_requests=deque([owner]),
         queued_request_count=1,
     )
-    record_failure = AsyncMock()
+    record_failure = AsyncMock(return_value=None)
     monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
     monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
 
@@ -27311,7 +27311,7 @@ async def test_http_bridge_reader_failure_preserves_pre_drain_request_for_retry_
         pending_requests=deque([owner]),
         queued_request_count=1,
     )
-    record_failure = AsyncMock()
+    record_failure = AsyncMock(return_value=None)
     monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
     monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
 
@@ -28651,7 +28651,7 @@ async def test_http_bridge_reader_failure_keeps_waiter_count_when_draining_reque
     )
     session.admission_waiter_count = 1
     fail_pending = AsyncMock()
-    record_failure = AsyncMock()
+    record_failure = AsyncMock(return_value=None)
     monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
     monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
 
@@ -28712,6 +28712,257 @@ async def test_http_bridge_repeated_zero_event_idle_timeouts_poison_anchor_with_
         response_events_seen=0,
         retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_repeated_zero_event_stream_incompletes_poison_anchor_with_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Issue #1830: consecutive eventless ``stream_incomplete`` failures on the
+    # same anchor must count toward anchor poison exactly like idle timeouts,
+    # or a poisoned anchor wedges the session behind the retry circuit forever.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key_value="bridge-anchor-poison-stream-incomplete",
+        pending_requests=deque([_make_eventless_http_bridge_owner()]),
+        queued_request_count=1,
+    )
+    session.admission_waiter_count = 1
+    session.durable_session_id = "durable-anchor-poison-stream-incomplete"
+    session.durable_owner_epoch = 3
+    durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=AsyncMock(),
+        rebind_session_account=AsyncMock(return_value=True),
+    )
+    service._durable_bridge = durable_bridge
+    fail_pending = AsyncMock()
+    retire = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", retire)
+
+    for failure_number in range(1, 8):
+        retired = await service._fail_http_bridge_reader_and_maybe_retire(
+            session,
+            error_code="stream_incomplete",
+            error_message="Upstream websocket closed before response.completed",
+        )
+        assert retired is (failure_number == 7)
+
+    durable_bridge.rebind_session_account.assert_awaited_once_with(
+        session_id="durable-anchor-poison-stream-incomplete",
+        api_key_id=None,
+        instance_id=proxy_service.get_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=3,
+        account_id="acc-bridge",
+        clear_continuity=True,
+    )
+    retire.assert_awaited_once_with(
+        session,
+        detail="repeated_zero_event_stream_incomplete",
+        response_events_seen=0,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retire_stale_pending_poisons_anchor_after_repeated_eventless_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Issue #1830: the shared retirement boundary is the only strike recorder
+    # when a wedged anchored session fails without admission waiters, so it
+    # must clear the poisoned durable anchor once the threshold is reached.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=AsyncMock(),
+        rebind_session_account=AsyncMock(return_value=True),
+    )
+    service._durable_bridge = durable_bridge
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
+
+    for _failure_number in range(7):
+        session = _make_bridge_session(
+            key_value="bridge-anchor-poison-retire",
+            pending_requests=deque([_make_eventless_http_bridge_owner()]),
+            queued_request_count=1,
+        )
+        session.durable_session_id = "durable-anchor-poison-retire"
+        session.durable_owner_epoch = 5
+        await service._retire_stale_pending_http_bridge_session(
+            session,
+            detail="stream_incomplete",
+        )
+
+    durable_bridge.rebind_session_account.assert_awaited_once_with(
+        session_id="durable-anchor-poison-retire",
+        api_key_id=None,
+        instance_id=proxy_service.get_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=5,
+        account_id="acc-bridge",
+        clear_continuity=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A clear that cannot be confirmed must not lose the self-heal: the next
+    # eligible eventless failure at or above the threshold re-attempts it.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=AsyncMock(),
+        rebind_session_account=AsyncMock(return_value=False),
+    )
+    service._durable_bridge = durable_bridge
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
+
+    for _failure_number in range(8):
+        session = _make_bridge_session(
+            key_value="bridge-anchor-poison-clear-retry",
+            pending_requests=deque([_make_eventless_http_bridge_owner()]),
+            queued_request_count=1,
+        )
+        session.durable_session_id = "durable-anchor-poison-clear-retry"
+        session.durable_owner_epoch = 5
+        await service._retire_stale_pending_http_bridge_session(
+            session,
+            detail="stream_incomplete",
+        )
+
+    assert durable_bridge.rebind_session_account.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Issue #1830 product path: an anchored bridge request fails with the terse
+    # parameterless previous-response rejection (classifiable only after code
+    # normalization). The bridge must enter local previous-response recovery
+    # instead of surfacing the failure into the ambiguous-transport class.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "previous_response_id": "resp_stale_anchor",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+        }
+    )
+    session = _make_bridge_session(key_value="sid-terse-recovery")
+    terse_rejection = ProxyResponseError(
+        400,
+        {
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Invalid `previous_response_id`.",
+            }
+        },
+    )
+    get_or_create = AsyncMock(side_effect=[session, session])
+    stream_attempts: list[str | None] = []
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+        request_deadline: float | None = None,
+    ):
+        del queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
+        stream_attempts.append(request_state.previous_response_id)
+        del text_data
+        if len(stream_attempts) == 1:
+            raise terse_rejection
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_http_bridge_local_owner_account_id", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-owner"))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_reset_http_bridge_session_after_local_terminal_error", AsyncMock())
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"session_id": "sid-terse-recovery"},
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert get_or_create.await_count == 2
+    recovery_call = get_or_create.await_args_list[1]
+    assert recovery_call.kwargs["allow_previous_response_recovery_rebind"] is True
+    assert recovery_call.kwargs["request_stage"] == "reattach"
+    assert stream_attempts == ["resp_stale_anchor", "resp_stale_anchor"]
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retire_stale_pending_clean_close_never_poisons_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=AsyncMock(),
+        rebind_session_account=AsyncMock(return_value=True),
+    )
+    service._durable_bridge = durable_bridge
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
+
+    for _failure_number in range(7):
+        session = _make_bridge_session(
+            key_value="bridge-anchor-clean-close",
+            pending_requests=deque([_make_eventless_http_bridge_owner()]),
+            queued_request_count=1,
+        )
+        session.durable_session_id = "durable-anchor-clean-close"
+        session.durable_owner_epoch = 6
+        await service._retire_stale_pending_http_bridge_session(
+            session,
+            detail="stream_incomplete",
+            retry_circuit_detail="clean_close",
+        )
+
+    durable_bridge.rebind_session_account.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -28806,10 +28806,12 @@ async def test_http_bridge_retire_stale_pending_poisons_anchor_after_repeated_ev
 
 @pytest.mark.asyncio
 async def test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # A clear that cannot be confirmed must not lose the self-heal: the next
-    # eligible eventless failure at or above the threshold re-attempts it.
+    # eligible eventless failure at or above the threshold re-attempts it, and
+    # each failed clear stays visible in the poison-clear telemetry.
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     durable_bridge = SimpleNamespace(
         lookup_retry_circuit=AsyncMock(return_value=None),
@@ -28819,20 +28821,22 @@ async def test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear(
     service._durable_bridge = durable_bridge
     monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
 
-    for _failure_number in range(8):
-        session = _make_bridge_session(
-            key_value="bridge-anchor-poison-clear-retry",
-            pending_requests=deque([_make_eventless_http_bridge_owner()]),
-            queued_request_count=1,
-        )
-        session.durable_session_id = "durable-anchor-poison-clear-retry"
-        session.durable_owner_epoch = 5
-        await service._retire_stale_pending_http_bridge_session(
-            session,
-            detail="stream_incomplete",
-        )
+    with caplog.at_level(logging.INFO):
+        for _failure_number in range(8):
+            session = _make_bridge_session(
+                key_value="bridge-anchor-poison-clear-retry",
+                pending_requests=deque([_make_eventless_http_bridge_owner()]),
+                queued_request_count=1,
+            )
+            session.durable_session_id = "durable-anchor-poison-clear-retry"
+            session.durable_owner_epoch = 5
+            await service._retire_stale_pending_http_bridge_session(
+                session,
+                detail="stream_incomplete",
+            )
 
     assert durable_bridge.rebind_session_account.await_count == 2
+    assert caplog.text.count("event=durable_anchor_poison_clear_failed") == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -34997,6 +34997,34 @@ def test_http_bridge_should_attempt_local_previous_response_recovery_invalid_req
     assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(non_recoverable_error) is False
 
 
+def test_http_bridge_should_attempt_local_previous_response_recovery_normalizes_upstream_error_frames():
+    # The terse parameterless rejection classified on the websocket path by
+    # #1818: no ``code``, no ``param``, classifiable only after normalizing
+    # ``type`` into the code slot (issue #1830).
+    terse_parameterless_error = proxy_module.ProxyResponseError(
+        400,
+        {
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Invalid `previous_response_id`.",
+            }
+        },
+    )
+    # Frames that carry the classifiable code only in ``type``.
+    type_only_not_found_error = proxy_module.ProxyResponseError(
+        404,
+        {
+            "error": {
+                "type": "previous_response_not_found",
+                "message": "Previous response with id 'resp_prev_anchor' not found.",
+            }
+        },
+    )
+
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(terse_parameterless_error) is True
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(type_only_not_found_error) is True
+
+
 def test_http_bridge_server_recovery_mode_retries_ambiguous_transport_once(monkeypatch: pytest.MonkeyPatch):
     ambiguous_error = proxy_module.ProxyResponseError(
         502,


### PR DESCRIPTION
## Root cause

Two gaps combined into the permanent "cooling down" 503 wedge documented in #1830 (the acknowledged P3 follow-up from #1818's merge notes):

1. **Bridge-local recovery gate reads raw error codes.** `_http_bridge_should_attempt_local_previous_response_recovery` (`app/modules/proxy/_service/http_bridge/helpers.py`) classified on `error.get("code")` without the `_normalize_error_code(code, type)` fallback the WebSocket rewrite path gained in #1818. A classifiable upstream previous-response rejection whose code rides only in `type` — or the terse parameterless ``Invalid `previous_response_id`.`` frame — fell through to the ambiguous-transport class, so the failure fed the retry circuit instead of anchored recovery.
2. **Anchor poison never counted the wedge's failure class.** Poisoning only triggered on `stream_idle_timeout`, and only on the reader path when admission waiters exist (`upstream_events.py`). The observed wedge fails eventlessly with `stream_incomplete` (the bridge's masked form of an upstream previous-response rejection on bridge request states, which never set `expose_stale_previous_response_classifier`), and the wedge loop retires through the shared retirement boundary (`_retire_stale_pending_http_bridge_session`), which recorded circuit strikes but discarded the count. Result: `http_responses_session_bridge_anchor_poison_failure_threshold` (default 7) never fired, the circuit cooled down forever, and only wiping the `http_bridge_*` tables freed sessions.

## Fix

- Normalize the error code (falling back to `type`) in the bridge-local recovery gate before all classification checks — same normalization convention as `_http_bridge_is_context_overflow_error` directly below it and the WS path from #1818.
- Map both ambiguous eventless transport classes (`stream_incomplete`, and `stream_idle_timeout` incl. its aliases) to anchor-poison details (`retry_circuit.py: _http_bridge_anchor_poison_detail`); `clean_close` never triggers poison.
- Widen the deferred reader-path poison branch to both classes and thread the poison detail through `durable_anchor_poisoned` / `durable_anchor_poison_clear_failed` observability.
- Evaluate the poison threshold at the shared retirement boundary too, clearing the poisoned durable anchor while the session still owns its durable lease, so a wedged anchored session failing **without** admission waiters also self-heals. A clear that cannot be confirmed is re-attempted on the next eligible eventless failure at/above the threshold.

Same-anchor justification: the durable anchor only advances on a completed response, which resets the retry circuit — so N consecutive circuit failures on one bridge key prove the anchor never advanced.

## OpenSpec

`openspec/changes/classify-bridge-recovery-error-frames/` (modifies `responses-api-compat`): gate normalization requirement + widened anchor-poison requirement. `openspec validate classify-bridge-recovery-error-frames --type change --strict` passes.

Note on poison-count composition: the threshold intentionally reuses the existing shared circuit counter (same as the pre-existing `stream_idle_timeout` poison branch). A run mixed with `clean_close` strikes can therefore reach the threshold with fewer eventless failures, but only an eligible eventless failure can *trigger* the clear, the same-anchor invariant holds regardless of class mix (the counter resets on any completed response), and a false-positive clear costs one full-history resend versus the permanent wedge it prevents.

## Test evidence (RED → GREEN)

New regressions, all failing on `main` (d148dd9a4) and passing on this branch:

| Test | On main | Here |
|---|---|---|
| `test_http_bridge_should_attempt_local_previous_response_recovery_normalizes_upstream_error_frames` (terse parameterless + type-only frames) | FAIL (`assert False is True`) | pass |
| `test_stream_via_http_bridge_recovers_terse_previous_response_rejection` (product path: anchored bridge stream, terse rejection → local recovery + retry succeeds) | FAIL (raw 400 propagates) | pass |
| `test_http_bridge_repeated_zero_event_stream_incompletes_poison_anchor_with_waiter` | FAIL (never poisons) | pass |
| `test_http_bridge_retire_stale_pending_poisons_anchor_after_repeated_eventless_failures` (waiterless boundary) | FAIL (rebind never awaited) | pass |
| `test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear` | FAIL (0 clears) | pass |
| `test_http_bridge_retire_stale_pending_clean_close_never_poisons_anchor` (guard) | pass | pass |

Suites: `tests/unit/test_proxy_http_bridge.py` + `tests/unit/test_proxy_utils.py` → 1755 passed, 1 failed (`test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` — pre-existing, fails identically on unmodified main in this environment). `tests/integration/test_http_responses_bridge.py` → 131 passed. `ruff check` / `ruff format --check` / `ty check` clean.

Local `codex review --base origin/main` raised three P2s, addressed as follows: product-path regression added for the gate (`test_stream_via_http_bridge_recovers_terse_previous_response_rejection`), failed-clear re-attempt covered by test + spec, and clean-close count composition documented above (pre-existing shared-counter semantics of the deferred poison branch, trigger-gated by class).

## Issue cover

Fixes #1830

The second, independent deadlock reported there (`operation_already_recorded_no_status_proof` — ghost ledger operation with no status proof) is **not** addressed by this PR; it remains a follow-up. This PR removes the primary wedge (misclassification + unreachable poison threshold) that produced the cooldown loop.

@kvz you offered to test — this branch is `fix/bridge-recovery-error-classification`. Your logged wedge shape (sub-second `stream_incomplete` with all-None diagnostics on the same anchor) should now self-heal at `http_responses_session_bridge_anchor_poison_failure_threshold` consecutive failures (default 7) and classifiable rejections should route into recovery instead of the circuit; we'd love confirmation from your setup with the bridge re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from upstream errors with alternate classification fields and terse rejection messages.
  * Improved handling of repeated incomplete or idle bridge streams, including durable connection cleanup.
  * Prevented cleanly closed connections from being incorrectly marked as poisoned.
  * Added retries and telemetry when durable connection cleanup initially fails.

* **Tests**
  * Added coverage for error recovery, stream failures, connection poisoning, cleanup retries, and clean closures.

* **Documentation**
  * Added specifications and implementation tasks describing bridge recovery and continuity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->