### PR TITLE
fix(proxy): O(1) shared-future admission waits + event-loop lag watchdog

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -484,6 +484,13 @@ class Settings(BaseSettings):
     # (``app/core/resilience/memory_monitor.py`` derives the warning level).
     memory_reject_threshold_mb: int = 0
 
+    # Event-loop lag watchdog (0 = disabled). Samples asyncio.sleep drift once
+    # per second; lag at or above the threshold emits a rate-limited warning
+    # and Prometheus signals (``app/core/resilience/loop_lag_monitor.py``).
+    # Default 0.5s: an order of magnitude above healthy scheduling jitter,
+    # well below the lag that fails 10s-budget health checks.
+    event_loop_lag_warn_threshold_seconds: float = Field(default=0.5, ge=0.0)
+
     # OpenTelemetry
     otel_enabled: bool = False
     otel_exporter_endpoint: str = ""

--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -302,6 +302,17 @@ if PROMETHEUS_AVAILABLE:
         ["outcome"],
         registry=REGISTRY,
     )
+    event_loop_lag_seconds = Gauge(
+        "codex_lb_event_loop_lag_seconds",
+        "Sampled event-loop scheduling lag (asyncio.sleep drift) in seconds",
+        registry=REGISTRY,
+        **({"multiprocess_mode": "livemax"} if MULTIPROCESS_MODE else {}),
+    )
+    event_loop_lag_warnings_total = Counter(
+        "codex_lb_event_loop_lag_warnings_total",
+        "Total event-loop lag samples at or above the warning threshold",
+        registry=REGISTRY,
+    )
     stream_keepalive_sent_total = Counter(
         "codex_lb_stream_keepalive_sent_total",
         "Total downstream SSE keepalive frames emitted by surface",
@@ -385,6 +396,8 @@ else:
     http_bridge_prewarm_total: CounterLike | None = None
     http_bridge_stuck_retire_total: CounterLike | None = None
     http_bridge_retry_circuit_total: CounterLike | None = None
+    event_loop_lag_seconds: GaugeLike | None = None
+    event_loop_lag_warnings_total: CounterLike | None = None
     stream_keepalive_sent_total: CounterLike | None = None
     stream_idle_timeout_total: CounterLike | None = None
     cache_invalidation_bump_failures_total: CounterLike | None = None
@@ -429,6 +442,8 @@ __all__ = [
     "cap_partition_replicas",
     "circuit_breaker_state",
     "continuity_fail_closed_total",
+    "event_loop_lag_seconds",
+    "event_loop_lag_warnings_total",
     "continuity_owner_resolution_total",
     "http_bridge_prewarm_total",
     "http_bridge_retry_circuit_total",

--- a/app/core/resilience/loop_lag_monitor.py
+++ b/app/core/resilience/loop_lag_monitor.py
@@ -1,0 +1,60 @@
+"""Event-loop lag watchdog.
+
+Samples scheduling delay by measuring ``asyncio.sleep`` drift. When the loop
+is starved (a callback storm, synchronous work on the loop, CPU saturation),
+every request and health check degrades at once while per-request logs stay
+quiet: nothing says "the loop itself is busy". The 2026-08-20 incident — an
+``asyncio.shield`` callback storm pinning one core for hours — surfaced only
+as mysterious global slowness and health-check flapping. This monitor turns
+that state into an explicit, rate-limited warning log plus Prometheus
+signals (``codex_lb_event_loop_lag_seconds`` gauge and
+``codex_lb_event_loop_lag_warnings_total`` counter) so operators and alerts
+can distinguish "loop starved" from "upstream slow".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from app.core.metrics import prometheus as prometheus_metrics
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_INTERVAL_SECONDS = 1.0
+# One warning line per window at most; the gauge/counter stay per-sample. The
+# worst lag seen inside a suppressed window is carried into the next line so
+# suppression never hides the magnitude of a spike.
+_WARN_LOG_INTERVAL_SECONDS = 60.0
+
+
+async def run_event_loop_lag_monitor(*, warn_threshold_seconds: float) -> None:
+    """Sample loop lag forever; the caller owns and cancels the task."""
+    last_warn_monotonic = float("-inf")
+    worst_suppressed_lag = 0.0
+    while True:
+        started = time.monotonic()
+        await asyncio.sleep(_SAMPLE_INTERVAL_SECONDS)
+        lag = max(0.0, time.monotonic() - started - _SAMPLE_INTERVAL_SECONDS)
+        gauge = prometheus_metrics.event_loop_lag_seconds
+        if gauge is not None:
+            gauge.set(lag)
+        if lag < warn_threshold_seconds:
+            continue
+        counter = prometheus_metrics.event_loop_lag_warnings_total
+        if counter is not None:
+            counter.inc()
+        now = time.monotonic()
+        if now - last_warn_monotonic < _WARN_LOG_INTERVAL_SECONDS:
+            worst_suppressed_lag = max(worst_suppressed_lag, lag)
+            continue
+        logger.warning(
+            "event_loop_lag lag_seconds=%.3f worst_suppressed_seconds=%.3f threshold_seconds=%.3f "
+            "(event loop starved: callback storm, sync work on the loop, or CPU saturation)",
+            lag,
+            worst_suppressed_lag,
+            warn_threshold_seconds,
+        )
+        last_warn_monotonic = now
+        worst_suppressed_lag = 0.0

--- a/app/core/utils/shared_future.py
+++ b/app/core/utils/shared_future.py
@@ -1,0 +1,80 @@
+"""Await shared futures without per-waiter callbacks on the shared object.
+
+``asyncio.wait_for(asyncio.shield(shared), timeout)`` attaches done callbacks
+to ``shared`` for every waiter and removes them with O(n) list scans when a
+waiter is cancelled or times out. With many waiters piled onto one long-lived
+future (the http-bridge inflight/capacity registries, refresh singleflight),
+a mass timeout turns the event loop into an O(N^2) callback grinder. Python
+3.14's ``shield`` additionally leaks one ``_clear_awaited_by_callback`` per
+attempt onto the still-pending future, so each retry cycle makes every later
+scan more expensive. In the 2026-08-20 production incident this starved the
+event loop for hours (98% of GIL samples inside ``Future.remove_done_callback``)
+with zero client sessions attached.
+
+``wait_on_shared_future`` keeps exactly one fan-out callback on the shared
+future regardless of waiter count. Each waiter awaits its own single-use proxy
+future, so waiter timeout and cancellation are O(1) set operations that never
+touch the shared future's callback list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+_WAITERS_ATTR = "_shared_future_fanout_waiters"
+
+
+def _fan_out(shared: "asyncio.Future[_T]", waiters: "set[asyncio.Future[_T]]") -> None:
+    for waiter in waiters:
+        if waiter.done():
+            continue
+        if shared.cancelled():
+            waiter.cancel()
+            continue
+        exc = shared.exception()
+        if exc is not None:
+            waiter.set_exception(exc)
+            # Consume eagerly: a waiter whose task was cancelled between this
+            # fan-out and its resumption would otherwise log
+            # "exception was never retrieved" from the proxy destructor.
+            waiter.exception()
+        else:
+            waiter.set_result(shared.result())
+    waiters.clear()
+
+
+async def wait_on_shared_future(
+    shared: "asyncio.Future[_T]",
+    *,
+    timeout: float | None = None,
+) -> _T:
+    """Drop-in equivalent of ``wait_for(shield(shared), timeout)`` for futures
+    awaited by many concurrent waiters.
+
+    - ``shared``'s result, exception, or cancellation propagates to every
+      waiter exactly as with ``shield``.
+    - ``timeout`` raises ``TimeoutError``; ``shared`` is never cancelled or
+      otherwise mutated by a waiter timing out or being cancelled.
+    - Cancelling the awaiting task detaches its proxy in O(1) and leaves
+      ``shared`` (and the work it represents) running.
+    """
+    if shared.done():
+        return shared.result()
+    waiters: set[asyncio.Future[_T]] | None = getattr(shared, _WAITERS_ATTR, None)
+    if waiters is None:
+        # No await between the ``done()`` check above and this registration,
+        # so the fan-out callback cannot have fired with an empty set.
+        waiters = set()
+        setattr(shared, _WAITERS_ATTR, waiters)
+        shared.add_done_callback(lambda done, _waiters=waiters: _fan_out(done, _waiters))
+    proxy: asyncio.Future[_T] = asyncio.get_running_loop().create_future()
+    waiters.add(proxy)
+    try:
+        if timeout is None:
+            return await proxy
+        return await asyncio.wait_for(proxy, timeout)
+    finally:
+        waiters.discard(proxy)

--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,7 @@ from app.core.middleware.inflight import InFlightMiddleware
 from app.core.openai.model_refresh_scheduler import build_model_refresh_scheduler
 from app.core.resilience.backpressure import BackpressureMiddleware
 from app.core.resilience.bulkhead import BulkheadMiddleware, get_bulkhead
+from app.core.resilience.loop_lag_monitor import run_event_loop_lag_monitor
 from app.core.resilience.memory_monitor import configure as configure_memory_monitor
 from app.core.retention.scheduler import build_data_retention_scheduler
 from app.core.scheduling.leader_election import get_leader_election
@@ -607,6 +608,13 @@ async def lifespan(app: FastAPI):
     ring_service = RingMembershipService(SessionLocal)
     instance_id = settings.http_responses_session_bridge_instance_id
     heartbeat_task = asyncio.create_task(_register_and_heartbeat(ring_service, instance_id))
+    loop_lag_task: asyncio.Task[None] | None = None
+    if settings.event_loop_lag_warn_threshold_seconds > 0:
+        loop_lag_task = asyncio.create_task(
+            run_event_loop_lag_monitor(
+                warn_threshold_seconds=settings.event_loop_lag_warn_threshold_seconds,
+            )
+        )
     startup_module._startup_complete = True
 
     try:
@@ -662,6 +670,13 @@ async def lifespan(app: FastAPI):
             heartbeat_task.cancel()
             try:
                 await asyncio.wait_for(heartbeat_task, timeout=2)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
+
+        if loop_lag_task is not None:
+            loop_lag_task.cancel()
+            try:
+                await asyncio.wait_for(loop_lag_task, timeout=2)
             except (asyncio.CancelledError, TimeoutError):
                 pass
 

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -30,6 +30,7 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
+from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountProxyBinding, AccountStatus
 from app.db.session import get_background_session
@@ -196,7 +197,12 @@ class _RefreshSingleflight:
                 self._inflight[key] = task
                 task.add_done_callback(lambda done, *, cache_key=key: self._schedule_complete(cache_key, done))
         assert task is not None
-        return await asyncio.shield(task)
+        # Not asyncio.shield: shield attaches per-waiter callbacks to the
+        # shared singleflight task, which degrades to O(N^2) removal scans
+        # when piled-up waiters are cancelled (see shared_future.py). The
+        # helper preserves shield semantics: a cancelled waiter detaches
+        # without aborting the refresh.
+        return await wait_on_shared_future(task)
 
     def _schedule_complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:
         asyncio.create_task(self._complete(key, task))
@@ -291,9 +297,9 @@ class AuthManager:
     async def _run_refresh(self, account: Account) -> Account:
         """Singleflight body for token refresh.
 
-        Runs inside a detached task that the singleflight keeps alive with
-        ``asyncio.shield`` (so concurrent waiters share one refresh and a
-        cancelled waiter does not abort it). Because the task outlives the
+        Runs inside a detached task that the singleflight keeps alive via
+        ``wait_on_shared_future`` (so concurrent waiters share one refresh and
+        a cancelled waiter does not abort it). Because the task outlives the
         caller, it MUST NOT use the caller's request-scoped session: when a
         client disconnects, the caller is cancelled and its
         ``async with get_background_session()`` closes that session, while this

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -46,6 +46,7 @@ from app.core.metrics.prometheus import (
     bridge_soft_local_rebind_total,
 )
 from app.core.utils.request_id import ensure_request_scope_id
+from app.core.utils.shared_future import wait_on_shared_future
 from app.db.models import (
     AccountStatus,
     StickySessionKind,
@@ -1365,8 +1366,11 @@ class _HTTPBridgeMixin(
             if capacity_wait_future is not None:
                 wait_timeout_seconds = _proxy_admission_wait_timeout_seconds(settings)
                 try:
-                    await asyncio.wait_for(
-                        asyncio.shield(capacity_wait_future),
+                    # Not wait_for(shield(...)): shield attaches per-waiter
+                    # callbacks to the shared registry future, which livelocks
+                    # the event loop under mass timeout (see shared_future.py).
+                    await wait_on_shared_future(
+                        capacity_wait_future,
                         timeout=wait_timeout_seconds,
                     )
                 except asyncio.CancelledError:
@@ -1396,8 +1400,11 @@ class _HTTPBridgeMixin(
             if inflight_future is not None and not owns_creation:
                 wait_timeout_seconds = _proxy_admission_wait_timeout_seconds(settings)
                 try:
-                    session = await asyncio.wait_for(
-                        asyncio.shield(inflight_future),
+                    # Not wait_for(shield(...)): shield attaches per-waiter
+                    # callbacks to the shared registry future, which livelocks
+                    # the event loop under mass timeout (see shared_future.py).
+                    session = await wait_on_shared_future(
+                        inflight_future,
                         timeout=wait_timeout_seconds,
                     )
                 except asyncio.CancelledError:

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 130 settings. Every setting is an environment
+codex-lb currently exposes 131 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -251,6 +251,7 @@ the host side of the compose `ports` mapping instead.
 
 | Environment variable | Type | Default |
 | --- | --- | --- |
+| `CODEX_LB_EVENT_LOOP_LAG_WARN_THRESHOLD_SECONDS` | `float` | `0.5` |
 | `CODEX_LB_TELEMETRY_ENABLED` | `bool \| None` | `None` |
 | `CODEX_LB_TELEMETRY_ENDPOINT` | `str` | `'https://telemetry.tokmaxxing.com'` |
 | `CODEX_LB_TIMEOUT_INVARIANT_VALIDATION_STRICT` | `bool` | `False` |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -323,4 +323,4 @@ issue [#1340](https://github.com/Soju06/codex-lb/issues/1340)):
 
 ---
 
-*Specs: [user-documentation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · [responses-api-compat](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat) · [rate-limit-reset-credits](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/rate-limit-reset-credits) · [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*
+*Specs: [user-documentation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · [responses-api-compat](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat) · [rate-limit-reset-credits](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/rate-limit-reset-credits) · [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation) · [proxy-runtime-observability](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/proxy-runtime-observability)*

--- a/openspec/changes/harden-shared-future-admission-waits/proposal.md
+++ b/openspec/changes/harden-shared-future-admission-waits/proposal.md
@@ -1,0 +1,48 @@
+# Harden shared-future admission waits and surface event-loop lag
+
+## Why
+
+On 2026-08-20 a production instance livelocked: the event loop spent ~98% of
+its CPU inside `asyncio.Future.remove_done_callback` and kept grinding at full
+CPU with zero client sessions attached. Admission waiters were piling onto
+shared registry futures via `asyncio.wait_for(asyncio.shield(...))`, which
+attaches per-waiter callbacks to the shared future and removes them with O(n)
+scans; on Python 3.14 `shield` additionally leaks one callback per attempt
+onto a still-pending future, so mass timeouts and client-disconnect storms
+degrade to O(n²) and starve the loop. The outage surfaced only as global
+slowness and health-check flapping — no signal said "the event loop itself is
+starved", which stretched diagnosis by hours.
+
+## What Changes
+
+- Replace `wait_for(shield(shared))` on shared, many-waiter futures (http-bridge
+  inflight/capacity registries, token-refresh singleflight) with a fan-out
+  helper that keeps exactly one callback on the shared future and gives each
+  waiter a private O(1)-detach proxy future. Wait semantics (result/exception/
+  cancellation propagation, timeout contract, waiter cancellation isolation)
+  are unchanged.
+- Add an event-loop lag watchdog: a once-per-second sampler that exports
+  `codex_lb_event_loop_lag_seconds` / `codex_lb_event_loop_lag_warnings_total`
+  and emits a rate-limited warning log when scheduling lag crosses a threshold.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: admission waits on shared futures must not attach
+  per-waiter callbacks to the shared object.
+- `proxy-runtime-observability`: event-loop scheduling lag is an explicit
+  operator signal (metrics + rate-limited warning log).
+
+## Impact
+
+- `app/core/utils/shared_future.py` (new helper), `app/modules/proxy/_service/http_bridge/mixin.py`,
+  `app/modules/accounts/auth_manager.py` (call-site swaps; no behavior change).
+- `app/core/resilience/loop_lag_monitor.py` (new watchdog),
+  `app/core/metrics/prometheus.py`, `app/main.py`,
+  `app/core/config/settings.py` (`event_loop_lag_warn_threshold_seconds`,
+  default 0.5s, `0` disables; zero-config — no operator action needed).

--- a/openspec/changes/harden-shared-future-admission-waits/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/harden-shared-future-admission-waits/specs/proxy-admission-control/spec.md
@@ -6,11 +6,15 @@ When multiple requests wait on one shared future (an inflight bridge session
 creation, a capacity slot, or a token-refresh singleflight), attaching a
 waiter, a waiter timing out, and a waiter being cancelled MUST each perform
 O(1) work on the shared future. The shared future MUST carry a constant number
-of done callbacks regardless of waiter count, and a waiter's timeout or
-cancellation MUST NOT cancel or otherwise mutate the shared future or the work
-it represents. The shared future's result, exception, or cancellation MUST
-propagate to every waiter with the same semantics as
-`asyncio.wait_for(asyncio.shield(shared), timeout)`.
+of done callbacks regardless of waiter count, and the wait mechanism itself
+MUST NOT cancel or otherwise mutate the shared future or the work it
+represents when a waiter times out or is cancelled. Admission handlers MAY
+still settle the shared future explicitly after a waiter's timeout (the
+http-bridge timeout handler fails and unregisters the inflight future so
+piled-up waiters converge on one overload outcome); that settlement is an
+admission-contract decision, not a side effect of waiting. The shared future's
+result, exception, or cancellation MUST propagate to every waiter with the
+same semantics as `asyncio.wait_for(asyncio.shield(shared), timeout)`.
 
 #### Scenario: Waiter pile-up keeps the shared future's callback list constant
 

--- a/openspec/changes/harden-shared-future-admission-waits/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/harden-shared-future-admission-waits/specs/proxy-admission-control/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Admission waits on shared futures scale O(1) per waiter
+
+When multiple requests wait on one shared future (an inflight bridge session
+creation, a capacity slot, or a token-refresh singleflight), attaching a
+waiter, a waiter timing out, and a waiter being cancelled MUST each perform
+O(1) work on the shared future. The shared future MUST carry a constant number
+of done callbacks regardless of waiter count, and a waiter's timeout or
+cancellation MUST NOT cancel or otherwise mutate the shared future or the work
+it represents. The shared future's result, exception, or cancellation MUST
+propagate to every waiter with the same semantics as
+`asyncio.wait_for(asyncio.shield(shared), timeout)`.
+
+#### Scenario: Waiter pile-up keeps the shared future's callback list constant
+
+- **WHEN** many requests wait on the same inflight bridge-session future
+- **THEN** the shared future carries a constant number of done callbacks
+- **AND** the callback count does not grow with the number of waiters
+
+#### Scenario: Mass timeout does not degrade the event loop
+
+- **GIVEN** waiters piled onto a shared future that has not resolved within
+  the admission wait timeout
+- **WHEN** the waiters time out together
+- **THEN** each timeout detaches in O(1) without scanning the shared future's
+  callback list
+- **AND** the surviving admission contract (local-overload `429` with the
+  capacity error code) is unchanged
+
+#### Scenario: Client-disconnect storm leaves the owner's creation running
+
+- **WHEN** every waiter on an inflight session future is cancelled by client
+  disconnects
+- **THEN** the shared future stays pending and the owner's session creation
+  continues
+- **AND** no per-waiter callbacks remain attached to the shared future

--- a/openspec/changes/harden-shared-future-admission-waits/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/harden-shared-future-admission-waits/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Event-loop scheduling lag is observable
+
+The system MUST sample event-loop scheduling lag (timer drift of a
+once-per-second sleep) while serving and export it as the
+`codex_lb_event_loop_lag_seconds` gauge. Samples at or above the configured
+warning threshold MUST increment `codex_lb_event_loop_lag_warnings_total` and
+emit a warning log that names the observed lag, the worst lag suppressed since
+the previous line, and the threshold; the warning log MUST be rate-limited so
+a sustained stall cannot flood the log. The threshold MUST be configurable via
+`event_loop_lag_warn_threshold_seconds` with a working default requiring no
+operator action, and `0` MUST disable the watchdog.
+
+#### Scenario: Starved event loop produces an explicit operator signal
+
+- **WHEN** the event loop is starved (callback storm, synchronous work on the
+  loop, or CPU saturation) and scheduling lag reaches the warning threshold
+- **THEN** `codex_lb_event_loop_lag_warnings_total` increments
+- **AND** a rate-limited `event_loop_lag` warning names the observed lag and
+  threshold, distinguishing loop starvation from upstream slowness
+
+#### Scenario: Healthy loop stays quiet
+
+- **WHEN** scheduling lag stays below the warning threshold
+- **THEN** the gauge is still updated for dashboards
+- **AND** no warning is logged and the warning counter does not increment
+
+#### Scenario: Watchdog can be disabled
+
+- **WHEN** `event_loop_lag_warn_threshold_seconds` is set to `0`
+- **THEN** the watchdog task is not started

--- a/openspec/changes/harden-shared-future-admission-waits/tasks.md
+++ b/openspec/changes/harden-shared-future-admission-waits/tasks.md
@@ -1,0 +1,18 @@
+## 1. Shared-future waiter fan-out
+
+- [x] 1.1 Add `wait_on_shared_future` (`app/core/utils/shared_future.py`): one fan-out callback on the shared future, per-waiter proxy futures with O(1) attach/detach, `wait_for(shield())`-equivalent semantics.
+- [x] 1.2 Swap the http-bridge admission wait sites (inflight session future, capacity wait future) in `app/modules/proxy/_service/http_bridge/mixin.py` to the helper.
+- [x] 1.3 Swap the token-refresh singleflight wait in `app/modules/accounts/auth_manager.py` to the helper.
+
+## 2. Event-loop lag watchdog
+
+- [x] 2.1 Add `app/core/resilience/loop_lag_monitor.py`: 1s sleep-drift sampler, gauge + counter export, rate-limited warning log.
+- [x] 2.2 Register `codex_lb_event_loop_lag_seconds` and `codex_lb_event_loop_lag_warnings_total` in `app/core/metrics/prometheus.py` (both branches + `__all__`).
+- [x] 2.3 Wire the monitor task into the app lifespan (`app/main.py`) behind `event_loop_lag_warn_threshold_seconds` (default 0.5, `0` disables), cancelled on shutdown.
+
+## 3. Verification
+
+- [x] 3.1 Helper semantics tests (`tests/unit/test_shared_future_waiters.py`): result/exception/cancellation propagation, timeout leaves shared pending, mass-timeout keeps callback count at 1, waiter cancellation isolation, singleflight task survival.
+- [x] 3.2 Bridge-surface regression test (`tests/unit/test_proxy_http_bridge.py::test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_future`): 50 admission waiters on one inflight future keep exactly one shared callback through a cancellation storm and mass timeout; verified to fail against the old shield pattern.
+- [x] 3.3 Watchdog tests (`tests/unit/test_loop_lag_monitor.py`): starved loop warns + increments counter, healthy loop stays quiet, warning log rate-limited.
+- [x] 3.4 Run affected unit suites, ruff, and strict OpenSpec validation.

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -265,7 +265,9 @@ def render_settings_reference() -> str:
             "[rate-limit-reset-credits]"
             "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/rate-limit-reset-credits) · "
             "[deployment-installation]"
-            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*",
+            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation) · "
+            "[proxy-runtime-observability]"
+            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/proxy-runtime-observability)*",
             "",
         ]
     )

--- a/tests/unit/test_loop_lag_monitor.py
+++ b/tests/unit/test_loop_lag_monitor.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from app.core.resilience import loop_lag_monitor
+
+pytestmark = pytest.mark.unit
+
+
+class _StubGauge:
+    def __init__(self) -> None:
+        self.values: list[float] = []
+
+    def set(self, value: float) -> None:
+        self.values.append(value)
+
+
+class _StubCounter:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def inc(self, amount: float = 1) -> None:
+        self.count += amount
+
+
+@pytest.fixture
+def stub_metrics(monkeypatch):
+    gauge = _StubGauge()
+    counter = _StubCounter()
+    monkeypatch.setattr(loop_lag_monitor.prometheus_metrics, "event_loop_lag_seconds", gauge)
+    monkeypatch.setattr(loop_lag_monitor.prometheus_metrics, "event_loop_lag_warnings_total", counter)
+    monkeypatch.setattr(loop_lag_monitor, "_SAMPLE_INTERVAL_SECONDS", 0.01)
+    return gauge, counter
+
+
+async def _run_monitor_briefly(*, warn_threshold_seconds: float, block_seconds: float) -> asyncio.Task[None]:
+    task = asyncio.create_task(
+        loop_lag_monitor.run_event_loop_lag_monitor(warn_threshold_seconds=warn_threshold_seconds)
+    )
+    # Let the monitor enter its first sleep, then starve the loop synchronously
+    # so the sleep resumes late — exactly what a callback storm looks like.
+    await asyncio.sleep(0)
+    if block_seconds:
+        time.sleep(block_seconds)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+async def test_starved_loop_emits_warning_and_metrics(stub_metrics, caplog):
+    gauge, counter = stub_metrics
+    with caplog.at_level(logging.WARNING, logger=loop_lag_monitor.logger.name):
+        await _run_monitor_briefly(warn_threshold_seconds=0.05, block_seconds=0.15)
+    assert any(v >= 0.05 for v in gauge.values)
+    assert counter.count >= 1
+    assert any("event_loop_lag" in record.message for record in caplog.records)
+
+
+async def test_healthy_loop_stays_quiet(stub_metrics, caplog):
+    gauge, counter = stub_metrics
+    with caplog.at_level(logging.WARNING, logger=loop_lag_monitor.logger.name):
+        await _run_monitor_briefly(warn_threshold_seconds=0.5, block_seconds=0.0)
+    assert gauge.values, "gauge should be sampled even when healthy"
+    assert counter.count == 0
+    assert not [r for r in caplog.records if "event_loop_lag" in r.message]
+
+
+async def test_warning_log_is_rate_limited(stub_metrics, caplog):
+    _, counter = stub_metrics
+    task = asyncio.create_task(loop_lag_monitor.run_event_loop_lag_monitor(warn_threshold_seconds=0.05))
+    with caplog.at_level(logging.WARNING, logger=loop_lag_monitor.logger.name):
+        await asyncio.sleep(0)
+        time.sleep(0.1)
+        await asyncio.sleep(0.05)
+        time.sleep(0.1)
+        await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    warning_lines = [r for r in caplog.records if "event_loop_lag" in r.message]
+    assert len(warning_lines) == 1, "second spike within the window must be suppressed"
+    assert counter.count >= 2, "counter still tracks every over-threshold sample"

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -31199,3 +31199,71 @@ async def test_settle_failed_creation_releases_a_row_rebound_away_from_the_winne
     # will be fenced on its next renewal and retry cleanly.
     assert superseded is False
     assert winner.durable_owner_epoch == 4
+
+
+@pytest.mark.asyncio
+async def test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_future(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the 2026-08-20 event-loop livelock: admission waiters
+    piling onto the shared inflight future must not attach per-waiter
+    callbacks. The old ``wait_for(asyncio.shield(...))`` pattern left
+    O(waiters) callbacks on the registry future (Python 3.14 shield never
+    removes ``_clear_awaited_by_callback`` on waiter cancellation) and paid
+    O(n) removal scans per timeout, so a mass timeout ground the event loop
+    at O(n^2)."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    # prompt_cache_key keeps the canonical key: session_header requests
+    # without turn state are rewritten to per-request parallel fork keys and
+    # never share the inflight future.
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "bridge-waiter-pileup", None)
+    inflight: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+    setattr(
+        inflight,
+        http_bridge_mixin_module._HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
+        time.monotonic(),
+    )
+    service._http_bridge_inflight_sessions[key] = inflight
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.2)
+
+    async def _single_instance_ring(settings: Any, ring_membership: Any = None) -> tuple[str, tuple[str, ...]]:
+        return "local-instance", ("local-instance",)
+
+    monkeypatch.setattr(proxy_service, "_active_http_bridge_instance_ring", _single_instance_ring)
+
+    async def _wait_once() -> Any:
+        return await service._get_or_create_http_bridge_session(
+            key,
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key="bridge-waiter-pileup"),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+        )
+
+    waiters = [asyncio.create_task(_wait_once()) for _ in range(50)]
+    await asyncio.sleep(0.05)
+    assert not inflight.done()
+    callbacks = getattr(inflight, "_callbacks", None)
+    assert callbacks is not None and len(callbacks) == 1, (
+        f"admission waiters must share one fan-out callback on the inflight future, found "
+        f"{None if callbacks is None else len(callbacks)}"
+    )
+
+    # Client-disconnect storm: cancelling waiters must leave the shared future
+    # pending (the owner's creation continues) and leak no callbacks.
+    for waiter in waiters[:25]:
+        waiter.cancel()
+    cancelled = await asyncio.gather(*waiters[:25], return_exceptions=True)
+    assert all(isinstance(result, asyncio.CancelledError) for result in cancelled)
+    assert not inflight.done()
+    callbacks = getattr(inflight, "_callbacks", None)
+    assert callbacks is not None and len(callbacks) == 1
+
+    # The surviving waiters time out: the first to fire fails the shared
+    # future for the rest with the local-overload contract error.
+    remaining = await asyncio.gather(*waiters[25:], return_exceptions=True)
+    assert all(isinstance(result, ProxyResponseError) and result.status_code == 429 for result in remaining)
+    assert key not in service._http_bridge_inflight_sessions

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -69,7 +69,7 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 # operator-selectable because startup invariant failures need two supported
 # modes: report-only by default for mixed/self-hosted environments, and
 # fail-fast when CI or strict operators want config drift to abort startup.
-MAX_SETTINGS_FIELDS = 130
+MAX_SETTINGS_FIELDS = 131
 
 
 def test_generated_settings_reference_matches_code() -> None:

--- a/tests/unit/test_shared_future_waiters.py
+++ b/tests/unit/test_shared_future_waiters.py
@@ -1,0 +1,136 @@
+"""Regression tests for the shared-future waiter helper.
+
+The helper replaces ``wait_for(shield(shared))`` on futures awaited by many
+concurrent waiters (http-bridge inflight/capacity registries, token-refresh
+singleflight). The structural invariant under test: no matter how many
+waiters attach, time out, or are cancelled, the shared future carries exactly
+one done callback and no leaked per-waiter state. Under the old shield
+pattern each waiter attached callbacks to the shared future and removed them
+with O(n) scans — a mass timeout livelocked the event loop (2026-08-20
+production incident).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core.utils.shared_future import _WAITERS_ATTR, wait_on_shared_future
+
+pytestmark = pytest.mark.unit
+
+
+def _callback_count(future: asyncio.Future) -> int | None:
+    callbacks = getattr(future, "_callbacks", None)
+    if callbacks is None:
+        return None
+    return len(callbacks)
+
+
+async def test_result_propagates_to_all_waiters():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    waiters = [asyncio.create_task(wait_on_shared_future(shared, timeout=5)) for _ in range(10)]
+    await asyncio.sleep(0)
+    shared.set_result("session")
+    assert await asyncio.gather(*waiters) == ["session"] * 10
+
+
+async def test_exception_propagates_to_all_waiters():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    waiters = [asyncio.create_task(wait_on_shared_future(shared, timeout=5)) for _ in range(4)]
+    await asyncio.sleep(0)
+    shared.set_exception(RuntimeError("creation failed"))
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+    assert all(isinstance(r, RuntimeError) and str(r) == "creation failed" for r in results)
+
+
+async def test_shared_cancellation_cancels_waiters():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    waiters = [asyncio.create_task(wait_on_shared_future(shared, timeout=5)) for _ in range(4)]
+    await asyncio.sleep(0)
+    shared.cancel()
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+    assert all(isinstance(r, asyncio.CancelledError) for r in results)
+
+
+async def test_timeout_raises_and_leaves_shared_pending():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    with pytest.raises(TimeoutError):
+        await wait_on_shared_future(shared, timeout=0.01)
+    assert not shared.done()
+    assert not shared.cancelled()
+    # The owner can still complete the creation after waiters gave up.
+    shared.set_result("late")
+    assert await wait_on_shared_future(shared) == "late"
+
+
+async def test_mass_timeout_does_not_accumulate_callbacks_on_shared():
+    """The incident shape: many waiters piling onto one pending future and
+    timing out together must leave the shared future's callback list at its
+    constant size (one fan-out callback), not one-or-more per waiter."""
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    for _ in range(3):  # repeated retry rounds, as in the admission loop
+        waiters = [asyncio.create_task(wait_on_shared_future(shared, timeout=0.01)) for _ in range(200)]
+        results = await asyncio.gather(*waiters, return_exceptions=True)
+        assert all(isinstance(r, TimeoutError) for r in results)
+    count = _callback_count(shared)
+    if count is not None:
+        assert count == 1
+    assert getattr(shared, _WAITERS_ATTR) == set()
+    assert not shared.done()
+    shared.cancel()
+
+
+async def test_cancelling_one_waiter_leaves_others_and_shared_intact():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    victim = asyncio.create_task(wait_on_shared_future(shared, timeout=5))
+    survivor = asyncio.create_task(wait_on_shared_future(shared, timeout=5))
+    await asyncio.sleep(0)
+    victim.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await victim
+    assert not shared.done()
+    shared.set_result("session")
+    assert await survivor == "session"
+
+
+async def test_done_shared_returns_immediately():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    shared.set_result("cached")
+    assert await wait_on_shared_future(shared, timeout=0.01) == "cached"
+
+    failed: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    failed.set_exception(RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        await wait_on_shared_future(failed)
+
+
+async def test_late_waiter_after_fan_out_gets_result():
+    shared: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    first = asyncio.create_task(wait_on_shared_future(shared, timeout=5))
+    await asyncio.sleep(0)
+    shared.set_result("session")
+    assert await first == "session"
+    # Fan-out already ran and cleared the waiter set; a late waiter must not
+    # hang on the emptied set.
+    assert await wait_on_shared_future(shared, timeout=0.01) == "session"
+
+
+async def test_shared_task_keeps_running_when_all_waiters_cancel():
+    """Singleflight semantics: waiter cancellation must not abort the work."""
+    finished = asyncio.Event()
+
+    async def _work() -> str:
+        await asyncio.sleep(0.05)
+        finished.set()
+        return "refreshed"
+
+    task = asyncio.create_task(_work())
+    waiter = asyncio.create_task(wait_on_shared_future(task))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert await task == "refreshed"
+    assert finished.is_set()


### PR DESCRIPTION
## Why

2026-08-20 production incident (soju07): the serving instance livelocked — the event loop burned ~100% CPU for hours **with zero client sessions attached**. py-spy GIL profiling showed 98% of samples (589/599) inside `asyncio.shield`'s `_outer_done_callback`, i.e. `Future.remove_done_callback` O(n) scans (`asyncio/tasks.py:996/998` on CPython 3.14). Externally this surfaced only as global slowness (13.6s `/v1/models`, 4–6s static assets), `/health/ready` 503s, and HAProxy DOWN/UP flapping.

### Mechanism

Admission waiters piled onto **shared registry futures** via `asyncio.wait_for(asyncio.shield(shared))`:

- every waiter attaches callbacks to the shared future; Python 3.14's `shield` attaches **three** per call and **leaks one** (`_clear_awaited_by_callback`) when the waiter is cancelled while the future is pending,
- waiter timeout/cancellation pays an O(n) `remove_done_callback` scan over that growing list,
- mass timeouts / client-disconnect storms therefore degrade to **O(n²)** and starve the loop, which slows creations further, piles more waiters, and self-sustains.

Measured on CPython 3.14 (2,000 waiters × 5 timeout rounds on one pending future):

| pattern | wall time | callbacks left on the shared future |
|---|---|---|
| `wait_for(shield())` | 3.589s | **10,001 (leaked)** |
| `wait_on_shared_future` | 0.511s | **1** |

## What

1. **`app/core/utils/shared_future.py`** — `wait_on_shared_future(shared, timeout=)`: one fan-out callback on the shared future regardless of waiter count; each waiter awaits a private proxy future, so attach/timeout/cancel are O(1) set ops. Semantics identical to `wait_for(shield(shared), timeout)` (result/exception/cancellation propagation, timeout leaves the shared future untouched, waiter cancellation never aborts the shared work).
2. **Call-site swaps** (no behavior change): http-bridge inflight-session wait, capacity wait (`mixin.py`), token-refresh singleflight (`auth_manager.py`). Per-task `shield` uses (close/release/drain paths) are single-waiter and left as-is.
3. **Prevention — event-loop lag watchdog** (`app/core/resilience/loop_lag_monitor.py`): 1s sleep-drift sampler exporting `codex_lb_event_loop_lag_seconds` (gauge) and `codex_lb_event_loop_lag_warnings_total` (counter) plus a rate-limited `event_loop_lag` warning. This incident produced no direct signal that the loop itself was starved; this makes that state alertable and cuts future diagnosis from hours to one log line.

## Settings justification (simplicity gate)

`event_loop_lag_warn_threshold_seconds` (default **0.5s**, `0` disables) — zero-config: the default works without operator action. It is a setting rather than a constant because the meaningful threshold scales with host CPU class (this incident's host is a 2-core Neoverse-N1; larger hosts may want a tighter bound), and operators need a supported off-switch for constrained environments. No `.env.example` or README changes.

## OpenSpec

`openspec/changes/harden-shared-future-admission-waits/` — deltas for `proxy-admission-control` (O(1) shared-future waits) and `proxy-runtime-observability` (loop-lag signal). `openspec validate harden-shared-future-admission-waits --strict` passes.

## Tests

- `tests/unit/test_shared_future_waiters.py` — helper semantics: propagation (result/exception/cancel), timeout leaves shared pending, mass-timeout keeps callback count at exactly 1 across retry rounds, waiter-cancellation isolation, singleflight task survival.
- `tests/unit/test_proxy_http_bridge.py::test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_future` — **bridge-surface regression at the failing path**: 50 admission waiters on one inflight future keep exactly one shared callback through a 25-waiter cancellation storm and a mass timeout (429 `capacity_exhausted_active_sessions` contract preserved). Verified to **fail against the old shield pattern** (callback count 4 > 1 within 50ms of pile-up).
- `tests/unit/test_loop_lag_monitor.py` — starved loop warns + increments counter, healthy loop quiet, warning log rate-limited.
- Full `tests/unit/test_proxy_http_bridge.py`: 634 passed, 1 failed — `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` fails identically on clean `origin/main` (pre-existing, unrelated).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-loop lag monitoring with configurable warning thresholds.
  * Added Prometheus metrics for scheduling lag and threshold breaches.
  * Set the default warning threshold to 0.5 seconds; setting it to 0 disables monitoring.
* **Reliability Improvements**
  * Improved shared-operation handling so individual timeouts or cancellations do not disrupt other requests or ongoing refresh operations.
  * Preserved consistent behavior during high-concurrency admission and authentication flows.
* **Observability**
  * Added rate-limited warnings for event-loop delays exceeding the configured threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->