### PR TITLE
fix(proxy): release grouped terminal append barriers on hard spool errors

### DIFF
--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -618,6 +618,8 @@ async def _persist_http_bridge_operation_event(
                 )
         await release_terminal_delivery_barrier()
         return terminal_enqueued
+
+
 async def _wait_for_http_bridge_recovery_settlement_retry(
     service: Any,
     *,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -430,6 +430,24 @@ async def _persist_http_bridge_operation_event(
     append_event = getattr(getattr(service, "_durable_bridge", None), "append_operation_event", None)
     if not operation_id or session_id is None or owner_epoch is None:
         return False
+    append_barrier_released = False
+    delivery_barrier_released = False
+    terminal_enqueued = False
+
+    async def release_terminal_append_barrier() -> None:
+        nonlocal append_barrier_released
+        if terminal_append_barrier is None or append_barrier_released:
+            return
+        append_barrier_released = True
+        await terminal_append_barrier()
+
+    async def release_terminal_delivery_barrier() -> None:
+        nonlocal delivery_barrier_released
+        if terminal_delivery_barrier is None or delivery_barrier_released:
+            return
+        delivery_barrier_released = True
+        await terminal_delivery_barrier()
+
     try:
         batcher = getattr(service, "_http_bridge_operation_event_batcher", None)
         append_terminal_batch = getattr(batcher, "append_terminal_event", None)
@@ -487,14 +505,16 @@ async def _persist_http_bridge_operation_event(
                 ),
                 name=f"http-bridge-terminal-append-{operation_id}",
             )
-            append_result, deferred_cancellation = await _await_task_deferring_cancellation(append_task)
-            if terminal_append_barrier is not None:
-                await terminal_append_barrier()
+            # Counted grouped siblings wait on this barrier; release it even when
+            # append raises so gather(..., return_exceptions=True) cannot strand them.
+            try:
+                append_result, deferred_cancellation = await _await_task_deferring_cancellation(append_task)
+            finally:
+                await release_terminal_append_barrier()
             persisted = bool(append_result)
             if not persisted:
                 logger.info("HTTP bridge terminal event spool became incomplete operation_id=%s", operation_id)
             settlement_required = bool(getattr(append_result, "settlement_required", False))
-            terminal_enqueued = False
             if settlement_required:
                 terminal_enqueued, delivery_cancellation = await enqueue_terminal_delivery_deferring_cancellation()
                 deferred_cancellation = deferred_cancellation or delivery_cancellation
@@ -502,7 +522,7 @@ async def _persist_http_bridge_operation_event(
                 if not terminal_enqueued:
                     terminal_enqueued, delivery_cancellation = await enqueue_terminal_delivery_deferring_cancellation()
                     deferred_cancellation = deferred_cancellation or delivery_cancellation
-                await terminal_delivery_barrier()
+                await release_terminal_delivery_barrier()
             if settlement_required:
                 settle_terminal_batch = getattr(batcher, "settle_terminal_event", None)
 
@@ -581,9 +601,23 @@ async def _persist_http_bridge_operation_event(
         # when every event was durably persisted, so never fail a live stream
         # because the optional spool is unavailable.
         logger.warning("Failed to persist HTTP bridge operation event operation_id=%s", operation_id, exc_info=True)
-        return False
-
-
+        await release_terminal_append_barrier()
+        if terminal_event_queue is not None and terminal and not terminal_enqueued:
+            try:
+                await terminal_event_queue.put(event_block)
+                await terminal_event_queue.put(None)
+                if terminal_delivery_scope is not None:
+                    async with session.pending_lock:
+                        terminal_delivery_scope.terminal_enqueued = True
+                terminal_enqueued = True
+            except Exception:
+                logger.debug(
+                    "Failed to enqueue HTTP bridge terminal after spool error operation_id=%s",
+                    operation_id,
+                    exc_info=True,
+                )
+        await release_terminal_delivery_barrier()
+        return terminal_enqueued
 async def _wait_for_http_bridge_recovery_settlement_retry(
     service: Any,
     *,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5665,6 +5665,92 @@ async def test_grouped_terminal_fanout_queues_all_siblings_before_stalled_settle
 
 
 @pytest.mark.asyncio
+async def test_grouped_terminal_fanout_releases_append_barrier_when_sibling_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hard append failure before the barrier must not strand sibling waiters."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    queues: list[asyncio.Queue[str | None]] = [asyncio.Queue(), asyncio.Queue()]
+    request_states: list[proxy_service._WebSocketRequestState] = []
+    for index, event_queue in enumerate(queues):
+        request_state = proxy_service._WebSocketRequestState(
+            request_id=f"req-grouped-append-raise-{index}",
+            model="gpt-5.6-sol",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=time.monotonic(),
+            event_queue=event_queue,
+            transport="http",
+            previous_response_id="resp-shared-grouped-append-raise",
+            skip_request_log=True,
+        )
+        request_state.operation_id = f"op-grouped-append-raise-{index}"
+        request_states.append(request_state)
+    session = _make_bridge_session(
+        key_value="grouped-terminal-append-raise",
+        pending_requests=deque(request_states),
+        queued_request_count=2,
+    )
+    session.durable_session_id = "durable-grouped-terminal-append-raise"
+    session.durable_owner_epoch = 7
+    all_appends_started = asyncio.Event()
+    append_calls: list[str] = []
+
+    async def append_terminal_event(*args: Any, **kwargs: Any) -> TerminalOperationEventAppendResult:
+        del args
+        operation_id = kwargs["operation_id"]
+        append_calls.append(operation_id)
+        if len(append_calls) == 2:
+            all_appends_started.set()
+        if operation_id == "op-grouped-append-raise-0":
+            raise RuntimeError("append raised before barrier")
+        return TerminalOperationEventAppendResult(persisted=True, settlement_required=False)
+
+    async def settle_terminal_event(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+
+    finalize_request = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request)
+    monkeypatch.setattr(service, "_maybe_release_idle_http_bridge_session_lease", AsyncMock())
+    service._http_bridge_operation_event_batcher = cast(
+        Any,
+        SimpleNamespace(
+            append_terminal_event=append_terminal_event,
+            settle_terminal_event=settle_terminal_event,
+        ),
+    )
+    process_task = asyncio.create_task(
+        service._process_http_bridge_upstream_text(
+            session,
+            json.dumps(
+                {
+                    "type": "error",
+                    "status": 400,
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "previous_response_not_found",
+                        "message": "Previous response with id 'resp-shared-grouped-append-raise' not found.",
+                        "param": "previous_response_id",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        )
+    )
+
+    await asyncio.wait_for(all_appends_started.wait(), timeout=1.0)
+    await asyncio.wait_for(process_task, timeout=1.0)
+    assert sorted(append_calls) == ["op-grouped-append-raise-0", "op-grouped-append-raise-1"]
+    for event_queue in queues:
+        terminal_event = await asyncio.wait_for(event_queue.get(), timeout=1.0)
+        assert terminal_event is not None
+        assert '"type":"response.failed"' in terminal_event
+        assert await asyncio.wait_for(event_queue.get(), timeout=1.0) is None
+    assert finalize_request.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_ordinary_completed_alias_rejection_preserves_successful_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Grouped terminal fan-out counted append participants and waited on `append_ready`, but `_persist_http_bridge_operation_event` only called `terminal_append_barrier` after a successful append await. A hard exception before that call returned `False` from the soft-fail `except` without arriving at the barrier, so siblings hung forever on `append_ready.wait()` even though `gather(..., return_exceptions=True)` did not cancel them.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Related to #1775 (sibling hang class; not a duplicate of that PR)

## OpenSpec

- [x] Not applicable — bug fix that matches the existing concurrency / soft-fail invariants

Change directory: N/A

## Problem

In `upstream_events.py`, grouped terminal fan-out builds `append_participants` then waits on `append_ready`. `_persist_http_bridge_operation_event` only called `terminal_append_barrier` after successful append await. Broad `except Exception` returned `False` without calling the barrier → siblings stranded.

## Solution

- Release the append barrier in a `try`/`finally` around the append await so every counted participant arrives.
- On hard spool exceptions, also release the delivery barrier (idempotently) and still enqueue the live terminal when needed so soft-fail live-stream delivery is preserved and siblings are not stranded on `delivery_ready`.
- Soft `persisted=False` path unchanged for the happy spool-incomplete case.

## Verification

```
/Volumes/ExtraDisk/Dev/codex-lb/.venv/bin/python -m pytest \
  tests/unit/test_proxy_http_bridge.py::test_grouped_terminal_fanout_releases_append_barrier_when_sibling_raises \
  tests/unit/test_proxy_http_bridge.py::test_grouped_terminal_fanout_queues_all_siblings_before_stalled_settlement -q
# 4 passed

ruff check app/modules/proxy/_service/http_bridge/upstream_events.py tests/unit/test_proxy_http_bridge.py
# All checks passed
```

## Changes

- Ensure counted grouped terminal participants always arrive at append (and delivery) barriers on hard spool exceptions
- Add regression test: N=2 fan-out, one append raises before barrier, assert gather completes and siblings are not stranded

## Test plan

- [x] Focused unit regression for hard append raise before barrier
- [x] Existing grouped terminal fan-out settlement tests still pass
- [ ] Required CI green on this head
- [ ] CodeRabbit automatic review clean / threads resolved


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of terminal event delivery when event persistence encounters an error.
  * Ensured requests receive terminal failure notifications and complete cleanup even when grouped event handling partially fails.
  * Prevented stalled append or delivery operations during terminal event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->