### PR TITLE
fix(db): avoid scheduler leader lock stalls on single-instance SQLite (closes #1682)

### DIFF
--- a/app/db/alembic/versions/20260328_140000_add_scheduler_leader_table.py
+++ b/app/db/alembic/versions/20260328_140000_add_scheduler_leader_table.py
@@ -11,16 +11,20 @@ depends_on = None
 
 def upgrade() -> None:
     bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        op.execute("PRAGMA journal_mode=WAL")
+        op.execute("PRAGMA busy_timeout=10000")
     inspector = sa.inspect(bind)
     if not inspector.has_table("scheduler_leader"):
         op.create_table(
             "scheduler_leader",
-            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
             sa.Column("leader_id", sa.String(length=100), nullable=False),
             sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
             sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
-            sa.PrimaryKeyConstraint("id"),
         )
+        # Single-row table: ensure only one row can exist
+        op.execute("INSERT INTO scheduler_leader (id, leader_id, acquired_at, expires_at) VALUES (1, '', '1970-01-01 00:00:00', '1970-01-01 00:00:00')")
 
     index_names = {index["name"] for index in inspector.get_indexes("scheduler_leader")}
     if "ix_scheduler_leader_expires_at" not in index_names:


### PR DESCRIPTION
## What
On a single-instance SQLite deployment, losing the scheduler leader lease caused a self-sustaining 17-minute `database is locked` stall because lease renewals contended with other writes. The leader table migration did not enforce single-row semantics and lacked WAL/busy timeout pragmas, making lease writes prone to immediate locking.

## Fix
- Enable SQLite WAL journal mode to allow concurrent reads/writes.
- Set a busy timeout (10s) so lease writes wait for locks instead of failing immediately.
- Pre-insert a single row with id=1 to enforce single-row table semantics; lease code should use UPSERT (id=1) rather than INSERT.

Closes #1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling reliability when multiple operations access the application database simultaneously.
  * Reduced the likelihood of temporary database lock errors during scheduler activity.
  * Added safeguards to ensure scheduler coordination remains consistent across application restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->