### PR TITLE
feat(frontend): configure model-source reasoning efforts

### DIFF
--- a/frontend/src/features/model-sources/components/model-source-edit-dialog.test.tsx
+++ b/frontend/src/features/model-sources/components/model-source-edit-dialog.test.tsx
@@ -290,12 +290,25 @@ describe("ModelSourceEditDialog", () => {
     });
 
     const rawMetadata = JSON.parse(onSubmit.mock.calls[0][1].models[0].rawMetadataJson);
-    expect(rawMetadata).toEqual({ custom_key: "kept", supports_reasoning: true });
+    expect(rawMetadata).toEqual({
+      custom_key: "kept",
+      supports_reasoning: true,
+      supported_reasoning_levels: ["low", "medium", "high"],
+      default_reasoning_level: "medium",
+    });
   });
 
   it("prefills the reasoning toggle from raw metadata", () => {
     const source = createModelSource();
-    source.models[0].rawMetadataJson = '{"supports_reasoning": true}';
+    source.models[0].rawMetadataJson = JSON.stringify({
+      supports_reasoning: true,
+      supported_reasoning_levels: [
+        { effort: "none", description: "disable chain of thought" },
+        "provider-specific",
+        "ultra",
+      ],
+      default_reasoning_level: "provider-specific",
+    });
 
     renderWithProviders(
       <ModelSourceEditDialog
@@ -308,6 +321,49 @@ describe("ModelSourceEditDialog", () => {
     );
 
     expect(screen.getByRole("checkbox", { name: "Reasoning" })).toBeChecked();
+    expect(screen.getByLabelText("Supported reasoning efforts")).toHaveValue(
+      "none, provider-specific, ultra",
+    );
+    expect(screen.getByRole("combobox", { name: "Default reasoning effort" })).toHaveTextContent(
+      "provider-specific",
+    );
+  });
+
+  it("keeps arbitrary reasoning efforts and renormalizes a stale default", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const source = createModelSource();
+    source.models[0].rawMetadataJson = JSON.stringify({
+      supports_reasoning: true,
+      supported_reasoning_levels: ["none", "provider-specific", "ultra"],
+      default_reasoning_level: "provider-specific",
+    });
+
+    renderWithProviders(
+      <ModelSourceEditDialog
+        open
+        busy={false}
+        source={source}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const reasoningEfforts = screen.getByLabelText("Supported reasoning efforts");
+    await user.clear(reasoningEfforts);
+    await user.type(reasoningEfforts, "none, custom-tier");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const rawMetadata = JSON.parse(onSubmit.mock.calls[0][1].models[0].rawMetadataJson);
+    expect(rawMetadata).toEqual({
+      supports_reasoning: true,
+      supported_reasoning_levels: ["none", "custom-tier"],
+      default_reasoning_level: "none",
+    });
   });
 
   it("sends the api key only when the field is filled", async () => {

--- a/frontend/src/features/model-sources/components/model-source-edit-dialog.tsx
+++ b/frontend/src/features/model-sources/components/model-source-edit-dialog.tsx
@@ -17,6 +17,7 @@ import { ModelSourceFormFields } from "@/features/model-sources/components/model
 import {
   createModelSourceFormSchema,
   draftFromSource,
+  mergeReasoningMetadata,
   modelIdsToInput,
   modelSourceDraftReducer,
   type ModelSourceDraft,
@@ -41,8 +42,6 @@ type ModelDraftChangeFlags = {
   supportsVision: boolean;
   supportsReasoning: boolean;
 };
-
-const SUPPORTS_REASONING_KEY = "supports_reasoning";
 
 function parsePositiveInt(value: string): number | null {
   const trimmed = value.trim();
@@ -84,35 +83,15 @@ function getModelDraftChangeFlags(
     supportsStreaming: draft.supportsStreaming !== initialDraft.supportsStreaming,
     supportsTools: draft.supportsTools !== initialDraft.supportsTools,
     supportsVision: draft.supportsVision !== initialDraft.supportsVision,
-    supportsReasoning: draft.supportsReasoning !== initialDraft.supportsReasoning,
+    supportsReasoning:
+      draft.supportsReasoning !== initialDraft.supportsReasoning ||
+      JSON.stringify(draft.reasoningEfforts) !== JSON.stringify(initialDraft.reasoningEfforts) ||
+      draft.defaultReasoningEffort !== initialDraft.defaultReasoningEffort,
   };
 }
 
 function hasAnyModelDraftChange(flags: ModelDraftChangeFlags): boolean {
   return Object.values(flags).some(Boolean);
-}
-
-function mergeReasoningMetadata(
-  existingMetadata: string | null | undefined,
-  supportsReasoning: boolean,
-): string | null {
-  let metadata: Record<string, unknown> = {};
-  if (existingMetadata) {
-    try {
-      const parsed: unknown = JSON.parse(existingMetadata);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        metadata = parsed as Record<string, unknown>;
-      }
-    } catch {
-      metadata = {};
-    }
-  }
-  if (supportsReasoning) {
-    metadata[SUPPORTS_REASONING_KEY] = true;
-  } else {
-    delete metadata[SUPPORTS_REASONING_KEY];
-  }
-  return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null;
 }
 
 function buildModelInputs(
@@ -155,7 +134,12 @@ function buildModelInputs(
         ? parseNonNegativeFloat(draft.audioPerMinute)
         : existingModel?.audioPerMinute ?? null,
       rawMetadataJson: draftChangeFlags.supportsReasoning
-        ? mergeReasoningMetadata(existingModel?.rawMetadataJson, draft.supportsReasoning)
+        ? mergeReasoningMetadata(
+            existingModel?.rawMetadataJson,
+            draft.supportsReasoning,
+            draft.reasoningEfforts,
+            draft.defaultReasoningEffort,
+          )
         : existingModel?.rawMetadataJson ?? null,
       isEnabled: existingModel?.isEnabled ?? true,
     };

--- a/frontend/src/features/model-sources/components/model-source-form-fields.tsx
+++ b/frontend/src/features/model-sources/components/model-source-form-fields.tsx
@@ -4,10 +4,12 @@ import { useTranslation } from "react-i18next";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type {
   ModelSourceDraft,
   ModelSourceFormValues,
 } from "@/features/model-sources/components/model-source-form";
+import { parseReasoningEffortsInput } from "@/features/model-sources/components/model-source-form";
 
 type ModelSourceFormFieldsProps = {
   control: Control<ModelSourceFormValues>;
@@ -27,6 +29,8 @@ const CAPABILITY_TOGGLES = [
   ["supportsVision", "modelSources.capabilities.vision"] as const,
   ["supportsReasoning", "modelSources.capabilities.reasoning"] as const,
 ];
+
+const DEFAULT_REASONING_EFFORTS = ["low", "medium", "high"];
 
 export function ModelSourceFormFields({
   control,
@@ -176,12 +180,91 @@ export function ModelSourceFormFields({
           <label key={key} className="flex items-center gap-2 rounded-md border p-2 text-sm">
             <Checkbox
               checked={draft[key]}
-              onCheckedChange={(checked) => updateDraft({ [key]: checked === true })}
+              onCheckedChange={(checked) =>
+                updateDraft({
+                  [key]: checked === true,
+                  ...(key === "supportsReasoning" && checked === true
+                    ? {
+                        reasoningEffortsInput:
+                          draft.reasoningEffortsInput || DEFAULT_REASONING_EFFORTS.join(", "),
+                        reasoningEfforts:
+                          draft.reasoningEfforts.length > 0
+                            ? draft.reasoningEfforts
+                            : DEFAULT_REASONING_EFFORTS,
+                        defaultReasoningEffort: draft.defaultReasoningEffort || "medium",
+                      }
+                    : {}),
+                })
+              }
             />
 	            {t(labelKey)}
           </label>
         ))}
       </div>
+
+      {draft.supportsReasoning ? (
+        <div className="space-y-3 rounded-md border p-3">
+          <div>
+            <div className="text-sm font-medium">{t("modelSources.fields.reasoningEfforts")}</div>
+            <p className="text-xs text-muted-foreground">
+              {t("modelSources.fields.reasoningEffortsDescription")}
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground" htmlFor="model-source-reasoning-efforts">
+              {t("modelSources.fields.reasoningEfforts")}
+            </label>
+            <Input
+              id="model-source-reasoning-efforts"
+              aria-label={t("modelSources.fields.reasoningEfforts")}
+              value={draft.reasoningEffortsInput}
+              onChange={(event) => {
+                const reasoningEffortsInput = event.target.value;
+                const reasoningEfforts = parseReasoningEffortsInput(reasoningEffortsInput);
+                updateDraft({
+                  reasoningEffortsInput,
+                  reasoningEfforts,
+                  defaultReasoningEffort: reasoningEfforts.includes(draft.defaultReasoningEffort)
+                    ? draft.defaultReasoningEffort
+                    : (reasoningEfforts[0] ?? ""),
+                });
+              }}
+              placeholder={t("modelSources.fields.reasoningEffortsPlaceholder")}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label
+              className="text-xs text-muted-foreground"
+              htmlFor="model-source-default-reasoning-effort"
+            >
+              {t("modelSources.fields.defaultReasoningEffort")}
+            </label>
+            <Select
+              value={draft.defaultReasoningEffort}
+              onValueChange={(value) => updateDraft({ defaultReasoningEffort: value })}
+              disabled={draft.reasoningEfforts.length === 0}
+            >
+              <SelectTrigger
+                id="model-source-default-reasoning-effort"
+                aria-label={t("modelSources.fields.defaultReasoningEffort")}
+                className="w-full"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {draft.reasoningEfforts.map((effort) => (
+                  <SelectItem key={effort} value={effort}>
+                    {effort}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/frontend/src/features/model-sources/components/model-source-form.test.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeReasoningMetadata, parseReasoningEffortsInput } from "./model-source-form";
+
+describe("model-source-form reasoning effort normalization", () => {
+  it("trims whitespace and preserves casing for effort values", () => {
+    expect(parseReasoningEffortsInput("  Ultra,   xhigh , low  ")).toEqual([
+      "Ultra",
+      "xhigh",
+      "low",
+    ]);
+  });
+
+  it("preserves casing for declared default reasoning effort", () => {
+    const metadata = mergeReasoningMetadata(
+      null,
+      true,
+      ["Ultra", "provider-specific", "xhigh"],
+      "  provider-specific  ",
+    );
+    const parsed = JSON.parse(metadata ?? "{}");
+
+    expect(parsed.supported_reasoning_levels).toEqual(["Ultra", "provider-specific", "xhigh"]);
+    expect(parsed.default_reasoning_level).toBe("provider-specific");
+  });
+});
+

--- a/frontend/src/features/model-sources/components/model-source-form.test.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { mergeReasoningMetadata, parseReasoningEffortsInput } from "./model-source-form";
 
 describe("model-source-form reasoning effort normalization", () => {
@@ -24,4 +23,3 @@ describe("model-source-form reasoning effort normalization", () => {
     expect(parsed.default_reasoning_level).toBe("provider-specific");
   });
 });
-

--- a/frontend/src/features/model-sources/components/model-source-form.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.ts
@@ -36,6 +36,9 @@ export type ModelSourceDraft = {
   supportsTools: boolean;
   supportsVision: boolean;
   supportsReasoning: boolean;
+  reasoningEffortsInput: string;
+  reasoningEfforts: string[];
+  defaultReasoningEffort: string;
   contextWindow: string;
   maxOutputTokens: string;
   inputPer1M: string;
@@ -53,6 +56,9 @@ export const initialModelSourceDraft: ModelSourceDraft = {
   supportsTools: false,
   supportsVision: false,
   supportsReasoning: false,
+  reasoningEffortsInput: "",
+  reasoningEfforts: [],
+  defaultReasoningEffort: "",
   contextWindow: "",
   maxOutputTokens: "",
   inputPer1M: "",
@@ -86,9 +92,44 @@ function parseNonNegativeFloat(value: string): number | undefined {
 // model's raw metadata JSON, which the proxy reads to pass reasoning fields
 // through and to advertise supports_reasoning in /v1/models. Merge it into
 // any raw metadata the model already carries so other keys survive edits.
-export function mergeReasoningFlag(
+const DEFAULT_REASONING_EFFORTS = ["low", "medium", "high"];
+
+function normalizeReasoningEffort(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function dedupeReasoningEfforts(values: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = normalizeReasoningEffort(value);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+export function parseReasoningEffortsInput(value: string): string[] {
+  return dedupeReasoningEfforts(value.split(/[\n,]/));
+}
+
+function normalizeDefaultReasoningEffort(
+  reasoningEfforts: string[],
+  defaultReasoningEffort: string,
+): string {
+  const normalizedDefault = normalizeReasoningEffort(defaultReasoningEffort);
+  if (normalizedDefault && reasoningEfforts.includes(normalizedDefault)) {
+    return normalizedDefault;
+  }
+  return reasoningEfforts[0] ?? "";
+}
+
+export function mergeReasoningMetadata(
   existing: string | null | undefined,
   supportsReasoning: boolean,
+  reasoningEfforts: string[] = [],
+  defaultReasoningEffort = "",
 ): string | null {
   let metadata: Record<string, unknown> = {};
   if (existing) {
@@ -103,8 +144,20 @@ export function mergeReasoningFlag(
   }
   if (supportsReasoning) {
     metadata.supports_reasoning = true;
+    if (reasoningEfforts.length > 0) {
+      metadata.supported_reasoning_levels = reasoningEfforts;
+      metadata.default_reasoning_level = normalizeDefaultReasoningEffort(
+        reasoningEfforts,
+        defaultReasoningEffort,
+      );
+    } else {
+      delete metadata.supported_reasoning_levels;
+      delete metadata.default_reasoning_level;
+    }
   } else {
     delete metadata.supports_reasoning;
+    delete metadata.supported_reasoning_levels;
+    delete metadata.default_reasoning_level;
   }
   return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null;
 }
@@ -137,7 +190,12 @@ export function modelInputsFromForm(
       cachedInputPer1M: cachedInputPer1M ?? null,
       outputPer1M: outputPer1M ?? null,
       audioPerMinute: audioPerMinute ?? null,
-      rawMetadataJson: mergeReasoningFlag(existingRawMetadata[model], draft.supportsReasoning),
+      rawMetadataJson: mergeReasoningMetadata(
+        existingRawMetadata[model],
+        draft.supportsReasoning,
+        draft.reasoningEfforts,
+        draft.defaultReasoningEffort,
+      ),
       isEnabled: existingEnabledByModel[model] ?? true,
     }));
 }
@@ -149,22 +207,58 @@ function numberToInput(value: number | null | undefined): string {
 // Derive the shared draft from an existing source. The create UI applies one
 // set of per-model settings to every model, so editing mirrors that by reading
 // the first model's values as the representative settings.
-function rawMetadataHasReasoning(rawMetadataJson: string | null | undefined): boolean {
-  if (!rawMetadataJson) return false;
+function parseReasoningMetadata(rawMetadataJson: string | null | undefined): {
+  supportsReasoning: boolean;
+  reasoningEffortsInput: string;
+  reasoningEfforts: string[];
+  defaultReasoningEffort: string;
+} {
+  const fallback = {
+    supportsReasoning: false,
+    reasoningEffortsInput: "",
+    reasoningEfforts: [],
+    defaultReasoningEffort: "",
+  };
+  if (!rawMetadataJson) return fallback;
   try {
     const parsed: unknown = JSON.parse(rawMetadataJson);
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      (parsed as Record<string, unknown>).supports_reasoning === true
-    );
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return fallback;
+    }
+    const metadata = parsed as Record<string, unknown>;
+    const supportsReasoning = metadata.supports_reasoning === true;
+    const declaredLevels = Array.isArray(metadata.supported_reasoning_levels)
+      ? dedupeReasoningEfforts(
+          metadata.supported_reasoning_levels.flatMap((value): string[] => {
+            if (typeof value === "string") return [value];
+            if (typeof value !== "object" || value === null || Array.isArray(value)) return [];
+            const effort = (value as Record<string, unknown>).effort;
+            return typeof effort === "string" ? [effort] : [];
+          }),
+        )
+      : [];
+    const reasoningEfforts =
+      supportsReasoning && declaredLevels.length === 0 ? DEFAULT_REASONING_EFFORTS : declaredLevels;
+
+    return {
+      supportsReasoning,
+      reasoningEffortsInput: reasoningEfforts.join(", "),
+      reasoningEfforts,
+      defaultReasoningEffort: normalizeDefaultReasoningEffort(
+        reasoningEfforts,
+        typeof metadata.default_reasoning_level === "string"
+          ? metadata.default_reasoning_level
+          : "",
+      ),
+    };
   } catch {
-    return false;
+    return fallback;
   }
 }
 
 export function draftFromSource(source: ModelSource): ModelSourceDraft {
   const firstModel = source.models[0];
+  const reasoningMetadata = parseReasoningMetadata(firstModel?.rawMetadataJson);
   return {
     supportsChatCompletions: source.supportsChatCompletions,
     supportsResponses: source.supportsResponses,
@@ -173,7 +267,10 @@ export function draftFromSource(source: ModelSource): ModelSourceDraft {
     supportsStreaming: firstModel?.supportsStreaming ?? true,
     supportsTools: firstModel?.supportsTools ?? false,
     supportsVision: firstModel?.supportsVision ?? false,
-    supportsReasoning: rawMetadataHasReasoning(firstModel?.rawMetadataJson),
+    supportsReasoning: reasoningMetadata.supportsReasoning,
+    reasoningEffortsInput: reasoningMetadata.reasoningEffortsInput,
+    reasoningEfforts: reasoningMetadata.reasoningEfforts,
+    defaultReasoningEffort: reasoningMetadata.defaultReasoningEffort,
     contextWindow: numberToInput(firstModel?.contextWindow),
     maxOutputTokens: numberToInput(firstModel?.maxOutputTokens),
     inputPer1M: numberToInput(firstModel?.inputPer1M),

--- a/frontend/src/features/model-sources/components/model-source-form.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.ts
@@ -95,7 +95,7 @@ function parseNonNegativeFloat(value: string): number | undefined {
 const DEFAULT_REASONING_EFFORTS = ["low", "medium", "high"];
 
 function normalizeReasoningEffort(value: string): string {
-  return value.trim().toLowerCase();
+  return value.trim();
 }
 
 function dedupeReasoningEfforts(values: Iterable<string>): string[] {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1449,5 +1449,9 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Proxy pool update failed",
   "upstreamProxy.validation.hostRequired": "Host is required",
   "upstreamProxy.validation.nameRequired": "Name is required",
-  "upstreamProxy.validation.portInvalid": "Enter a port between 1 and 65535"
+  "upstreamProxy.validation.portInvalid": "Enter a port between 1 and 65535",
+  "modelSources.fields.reasoningEfforts": "Supported reasoning efforts",
+  "modelSources.fields.reasoningEffortsDescription": "List the effort slugs this model source accepts and choose which one should be the default.",
+  "modelSources.fields.reasoningEffortsPlaceholder": "none, low, provider-specific",
+  "modelSources.fields.defaultReasoningEffort": "Default reasoning effort"
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1449,5 +1449,9 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Pool 업데이트 실패",
   "upstreamProxy.validation.hostRequired": "Host는 필수입니다",
   "upstreamProxy.validation.nameRequired": "이름은 필수입니다",
-  "upstreamProxy.validation.portInvalid": "1부터 65535 사이의 port를 입력하세요"
+  "upstreamProxy.validation.portInvalid": "1부터 65535 사이의 port를 입력하세요",
+  "modelSources.fields.reasoningEfforts": "지원되는 추론 수준",
+  "modelSources.fields.reasoningEffortsDescription": "이 모델 소스가 허용하는 추론 수준 슬러그를 적고 기본값을 고르세요.",
+  "modelSources.fields.reasoningEffortsPlaceholder": "none, low, provider-specific",
+  "modelSources.fields.defaultReasoningEffort": "기본 추론 수준"
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1449,5 +1449,9 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Pool 更新失败",
   "upstreamProxy.validation.hostRequired": "主机不能为空",
   "upstreamProxy.validation.nameRequired": "名称必填",
-  "upstreamProxy.validation.portInvalid": "请输入 1 到 65535 之间的端口"
+  "upstreamProxy.validation.portInvalid": "请输入 1 到 65535 之间的端口",
+  "modelSources.fields.reasoningEfforts": "支持的推理级别",
+  "modelSources.fields.reasoningEffortsDescription": "填写这个模型源接受的推理级别标识，并选择默认值。",
+  "modelSources.fields.reasoningEffortsPlaceholder": "none, low, provider-specific",
+  "modelSources.fields.defaultReasoningEffort": "默认推理级别"
 }

--- a/openspec/changes/configure-model-source-reasoning-efforts/proposal.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+PR #1661 already landed the backend contract for operator-declared model-source
+reasoning efforts. PR #1675 still carries the useful dashboard part of that
+feature, but its original branch also duplicated the backend parser/spec work
+and baked in assumptions that #1661 explicitly rejected (`none` filtering and a
+fixed effort enum).
+
+The dashboard still needs a way to configure the metadata that the backend now
+honors, and it needs to preserve arbitrary provider-specific effort slugs rather
+than forcing one hardcoded vocabulary.
+
+## What Changes
+
+- Add model-source dashboard controls for the reasoning-effort metadata that
+  `#1661` already reads from `raw_metadata_json`.
+- Store supported efforts as an operator-edited list of slugs instead of a
+  fixed checkbox enum, so the UI can round-trip `none` and provider-specific
+  effort names.
+- Keep the existing reasoning toggle, seed reasonable defaults when an operator
+  enables it for the first time, and normalize stale defaults back onto the
+  configured effort list during edit/save.
+- Localize the new dashboard copy in `en`, `ko`, and `zh-CN`.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: model-source create/edit dialogs can configure and
+  preserve supported reasoning-effort metadata for source models.
+
+## Impact
+
+- Dashboard only: model-source form state, create/edit dialogs, i18n, and
+  focused frontend regression tests.
+- No API contract, database, backend parser, proxy routing, or request-policy
+  behavior changes in this PR; those remain owned by #1661.

--- a/openspec/changes/configure-model-source-reasoning-efforts/specs/frontend-architecture/spec.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/specs/frontend-architecture/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Model-source reasoning metadata editor
+
+The dashboard MUST let operators configure the reasoning metadata stored on
+model-source models without assuming one global effort vocabulary.
+
+#### Scenario: Edit arbitrary supported reasoning efforts
+
+- **GIVEN** a model source whose `raw_metadata_json` contains
+  `supports_reasoning: true`
+- **AND** its `supported_reasoning_levels` include values such as `none` or a
+  provider-specific slug
+- **WHEN** the dashboard opens the model-source create or edit form
+- **THEN** the reasoning controls MUST show those effort slugs without dropping
+  or rewriting them
+- **AND** saving the form MUST write the edited effort list back into
+  `supported_reasoning_levels`.
+
+#### Scenario: Normalize stale defaults during save
+
+- **GIVEN** a model source whose configured default effort is no longer present
+  in the edited supported-effort list
+- **WHEN** the operator saves the form
+- **THEN** the dashboard MUST replace the stale default with one of the
+  configured supported efforts
+- **AND** it MUST NOT leave `default_reasoning_level` pointing at a removed
+  value.
+
+#### Scenario: Seed a first-time reasoning configuration
+
+- **GIVEN** an operator enables reasoning for a model source that previously had
+  no configured supported-effort list
+- **WHEN** the dashboard reveals the reasoning metadata controls
+- **THEN** the form MUST seed an editable default effort list and default value
+  so the operator can save a valid initial configuration
+- **AND** the operator MUST still be able to replace that seed with arbitrary
+  effort slugs before saving.

--- a/openspec/changes/configure-model-source-reasoning-efforts/tasks.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/tasks.md
@@ -1,0 +1,15 @@
+## 1. Model-source dashboard
+
+- [x] 1.1 Extend model-source form state so it can parse, round-trip, and save
+  supported reasoning efforts plus the default effort from raw metadata.
+- [x] 1.2 Add create/edit dialog controls for the effort list and default
+  selector without constraining operators to a fixed enum.
+- [x] 1.3 Keep the existing reasoning toggle and preserve unrelated raw metadata
+  keys during edits.
+
+## 2. Verification
+
+- [x] 2.1 Add focused frontend regression coverage for default seeding,
+  arbitrary effort round-tripping, and stale-default normalization.
+- [x] 2.2 Run focused frontend checks and strict OpenSpec validation for this
+  change.


### PR DESCRIPTION
Rebuilds the surviving UI-only portion of #1675 on current main.

The previous contributor branch also carried stale backend/catalog work. This carrier keeps the editable reasoning-effort controls, correctly round-trips object-form metadata, and includes the focused OpenSpec delta.

Validation: eslint, focused Vitest (10 tests), frontend typecheck, OpenSpec strict validation, and diff-scope gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure supported reasoning efforts when editing a model source.
  - Select a default reasoning effort, with automatic fallback when unavailable.
  - Preserve custom reasoning metadata and values during edits.
  - Automatically initialize reasoning settings when reasoning is enabled.

- **Localization**
  - Added reasoning-effort configuration text in English, Korean, and Simplified Chinese.

- **Bug Fixes**
  - Corrected stale defaults and maintained consistent reasoning settings when saving edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->