### PR TITLE
fix(proxy): keep source Responses SSE alive and normalized

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1238,6 +1238,7 @@ async def _iter_sse_events(
 
     buffer = bytearray()
     scanned = 0
+    swallow_lf = False
     chunk_iterator = resp.content.iter_chunked(_SSE_READ_CHUNK_SIZE)
     iterator = chunk_iterator.__aiter__()
 
@@ -1259,6 +1260,13 @@ async def _iter_sse_events(
             continue
 
         buffer.extend(chunk)
+        if swallow_lf:
+            swallow_lf = False
+            if buffer and buffer[0] == 0x0A:
+                # Residue of a CRLF ending whose CR closed the previous chunk:
+                # the separator was already dispatched with the bare CR, so
+                # this LF belongs to it, not to the next event.
+                del buffer[0]
         while True:
             # `scanned` marks the prefix already known to hold no separator,
             # so each new chunk only scans the new bytes (plus the straddle
@@ -1275,6 +1283,7 @@ async def _iter_sse_events(
             event_end = index + separator_len
             raw_event = bytes(buffer[:event_end])
             del buffer[:event_end]
+            swallow_lf = raw_event.endswith(b"\r") and not buffer
             scanned = 0
 
             if len(raw_event) > max_event_bytes:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1150,13 +1150,41 @@ def _remaining_total_timeout(timeout_seconds: float | None, started_at: float, n
     return max(0.001, timeout_seconds - max(0.0, now - started_at))
 
 
-def _find_sse_separator(buffer: bytes | bytearray, start: int = 0) -> tuple[int, int] | None:
-    separators = (b"\r\n\r\n", b"\n\n", b"\r\r")
-    positions = [(buffer.find(separator, start), len(separator)) for separator in separators]
-    valid_positions = [position for position in positions if position[0] >= 0]
-    if not valid_positions:
+def _sse_line_ending_len(buffer: bytes | bytearray, index: int) -> int | None:
+    """Return the length of an SSE line ending at ``index``, or ``None``.
+
+    Only CR, LF, and CRLF count as line boundaries. CRLF is one ending.
+    """
+    if index >= len(buffer):
         return None
-    return min(valid_positions, key=lambda item: item[0])
+    if buffer[index] == 0x0D:
+        if index + 1 < len(buffer) and buffer[index + 1] == 0x0A:
+            return 2
+        return 1
+    if buffer[index] == 0x0A:
+        return 1
+    return None
+
+
+def _find_sse_separator(buffer: bytes | bytearray, start: int = 0) -> tuple[int, int] | None:
+    """Find the earliest SSE blank-line separator in ``buffer``.
+
+    A blank line is two consecutive SSE line endings (CR / LF / CRLF), including
+    mixed pairs such as ``\\n\\r`` and ``\\n\\r\\n``. Returns
+    ``(index, separator_len)`` where ``index`` is the start of the first ending.
+    """
+    index = max(0, start)
+    length = len(buffer)
+    while index < length:
+        first = _sse_line_ending_len(buffer, index)
+        if first is None:
+            index += 1
+            continue
+        second = _sse_line_ending_len(buffer, index + first)
+        if second is not None:
+            return (index, first + second)
+        index += first
+    return None
 
 
 def _pop_sse_event(buffer: bytearray) -> bytes | None:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1172,18 +1172,39 @@ def _find_sse_separator(buffer: bytes | bytearray, start: int = 0) -> tuple[int,
     A blank line is two consecutive SSE line endings (CR / LF / CRLF), including
     mixed pairs such as ``\\n\\r`` and ``\\n\\r\\n``. Returns
     ``(index, separator_len)`` where ``index`` is the start of the first ending.
+
+    Candidates are located with C-level ``bytes.find`` and endings are
+    classified only at candidate positions, so the account-backed SSE relay
+    hot path never scans byte-by-byte in Python.
     """
-    index = max(0, start)
     length = len(buffer)
+    index = max(0, start)
+    # Next CR / LF position at or after ``index``: -2 not yet searched,
+    # -1 absent in the rest of the buffer. Caching both keeps the scan O(n)
+    # when one ending byte is frequent and the other is far away.
+    cr = -2
+    lf = -2
     while index < length:
-        first = _sse_line_ending_len(buffer, index)
-        if first is None:
-            index += 1
-            continue
-        second = _sse_line_ending_len(buffer, index + first)
+        if cr != -1 and cr < index:
+            cr = buffer.find(b"\r", index)
+        if lf != -1 and lf < index:
+            lf = buffer.find(b"\n", index)
+        if cr == -1:
+            candidate = lf
+        elif lf == -1:
+            candidate = cr
+        else:
+            candidate = cr if cr < lf else lf
+        if candidate == -1:
+            return None
+        if buffer[candidate] == 0x0D and candidate + 1 < length and buffer[candidate + 1] == 0x0A:
+            first = 2
+        else:
+            first = 1
+        second = _sse_line_ending_len(buffer, candidate + first)
         if second is not None:
-            return (index, first + second)
-        index += first
+            return (candidate, first + second)
+        index = candidate + first
     return None
 
 

--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -60,42 +60,51 @@ async def inject_sse_keepalives(
 
     A non-positive ``interval_seconds`` disables injection entirely.
     """
-    if interval_seconds <= 0:
-        async for chunk in source:
-            yield chunk
-        return
-
-    async def _next_chunk(it: AsyncIterator[str]) -> str:
-        return await it.__anext__()
-
     iterator = source.__aiter__()
-    pending: asyncio.Task[str] | None = None
     try:
-        while True:
-            if pending is None:
-                pending = asyncio.create_task(_next_chunk(iterator))
-            try:
-                chunk = await asyncio.wait_for(
-                    asyncio.shield(pending),
-                    timeout=interval_seconds,
-                )
-            except asyncio.TimeoutError:
-                if on_keepalive is not None:
-                    on_keepalive()
-                yield keepalive_frame
-                continue
-            except StopAsyncIteration:
+        if interval_seconds <= 0:
+            async for chunk in iterator:
+                yield chunk
+            return
+
+        async def _next_chunk(it: AsyncIterator[str]) -> str:
+            return await it.__anext__()
+
+        pending: asyncio.Task[str] | None = None
+        try:
+            while True:
+                if pending is None:
+                    pending = asyncio.create_task(_next_chunk(iterator))
+                try:
+                    chunk = await asyncio.wait_for(
+                        asyncio.shield(pending),
+                        timeout=interval_seconds,
+                    )
+                except asyncio.TimeoutError:
+                    if on_keepalive is not None:
+                        on_keepalive()
+                    yield keepalive_frame
+                    continue
+                except StopAsyncIteration:
+                    pending = None
+                    break
                 pending = None
-                break
-            pending = None
-            yield chunk
+                yield chunk
+        finally:
+            if pending is not None and not pending.done():
+                pending.cancel()
+                try:
+                    await pending
+                except BaseException:
+                    pass
     finally:
-        if pending is not None and not pending.done():
-            pending.cancel()
-            try:
-                await pending
-            except BaseException:
-                pass
+        aclose = getattr(iterator, "aclose", None)
+        if aclose is not None:
+            await aclose()
+        elif iterator is not source:
+            source_aclose = getattr(source, "aclose", None)
+            if source_aclose is not None:
+                await source_aclose()
 
 
 def format_sse_event(payload: JsonPayload) -> str:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5634,12 +5634,24 @@ async def _wrap_source_responses_public_stream(
                     try:
                         await _aclose_stream(normalized)
                     finally:
-                        await _aclose_stream(event_blocks)
+                        try:
+                            await _aclose_stream(event_blocks)
+                        finally:
+                            # ``aclose()`` on a never-started async generator
+                            # skips its ``finally`` blocks, so the eagerly
+                            # opened source body must be closed directly when
+                            # teardown happens before iteration starts (e.g. a
+                            # native client disconnecting right after the
+                            # initial heartbeat).
+                            await _aclose_stream(stream)
             else:
                 try:
                     await _aclose_stream(normalized)
                 finally:
-                    await _aclose_stream(event_blocks)
+                    try:
+                        await _aclose_stream(event_blocks)
+                    finally:
+                        await _aclose_stream(stream)
 
 
 async def _source_chat_stream_with_settlement(
@@ -8459,14 +8471,19 @@ async def _normalize_public_responses_stream(
             continue
         payload = _parse_sse_payload(event_block)
         if payload is None:
-            if _looks_like_sse_data_block(event_block):
+            is_unparseable_data = _looks_like_sse_data_block(event_block)
+            if is_unparseable_data:
                 contract_violation_kind = contract_violation_kind or "invalid_json"
             if forward_unparseable_data:
                 # Source-routed streams forward blocks the proxy cannot parse
                 # byte-identically instead of eating upstream data: the pre-wrap
                 # contract was raw passthrough, and merged model-source routing
                 # tests assert source bytes reach the client.
-                unparseable_forwarded = True
+                if is_unparseable_data:
+                    # Only unparseable *data* suppresses terminal synthesis;
+                    # valid non-data control blocks (e.g. ``retry:``) keep the
+                    # truncated-stream failure contract intact.
+                    unparseable_forwarded = True
                 yield event_block
             continue
         parsed_payload = payload

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import codecs
 import json
 import logging
 import math
@@ -48,10 +47,13 @@ from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_RESET_CREDITS, bump_cache_invalidation_local
 from app.core.clients.files import FileProxyError
 from app.core.clients.proxy import (
+    _SSE_SEPARATOR_OVERLAP,
     CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     CodexControlRequestPrivacyPolicy,
     CodexControlResponse,
     ProxyResponseError,
+    StreamEventTooLargeError,
+    _find_sse_separator,
     _is_native_codex_request,
 )
 from app.core.clients.proxy_websocket import (
@@ -1152,6 +1154,8 @@ async def responses(
             api_key=api_key,
             rate_limit_headers=rate_limit_headers,
             pre_normalization_effort=pre_normalization_effort,
+            enforce_openai_sdk_contract=openai_sdk_request,
+            native_codex_heartbeat=native_codex_heartbeat,
         )
 
     apply_enforced_service_tier_model_fallback(
@@ -4735,6 +4739,8 @@ async def _source_responses_response(
     api_key: ApiKeyData | None,
     rate_limit_headers: Mapping[str, str],
     pre_normalization_effort: str | None,
+    enforce_openai_sdk_contract: bool = True,
+    native_codex_heartbeat: bool = False,
 ) -> Response:
     # This is the first point where the request is known to be served by a
     # model source rather than a subscription account, so it is the only place
@@ -4823,14 +4829,22 @@ async def _source_responses_response(
             # that buffer gate remains.
             if isinstance(response, StreamingResponse):
                 return StreamingResponse(
-                    _wrap_source_responses_public_stream(response.body_iterator),
+                    _wrap_source_responses_public_stream(
+                        response.body_iterator,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                        native_codex_heartbeat=native_codex_heartbeat,
+                    ),
                     media_type=response.media_type,
                     status_code=response.status_code,
                     headers=dict(response.headers),
                 )
             return response
         body = _source_chat_stream_with_settlement(
-            _wrap_source_responses_public_stream(stream.body),
+            _wrap_source_responses_public_stream(
+                stream.body,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                native_codex_heartbeat=native_codex_heartbeat,
+            ),
             usage_holder=stream.usage_holder,
             request=request,
             source=source,
@@ -5507,16 +5521,18 @@ async def _buffered_limited_source_chat_stream_response(
 
 async def _iter_source_sse_event_blocks(
     stream: AsyncIterable[bytes | str | memoryview[int]],
+    *,
+    max_event_bytes: int | None = None,
 ) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
-    SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
-    UTF-8 characters spanning chunks survive, and hold a trailing ``\\r`` until the
-    next chunk so a split CRLF cannot become a false ``\\n\\n`` boundary.
+    Detects LF, CRLF, and CR-only blank-line separators without rewriting the
+    retained event's terminator bytes, so unmodified pass-through stays
+    byte-identical. Bounds reassembly with ``max_sse_event_bytes``.
     """
-    decoder = codecs.getincrementaldecoder("utf-8")("replace")
-    buffer = ""
-    pending_cr = False
+    limit = max_event_bytes if max_event_bytes is not None else get_settings().max_sse_event_bytes
+    buffer = bytearray()
+    scanned = 0
     iterator: AsyncIterator[bytes | str | memoryview[int]] | None = None
     try:
         iterator = stream.__aiter__()
@@ -5529,28 +5545,28 @@ async def _iter_source_sse_event_blocks(
                 raw = chunk.encode("utf-8")
             else:
                 raw = chunk
-            text = decoder.decode(raw)
-            if pending_cr:
-                if text.startswith("\n"):
-                    text = text[1:]
-                buffer += "\n"
-                pending_cr = False
-            if text.endswith("\r"):
-                pending_cr = True
-                text = text[:-1]
-            buffer += text.replace("\r\n", "\n").replace("\r", "\n")
-            while "\n\n" in buffer:
-                raw_block, buffer = buffer.split("\n\n", 1)
-                if raw_block:
-                    yield f"{raw_block}\n\n"
-        trailing = decoder.decode(b"", final=True)
-        if pending_cr:
-            buffer += "\n"
-            pending_cr = False
-        if trailing:
-            buffer += trailing.replace("\r\n", "\n").replace("\r", "\n")
-        if buffer.strip():
-            yield buffer
+            buffer.extend(raw)
+            while True:
+                separator = _find_sse_separator(buffer, max(0, scanned - _SSE_SEPARATOR_OVERLAP))
+                if separator is None:
+                    scanned = len(buffer)
+                    if len(buffer) > limit:
+                        raise StreamEventTooLargeError(len(buffer), limit)
+                    break
+                index, separator_len = separator
+                event_end = index + separator_len
+                raw_event = bytes(buffer[:event_end])
+                del buffer[:event_end]
+                scanned = 0
+                if len(raw_event) > limit:
+                    raise StreamEventTooLargeError(len(raw_event), limit)
+                if raw_event.strip():
+                    yield raw_event.decode("utf-8", errors="replace")
+        if buffer:
+            if len(buffer) > limit:
+                raise StreamEventTooLargeError(len(buffer), limit)
+            if buffer.strip():
+                yield bytes(buffer).decode("utf-8", errors="replace")
     finally:
         try:
             if iterator is not None:
@@ -5560,24 +5576,69 @@ async def _iter_source_sse_event_blocks(
                 await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(
+async def _wrap_source_responses_public_stream(
     stream: AsyncIterable[bytes | str | memoryview[int]],
+    *,
+    enforce_openai_sdk_contract: bool = True,
+    native_codex_heartbeat: bool = False,
 ) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and
-    injects keepalives. Source-routed ``/v1/responses`` previously forwarded
-    raw upstream byte chunks and could idle out through front-door proxies.
+    injects keepalives. Source-routed Responses previously forwarded raw
+    upstream byte chunks and could idle out through front-door proxies.
+
+    Transport-aware: public OpenAI SDK clients get contract enforcement and
+    comment keepalives; native Codex clients keep ``codex.*`` events and
+    ``codex.keepalive`` framing like the subscription path.
     """
-    return inject_sse_keepalives(
-        _normalize_public_responses_stream(
-            _iter_source_sse_event_blocks(stream),
-            enforce_openai_sdk_contract=True,
-        ),
-        get_settings().sse_keepalive_interval_seconds,
-        keepalive_frame=SSE_KEEPALIVE_FRAME,
+    use_codex_keepalive = native_codex_heartbeat or not enforce_openai_sdk_contract
+    keepalive_frame = CODEX_KEEPALIVE_FRAME if use_codex_keepalive else SSE_KEEPALIVE_FRAME
+    settings = get_settings()
+    event_blocks = _iter_source_sse_event_blocks(
+        stream,
+        max_event_bytes=getattr(settings, "max_sse_event_bytes", 16 * 1024 * 1024),
+    )
+    normalized = _normalize_public_responses_stream(
+        event_blocks,
+        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+    )
+    keepalive_stream = inject_sse_keepalives(
+        normalized,
+        settings.sse_keepalive_interval_seconds,
+        keepalive_frame=keepalive_frame,
         on_keepalive=lambda: _record_stream_keepalive("responses_source"),
     )
+    outbound: AsyncIterator[str] = keepalive_stream
+    if use_codex_keepalive:
+        outbound = _prepend_initial_sse_heartbeat(
+            keepalive_stream,
+            keepalive_frame,
+            request_id=get_request_id(),
+            route_family="responses_source",
+        )
+    try:
+        async for chunk in outbound:
+            yield chunk
+    finally:
+        # Deterministic cascade: outer stream first, then any layers it may not
+        # have closed when the client disconnects mid-flight.
+        try:
+            await _aclose_stream(outbound)
+        finally:
+            if outbound is not keepalive_stream:
+                try:
+                    await _aclose_stream(keepalive_stream)
+                finally:
+                    try:
+                        await _aclose_stream(normalized)
+                    finally:
+                        await _aclose_stream(event_blocks)
+            else:
+                try:
+                    await _aclose_stream(normalized)
+                finally:
+                    await _aclose_stream(event_blocks)
 
 
 async def _source_chat_stream_with_settlement(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -302,6 +302,7 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
+_SourceStreamChunkT = TypeVar("_SourceStreamChunkT", bytes, str)
 
 _REASONING_SUMMARY_DELTA_TYPES = frozenset({"response.reasoning_summary_text.delta"})
 _REASONING_SUMMARY_DONE_TYPES = frozenset(
@@ -4816,7 +4817,7 @@ async def _source_responses_response(
                 rate_limit_headers=rate_limit_headers,
             )
         body = _source_chat_stream_with_settlement(
-            stream.body,
+            _wrap_source_responses_public_stream(stream.body),
             usage_holder=stream.usage_holder,
             request=request,
             source=source,
@@ -5491,8 +5492,45 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
+async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Reassemble chunked source bytes into SSE event blocks for public shaping."""
+    buffer = b""
+    try:
+        async for chunk in stream:
+            if not chunk:
+                continue
+            buffer += chunk
+            while b"\n\n" in buffer:
+                raw_block, buffer = buffer.split(b"\n\n", 1)
+                text = raw_block.decode("utf-8")
+                if text:
+                    yield f"{text}\n\n"
+        if buffer.strip():
+            yield buffer.decode("utf-8")
+    finally:
+        await _aclose_stream(stream)
+
+
+def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
+
+    Account-backed ``_stream_responses`` already reassembles, normalizes, and
+    injects keepalives. Source-routed ``/v1/responses`` previously forwarded
+    raw upstream byte chunks and could idle out through front-door proxies.
+    """
+    return inject_sse_keepalives(
+        _normalize_public_responses_stream(
+            _iter_source_sse_event_blocks(stream),
+            enforce_openai_sdk_contract=True,
+        ),
+        get_settings().sse_keepalive_interval_seconds,
+        keepalive_frame=SSE_KEEPALIVE_FRAME,
+        on_keepalive=lambda: _record_stream_keepalive("responses_source"),
+    )
+
+
 async def _source_chat_stream_with_settlement(
-    stream: AsyncIterator[bytes],
+    stream: AsyncIterator[_SourceStreamChunkT],
     *,
     usage_holder: SourceUsageHolder,
     request: Request,
@@ -5500,7 +5538,7 @@ async def _source_chat_stream_with_settlement(
     api_key: ApiKeyData | None,
     model: str,
     reservation: ApiKeyUsageReservationData | None,
-) -> AsyncIterator[bytes]:
+) -> AsyncIterator[_SourceStreamChunkT]:
     status = "success"
     error_code: str | None = None
     error_message: str | None = None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4806,7 +4806,7 @@ async def _source_responses_response(
             )
             return _logged_error_json_response(request, exc.status_code, exc.payload, headers=rate_limit_headers)
         if _reservation_requires_usage(reservation):
-            return await _buffered_limited_source_chat_stream_response(
+            response = await _buffered_limited_source_chat_stream_response(
                 request,
                 source=source,
                 api_key=api_key,
@@ -4816,6 +4816,18 @@ async def _source_responses_response(
                 usage_holder=stream.usage_holder,
                 rate_limit_headers=rate_limit_headers,
             )
+            # Limited keys stay fail-closed: usage must be present before any
+            # body bytes reach the client. Public normalize still applies to the
+            # replayed body; keepalives cannot precede upstream completion while
+            # that buffer gate remains.
+            if isinstance(response, StreamingResponse):
+                return StreamingResponse(
+                    _wrap_source_responses_public_stream(response.body_iterator),
+                    media_type=response.media_type,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                )
+            return response
         body = _source_chat_stream_with_settlement(
             _wrap_source_responses_public_stream(stream.body),
             usage_holder=stream.usage_holder,
@@ -5493,20 +5505,23 @@ async def _buffered_limited_source_chat_stream_response(
 
 
 async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
-    """Reassemble chunked source bytes into SSE event blocks for public shaping."""
-    buffer = b""
+    """Reassemble chunked source bytes into SSE event blocks for public shaping.
+
+    SSE permits CR, LF, and CRLF line endings. Normalize to LF so event-block
+    detection only needs ``\\n\\n``, matching ``SourceStreamUsageParser``.
+    """
+    buffer = ""
     try:
         async for chunk in stream:
             if not chunk:
                 continue
-            buffer += chunk
-            while b"\n\n" in buffer:
-                raw_block, buffer = buffer.split(b"\n\n", 1)
-                text = raw_block.decode("utf-8")
-                if text:
-                    yield f"{text}\n\n"
+            buffer += chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n").replace("\r", "\n")
+            while "\n\n" in buffer:
+                raw_block, buffer = buffer.split("\n\n", 1)
+                if raw_block:
+                    yield f"{raw_block}\n\n"
         if buffer.strip():
-            yield buffer.decode("utf-8")
+            yield buffer
     finally:
         await _aclose_stream(stream)
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5455,8 +5455,9 @@ async def _iter_source_sse_event_blocks(
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
     pending_cr = False
+    iterator = stream.__aiter__()
     try:
-        async for chunk in stream:
+        async for chunk in iterator:
             if not chunk:
                 continue
             if isinstance(chunk, memoryview):
@@ -5488,7 +5489,9 @@ async def _iter_source_sse_event_blocks(
         if buffer.strip():
             yield buffer
     finally:
-        await _aclose_stream(stream)
+        await _aclose_stream(iterator)
+        if iterator is not stream:
+            await _aclose_stream(stream)
 
 
 def _wrap_source_responses_public_stream(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5517,8 +5517,9 @@ async def _iter_source_sse_event_blocks(
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
     pending_cr = False
+    iterator = stream.__aiter__()
     try:
-        async for chunk in stream:
+        async for chunk in iterator:
             if not chunk:
                 continue
             if isinstance(chunk, memoryview):
@@ -5550,7 +5551,9 @@ async def _iter_source_sse_event_blocks(
         if buffer.strip():
             yield buffer
     finally:
-        await _aclose_stream(stream)
+        await _aclose_stream(iterator)
+        if iterator is not stream:
+            await _aclose_stream(stream)
 
 
 def _wrap_source_responses_public_stream(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -9307,7 +9307,17 @@ def _extract_public_output_item_text(item: Mapping[str, JsonValue]) -> str | Non
 
 
 def _looks_like_sse_data_block(event_block: str) -> bool:
-    return "data:" in event_block
+    """True when the block contains an SSE ``data`` field line.
+
+    Inspects complete field lines instead of substring matching, so field
+    values containing the literal ``data:`` (for example ``id: data:1``) do
+    not count as data, while the valid empty-field form (a bare ``data``
+    line) does.
+    """
+    for line in event_block.splitlines():
+        if line == "data" or line.startswith("data:"):
+            return True
+    return False
 
 
 def _looks_like_sse_comment_block(event_block: str) -> bool:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6,7 +6,7 @@ import json
 import logging
 import math
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -5505,7 +5505,9 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
-async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
+async def _iter_source_sse_event_blocks(
+    stream: AsyncIterable[bytes | str | memoryview[int]],
+) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
     SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
@@ -5519,7 +5521,13 @@ async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> A
         async for chunk in stream:
             if not chunk:
                 continue
-            text = decoder.decode(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+            if isinstance(chunk, memoryview):
+                raw = chunk.tobytes()
+            elif isinstance(chunk, str):
+                raw = chunk.encode("utf-8")
+            else:
+                raw = chunk
+            text = decoder.decode(raw)
             if pending_cr:
                 if text.startswith("\n"):
                     text = text[1:]
@@ -5545,7 +5553,9 @@ async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> A
         await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
+def _wrap_source_responses_public_stream(
+    stream: AsyncIterable[bytes | str | memoryview[int]],
+) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and
@@ -8098,7 +8108,7 @@ async def _log_source_chat_completion(
         )
 
 
-async def _aclose_stream(stream: AsyncIterator[object]) -> None:
+async def _aclose_stream(stream: object) -> None:
     aclose = getattr(stream, "aclose", None)
     if aclose is not None:
         await aclose()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import json
 import logging
 import math
@@ -5442,29 +5443,47 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
-async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
-    SSE permits CR, LF, and CRLF line endings. Normalize to LF so event-block
-    detection only needs ``\\n\\n``, matching ``SourceStreamUsageParser``.
+    SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
+    UTF-8 characters spanning chunks survive, and hold a trailing ``\\r`` until the
+    next chunk so a split CRLF cannot become a false ``\\n\\n`` boundary.
     """
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
+    pending_cr = False
     try:
         async for chunk in stream:
             if not chunk:
                 continue
-            buffer += chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n").replace("\r", "\n")
+            text = decoder.decode(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+            if pending_cr:
+                if text.startswith("\n"):
+                    text = text[1:]
+                buffer += "\n"
+                pending_cr = False
+            if text.endswith("\r"):
+                pending_cr = True
+                text = text[:-1]
+            buffer += text.replace("\r\n", "\n").replace("\r", "\n")
             while "\n\n" in buffer:
                 raw_block, buffer = buffer.split("\n\n", 1)
                 if raw_block:
                     yield f"{raw_block}\n\n"
+        trailing = decoder.decode(b"", final=True)
+        if pending_cr:
+            buffer += "\n"
+            pending_cr = False
+        if trailing:
+            buffer += trailing.replace("\r\n", "\n").replace("\r", "\n")
         if buffer.strip():
             yield buffer
     finally:
         await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6,7 +6,7 @@ import json
 import logging
 import math
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -5443,7 +5443,9 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
-async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
+async def _iter_source_sse_event_blocks(
+    stream: AsyncIterable[bytes | str | memoryview[int]],
+) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
     SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
@@ -5457,7 +5459,13 @@ async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> A
         async for chunk in stream:
             if not chunk:
                 continue
-            text = decoder.decode(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+            if isinstance(chunk, memoryview):
+                raw = chunk.tobytes()
+            elif isinstance(chunk, str):
+                raw = chunk.encode("utf-8")
+            else:
+                raw = chunk
+            text = decoder.decode(raw)
             if pending_cr:
                 if text.startswith("\n"):
                     text = text[1:]
@@ -5483,7 +5491,9 @@ async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> A
         await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
+def _wrap_source_responses_public_stream(
+    stream: AsyncIterable[bytes | str | memoryview[int]],
+) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and
@@ -8039,7 +8049,7 @@ async def _log_source_chat_completion(
         )
 
 
-async def _aclose_stream(stream: AsyncIterator[object]) -> None:
+async def _aclose_stream(stream: object) -> None:
     aclose = getattr(stream, "aclose", None)
     if aclose is not None:
         await aclose()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5455,8 +5455,9 @@ async def _iter_source_sse_event_blocks(
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
     pending_cr = False
-    iterator = stream.__aiter__()
+    iterator: AsyncIterator[bytes | str | memoryview[int]] | None = None
     try:
+        iterator = stream.__aiter__()
         async for chunk in iterator:
             if not chunk:
                 continue
@@ -5489,9 +5490,12 @@ async def _iter_source_sse_event_blocks(
         if buffer.strip():
             yield buffer
     finally:
-        await _aclose_stream(iterator)
-        if iterator is not stream:
-            await _aclose_stream(stream)
+        try:
+            if iterator is not None:
+                await _aclose_stream(iterator)
+        finally:
+            if iterator is not stream:
+                await _aclose_stream(stream)
 
 
 def _wrap_source_responses_public_stream(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5528,11 +5528,16 @@ async def _iter_source_sse_event_blocks(
 
     Detects LF, CRLF, and CR-only blank-line separators without rewriting the
     retained event's terminator bytes, so unmodified pass-through stays
-    byte-identical. Bounds reassembly with ``max_sse_event_bytes``.
+    byte-identical. Ignores one optional leading UTF-8 BOM, and swallows the
+    LF residue of a CRLF separator whose CR arrived at the end of the prior
+    chunk (CR-only dispatch must not wait for the disambiguating byte).
+    Bounds reassembly with ``max_sse_event_bytes``.
     """
     limit = max_event_bytes if max_event_bytes is not None else get_settings().max_sse_event_bytes
     buffer = bytearray()
     scanned = 0
+    bom_pending = True
+    swallow_lf = False
     iterator: AsyncIterator[bytes | str | memoryview[int]] | None = None
     try:
         iterator = stream.__aiter__()
@@ -5546,6 +5551,23 @@ async def _iter_source_sse_event_blocks(
             else:
                 raw = chunk
             buffer.extend(raw)
+            if bom_pending:
+                if len(buffer) >= 3:
+                    if buffer[:3] == b"\xef\xbb\xbf":
+                        del buffer[:3]
+                    bom_pending = False
+                elif bytes(buffer) in (b"\xef", b"\xef\xbb"):
+                    # Partial possible BOM: wait for the disambiguating bytes.
+                    continue
+                else:
+                    bom_pending = False
+            if swallow_lf:
+                swallow_lf = False
+                if buffer and buffer[0] == 0x0A:
+                    # Residue of a CRLF ending whose CR closed the previous
+                    # chunk: the separator was already dispatched with the
+                    # bare CR, so this LF belongs to it, not the next event.
+                    del buffer[0]
             while True:
                 separator = _find_sse_separator(buffer, max(0, scanned - _SSE_SEPARATOR_OVERLAP))
                 if separator is None:
@@ -5557,6 +5579,7 @@ async def _iter_source_sse_event_blocks(
                 event_end = index + separator_len
                 raw_event = bytes(buffer[:event_end])
                 del buffer[:event_end]
+                swallow_lf = raw_event.endswith(b"\r") and not buffer
                 scanned = 0
                 if len(raw_event) > limit:
                     raise StreamEventTooLargeError(len(raw_event), limit)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5602,6 +5602,7 @@ async def _wrap_source_responses_public_stream(
     normalized = _normalize_public_responses_stream(
         event_blocks,
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+        forward_unparseable_data=True,
     )
     keepalive_stream = inject_sse_keepalives(
         normalized,
@@ -8349,6 +8350,7 @@ async def _normalize_public_responses_stream(
     stream: AsyncIterator[str],
     *,
     enforce_openai_sdk_contract: bool = True,
+    forward_unparseable_data: bool = False,
 ) -> AsyncIterator[str]:
     stream = _normalize_reasoning_summary_stream(stream)
     """Normalize the upstream SSE event stream for the public /v1 surface.
@@ -8367,6 +8369,7 @@ async def _normalize_public_responses_stream(
     """
     terminal_seen = False
     done_seen = False
+    unparseable_forwarded = False
     contract_violation_kind: str | None = None
     next_sequence_number = 0
     seen_text_delta_keys: set[tuple[str | None, int | None]] = set()
@@ -8458,6 +8461,13 @@ async def _normalize_public_responses_stream(
         if payload is None:
             if _looks_like_sse_data_block(event_block):
                 contract_violation_kind = contract_violation_kind or "invalid_json"
+            if forward_unparseable_data:
+                # Source-routed streams forward blocks the proxy cannot parse
+                # byte-identically instead of eating upstream data: the pre-wrap
+                # contract was raw passthrough, and merged model-source routing
+                # tests assert source bytes reach the client.
+                unparseable_forwarded = True
+                yield event_block
             continue
         parsed_payload = payload
         raw_event_type = payload.get("type")
@@ -8584,6 +8594,12 @@ async def _normalize_public_responses_stream(
     if terminal_seen:
         if not done_seen and not enforce_openai_sdk_contract:
             yield "data: [DONE]\n\n"
+        return
+    if unparseable_forwarded:
+        # Raw source blocks already reached the client. Synthesizing a
+        # terminal here would mislabel a stream the proxy could not
+        # interpret (for example a successful source stream whose terminal
+        # event was not valid JSON) as a failure.
         return
     error_kind = contract_violation_kind or (
         "upstream_stream_truncated" if enforce_openai_sdk_contract else "stream_incomplete"

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4744,7 +4744,7 @@ async def _source_responses_response(
             )
             return _logged_error_json_response(request, exc.status_code, exc.payload, headers=rate_limit_headers)
         if _reservation_requires_usage(reservation):
-            return await _buffered_limited_source_chat_stream_response(
+            response = await _buffered_limited_source_chat_stream_response(
                 request,
                 source=source,
                 api_key=api_key,
@@ -4754,6 +4754,18 @@ async def _source_responses_response(
                 usage_holder=stream.usage_holder,
                 rate_limit_headers=rate_limit_headers,
             )
+            # Limited keys stay fail-closed: usage must be present before any
+            # body bytes reach the client. Public normalize still applies to the
+            # replayed body; keepalives cannot precede upstream completion while
+            # that buffer gate remains.
+            if isinstance(response, StreamingResponse):
+                return StreamingResponse(
+                    _wrap_source_responses_public_stream(response.body_iterator),
+                    media_type=response.media_type,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                )
+            return response
         body = _source_chat_stream_with_settlement(
             _wrap_source_responses_public_stream(stream.body),
             usage_holder=stream.usage_holder,
@@ -5431,20 +5443,23 @@ async def _buffered_limited_source_chat_stream_response(
 
 
 async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
-    """Reassemble chunked source bytes into SSE event blocks for public shaping."""
-    buffer = b""
+    """Reassemble chunked source bytes into SSE event blocks for public shaping.
+
+    SSE permits CR, LF, and CRLF line endings. Normalize to LF so event-block
+    detection only needs ``\\n\\n``, matching ``SourceStreamUsageParser``.
+    """
+    buffer = ""
     try:
         async for chunk in stream:
             if not chunk:
                 continue
-            buffer += chunk
-            while b"\n\n" in buffer:
-                raw_block, buffer = buffer.split(b"\n\n", 1)
-                text = raw_block.decode("utf-8")
-                if text:
-                    yield f"{text}\n\n"
+            buffer += chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n").replace("\r", "\n")
+            while "\n\n" in buffer:
+                raw_block, buffer = buffer.split("\n\n", 1)
+                if raw_block:
+                    yield f"{raw_block}\n\n"
         if buffer.strip():
-            yield buffer.decode("utf-8")
+            yield buffer
     finally:
         await _aclose_stream(stream)
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import codecs
 import json
 import logging
 import math
@@ -48,10 +47,13 @@ from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_RESET_CREDITS, bump_cache_invalidation_local
 from app.core.clients.files import FileProxyError
 from app.core.clients.proxy import (
+    _SSE_SEPARATOR_OVERLAP,
     CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     CodexControlRequestPrivacyPolicy,
     CodexControlResponse,
     ProxyResponseError,
+    StreamEventTooLargeError,
+    _find_sse_separator,
     _is_native_codex_request,
 )
 from app.core.clients.proxy_websocket import (
@@ -1147,6 +1149,8 @@ async def responses(
             api_key=api_key,
             rate_limit_headers=rate_limit_headers,
             pre_normalization_effort=pre_normalization_effort,
+            enforce_openai_sdk_contract=openai_sdk_request,
+            native_codex_heartbeat=native_codex_heartbeat,
         )
 
     apply_enforced_service_tier_model_fallback(
@@ -4673,6 +4677,8 @@ async def _source_responses_response(
     api_key: ApiKeyData | None,
     rate_limit_headers: Mapping[str, str],
     pre_normalization_effort: str | None,
+    enforce_openai_sdk_contract: bool = True,
+    native_codex_heartbeat: bool = False,
 ) -> Response:
     # This is the first point where the request is known to be served by a
     # model source rather than a subscription account, so it is the only place
@@ -4761,14 +4767,22 @@ async def _source_responses_response(
             # that buffer gate remains.
             if isinstance(response, StreamingResponse):
                 return StreamingResponse(
-                    _wrap_source_responses_public_stream(response.body_iterator),
+                    _wrap_source_responses_public_stream(
+                        response.body_iterator,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                        native_codex_heartbeat=native_codex_heartbeat,
+                    ),
                     media_type=response.media_type,
                     status_code=response.status_code,
                     headers=dict(response.headers),
                 )
             return response
         body = _source_chat_stream_with_settlement(
-            _wrap_source_responses_public_stream(stream.body),
+            _wrap_source_responses_public_stream(
+                stream.body,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                native_codex_heartbeat=native_codex_heartbeat,
+            ),
             usage_holder=stream.usage_holder,
             request=request,
             source=source,
@@ -5445,16 +5459,18 @@ async def _buffered_limited_source_chat_stream_response(
 
 async def _iter_source_sse_event_blocks(
     stream: AsyncIterable[bytes | str | memoryview[int]],
+    *,
+    max_event_bytes: int | None = None,
 ) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
-    SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
-    UTF-8 characters spanning chunks survive, and hold a trailing ``\\r`` until the
-    next chunk so a split CRLF cannot become a false ``\\n\\n`` boundary.
+    Detects LF, CRLF, and CR-only blank-line separators without rewriting the
+    retained event's terminator bytes, so unmodified pass-through stays
+    byte-identical. Bounds reassembly with ``max_sse_event_bytes``.
     """
-    decoder = codecs.getincrementaldecoder("utf-8")("replace")
-    buffer = ""
-    pending_cr = False
+    limit = max_event_bytes if max_event_bytes is not None else get_settings().max_sse_event_bytes
+    buffer = bytearray()
+    scanned = 0
     iterator: AsyncIterator[bytes | str | memoryview[int]] | None = None
     try:
         iterator = stream.__aiter__()
@@ -5467,28 +5483,28 @@ async def _iter_source_sse_event_blocks(
                 raw = chunk.encode("utf-8")
             else:
                 raw = chunk
-            text = decoder.decode(raw)
-            if pending_cr:
-                if text.startswith("\n"):
-                    text = text[1:]
-                buffer += "\n"
-                pending_cr = False
-            if text.endswith("\r"):
-                pending_cr = True
-                text = text[:-1]
-            buffer += text.replace("\r\n", "\n").replace("\r", "\n")
-            while "\n\n" in buffer:
-                raw_block, buffer = buffer.split("\n\n", 1)
-                if raw_block:
-                    yield f"{raw_block}\n\n"
-        trailing = decoder.decode(b"", final=True)
-        if pending_cr:
-            buffer += "\n"
-            pending_cr = False
-        if trailing:
-            buffer += trailing.replace("\r\n", "\n").replace("\r", "\n")
-        if buffer.strip():
-            yield buffer
+            buffer.extend(raw)
+            while True:
+                separator = _find_sse_separator(buffer, max(0, scanned - _SSE_SEPARATOR_OVERLAP))
+                if separator is None:
+                    scanned = len(buffer)
+                    if len(buffer) > limit:
+                        raise StreamEventTooLargeError(len(buffer), limit)
+                    break
+                index, separator_len = separator
+                event_end = index + separator_len
+                raw_event = bytes(buffer[:event_end])
+                del buffer[:event_end]
+                scanned = 0
+                if len(raw_event) > limit:
+                    raise StreamEventTooLargeError(len(raw_event), limit)
+                if raw_event.strip():
+                    yield raw_event.decode("utf-8", errors="replace")
+        if buffer:
+            if len(buffer) > limit:
+                raise StreamEventTooLargeError(len(buffer), limit)
+            if buffer.strip():
+                yield bytes(buffer).decode("utf-8", errors="replace")
     finally:
         try:
             if iterator is not None:
@@ -5498,24 +5514,69 @@ async def _iter_source_sse_event_blocks(
                 await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(
+async def _wrap_source_responses_public_stream(
     stream: AsyncIterable[bytes | str | memoryview[int]],
+    *,
+    enforce_openai_sdk_contract: bool = True,
+    native_codex_heartbeat: bool = False,
 ) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and
-    injects keepalives. Source-routed ``/v1/responses`` previously forwarded
-    raw upstream byte chunks and could idle out through front-door proxies.
+    injects keepalives. Source-routed Responses previously forwarded raw
+    upstream byte chunks and could idle out through front-door proxies.
+
+    Transport-aware: public OpenAI SDK clients get contract enforcement and
+    comment keepalives; native Codex clients keep ``codex.*`` events and
+    ``codex.keepalive`` framing like the subscription path.
     """
-    return inject_sse_keepalives(
-        _normalize_public_responses_stream(
-            _iter_source_sse_event_blocks(stream),
-            enforce_openai_sdk_contract=True,
-        ),
-        get_settings().sse_keepalive_interval_seconds,
-        keepalive_frame=SSE_KEEPALIVE_FRAME,
+    use_codex_keepalive = native_codex_heartbeat or not enforce_openai_sdk_contract
+    keepalive_frame = CODEX_KEEPALIVE_FRAME if use_codex_keepalive else SSE_KEEPALIVE_FRAME
+    settings = get_settings()
+    event_blocks = _iter_source_sse_event_blocks(
+        stream,
+        max_event_bytes=getattr(settings, "max_sse_event_bytes", 16 * 1024 * 1024),
+    )
+    normalized = _normalize_public_responses_stream(
+        event_blocks,
+        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+    )
+    keepalive_stream = inject_sse_keepalives(
+        normalized,
+        settings.sse_keepalive_interval_seconds,
+        keepalive_frame=keepalive_frame,
         on_keepalive=lambda: _record_stream_keepalive("responses_source"),
     )
+    outbound: AsyncIterator[str] = keepalive_stream
+    if use_codex_keepalive:
+        outbound = _prepend_initial_sse_heartbeat(
+            keepalive_stream,
+            keepalive_frame,
+            request_id=get_request_id(),
+            route_family="responses_source",
+        )
+    try:
+        async for chunk in outbound:
+            yield chunk
+    finally:
+        # Deterministic cascade: outer stream first, then any layers it may not
+        # have closed when the client disconnects mid-flight.
+        try:
+            await _aclose_stream(outbound)
+        finally:
+            if outbound is not keepalive_stream:
+                try:
+                    await _aclose_stream(keepalive_stream)
+                finally:
+                    try:
+                        await _aclose_stream(normalized)
+                    finally:
+                        await _aclose_stream(event_blocks)
+            else:
+                try:
+                    await _aclose_stream(normalized)
+                finally:
+                    await _aclose_stream(event_blocks)
 
 
 async def _source_chat_stream_with_settlement(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5517,8 +5517,9 @@ async def _iter_source_sse_event_blocks(
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
     pending_cr = False
-    iterator = stream.__aiter__()
+    iterator: AsyncIterator[bytes | str | memoryview[int]] | None = None
     try:
+        iterator = stream.__aiter__()
         async for chunk in iterator:
             if not chunk:
                 continue
@@ -5551,9 +5552,12 @@ async def _iter_source_sse_event_blocks(
         if buffer.strip():
             yield buffer
     finally:
-        await _aclose_stream(iterator)
-        if iterator is not stream:
-            await _aclose_stream(stream)
+        try:
+            if iterator is not None:
+                await _aclose_stream(iterator)
+        finally:
+            if iterator is not stream:
+                await _aclose_stream(stream)
 
 
 def _wrap_source_responses_public_stream(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -303,6 +303,7 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
+_SourceStreamChunkT = TypeVar("_SourceStreamChunkT", bytes, str)
 
 _REASONING_SUMMARY_DELTA_TYPES = frozenset({"response.reasoning_summary_text.delta"})
 _REASONING_SUMMARY_DONE_TYPES = frozenset(
@@ -4754,7 +4755,7 @@ async def _source_responses_response(
                 rate_limit_headers=rate_limit_headers,
             )
         body = _source_chat_stream_with_settlement(
-            stream.body,
+            _wrap_source_responses_public_stream(stream.body),
             usage_holder=stream.usage_holder,
             request=request,
             source=source,
@@ -5429,8 +5430,45 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
+async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Reassemble chunked source bytes into SSE event blocks for public shaping."""
+    buffer = b""
+    try:
+        async for chunk in stream:
+            if not chunk:
+                continue
+            buffer += chunk
+            while b"\n\n" in buffer:
+                raw_block, buffer = buffer.split(b"\n\n", 1)
+                text = raw_block.decode("utf-8")
+                if text:
+                    yield f"{text}\n\n"
+        if buffer.strip():
+            yield buffer.decode("utf-8")
+    finally:
+        await _aclose_stream(stream)
+
+
+def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
+
+    Account-backed ``_stream_responses`` already reassembles, normalizes, and
+    injects keepalives. Source-routed ``/v1/responses`` previously forwarded
+    raw upstream byte chunks and could idle out through front-door proxies.
+    """
+    return inject_sse_keepalives(
+        _normalize_public_responses_stream(
+            _iter_source_sse_event_blocks(stream),
+            enforce_openai_sdk_contract=True,
+        ),
+        get_settings().sse_keepalive_interval_seconds,
+        keepalive_frame=SSE_KEEPALIVE_FRAME,
+        on_keepalive=lambda: _record_stream_keepalive("responses_source"),
+    )
+
+
 async def _source_chat_stream_with_settlement(
-    stream: AsyncIterator[bytes],
+    stream: AsyncIterator[_SourceStreamChunkT],
     *,
     usage_holder: SourceUsageHolder,
     request: Request,
@@ -5438,7 +5476,7 @@ async def _source_chat_stream_with_settlement(
     api_key: ApiKeyData | None,
     model: str,
     reservation: ApiKeyUsageReservationData | None,
-) -> AsyncIterator[bytes]:
+) -> AsyncIterator[_SourceStreamChunkT]:
     status = "success"
     error_code: str | None = None
     error_message: str | None = None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import json
 import logging
 import math
@@ -5504,29 +5505,47 @@ async def _buffered_limited_source_chat_stream_response(
     )
 
 
-async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+async def _iter_source_sse_event_blocks(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
     """Reassemble chunked source bytes into SSE event blocks for public shaping.
 
-    SSE permits CR, LF, and CRLF line endings. Normalize to LF so event-block
-    detection only needs ``\\n\\n``, matching ``SourceStreamUsageParser``.
+    SSE permits CR, LF, and CRLF line endings. Decode incrementally so multi-byte
+    UTF-8 characters spanning chunks survive, and hold a trailing ``\\r`` until the
+    next chunk so a split CRLF cannot become a false ``\\n\\n`` boundary.
     """
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
     buffer = ""
+    pending_cr = False
     try:
         async for chunk in stream:
             if not chunk:
                 continue
-            buffer += chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n").replace("\r", "\n")
+            text = decoder.decode(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+            if pending_cr:
+                if text.startswith("\n"):
+                    text = text[1:]
+                buffer += "\n"
+                pending_cr = False
+            if text.endswith("\r"):
+                pending_cr = True
+                text = text[:-1]
+            buffer += text.replace("\r\n", "\n").replace("\r", "\n")
             while "\n\n" in buffer:
                 raw_block, buffer = buffer.split("\n\n", 1)
                 if raw_block:
                     yield f"{raw_block}\n\n"
+        trailing = decoder.decode(b"", final=True)
+        if pending_cr:
+            buffer += "\n"
+            pending_cr = False
+        if trailing:
+            buffer += trailing.replace("\r\n", "\n").replace("\r", "\n")
         if buffer.strip():
             yield buffer
     finally:
         await _aclose_stream(stream)
 
 
-def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+def _wrap_source_responses_public_stream(stream: AsyncIterator[bytes | str]) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
     Account-backed ``_stream_responses`` already reassembles, normalizes, and

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -9312,9 +9312,11 @@ def _looks_like_sse_data_block(event_block: str) -> bool:
     Inspects complete field lines instead of substring matching, so field
     values containing the literal ``data:`` (for example ``id: data:1``) do
     not count as data, while the valid empty-field form (a bare ``data``
-    line) does.
+    line) does. Lines are split only on the CR / LF / CRLF endings SSE
+    recognizes: ``str.splitlines`` would also split on Unicode separators
+    such as U+2028, which are legal inside field values.
     """
-    for line in event_block.splitlines():
+    for line in event_block.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
         if line == "data" or line.startswith("data:"):
             return True
     return False

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -8882,12 +8882,18 @@ def _synthetic_pre_created_item_id(response_id: str | None) -> str:
 
 
 def _has_canonical_event_framing(event_block: str, event_type: JsonValue) -> bool:
-    """True when the block already carries the `event: <type>` line that
+    """True when the block already carries the ``event: <type>`` line that
     format_sse_event would emit (or the payload has no type, where canonical
-    framing is data-only)."""
+    framing is data-only). Any SSE line ending (LF, CRLF, or CR) after the
+    event line counts: unchanged-event pass-through must not depend on the
+    source's terminator style."""
     if not isinstance(event_type, str) or not event_type:
         return event_block.startswith("data: ")
-    return event_block.startswith(f"event: {event_type}\n")
+    prefix = f"event: {event_type}"
+    if not event_block.startswith(prefix):
+        return False
+    rest = event_block[len(prefix) :]
+    return rest.startswith(("\n", "\r"))
 
 
 def _normalize_public_stream_payload(

--- a/openspec/changes/fix-source-responses-sse-keepalives/.openspec.yaml
+++ b/openspec/changes/fix-source-responses-sse-keepalives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/fix-source-responses-sse-keepalives/proposal.md
+++ b/openspec/changes/fix-source-responses-sse-keepalives/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Streaming source-routed `POST /v1/responses` returned raw model-source SSE bytes without the normalize-and-keepalive wrapping that account-backed streaming applies. Idle upstream gaps could trip front-door proxy timeouts, split byte chunks could surface partial SSE frames, and native Codex clients selecting a model source lost their heartbeat framing (discovery `CLB-20260820-02`).
+
+## What Changes
+
+- Source-routed Responses streaming reassembles upstream byte chunks into complete SSE event blocks, applies public Responses normalization, and injects SSE keepalives.
+- Native Codex source-routed streams preserve `codex.*` events and use `codex.keepalive` heartbeat framing like the subscription path.
+- Reassembly preserves upstream terminator bytes for unmodified events, recognizes CR, LF, CRLF, and mixed blank-line separators, bounds buffered event size, and forwards unparseable source data verbatim without synthesizing a terminal event.
+- Reservation settlement stays outermost and stream resources close deterministically on completion, failure, or cancellation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require source-routed Responses streaming to stay proxy-timeout friendly, transport-aware, byte-faithful for content the proxy does not rewrite, memory-bounded, and settlement-safe.
+
+## Impact
+
+- Affected code: `app/modules/proxy/api.py`, `app/core/clients/proxy.py`, `app/core/utils/sse.py`.
+- Affected tests: source-responses integration coverage in `tests/integration/test_proxy_api_extended.py` and SSE separator unit coverage in `tests/unit/test_proxy_utils.py`, including a perf regression guard for the shared separator scan.
+- No API surface, schema, persistence, dependency, or configuration changes.

--- a/openspec/changes/fix-source-responses-sse-keepalives/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-source-responses-sse-keepalives/specs/responses-api-compat/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Source-routed Responses streaming stays alive and transport-aware
+
+Streaming source-routed `POST /v1/responses` MUST reassemble upstream byte chunks into complete SSE event blocks, MUST apply public Responses stream normalization, and MUST inject SSE comment keepalives so idle upstream gaps do not trip front-door proxy timeouts. Native Codex clients that select a model source MUST keep `codex.*` events unfiltered and MUST receive `codex.keepalive` heartbeat framing, including an initial heartbeat, matching the subscription path.
+
+#### Scenario: Keepalive precedes a slow first upstream event
+
+- **WHEN** a source-routed `/v1/responses` stream is open and the upstream source has not yet produced its first event within the keepalive interval
+- **THEN** the client receives an SSE comment keepalive frame before the first upstream event
+
+#### Scenario: Native Codex source stream keeps vendor framing
+
+- **WHEN** a native Codex client streams a source-routed response
+- **THEN** `codex.*` events are forwarded rather than dropped
+- **AND** heartbeats use `codex.keepalive` data framing with an initial heartbeat
+
+### Requirement: Source SSE reassembly is byte-faithful and memory-bounded
+
+Source-routed SSE reassembly MUST recognize blank-line event separators built from any two consecutive SSE line endings (CR, LF, or CRLF, including mixed pairs), MUST preserve the original terminator bytes of events the proxy does not rewrite, MUST preserve multi-byte UTF-8 sequences and CRLF pairs split across chunk boundaries, and MUST bound the reassembled event size by the configured maximum, closing the stream when the bound is exceeded. Data blocks the proxy cannot parse MUST be forwarded byte-identically, and after raw source data has been forwarded the proxy MUST NOT synthesize a terminal event for that stream. The shared separator scan MUST locate line-ending candidates with C-level search rather than per-byte iteration in Python.
+
+#### Scenario: Mixed line endings dispatch complete events
+
+- **WHEN** a source terminates an SSE event with CR-only, CRLF, or mixed blank-line separators, possibly split across chunk boundaries
+- **THEN** the complete event is dispatched without waiting for additional upstream data
+- **AND** events the proxy does not rewrite keep their original terminator bytes
+
+#### Scenario: Oversized source event fails closed
+
+- **WHEN** a reassembled source SSE event exceeds the configured maximum event size
+- **THEN** the stream is closed with an event-too-large failure instead of buffering without bound
+
+#### Scenario: Unparseable source data passes through
+
+- **WHEN** a source emits a data block that is not parseable JSON
+- **THEN** the block reaches the client byte-identically
+- **AND** the proxy does not append a synthesized terminal event to that stream
+
+### Requirement: Source stream settlement and cleanup are deterministic
+
+Source-routed Responses streaming MUST keep API-key reservation settlement outermost so an early normalization return still settles the reservation without recording a client disconnect, and MUST close the stream iterator and its owning stream deterministically on completion, failure, or cancellation, including when iterator creation or iterator close raises.
+
+#### Scenario: Error frame still settles the reservation
+
+- **WHEN** normalization ends a source-routed stream early on an upstream error frame
+- **THEN** the API-key reservation settles
+- **AND** the request is not recorded as a client disconnect
+
+#### Scenario: Stream resources close after cancellation
+
+- **WHEN** a source-routed stream ends by completion, failure, or client cancellation
+- **THEN** the stream iterator and its owning stream are both closed

--- a/openspec/changes/fix-source-responses-sse-keepalives/tasks.md
+++ b/openspec/changes/fix-source-responses-sse-keepalives/tasks.md
@@ -1,0 +1,18 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add integration regressions for a pre-first-event keepalive on source-routed `/v1/responses` and for reservation settlement when normalization ends on an upstream error frame.
+- [x] 1.2 Add reassembly regressions for split chunks, split UTF-8, CR/LF/CRLF and mixed blank-line separators, preserved terminator bytes, and the bounded event-size failure.
+- [x] 1.3 Add a regression proving unparseable source data blocks pass through verbatim without a synthesized terminal event.
+- [x] 1.4 Add a perf regression guard proving the shared SSE separator scan stays find-based instead of per-byte.
+
+## 2. Source stream adaptation
+
+- [x] 2.1 Reassemble source byte chunks into complete SSE event blocks with an incremental UTF-8 decoder and preserved terminators.
+- [x] 2.2 Apply public Responses normalization and SSE comment keepalives on the public route; preserve `codex.*` events and `codex.keepalive` heartbeat framing on the native Codex route.
+- [x] 2.3 Keep reservation settlement outermost so normalization early-return still settles, and close iterator and owning stream deterministically on completion, failure, or cancellation.
+- [x] 2.4 Locate SSE separator candidates with C-level `bytes.find`, classifying line endings only at candidate positions.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused source-responses integration subset, the SSE separator unit subset, and lint on changed files.
+- [x] 3.2 Validate the scoped OpenSpec change strictly and keep the delta in sync with the implementation.

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2876,9 +2876,7 @@ async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch
     from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
 
     async def crlf_split_body():
-        event = (
-            'data: {"type":"response.completed","response":{"id":"resp_crlf"}}\r\n\r\n'
-        )
+        event = 'data: {"type":"response.completed","response":{"id":"resp_crlf"}}\r\n\r\n'
         mid = max(1, len(event) // 2)
         yield event[:mid].encode("utf-8")
         yield event[mid:].encode("utf-8")
@@ -2932,6 +2930,72 @@ async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch
     assert isinstance(response, StreamingResponse)
     joined = "".join([cast(str, chunk) async for chunk in response.body_iterator])
     assert "resp_crlf" in joined
+    assert joined.find("response.created") < joined.find("response.completed")
+
+
+@pytest.mark.asyncio
+async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch):
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
+
+    async def split_boundary_body():
+        # "é" is UTF-8 C3 A9; split after C3. Also split CRLF after CR.
+        prefix = b'data: {"type":"response.completed","response":{"id":"resp_'
+        mid = "caf\u00e9".encode("utf-8")
+        yield prefix + mid[:4]  # ends mid UTF-8 sequence for é
+        yield mid[4:] + b'"}}\r'
+        yield b"\n\r\n"
+
+    async def fake_stream_source_responses(_source, _payload):
+        return SourceResponsesStream(
+            body=split_boundary_body(),
+            usage_holder=SourceUsageHolder(),
+            upstream_status_code=200,
+        )
+
+    async def allow_request_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "stream_source_responses", fake_stream_source_responses)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", allow_request_limits)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+            "client": ("203.0.113.12", 54321),
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "src-model", "instructions": "hi", "input": [], "stream": True}
+    )
+    source = ModelSource(
+        id="src_utf8_crlf",
+        name="utf8-crlf-source",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=False,
+        supports_responses=True,
+    )
+
+    response = await proxy_api_module._source_responses_response(
+        request,
+        payload,
+        source=source,
+        api_key=None,
+        rate_limit_headers={},
+        pre_normalization_effort=None,
+    )
+    assert isinstance(response, StreamingResponse)
+    joined = "".join([cast(str, chunk) async for chunk in response.body_iterator])
+    assert "resp_caf" in joined
+    assert "\\u00e9" in joined or "caf\u00e9" in joined
     assert joined.find("response.created") < joined.find("response.completed")
 
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2863,8 +2863,76 @@ async def test_source_responses_stream_starts_sse_keepalive_before_first_upstrea
             break
     joined = "".join(remaining)
     assert "resp_source_delayed" in joined
-    # Public contract synthesizes response.created before the delayed terminal.
-    assert "response.created" in joined
+    created_at = joined.find("response.created")
+    completed_at = joined.find("response.completed")
+    assert created_at != -1
+    assert completed_at != -1
+    assert created_at < completed_at
+
+
+@pytest.mark.asyncio
+async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch):
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
+
+    async def crlf_split_body():
+        event = (
+            'data: {"type":"response.completed","response":{"id":"resp_crlf"}}\r\n\r\n'
+        )
+        mid = max(1, len(event) // 2)
+        yield event[:mid].encode("utf-8")
+        yield event[mid:].encode("utf-8")
+
+    async def fake_stream_source_responses(_source, _payload):
+        return SourceResponsesStream(
+            body=crlf_split_body(),
+            usage_holder=SourceUsageHolder(),
+            upstream_status_code=200,
+        )
+
+    async def allow_request_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "stream_source_responses", fake_stream_source_responses)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", allow_request_limits)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+            "client": ("203.0.113.11", 54321),
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "src-model", "instructions": "hi", "input": [], "stream": True}
+    )
+    source = ModelSource(
+        id="src_crlf",
+        name="crlf-source",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=False,
+        supports_responses=True,
+    )
+
+    response = await proxy_api_module._source_responses_response(
+        request,
+        payload,
+        source=source,
+        api_key=None,
+        rate_limit_headers={},
+        pre_normalization_effort=None,
+    )
+    assert isinstance(response, StreamingResponse)
+    joined = "".join([cast(str, chunk) async for chunk in response.body_iterator])
+    assert "resp_crlf" in joined
+    assert joined.find("response.created") < joined.find("response.completed")
 
 
 @pytest.mark.asyncio
@@ -2941,7 +3009,9 @@ async def test_source_responses_normalize_error_still_settles_reservation(monkey
     assert isinstance(response, StreamingResponse)
     chunks = [cast(str, chunk) async for chunk in response.body_iterator]
     joined = "".join(chunks)
-    assert "response.failed" in joined or '"type":"error"' in joined or "boom" in joined
+    assert "response.created" in joined
+    assert "response.failed" in joined
+    assert "resp_should_not_matter" not in joined
     assert settle_calls, "normalize early-return must still settle the outer reservation"
     assert "cancelled" not in log_statuses
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2781,6 +2781,172 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
 
 
 @pytest.mark.asyncio
+async def test_source_responses_stream_starts_sse_keepalive_before_first_upstream_event(monkeypatch):
+    """Source-routed /v1/responses must keep SSE alive like account streams."""
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
+
+    release_upstream = asyncio.Event()
+    keepalives: list[str] = []
+
+    async def delayed_body():
+        await release_upstream.wait()
+        # Split across chunk boundaries so reassembly is required.
+        event = _sse_event({"type": "response.completed", "response": {"id": "resp_source_delayed"}})
+        mid = max(1, len(event) // 2)
+        yield event[:mid].encode("utf-8")
+        yield event[mid:].encode("utf-8")
+
+    async def fake_stream_source_responses(_source, _payload):
+        return SourceResponsesStream(
+            body=delayed_body(),
+            usage_holder=SourceUsageHolder(),
+            upstream_status_code=200,
+        )
+
+    async def allow_request_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0.01)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "stream_source_responses", fake_stream_source_responses)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", allow_request_limits)
+    monkeypatch.setattr(
+        proxy_api_module,
+        "_record_stream_keepalive",
+        lambda surface: keepalives.append(surface),
+    )
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+            "client": ("203.0.113.9", 54321),
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "src-model", "instructions": "hi", "input": [], "stream": True}
+    )
+    source = ModelSource(
+        id="src_keepalive",
+        name="keepalive-source",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=False,
+        supports_responses=True,
+    )
+
+    response = await proxy_api_module._source_responses_response(
+        request,
+        payload,
+        source=source,
+        api_key=None,
+        rate_limit_headers={},
+        pre_normalization_effort=None,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    iterator = response.body_iterator.__aiter__()
+    first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first_chunk == SSE_KEEPALIVE_FRAME
+    assert keepalives == ["responses_source"]
+    release_upstream.set()
+    remaining: list[str] = []
+    while True:
+        try:
+            remaining.append(cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)))
+        except StopAsyncIteration:
+            break
+    joined = "".join(remaining)
+    assert "resp_source_delayed" in joined
+    # Public contract synthesizes response.created before the delayed terminal.
+    assert "response.created" in joined
+
+
+@pytest.mark.asyncio
+async def test_source_responses_normalize_error_still_settles_reservation(monkeypatch):
+    """Normalize early-return must not aclose settlement as client_disconnected."""
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsage, SourceUsageHolder
+
+    settle_calls: list[object] = []
+    log_statuses: list[str] = []
+
+    async def error_then_completed_body():
+        yield b'data: {"type":"error","error":{"message":"boom","code":"server_error"}}\n\n'
+        yield b'data: {"type":"response.completed","response":{"id":"resp_should_not_matter"}}\n\n'
+
+    async def fake_stream_source_responses(_source, _payload):
+        return SourceResponsesStream(
+            body=error_then_completed_body(),
+            usage_holder=SourceUsageHolder(usage=SourceUsage(input_tokens=1, output_tokens=1)),
+            upstream_status_code=200,
+        )
+
+    async def allow_request_limits(*args, **kwargs):
+        del args, kwargs
+        return object()
+
+    async def record_settle(reservation, **kwargs):
+        del kwargs
+        settle_calls.append(reservation)
+        return True
+
+    async def record_log(*args, **kwargs):
+        del args
+        log_statuses.append(str(kwargs.get("status")))
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "stream_source_responses", fake_stream_source_responses)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", allow_request_limits)
+    monkeypatch.setattr(proxy_api_module, "_settle_source_reservation", record_settle)
+    monkeypatch.setattr(proxy_api_module, "_log_source_chat_completion", record_log)
+    monkeypatch.setattr(proxy_api_module, "_reservation_requires_usage", lambda _reservation: False)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+            "client": ("203.0.113.10", 54321),
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "src-model", "instructions": "hi", "input": [], "stream": True}
+    )
+    source = ModelSource(
+        id="src_normalize_error",
+        name="normalize-error-source",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=False,
+        supports_responses=True,
+    )
+
+    response = await proxy_api_module._source_responses_response(
+        request,
+        payload,
+        source=source,
+        api_key=None,
+        rate_limit_headers={},
+        pre_normalization_effort=None,
+    )
+    assert isinstance(response, StreamingResponse)
+    chunks = [cast(str, chunk) async for chunk in response.body_iterator]
+    joined = "".join(chunks)
+    assert "response.failed" in joined or '"type":"error"' in joined or "boom" in joined
+    assert settle_calls, "normalize early-return must still settle the outer reservation"
+    assert "cancelled" not in log_statuses
+
+
+@pytest.mark.asyncio
 async def test_backend_desktop_openai_shape_uses_codex_heartbeat_with_sdk_normalization(
     async_client,
     monkeypatch,

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2995,6 +2995,19 @@ async def test_iter_source_sse_event_blocks_preserves_crlf_and_cr_terminators():
 
 
 @pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_preserves_mixed_lf_cr_terminators():
+    async def body():
+        yield b'data: {"type":"response.completed","response":{"id":"resp_lf_cr"}}\n\r'
+        yield b'data: {"type":"response.failed"}\n\r\n'
+
+    blocks = [block async for block in proxy_api_module._iter_source_sse_event_blocks(body())]
+    assert blocks == [
+        'data: {"type":"response.completed","response":{"id":"resp_lf_cr"}}\n\r',
+        'data: {"type":"response.failed"}\n\r\n',
+    ]
+
+
+@pytest.mark.asyncio
 async def test_iter_source_sse_event_blocks_dispatches_cr_only_without_waiting():
     release_next = asyncio.Event()
     closed = asyncio.Event()

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2930,7 +2930,11 @@ async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch
     assert isinstance(response, StreamingResponse)
     joined = "".join([cast(str, chunk) async for chunk in response.body_iterator])
     assert "resp_crlf" in joined
-    assert joined.find("response.created") < joined.find("response.completed")
+    created_at = joined.find("response.created")
+    completed_at = joined.find("response.completed")
+    assert created_at != -1
+    assert completed_at != -1
+    assert created_at < completed_at
 
 
 @pytest.mark.asyncio
@@ -3198,6 +3202,66 @@ async def test_wrap_source_responses_closes_source_on_early_error_and_client_clo
 
 
 @pytest.mark.asyncio
+async def test_wrap_source_responses_closes_raw_source_after_initial_heartbeat_disconnect(monkeypatch):
+    """A native client dropping right after the prefixed heartbeat must close the raw source."""
+
+    class _RawSource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __aiter__(self) -> "_RawSource":
+            return self
+
+        async def __anext__(self) -> bytes:
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    raw_source = _RawSource()
+    stream = proxy_api_module._wrap_source_responses_public_stream(
+        raw_source,
+        enforce_openai_sdk_contract=False,
+        native_codex_heartbeat=True,
+    )
+    iterator = stream.__aiter__()
+    first = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first == CODEX_KEEPALIVE_FRAME
+    # None of the inner layers has started iterating yet; closing the wrapper
+    # must still release the eagerly opened source body.
+    await cast(Any, iterator).aclose()
+    assert raw_source.closed is True
+
+
+@pytest.mark.asyncio
+async def test_source_stream_retry_control_block_keeps_truncation_failure(monkeypatch):
+    """Valid non-data control blocks pass through without suppressing truncation synthesis."""
+
+    async def control_then_truncated_body():
+        yield b"retry: 1000\n\n"
+        yield b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_ctrl"}}\n\n'
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            control_then_truncated_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert "retry: 1000" in joined
+    assert "resp_ctrl" in joined
+    assert "response.failed" in joined
+
+
+@pytest.mark.asyncio
 async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch):
     from app.db.models import ModelSource
     from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
@@ -3260,7 +3324,11 @@ async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch
     joined = "".join([cast(str, chunk) async for chunk in response.body_iterator])
     assert "resp_caf" in joined
     assert "\\u00e9" in joined or "caf\u00e9" in joined
-    assert joined.find("response.created") < joined.find("response.completed")
+    created_at = joined.find("response.created")
+    completed_at = joined.find("response.completed")
+    assert created_at != -1
+    assert completed_at != -1
+    assert created_at < completed_at
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2982,6 +2982,144 @@ async def test_iter_source_sse_event_blocks_closes_owner_when_iterator_close_fai
 
 
 @pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_preserves_crlf_and_cr_terminators():
+    async def body():
+        yield b'event: response.completed\r\ndata: {"type":"response.completed"}\r\n\r\n'
+        yield b'event: response.failed\rdata: {"type":"response.failed"}\r\r'
+
+    blocks = [block async for block in proxy_api_module._iter_source_sse_event_blocks(body())]
+    assert blocks == [
+        'event: response.completed\r\ndata: {"type":"response.completed"}\r\n\r\n',
+        'event: response.failed\rdata: {"type":"response.failed"}\r\r',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_dispatches_cr_only_without_waiting():
+    release_next = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def body():
+        try:
+            yield b'data: {"type":"response.completed","response":{"id":"resp_cr"}}\r\r'
+            await release_next.wait()
+            yield b'data: {"type":"response.failed"}\r\r'
+        finally:
+            closed.set()
+
+    iterator = proxy_api_module._iter_source_sse_event_blocks(body()).__aiter__()
+    first = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first == 'data: {"type":"response.completed","response":{"id":"resp_cr"}}\r\r'
+    release_next.set()
+    second = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert second.endswith("\r\r")
+    with pytest.raises(StopAsyncIteration):
+        await iterator.__anext__()
+    assert closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_rejects_oversize_event():
+    from app.core.clients.proxy import StreamEventTooLargeError
+
+    async def body():
+        yield b"data: " + (b"x" * 64) + b"\n\n"
+
+    with pytest.raises(StreamEventTooLargeError):
+        async for _ in proxy_api_module._iter_source_sse_event_blocks(body(), max_event_bytes=32):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_wrap_source_responses_native_codex_preserves_codex_events_and_keepalive(monkeypatch):
+    keepalives: list[str] = []
+    release_upstream = asyncio.Event()
+
+    async def delayed_body():
+        await release_upstream.wait()
+        yield (
+            b'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+            b'data: {"type":"response.completed","response":{"id":"resp_codex_src","output":[]}}\n\n'
+        )
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0.01, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_api_module,
+        "_record_stream_keepalive",
+        lambda surface: keepalives.append(surface),
+    )
+
+    stream = proxy_api_module._wrap_source_responses_public_stream(
+        delayed_body(),
+        enforce_openai_sdk_contract=False,
+        native_codex_heartbeat=True,
+    )
+    iterator = stream.__aiter__()
+    first = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first == CODEX_KEEPALIVE_FRAME
+    # Prefixed heartbeat does not record metrics; wait for an injected idle frame.
+    second = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert second == CODEX_KEEPALIVE_FRAME
+    assert keepalives == ["responses_source"]
+    release_upstream.set()
+    remaining = [cast(str, chunk) async for chunk in iterator]
+    joined = "".join(remaining)
+    assert "codex.rate_limits" in joined
+    assert "response.created" not in joined
+    assert "resp_codex_src" in joined
+
+
+@pytest.mark.asyncio
+async def test_wrap_source_responses_closes_source_on_early_error_and_client_close(monkeypatch):
+    closed: list[str] = []
+
+    async def error_body():
+        try:
+            yield b'data: {"type":"error","error":{"message":"boom","code":"server_error"}}\n\n'
+            yield b'data: {"type":"response.completed","response":{"id":"resp_skip"}}\n\n'
+        finally:
+            closed.append("source")
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        cast(str, chunk)
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            error_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert "response.failed" in joined
+    assert "resp_skip" not in joined
+    assert closed == ["source"]
+
+    closed.clear()
+    hold = asyncio.Event()
+
+    async def held_body():
+        try:
+            yield b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_hold"}}\n\n'
+            await hold.wait()
+            yield b'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_hold"}}\n\n'
+        finally:
+            closed.append("source")
+
+    stream = proxy_api_module._wrap_source_responses_public_stream(
+        held_body(),
+        enforce_openai_sdk_contract=True,
+    )
+    iterator = stream.__aiter__()
+    first = await iterator.__anext__()
+    assert "response.created" in first
+    await iterator.aclose()
+    assert closed == ["source"]
+    hold.set()
+
+
+@pytest.mark.asyncio
 async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch):
     from app.db.models import ModelSource
     from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3308,6 +3308,7 @@ async def test_source_stream_unicode_separator_in_field_value_keeps_truncation_f
     assert "resp_u2028" in joined
     assert "response.failed" in joined
 
+
 @pytest.mark.asyncio
 async def test_source_stream_bare_data_field_suppresses_synthetic_terminal(monkeypatch):
     """The valid empty-field form (a bare 'data' line) counts as unparseable source data."""
@@ -3328,6 +3329,38 @@ async def test_source_stream_bare_data_field_suppresses_synthetic_terminal(monke
     joined = "".join(chunks)
     assert "data\n\n" in joined
     assert "response.failed" not in joined
+
+
+@pytest.mark.asyncio
+async def test_wrap_source_responses_preserves_crlf_framing_of_unchanged_events(monkeypatch):
+    """An unchanged CRLF-framed standard event must pass through byte-identically."""
+    crlf_delta_block = (
+        "event: response.output_text.delta\r\n"
+        'data: {"type":"response.output_text.delta","item_id":"item_crlf","output_index":0,'
+        '"content_index":0,"delta":"hi"}\r\n\r\n'
+    )
+
+    async def crlf_framed_body():
+        yield b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_crlf_frame"}}\n\n'
+        yield crlf_delta_block.encode("utf-8")
+        yield (
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_crlf_frame","output":[]}}\n\n'
+        )
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            crlf_framed_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert crlf_delta_block in joined
+    assert "resp_crlf_frame" in joined
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2934,6 +2934,71 @@ async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_source_responses_forwards_unparseable_blocks_without_synthetic_terminal(monkeypatch):
+    """Unparseable source data passes through verbatim instead of becoming response.failed."""
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder
+
+    malformed_block = 'data: {"type":"response.completed","response":{"id":"resp_unparseable"}\n\n'
+
+    async def malformed_body():
+        yield malformed_block.encode("utf-8")
+
+    async def fake_stream_source_responses(_source, _payload):
+        return SourceResponsesStream(
+            body=malformed_body(),
+            usage_holder=SourceUsageHolder(),
+            upstream_status_code=200,
+        )
+
+    async def allow_request_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "stream_source_responses", fake_stream_source_responses)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", allow_request_limits)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+            "client": ("203.0.113.9", 54321),
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "src-model", "instructions": "hi", "input": [], "stream": True}
+    )
+    source = ModelSource(
+        id="src_unparseable",
+        name="unparseable-source",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=False,
+        supports_responses=True,
+    )
+
+    response = await proxy_api_module._source_responses_response(
+        request,
+        payload,
+        source=source,
+        api_key=None,
+        rate_limit_headers={},
+        pre_normalization_effort=None,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    chunks = [cast(str, chunk) async for chunk in response.body_iterator]
+    joined = "".join(chunks)
+    assert malformed_block in joined
+    assert "response.failed" not in joined
+
+
+@pytest.mark.asyncio
 async def test_iter_source_sse_event_blocks_closes_owner_when_aiter_fails():
     closed: list[str] = []
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3051,6 +3051,47 @@ async def test_iter_source_sse_event_blocks_closes_owner_when_iterator_close_fai
 
 
 @pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_swallows_lf_residue_of_split_crlf():
+    """...\r\n\r | \n chunking dispatches at the bare CR and drops the LF residue."""
+
+    async def split_after_cr_body():
+        yield b'data: {"type":"response.created"}\r\n\r'
+        yield b'\ndata: {"type":"response.completed"}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._iter_source_sse_event_blocks(
+            split_after_cr_body(),
+            max_event_bytes=4096,
+        )
+    ]
+
+    assert blocks == [
+        'data: {"type":"response.created"}\r\n\r',
+        'data: {"type":"response.completed"}\n\n',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_ignores_leading_utf8_bom():
+    """One optional leading UTF-8 BOM is ignored, split across chunks or not."""
+
+    async def bom_body():
+        yield b"\xef\xbb"
+        yield b'\xbfdata: {"type":"response.completed","response":{"id":"resp_bom"}}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._iter_source_sse_event_blocks(
+            bom_body(),
+            max_event_bytes=4096,
+        )
+    ]
+
+    assert blocks == ['data: {"type":"response.completed","response":{"id":"resp_bom"}}\n\n']
+
+
+@pytest.mark.asyncio
 async def test_iter_source_sse_event_blocks_preserves_crlf_and_cr_terminators():
     async def body():
         yield b'event: response.completed\r\ndata: {"type":"response.completed"}\r\n\r\n'

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -2934,6 +2934,54 @@ async def test_source_responses_stream_reassembles_crlf_event_blocks(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_closes_owner_when_aiter_fails():
+    closed: list[str] = []
+
+    class _Owner:
+        def __aiter__(self):
+            closed.append("aiter")
+            raise RuntimeError("aiter failed")
+
+        async def aclose(self) -> None:
+            closed.append("owner")
+
+    with pytest.raises(RuntimeError, match="aiter failed"):
+        async for _ in proxy_api_module._iter_source_sse_event_blocks(_Owner()):
+            pass
+
+    assert closed == ["aiter", "owner"]
+
+
+@pytest.mark.asyncio
+async def test_iter_source_sse_event_blocks_closes_owner_when_iterator_close_fails():
+    closed: list[str] = []
+
+    class _Iterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            closed.append("iterator")
+            raise RuntimeError("iterator close failed")
+
+    class _Owner:
+        def __aiter__(self):
+            return _Iterator()
+
+        async def aclose(self) -> None:
+            closed.append("owner")
+
+    with pytest.raises(RuntimeError, match="iterator close failed"):
+        async for _ in proxy_api_module._iter_source_sse_event_blocks(_Owner()):
+            pass
+
+    assert closed == ["iterator", "owner"]
+
+
+@pytest.mark.asyncio
 async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch):
     from app.db.models import ModelSource
     from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3262,6 +3262,52 @@ async def test_source_stream_retry_control_block_keeps_truncation_failure(monkey
 
 
 @pytest.mark.asyncio
+async def test_source_stream_data_substring_in_field_value_keeps_truncation_failure(monkeypatch):
+    """A field value containing the literal 'data:' is not a data block and must not suppress failures."""
+
+    async def id_field_then_truncated_body():
+        yield b"id: data:1\n\n"
+        yield b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_idfield"}}\n\n'
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            id_field_then_truncated_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert "id: data:1" in joined
+    assert "resp_idfield" in joined
+    assert "response.failed" in joined
+
+
+@pytest.mark.asyncio
+async def test_source_stream_bare_data_field_suppresses_synthetic_terminal(monkeypatch):
+    """The valid empty-field form (a bare 'data' line) counts as unparseable source data."""
+
+    async def bare_data_body():
+        yield b"data\n\n"
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            bare_data_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert "data\n\n" in joined
+    assert "response.failed" not in joined
+
+
+@pytest.mark.asyncio
 async def test_source_responses_stream_preserves_split_utf8_and_crlf(monkeypatch):
     from app.db.models import ModelSource
     from app.modules.model_sources.forwarding import SourceResponsesStream, SourceUsageHolder

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3286,6 +3286,29 @@ async def test_source_stream_data_substring_in_field_value_keeps_truncation_fail
 
 
 @pytest.mark.asyncio
+async def test_source_stream_unicode_separator_in_field_value_keeps_truncation_failure(monkeypatch):
+    """U+2028 inside a field value must not expose a false data line: SSE splits only on CR/LF/CRLF."""
+
+    async def unicode_field_then_truncated_body():
+        yield "id: metadata\u2028data:oops\n\n".encode("utf-8")
+        yield b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_u2028"}}\n\n'
+
+    settings = SimpleNamespace(sse_keepalive_interval_seconds=0, max_sse_event_bytes=16 * 1024 * 1024)
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api_module._wrap_source_responses_public_stream(
+            unicode_field_then_truncated_body(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+    joined = "".join(chunks)
+    assert "metadata\u2028data:oops" in joined
+    assert "resp_u2028" in joined
+    assert "response.failed" in joined
+
+@pytest.mark.asyncio
 async def test_source_stream_bare_data_field_suppresses_synthetic_terminal(monkeypatch):
     """The valid empty-field form (a bare 'data' line) counts as unparseable source data."""
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3063,7 +3063,7 @@ async def test_wrap_source_responses_native_codex_preserves_codex_events_and_kee
     assert second == CODEX_KEEPALIVE_FRAME
     assert keepalives == ["responses_source"]
     release_upstream.set()
-    remaining = [cast(str, chunk) async for chunk in iterator]
+    remaining = [chunk async for chunk in iterator]
     joined = "".join(remaining)
     assert "codex.rate_limits" in joined
     assert "response.created" not in joined
@@ -3085,7 +3085,7 @@ async def test_wrap_source_responses_closes_source_on_early_error_and_client_clo
     monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
 
     chunks = [
-        cast(str, chunk)
+        chunk
         async for chunk in proxy_api_module._wrap_source_responses_public_stream(
             error_body(),
             enforce_openai_sdk_contract=True,
@@ -3114,7 +3114,7 @@ async def test_wrap_source_responses_closes_source_on_early_error_and_client_clo
     iterator = stream.__aiter__()
     first = await iterator.__anext__()
     assert "response.created" in first
-    await iterator.aclose()
+    await cast(Any, iterator).aclose()
     assert closed == ["source"]
     hold.set()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6950,6 +6950,23 @@ async def test_iter_sse_events_separator_straddles_chunk_boundary():
 
 
 @pytest.mark.asyncio
+async def test_iter_sse_events_crlf_separator_split_after_final_cr_swallows_residual_lf():
+    """A \r\n\r\n delimiter split as ...\r\n\r | \n... dispatches at the bare CR
+    and swallows the residual LF so it does not prefix the next event."""
+    event = b'data: {"type":"response.completed"}\r\n\r\ndata: {"type":"next"}\n\n'
+    split = event.index(b"\r\n\r\n") + 3  # split immediately before the final LF
+    response = _DummyResponse([event[:split], event[split:]])
+    stream = proxy_module._iter_sse_events(cast(proxy_module.SSEResponse, response), 1.0, 4096)
+
+    chunks = [chunk async for chunk in stream]
+
+    assert chunks == [
+        'data: {"type":"response.completed"}\r\n\r',
+        'data: {"type":"next"}\n\n',
+    ]
+
+
+@pytest.mark.asyncio
 async def test_iter_sse_events_multiple_events_in_one_chunk_after_large_partial():
     """After a large partial event completes, the residual buffer must be
     rescanned from the start (cursor reset) so following events pop."""

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5228,6 +5228,58 @@ def test_find_sse_separator_accepts_mixed_lf_crlf_blank_line():
     assert event == buffer
 
 
+def test_find_sse_separator_reassembles_realistic_stream_without_per_byte_scan():
+    """Perf regression guard for the account-backed SSE relay hot path.
+
+    ``_find_sse_separator`` must locate line-ending candidates with C-level
+    ``bytes.find`` instead of stepping byte-by-byte in Python. A per-byte
+    rewrite measured roughly 70-100 ns/byte (about 50x slower than the
+    find-based scan), turning incremental reassembly of one mebibyte of
+    realistic 512-byte delta events into hundreds of milliseconds of
+    event-loop-blocking CPU. The bound below leaves an order of magnitude of
+    headroom for slow CI runners while still failing any per-byte scan.
+    """
+    delta = {
+        "type": "response.output_text.delta",
+        "item_id": "msg_0123456789abcdef",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "x" * 380,
+    }
+    event = b"event: response.output_text.delta\ndata: " + json.dumps(delta, separators=(",", ":")).encode() + b"\n\n"
+    event_count = 1024 * 1024 // len(event) + 1
+    payload = event * event_count
+
+    def reassemble() -> int:
+        buffer = bytearray()
+        scanned = 0
+        popped = 0
+        for offset in range(0, len(payload), 8192):
+            buffer.extend(payload[offset : offset + 8192])
+            while True:
+                separator = proxy_module._find_sse_separator(
+                    buffer, max(0, scanned - proxy_module._SSE_SEPARATOR_OVERLAP)
+                )
+                if separator is None:
+                    scanned = len(buffer)
+                    break
+                index, separator_len = separator
+                del buffer[: index + separator_len]
+                scanned = 0
+                popped += 1
+        assert not buffer
+        return popped
+
+    best = float("inf")
+    for _ in range(3):
+        started_at = time.perf_counter()
+        popped = reassemble()
+        best = min(best, time.perf_counter() - started_at)
+        assert popped == event_count
+
+    assert best < 0.05
+
+
 def test_pop_sse_event_returns_first_event_and_mutates_buffer():
     buffer = bytearray(b"data: one\n\ndata: two\n\n")
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5208,6 +5208,26 @@ def test_find_sse_separator_accepts_cr_only_blank_line():
     assert result == (10, 2)
 
 
+def test_find_sse_separator_accepts_mixed_lf_cr_blank_line():
+    buffer = b'data: {"type":"response.completed"}\n\r'
+
+    result = proxy_module._find_sse_separator(buffer)
+
+    assert result == (35, 2)
+    event = proxy_module._pop_sse_event(bytearray(buffer))
+    assert event == buffer
+
+
+def test_find_sse_separator_accepts_mixed_lf_crlf_blank_line():
+    buffer = b'data: {"type":"response.completed"}\n\r\n'
+
+    result = proxy_module._find_sse_separator(buffer)
+
+    assert result == (35, 3)
+    event = proxy_module._pop_sse_event(bytearray(buffer))
+    assert event == buffer
+
+
 def test_pop_sse_event_returns_first_event_and_mutates_buffer():
     buffer = bytearray(b"data: one\n\ndata: two\n\n")
 


### PR DESCRIPTION
## Summary

Source-routed streaming `POST /v1/responses` returned raw model-source SSE without the public normalize + keepalive wrapping that account-backed `_stream_responses` applies. Idle upstream gaps could trip front-door proxy timeouts. Wrap the source body with event reassembly, public Responses normalization, and SSE comment keepalives, with settlement outermost so normalize early-return still settles.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: discovery `CLB-20260820-02` (adjacent to #735 / keepalive work in #524)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/fix-source-responses-sse-keepalives/` (modified capability: `responses-api-compat`; `openspec validate fix-source-responses-sse-keepalives --type change --strict` passes).

## Changes

- Reassemble source byte chunks into SSE event blocks
- Apply `_normalize_public_responses_stream` + `inject_sse_keepalives`
- Keep `_source_chat_stream_with_settlement` outermost (bytes|str) so normalize early-return does not log `client_disconnected`
- Add regressions for pre-first-event keepalive and error-frame settlement
- Locate SSE separator candidates with C-level `bytes.find`, classifying endings only at candidates (~55x faster than the per-byte scan; perf regression test included)
- Forward unparseable source data blocks byte-identically without synthesizing a terminal event, keeping the model-source routing contract from #1859 intact

## Test plan

```
uv run pytest \
  tests/integration/test_proxy_api_extended.py::test_source_responses_stream_starts_sse_keepalive_before_first_upstream_event \
  tests/integration/test_proxy_api_extended.py::test_source_responses_normalize_error_still_settles_reservation \
  tests/integration/test_model_source_routing.py -k source_responses -q
# keepalive + settle: 2 passed; source_responses: 18 passed

uv run pytest tests/integration/test_api_keys_api.py -k keeps_model_source \
  tests/integration/test_model_source_routing.py \
  "tests/integration/test_proxy_api_extended.py -k 'source_responses or iter_source_sse'"
# 31 passed on current main after rebase

uv run pytest tests/unit/test_proxy_utils.py -k "sse_separator or pop_sse_event or iter_sse_events"
# 14 passed, incl. the separator perf regression guard

uv run ruff check app/core/clients/proxy.py app/modules/proxy/api.py \
  tests/integration/test_proxy_api_extended.py tests/unit/test_proxy_utils.py

openspec validate fix-source-responses-sse-keepalives --type change --strict
```

Intentionally unrun locally: full `local-ci`, typecheck (`ty`).

## Checklist

- [x] Title is in Conventional Commits format
- [x] Added or updated tests covering the change
- [x] Ran the focused local subset above
- [x] CHANGELOG is **not** edited by hand

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Responses API streaming across fragmented data and varied SSE line endings.
  * Added event-size limits, keepalives, and transport-aware event handling.
  * Preserved split UTF-8 text, native heartbeat events, and response-start ordering.
  * Added passthrough support for unparseable streaming events.

* **Bug Fixes**
  * Ensured streaming resources and reservations close properly after completion, failure, or cancellation.
  * Improved source selection by validating response ownership.
  * Improved early error handling and incomplete-stream reporting.
  * Added safer handling for malformed UTF-8, mixed separators, and bare `data` events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->