### PR TITLE
fix(helm): default Codex prewarm off to match Settings

### DIFF
--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -164,8 +164,8 @@ config:
   sessionBridgeIdleTtlSeconds: 120
   # @param config.sessionBridgeCodexIdleTtlSeconds Idle TTL for Codex session bridge sessions
   sessionBridgeCodexIdleTtlSeconds: 900
-  # @param config.sessionBridgeCodexPrewarmEnabled Proactively open upstream WebSocket for Codex sessions
-  sessionBridgeCodexPrewarmEnabled: true
+  # @param config.sessionBridgeCodexPrewarmEnabled Proactively open upstream WebSocket for Codex sessions (off by default; matches Settings / OpenSpec)
+  sessionBridgeCodexPrewarmEnabled: false
   # @param config.sessionBridgeMaxSessions Max in-memory bridge sessions per pod
   sessionBridgeMaxSessions: 256
   # @param config.sessionBridgeQueueLimit Max pending requests per bridge session

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -241,6 +241,16 @@ def test_helm_pool_budgets_count_both_postgres_engines() -> None:
         assert reserve >= _POSTGRES_DEFAULT_SUPERUSER_RESERVED_CONNECTIONS + _MIGRATOR_PEAK_CONNECTIONS
 
 
+def test_helm_codex_prewarm_defaults_off_like_settings() -> None:
+    defaults = yaml.safe_load((_CHART_DIR / "values.yaml").read_text())
+    bundled = yaml.safe_load((_CHART_DIR / "values-bundled.yaml").read_text())
+    configmap = (_CHART_DIR / "templates" / "configmap.yaml").read_text()
+
+    assert defaults["config"]["sessionBridgeCodexPrewarmEnabled"] is False
+    assert bundled["config"]["sessionBridgeCodexPrewarmEnabled"] is False
+    assert "CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED" in configmap
+
+
 def test_helm_pool_budget_values_flow_to_runtime_and_hpa_templates() -> None:
     configmap = (_CHART_DIR / "templates" / "configmap.yaml").read_text()
     deployment = (_CHART_DIR / "templates" / "deployment.yaml").read_text()

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -248,7 +248,10 @@ def test_helm_codex_prewarm_defaults_off_like_settings() -> None:
 
     assert defaults["config"]["sessionBridgeCodexPrewarmEnabled"] is False
     assert bundled["config"]["sessionBridgeCodexPrewarmEnabled"] is False
-    assert "CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED" in configmap
+    assert (
+        "CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED: "
+        "{{ .Values.config.sessionBridgeCodexPrewarmEnabled | toString | quote }}"
+    ) in configmap
 
 
 def test_helm_pool_budget_values_flow_to_runtime_and_hpa_templates() -> None:


### PR DESCRIPTION
## Summary

Chart `values.yaml` defaulted `sessionBridgeCodexPrewarmEnabled` to `true` while Settings (`False`) and OpenSpec (“Prewarm stays off by default”) require a default install to leave Codex session prewarm off. Align the Helm default with Settings / bundled values.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: discovery `CLB-20260820-03`

## OpenSpec

- [x] Not applicable — bug fix that matches the existing spec

`deployment-installation` already requires prewarm off by default.

## Changes

- Set `config.sessionBridgeCodexPrewarmEnabled: false` in chart `values.yaml`
- Add unit assertion that chart + bundled defaults stay off

## Test plan

```
uv run pytest tests/unit/test_helm_replica_artifacts.py::test_helm_codex_prewarm_defaults_off_like_settings -q
```

Intentionally unrun locally: Helm lint/template (CI), full `local-ci`.

## Checklist

- [x] Title is in Conventional Commits format
- [x] Added or updated tests covering the change
- [x] Ran the focused local subset above
- [x] CHANGELOG is **not** edited by hand

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Codex session bridge prewarming is now disabled by default.
  - Configuration guidance clarifies that this setting aligns with Settings/OpenSpec.
  - Helm deployments use the disabled default unless explicitly enabled.

- **Bug Fixes**
  - Ensured bundled and default Helm configurations consistently keep Codex prewarming disabled.
  - Verified the related environment variable is correctly exposed with the expected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->