### PR TITLE
fix(proxy): settle keyed stream usage before transient health

### DIFF
--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -2284,10 +2284,26 @@ class _StreamingRetryMixin:
                                 transient_retries,
                                 error_code,
                             )
-                            await proxy._handle_stream_error(account, error_payload, error_code)
-                            # Record remaining errors so total equals transient_retries,
-                            # meeting the load balancer backoff threshold (error_count >= 3).
-                            await proxy._load_balancer.record_errors(account, transient_retries - 1)
+                            if api_key is not None and api_key_reservation is not None:
+                                # Keyed streams must settle the shared reservation
+                                # before any account-health write (same ordering as
+                                # compact HTTP 500 and post-refresh transient
+                                # exhaustion). Immediate health here would run,
+                                # then ``break`` would skip the settle helper below.
+                                pending_post_refresh_transient_penalties.append(
+                                    (
+                                        account,
+                                        error_payload,
+                                        error_code,
+                                        (tex.status_code if isinstance(tex, ProxyResponseError) else 502),
+                                        transient_retries,
+                                    )
+                                )
+                            else:
+                                await proxy._handle_stream_error(account, error_payload, error_code)
+                                # Record remaining errors so total equals transient_retries,
+                                # meeting the load balancer backoff threshold (error_count >= 3).
+                                await proxy._load_balancer.record_errors(account, transient_retries - 1)
                             # Preserve last ProxyResponseError for propagate_http_errors path.
                             if isinstance(tex, ProxyResponseError):
                                 last_transient_exc = tex

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15170,7 +15170,127 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_keyed_transient_exhaustion_settles_before_account_health(
+    monkeypatch,
+):
+    """Keyed same-account transient exhaustion must settle before health writes.
+
+    Regression for CLB-20260820-01: exhausting ``_TransientStreamError`` retries
+    used to call ``_handle_stream_error`` / ``record_errors`` immediately, then
+    ``break`` past the settle helper while the shared reservation was still open.
+    """
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account_a = _make_account("acc_keyed_transient_settle_a")
+    account_b = _make_account("acc_keyed_transient_settle_b")
+    stream_account_ids: list[str] = []
+    settlement_order: list[str] = []
+    settlement_wait_flags: list[bool] = []
+    api_key = _make_api_key_data("key_keyed_transient_settle")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_keyed_transient_settle",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    release_unsettled = AsyncMock()
+    record_success = AsyncMock()
+    record_errors = AsyncMock()
+
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        stream_settlement: proxy_service._StreamSettlement,
+        *_args: object,
+        **_kwargs: object,
+    ) -> bool:
+        assert settled_api_key is api_key
+        assert settled_reservation is reservation
+        assert stream_account_ids[-1] == account_b.id
+        stream_settlement.usage_settlement_transferred = True
+        settlement_wait_flags.append(bool(_kwargs.get("wait_for_settlement")))
+        settlement_order.append("settle")
+        return True
+
+    async def handle_stream_error(
+        account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del error, http_status
+        settlement_order.append(f"health:{account.id}:{code}")
+        return {"failure_class": "retryable"}
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        account = account_b if account_a.id in excluded else account_a
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_account_ids.append(account.id)
+        if account.id == account_a.id:
+            raise proxy_service._TransientStreamError(
+                "invalid_request_error",
+                cast(
+                    UpstreamError,
+                    {
+                        "message": "Selected model is at capacity. Please try a different model.",
+                        "code": "invalid_request_error",
+                    },
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_keyed_transient_settle_ok"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
+    monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_release_unsettled_stream_api_key_usage", release_unsettled)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
+    monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-keyed-transient-settle"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=api_key,
+            api_key_reservation=reservation,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    terminal = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert terminal["response"]["id"] == "resp_keyed_transient_settle_ok"
+    assert stream_account_ids == [account_a.id, account_b.id]
+    assert settlement_wait_flags == [True]
+    assert settlement_order == [
+        "settle",
+        f"health:{account_a.id}:invalid_request_error",
+    ]
+    release_unsettled.assert_not_awaited()
+    record_errors.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_post_refresh_ambiguous_connect_exhaustion_counts_every_retry(monkeypatch):
+
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_transient_terminal")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15194,7 +15194,12 @@ async def test_stream_with_retry_keyed_transient_exhaustion_settles_before_accou
     )
     release_unsettled = AsyncMock()
     record_success = AsyncMock()
-    record_errors = AsyncMock()
+
+    async def record_retry_errors(account: Account, count: int) -> None:
+        assert account is account_a
+        settlement_order.append(f"extra:{count}")
+
+    record_errors = AsyncMock(side_effect=record_retry_errors)
 
     async def settle_usage(
         settled_api_key: ApiKeyData | None,
@@ -15244,7 +15249,7 @@ async def test_stream_with_retry_keyed_transient_exhaustion_settles_before_accou
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
-    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 3)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
@@ -15278,14 +15283,15 @@ async def test_stream_with_retry_keyed_transient_exhaustion_settles_before_accou
 
     terminal = json.loads(chunks[-1].split("data: ", 1)[1])
     assert terminal["response"]["id"] == "resp_keyed_transient_settle_ok"
-    assert stream_account_ids == [account_a.id, account_b.id]
+    assert stream_account_ids == [account_a.id, account_a.id, account_a.id, account_b.id]
     assert settlement_wait_flags == [True]
     assert settlement_order == [
         "settle",
         f"health:{account_a.id}:invalid_request_error",
+        "extra:2",
     ]
     release_unsettled.assert_not_awaited()
-    record_errors.assert_not_awaited()
+    record_errors.assert_awaited_once_with(account_a, 2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

On keyed HTTP streams, same-account transient-retry exhaustion was writing account health (and `record_errors`) immediately, then `break`ing past the settle helper while the shared API-key reservation was still open. Defer those penalties through the existing pending-penalty + settle-then-flush path used by post-refresh transient exhaustion and compact HTTP 500 failover.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: none (discovery finding `CLB-20260820-01`)

## OpenSpec

- [x] Not applicable — bug fix that matches the existing spec

Existing api-keys / stream-retry settlement ordering already requires deferred penalties to wait for reservation settlement. No delta change.

## Changes

- Keyed `_TransientStreamError` same-account exhaustion appends to `pending_post_refresh_transient_penalties` instead of calling `_handle_stream_error` / `record_errors` immediately
- Non-keyed streams keep the immediate health path
- Add unit regression asserting settle-before-health on keyed failover success

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py::test_stream_with_retry_keyed_transient_exhaustion_settles_before_account_health \
  tests/unit/test_proxy_utils.py::test_stream_with_retry_post_refresh_transient_exhaustion_fails_over \
  tests/unit/test_proxy_utils.py::test_compact_http_500_failover_settles_before_account_health -q
# 8 passed

uv run ruff check app/modules/proxy/_service/streaming/retry.py
uv run ruff format --check app/modules/proxy/_service/streaming/retry.py
```

Intentionally unrun locally: full `local-ci`, typecheck (`ty`), integration suite (covered by required CI).

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused local subset above.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary streaming interruptions for API-key-reserved requests.
  * Account usage is now settled before health penalties are applied, preventing premature account error reporting.
  * Unreserved streams continue to receive immediate health-error handling.

* **Tests**
  * Added regression coverage for usage settlement ordering during transient stream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->