### PR TITLE
fix(db): repair retired identity/warmup migration stamp

### DIFF
--- a/app/db/alembic/revision_ids.py
+++ b/app/db/alembic/revision_ids.py
@@ -27,6 +27,7 @@ OLD_TO_NEW_REVISION_MAP: dict[str, str] = {
     ),
     "20260410_020000_restore_import_without_overwrite_default_false": "20260409_020000_fix_http_bridge_last_seen_index",
     "20260525_000000_merge_routing_settings_security_heads": "20260513_000000_add_accounts_alias",
+    "20260814_020000_merge_identity_and_warmup_heads": "20260816_000000_add_model_source_embeddings",
 }
 
 NEW_TO_OLD_REVISION_MAP: dict[str, str] = {new: old for old, new in OLD_TO_NEW_REVISION_MAP.items()}

--- a/app/db/alembic/versions/20260813_000000_add_file_account_pins.py
+++ b/app/db/alembic/versions/20260813_000000_add_file_account_pins.py
@@ -20,16 +20,21 @@ _TABLE = "file_account_pins"
 
 def upgrade() -> None:
     bind = op.get_bind()
-    if sa.inspect(bind).has_table(_TABLE):
-        return
-    op.create_table(
-        _TABLE,
-        sa.Column("file_id", sa.String(), nullable=False),
-        sa.Column("account_id", sa.String(), nullable=False),
-        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
-        sa.PrimaryKeyConstraint("file_id"),
-    )
-    op.create_index("ix_file_account_pins_expires_at", _TABLE, ["expires_at"], unique=False)
+    inspector = sa.inspect(bind)
+    table_exists = inspector.has_table(_TABLE)
+    if not table_exists:
+        op.create_table(
+            _TABLE,
+            sa.Column("file_id", sa.String(), nullable=False),
+            sa.Column("account_id", sa.String(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("file_id"),
+        )
+    index_exists = table_exists and "ix_file_account_pins_expires_at" in {
+        index["name"] for index in inspector.get_indexes(_TABLE) if index.get("name")
+    }
+    if not index_exists:
+        op.create_index("ix_file_account_pins_expires_at", _TABLE, ["expires_at"], unique=False)
 
 
 def downgrade() -> None:

--- a/app/db/alembic/versions/20260820_000000_repair_retired_identity_and_warmup_stamp.py
+++ b/app/db/alembic/versions/20260820_000000_repair_retired_identity_and_warmup_stamp.py
@@ -1,0 +1,77 @@
+"""repair schemas stamped at the retired identity/warmup merge head
+
+Revision ID: 20260820_000000_repair_retired_identity_and_warmup_stamp
+Revises: 20260816_000000_add_model_source_embeddings
+Create Date: 2026-08-20
+
+Some local August 14, 2026 builds emitted the no-op merge stamp
+``20260814_020000_merge_identity_and_warmup_heads`` even when the current
+mainline file-pin, sticky-abandonment-scope, pending-deletion, API-key
+reasoning-policy, and model-source-embeddings lineage had never run, while the
+retired account-identity index and quota-planner lease-expiry column were
+still present. Startup remaps that dead stamp to the current pre-repair head so
+Alembic can continue; this forward-only repair step then replays the guarded
+current migrations and drops the two stale artifacts.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260820_000000_repair_retired_identity_and_warmup_stamp"
+down_revision = "20260816_000000_add_model_source_embeddings"
+branch_labels = None
+depends_on = None
+
+_OBSOLETE_ACCOUNT_INDEX = "idx_accounts_chatgpt_account_id"
+_OBSOLETE_QUOTA_COLUMN = "lease_expires_at"
+
+
+def _migration(module_name: str) -> ModuleType:
+    return importlib.import_module(f"app.db.alembic.versions.{module_name}")
+
+
+def _has_table(connection: Connection, table_name: str) -> bool:
+    return sa.inspect(connection).has_table(table_name)
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    if not _has_table(connection, table_name):
+        return set()
+    return {column["name"] for column in sa.inspect(connection).get_columns(table_name)}
+
+
+def _indexes(connection: Connection, table_name: str) -> set[str]:
+    if not _has_table(connection, table_name):
+        return set()
+    names = (index.get("name") for index in sa.inspect(connection).get_indexes(table_name))
+    return {name for name in names if name is not None}
+
+
+def upgrade() -> None:
+    _migration("20260813_000000_add_file_account_pins").upgrade()
+    _migration("20260812_120000_add_sticky_abandonment_scope").upgrade()
+    _migration("20260816_000000_add_account_pending_deletion").upgrade()
+    _migration("20260806_030000_add_api_key_allowed_reasoning_efforts").upgrade()
+    _migration("20260816_000000_add_model_source_embeddings").upgrade()
+
+    connection = op.get_bind()
+
+    if _OBSOLETE_ACCOUNT_INDEX in _indexes(connection, "accounts"):
+        op.drop_index(_OBSOLETE_ACCOUNT_INDEX, table_name="accounts", if_exists=True)
+
+    if _OBSOLETE_QUOTA_COLUMN in _columns(connection, "quota_planner_decisions"):
+        with op.batch_alter_table("quota_planner_decisions") as batch_op:
+            batch_op.drop_column(_OBSOLETE_QUOTA_COLUMN)
+
+
+def downgrade() -> None:
+    # This revision repairs databases carrying a retired local merge stamp. It
+    # must not resurrect the stale index/column or remove objects owned by the
+    # canonical current-main migrations it replays above.
+    pass

--- a/openspec/changes/repair-retired-identity-warmup-stamp/proposal.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Local August 14, 2026 builds could stamp SQLite databases at the retired
+`20260814_020000_merge_identity_and_warmup_heads` merge id even when the
+current mainline file-pin, sticky-abandonment-scope, pending-deletion,
+API-key reasoning-policy, and model-source-embeddings lineage had never run.
+Those databases also kept two artifacts current main no longer owns:
+`idx_accounts_chatgpt_account_id` and
+`quota_planner_decisions.lease_expires_at`. Current main therefore treats the
+stamp as schema-ahead and a drift check on the live clone reports eleven schema
+diffs.
+
+## What Changes
+
+- Auto-remap the retired merge stamp to the current pre-repair Alembic head so
+  upgrade can continue through normal `python -m app.db.migrate upgrade`.
+- Add one forward-only repair migration that replays the guarded current-main
+  migrations needed by the stamped-local shape and drops the two stale
+  artifacts when present.
+- Cover the representative SQLite shape with a regression test that proves the
+  repair converges to the current ORM schema.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `database-migrations`: retired local merge stamps upgrade cleanly to the
+  current schema without manual restamping.

--- a/openspec/changes/repair-retired-identity-warmup-stamp/specs/database-migrations/spec.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/specs/database-migrations/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Retired identity/warmup merge stamps repair to current schema
+
+The system MUST upgrade a database stamped at
+`20260814_020000_merge_identity_and_warmup_heads` by the retired local merge
+build to the current Alembic head without manual restamping. Startup or CLI
+remap MAY rewrite that retired stamp to the canonical pre-repair revision, but
+the subsequent upgrade MUST execute a forward repair that converges the schema
+to ORM metadata. The repaired schema MUST add the file-pin,
+sticky-abandonment-scope, pending-deletion, API-key reasoning-policy, and
+model-source-embeddings objects current main expects, and MUST remove the
+retired `idx_accounts_chatgpt_account_id` index and
+`quota_planner_decisions.lease_expires_at` column if they are still present.
+
+#### Scenario: A SQLite clone stamped at the retired merge head upgrades cleanly
+
+- **GIVEN** a SQLite database stamped at `20260814_020000_merge_identity_and_warmup_heads`
+- **AND** the schema still lacks `file_account_pins`, pending-deletion markers, API-key reasoning policy, model-source embeddings, and sticky abandonment scope
+- **AND** the retired `idx_accounts_chatgpt_account_id` index and `quota_planner_decisions.lease_expires_at` column are still present
+- **WHEN** startup or `python -m app.db.migrate upgrade` runs to head
+- **THEN** the upgrade completes without manual stamp surgery
+- **AND** `python -m app.db.migrate check` reports no schema drift

--- a/openspec/changes/repair-retired-identity-warmup-stamp/tasks.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/tasks.md
@@ -1,0 +1,9 @@
+## 1. Repair Path
+
+- [x] 1.1 Remap `20260814_020000_merge_identity_and_warmup_heads` to the current pre-repair Alembic revision
+- [x] 1.2 Add a forward-only repair migration that replays the missing current-main migrations and removes `idx_accounts_chatgpt_account_id` plus `quota_planner_decisions.lease_expires_at` when present
+
+## 2. Validation
+
+- [x] 2.1 Add a regression test for the representative SQLite drift shape stamped at the retired merge head
+- [x] 2.2 Validate OpenSpec and the focused migration tests

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1908,3 +1908,86 @@ async def test_file_account_pins_migration_upgrade_and_downgrade(tmp_path):
             assert await conn.run_sync(_schema_state) is not None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_retired_identity_and_warmup_merge_stamp_repairs_to_head(tmp_path):
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'retired-identity-warmup-repair.sqlite'}"
+    pre_repair_head = "20260816_000000_add_model_source_embeddings"
+    retired_merge_revision = "20260814_020000_merge_identity_and_warmup_heads"
+    expected_drift_checks = (
+        ("add_table", "file_account_pins"),
+        ("add_index", "ix_file_account_pins_expires_at"),
+        ("add_column", "accounts', Column('delete_requested_at'"),
+        ("add_column", "accounts', Column('delete_history_requested'"),
+        ("remove_index", "idx_accounts_chatgpt_account_id"),
+        ("add_index", "idx_accounts_delete_requested_at"),
+        ("add_column", "api_keys', Column('allowed_reasoning_efforts'"),
+        ("add_constraint", "ck_api_keys_reasoning_policy_exclusive"),
+        ("add_column", "model_sources', Column('supports_embeddings'"),
+        ("remove_column", "quota_planner_decisions', Column('lease_expires_at'"),
+        ("add_column", "sticky_sessions', Column('continuity_abandonment_scope'"),
+    )
+
+    def _schema_state(sync_conn):
+        inspector = sa_inspect(sync_conn)
+        return {
+            "has_file_account_pins": inspector.has_table("file_account_pins"),
+            "account_columns": {column["name"] for column in inspector.get_columns("accounts")},
+            "account_indexes": {index["name"] for index in inspector.get_indexes("accounts")},
+            "api_key_columns": {column["name"] for column in inspector.get_columns("api_keys")},
+            "api_key_checks": {
+                constraint["name"]
+                for constraint in inspector.get_check_constraints("api_keys")
+                if constraint.get("name")
+            },
+            "model_source_columns": {column["name"] for column in inspector.get_columns("model_sources")},
+            "quota_columns": {column["name"] for column in inspector.get_columns("quota_planner_decisions")},
+            "sticky_columns": {column["name"] for column in inspector.get_columns("sticky_sessions")},
+        }
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, pre_repair_head, bootstrap_legacy=False))
+    await to_thread.run_sync(
+        lambda: command.downgrade(_build_alembic_config(db_url), "20260806_000000_add_anonymous_telemetry")
+    )
+
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("CREATE INDEX IF NOT EXISTS idx_accounts_chatgpt_account_id ON accounts (chatgpt_account_id)")
+            )
+            await conn.execute(text("ALTER TABLE quota_planner_decisions ADD COLUMN lease_expires_at DATETIME"))
+            await conn.execute(
+                text("UPDATE alembic_version SET version_num = :revision"),
+                {"revision": retired_merge_revision},
+            )
+
+        drift = check_schema_drift(db_url)
+        assert len(drift) == len(expected_drift_checks)
+        for action, marker in expected_drift_checks:
+            assert any(action in diff and marker in diff for diff in drift)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert check_schema_drift(db_url) == ()
+
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state["has_file_account_pins"] is True
+        assert "delete_requested_at" in state["account_columns"]
+        assert "delete_history_requested" in state["account_columns"]
+        assert "idx_accounts_chatgpt_account_id" not in state["account_indexes"]
+        assert "idx_accounts_delete_requested_at" in state["account_indexes"]
+        assert "allowed_reasoning_efforts" in state["api_key_columns"]
+        assert "ck_api_keys_reasoning_policy_exclusive" in state["api_key_checks"]
+        assert "supports_embeddings" in state["model_source_columns"]
+        assert "lease_expires_at" not in state["quota_columns"]
+        assert "continuity_abandonment_scope" in state["sticky_columns"]
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1911,6 +1911,40 @@ async def test_file_account_pins_migration_upgrade_and_downgrade(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_file_account_pins_migration_repairs_existing_table_missing_index(tmp_path):
+    from sqlalchemy import inspect as sa_inspect
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'partial-file-account-pins.sqlite'}"
+    parent_revision = "20260806_000000_add_anonymous_telemetry"
+    pin_revision = "20260813_000000_add_file_account_pins"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "CREATE TABLE file_account_pins ("
+                    "file_id VARCHAR NOT NULL PRIMARY KEY, "
+                    "account_id VARCHAR NOT NULL, "
+                    "expires_at DATETIME NOT NULL)"
+                )
+            )
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pin_revision, bootstrap_legacy=False))
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pin_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            indexes = await conn.run_sync(
+                lambda sync_conn: {index["name"] for index in sa_inspect(sync_conn).get_indexes("file_account_pins")}
+            )
+        assert indexes == {"ix_file_account_pins_expires_at"}
+        await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert check_schema_drift(db_url) == ()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_retired_identity_and_warmup_merge_stamp_repairs_to_head(tmp_path):
     from alembic import command
     from sqlalchemy import inspect as sa_inspect


### PR DESCRIPTION
Fixes the local deployment lineage where `20260814_020000_merge_identity_and_warmup_heads` was stamped without all current-main schema changes.

The upgrade remaps only that retired stamp to the canonical pre-repair revision, then runs one forward-only, idempotent repair migration. It creates the missing file-pin, sticky-abandonment, pending-deletion, API-key reasoning-policy, and embeddings objects, and drops the obsolete account index and quota-planner lease field.

Validation:
- focused migration regression
- clone of the live SQLite database: `upgrade` reached the new head and `check` returned `schema_drift=none`
- `openspec validate repair-retired-identity-warmup-stamp --type change`

No live database or container was changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upgrades for databases stamped with a retired migration revision.
  * Automatically repairs missing schema changes and removes obsolete database artifacts.
  * Ensures repaired databases converge cleanly with the current schema without manual intervention.

* **Tests**
  * Added integration coverage validating schema repair, migration completion, and removal of schema drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->