### PR TITLE
chore: release v1.24.0-beta.4

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.24.0-beta.3"  # x-release-please-version
+__version__ = "1.24.0-beta.4"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.24.0-beta.3
-appVersion: 1.24.0-beta.3
+version: 1.24.0-beta.4
+appVersion: 1.24.0-beta.4
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.24.0-beta.3",
+  "version": "1.24.0-beta.4",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.24.0-beta.3"
+version = "1.24.0-beta.4"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.24.0-beta.3"
+version = "1.24.0-beta.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.24.0-beta.4 for the 1.24.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.24.0-beta.4 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1692; no manual beta workflow dispatch is required.

## Changes since v1.24.0-beta.3
- feat(frontend): configure model-source reasoning efforts (#1848) (eab7155)
- fix(proxy): absorb replay-safe compaction recovery (#1849) (
c59722)
- fix(proxy): report suppressed duplicate tool-call terminals (#1706) (
25d637)
- fix(db): repair retired identity/warmup migration stamp (#1847) (
b6c217)
- fix(proxy): demote quarantined bridge reattach keys (#1730) (
5e1f56)
- fix(proxy): guard model-transition owner-conflict fork (#1619) (
52092b)
- fix(proxy): wait on usage-refresh singleflight without asyncio.shield (#1897) (
798203)

## Release-candidate validation
Validated candidate: 71c91014d3aeb2461fc57553a7a0495dcc27f7da

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required

### Validation evidence (candidate 71c91014d3aeb2461fc57553a7a0495dcc27f7da)
- Backend/unit/integration + frontend: PR CI run 32702432878 on this exact head — unit, integration-core-1/2/3, PostgreSQL, e2e, bridge, frontend vitest/tsc/eslint/vite all SUCCESS.
- Wheel/package: local `uv build` on detached worktree at this SHA → `codex_lb-1.24.0b4-py3-none-any.whl` + `codex_lb-1.24.0b4.tar.gz`.
- Docker/container smoke: local image build at this SHA; `/health` 200, `app.__version__ == 1.24.0-beta.4`, unauthenticated `/api/accounts` 401, and `_UsageRefreshSingleflight` verified shield-free (`wait_on_shared_future` present) inside the container.
- Live upstream smoke not required: no upstream contract change in this train (usage-refresh wait mechanics #1897 + frontend reasoning-effort UI #1848); post-deploy smoke on SOJU07 will cover the live path.

## Install after publish
```bash
uvx --from "codex-lb==1.24.0b4" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.24.0-beta.4
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.24.0-beta.4 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.24.0.

