### PR TITLE
Re-offer the five reverted fixes as one reviewable branch

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -56,6 +56,7 @@ _TOOL_CALL_ITEM_TYPES = frozenset(_COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values(
 _COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"""data:image/[^,\s]+,[^\s"'<>]+""")
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
 _PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
+_ACTIVE_SKILL_CONTEXT_PREFIX = "<skill>"
 _EXPLICIT_PROMPT_CACHE_CONTENT_TYPES = frozenset({"input_text", "input_image", "input_file"})
 
 
@@ -1659,6 +1660,8 @@ def _compact_item_is_state_anchor(item: Mapping[str, JsonValue]) -> bool:
         if stripped.startswith(_GOAL_CONTINUATION_CONTEXT_PREFIX):
             return True
         if stripped.startswith(_PLAN_MODE_CONTEXT_PREFIX):
+            return True
+        if stripped.startswith(_ACTIVE_SKILL_CONTEXT_PREFIX):
             return True
     return False
 

--- a/app/db/alembic/revision_ids.py
+++ b/app/db/alembic/revision_ids.py
@@ -27,6 +27,7 @@ OLD_TO_NEW_REVISION_MAP: dict[str, str] = {
     ),
     "20260410_020000_restore_import_without_overwrite_default_false": "20260409_020000_fix_http_bridge_last_seen_index",
     "20260525_000000_merge_routing_settings_security_heads": "20260513_000000_add_accounts_alias",
+    "20260814_020000_merge_identity_and_warmup_heads": "20260816_000000_add_model_source_embeddings",
 }
 
 NEW_TO_OLD_REVISION_MAP: dict[str, str] = {new: old for old, new in OLD_TO_NEW_REVISION_MAP.items()}

--- a/app/db/alembic/versions/20260813_000000_add_file_account_pins.py
+++ b/app/db/alembic/versions/20260813_000000_add_file_account_pins.py
@@ -20,16 +20,21 @@ _TABLE = "file_account_pins"
 
 def upgrade() -> None:
     bind = op.get_bind()
-    if sa.inspect(bind).has_table(_TABLE):
-        return
-    op.create_table(
-        _TABLE,
-        sa.Column("file_id", sa.String(), nullable=False),
-        sa.Column("account_id", sa.String(), nullable=False),
-        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
-        sa.PrimaryKeyConstraint("file_id"),
-    )
-    op.create_index("ix_file_account_pins_expires_at", _TABLE, ["expires_at"], unique=False)
+    inspector = sa.inspect(bind)
+    table_exists = inspector.has_table(_TABLE)
+    if not table_exists:
+        op.create_table(
+            _TABLE,
+            sa.Column("file_id", sa.String(), nullable=False),
+            sa.Column("account_id", sa.String(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("file_id"),
+        )
+    index_exists = table_exists and "ix_file_account_pins_expires_at" in {
+        index["name"] for index in inspector.get_indexes(_TABLE) if index.get("name")
+    }
+    if not index_exists:
+        op.create_index("ix_file_account_pins_expires_at", _TABLE, ["expires_at"], unique=False)
 
 
 def downgrade() -> None:

--- a/app/db/alembic/versions/20260820_000000_repair_retired_identity_and_warmup_stamp.py
+++ b/app/db/alembic/versions/20260820_000000_repair_retired_identity_and_warmup_stamp.py
@@ -1,0 +1,77 @@
+"""repair schemas stamped at the retired identity/warmup merge head
+
+Revision ID: 20260820_000000_repair_retired_identity_and_warmup_stamp
+Revises: 20260816_000000_add_model_source_embeddings
+Create Date: 2026-08-20
+
+Some local August 14, 2026 builds emitted the no-op merge stamp
+``20260814_020000_merge_identity_and_warmup_heads`` even when the current
+mainline file-pin, sticky-abandonment-scope, pending-deletion, API-key
+reasoning-policy, and model-source-embeddings lineage had never run, while the
+retired account-identity index and quota-planner lease-expiry column were
+still present. Startup remaps that dead stamp to the current pre-repair head so
+Alembic can continue; this forward-only repair step then replays the guarded
+current migrations and drops the two stale artifacts.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260820_000000_repair_retired_identity_and_warmup_stamp"
+down_revision = "20260816_000000_add_model_source_embeddings"
+branch_labels = None
+depends_on = None
+
+_OBSOLETE_ACCOUNT_INDEX = "idx_accounts_chatgpt_account_id"
+_OBSOLETE_QUOTA_COLUMN = "lease_expires_at"
+
+
+def _migration(module_name: str) -> ModuleType:
+    return importlib.import_module(f"app.db.alembic.versions.{module_name}")
+
+
+def _has_table(connection: Connection, table_name: str) -> bool:
+    return sa.inspect(connection).has_table(table_name)
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    if not _has_table(connection, table_name):
+        return set()
+    return {column["name"] for column in sa.inspect(connection).get_columns(table_name)}
+
+
+def _indexes(connection: Connection, table_name: str) -> set[str]:
+    if not _has_table(connection, table_name):
+        return set()
+    names = (index.get("name") for index in sa.inspect(connection).get_indexes(table_name))
+    return {name for name in names if name is not None}
+
+
+def upgrade() -> None:
+    _migration("20260813_000000_add_file_account_pins").upgrade()
+    _migration("20260812_120000_add_sticky_abandonment_scope").upgrade()
+    _migration("20260816_000000_add_account_pending_deletion").upgrade()
+    _migration("20260806_030000_add_api_key_allowed_reasoning_efforts").upgrade()
+    _migration("20260816_000000_add_model_source_embeddings").upgrade()
+
+    connection = op.get_bind()
+
+    if _OBSOLETE_ACCOUNT_INDEX in _indexes(connection, "accounts"):
+        op.drop_index(_OBSOLETE_ACCOUNT_INDEX, table_name="accounts", if_exists=True)
+
+    if _OBSOLETE_QUOTA_COLUMN in _columns(connection, "quota_planner_decisions"):
+        with op.batch_alter_table("quota_planner_decisions") as batch_op:
+            batch_op.drop_column(_OBSOLETE_QUOTA_COLUMN)
+
+
+def downgrade() -> None:
+    # This revision repairs databases carrying a retired local merge stamp. It
+    # must not resurrect the stale index/column or remove objects owned by the
+    # canonical current-main migrations it replays above.
+    pass

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -627,6 +627,23 @@ def _has_http_bridge_response_output_marker(item: JsonValue) -> bool:
     return status in {"completed", "in_progress"}
 
 
+def _http_bridge_pending_response_events_seen(pending_states: Sequence[_WebSocketRequestState]) -> int:
+    return max(
+        (
+            max(
+                state.response_event_count,
+                int(
+                    state.response_id is not None
+                    or state.latency_response_created_ms is not None
+                    or state.downstream_visible
+                ),
+            )
+            for state in pending_states
+        ),
+        default=0,
+    )
+
+
 def _http_bridge_input_item_type(item: JsonValue) -> str | None:
     if not isinstance(item, dict):
         return None

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -216,6 +216,7 @@ from app.modules.proxy.affinity import (
 )
 from app.modules.proxy.continuity import (
     is_http_bridge_account_neutral_replay,
+    resolve_account_neutral_owner_binding,
     resolve_reconnect_preferred_account_id,
     resolve_required_account_id,
     without_http_bridge_session_affinity_headers,
@@ -1986,6 +1987,7 @@ class _HTTPBridgeMixin(
         require_security_work_authorized: bool = False,
         require_same_account: bool = False,
         require_preferred_account: bool = False,
+        allow_account_rebind: bool = False,
         owner_rebind_affinity: _AffinityPolicy | None = None,
         selection_affinity: _AffinityPolicy | None = None,
     ) -> None:
@@ -1994,10 +1996,8 @@ class _HTTPBridgeMixin(
         if selection_affinity is None and goal_restart:
             # Storage drops this bit; its request retains reconnect and account-switch authority.
             selection_affinity = request_state.affinity_policy
-        account_neutral_recovery = is_http_bridge_account_neutral_replay(
-            kind=session.key.affinity_kind, key=session.key.affinity_key
-        )
-        require_same_account = account_neutral_recovery or (require_same_account and not goal_restart)
+        neutral = resolve_account_neutral_owner_binding(session.key, request_state, allow_account_rebind)
+        require_same_account = neutral.owner_bound or (require_same_account and not goal_restart)
         old_upstream = session.upstream
         old_reader = session.upstream_reader if restart_reader else None
         session.handoff_in_progress = True
@@ -2039,11 +2039,16 @@ class _HTTPBridgeMixin(
             forced_refresh_account_id = request_state.force_refresh_account_id
             excluded_account_ids: set[str] = set(request_state.excluded_account_ids)
             requested_preferred_account_id = resolve_reconnect_preferred_account_id(
-                request_state, session.account.id, require_preferred_account, account_neutral_recovery
+                # A caller that allowed a rebind keeps its preferred account as a
+                # preference; promoting it to a required owner would re-pin the replay.
+                request_state,
+                session.account.id,
+                require_preferred_account and not neutral.rebind_allowed,
+                neutral.owner_bound,
             )
             required_preferred_account_id = resolve_required_account_id(
                 ("requested reconnect owner", requested_preferred_account_id),
-                ("account-neutral recovery", session.account.id if account_neutral_recovery else None),
+                ("account-neutral recovery", session.account.id if neutral.owner_bound else None),
             )
             close_skips_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
             hard_close_account_bound = session.key.strength == "hard" and (close_skips_account or require_same_account)
@@ -2157,7 +2162,7 @@ class _HTTPBridgeMixin(
                     service_tier=session.request_service_tier,
                     exclude_account_ids=excluded_account_ids,
                     preferred_account_id=preferred_candidate_id,
-                    preferred_account_is_continuity_owner=account_neutral_recovery,
+                    preferred_account_is_continuity_owner=neutral.owner_bound,
                     require_security_work_authorized=require_security_work_authorized,
                     lease_kind=None if reuse_current_account_lease else "stream",
                     estimated_lease_tokens=_estimated_lease_tokens_from_request_usage_budget(
@@ -2179,7 +2184,7 @@ class _HTTPBridgeMixin(
                 except BaseException:
                     complete_failed_handoff()
                     raise
-                if account_neutral_recovery and selection.error_code == CONTINUITY_OWNER_UNAVAILABLE:
+                if neutral.owner_bound and selection.error_code == CONTINUITY_OWNER_UNAVAILABLE:
                     complete_failed_handoff()
                     raise _http_bridge_previous_response_owner_unavailable_error()
                 if (

--- a/app/modules/proxy/_service/http_bridge/quarantine.py
+++ b/app/modules/proxy/_service/http_bridge/quarantine.py
@@ -43,6 +43,7 @@ class _HTTPBridgeQuarantineEntry:
     consecutive_eventless_timeouts: int = 0
     last_touched_monotonic: float = 0.0
     reason: str | None = None
+    generation: int = 0
 
 
 def _http_bridge_quarantine_registry(
@@ -100,6 +101,16 @@ def _http_bridge_session_key_quarantined(service: Any, key: _HTTPBridgeSessionKe
     return entry is not None and entry.quarantined_until > now
 
 
+def _http_bridge_session_key_quarantine_generation(service: Any, key: _HTTPBridgeSessionKey) -> int | None:
+    registry = _http_bridge_quarantine_registry(service)
+    now = time.monotonic()
+    _prune_http_bridge_quarantine_registry(registry, now)
+    entry = registry.get(key)
+    if entry is None or entry.quarantined_until <= now:
+        return None
+    return entry.generation
+
+
 def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *, reason: str) -> None:
     """Quarantine a bridge session that has proven silent/wedged.
 
@@ -113,6 +124,7 @@ def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *
     entry.quarantined_until = max(entry.quarantined_until, now + _HTTP_BRIDGE_QUARANTINE_TTL_SECONDS)
     entry.last_touched_monotonic = now
     entry.reason = reason
+    entry.generation += 1
     _prune_http_bridge_quarantine_registry(registry, now)
     session.quarantined = True
     if already_quarantined:
@@ -169,21 +181,41 @@ def _record_http_bridge_quarantine_eventless_timeout(service: Any, session: _HTT
     )
 
 
-def _clear_http_bridge_quarantine(service: Any, session: _HTTPBridgeSession) -> None:
-    """A completed response on this key disproves the wedge; drop all state."""
+def _clear_http_bridge_quarantine_key(
+    service: Any,
+    key: _HTTPBridgeSessionKey,
+    *,
+    account_id: str | None,
+    model: str | None,
+    generation: int | None = None,
+) -> None:
+    """A completed response on a recovery key disproves the original wedge."""
     registry = _http_bridge_quarantine_registry(service)
-    session.quarantined = False
-    entry = registry.pop(session.key, None)
+    entry = registry.get(key)
     if entry is None:
         return
+    if generation is not None and entry.generation != generation:
+        return
+    registry.pop(key, None)
     if entry.quarantined_until <= time.monotonic():
         return
     _log_http_bridge_event(
         "session_quarantine_cleared",
+        key,
+        account_id=account_id,
+        model=model,
+        detail=f"reason={entry.reason}",
+        cache_key_family=key.affinity_kind,
+        model_class=_extract_model_class(model) if model else None,
+    )
+
+
+def _clear_http_bridge_quarantine(service: Any, session: _HTTPBridgeSession) -> None:
+    """A completed response on this key disproves the wedge; drop all state."""
+    session.quarantined = False
+    _clear_http_bridge_quarantine_key(
+        service,
         session.key,
         account_id=session.account.id,
         model=session.request_model,
-        detail=f"reason={entry.reason}",
-        cache_key_family=session.key.affinity_kind,
-        model_class=_extract_model_class(session.request_model) if session.request_model else None,
     )

--- a/app/modules/proxy/_service/http_bridge/quarantine.py
+++ b/app/modules/proxy/_service/http_bridge/quarantine.py
@@ -56,6 +56,18 @@ def _http_bridge_quarantine_registry(
     return registry
 
 
+def _next_http_bridge_quarantine_generation(
+    service: Any,
+    registry: dict[_HTTPBridgeSessionKey, _HTTPBridgeQuarantineEntry],
+) -> int:
+    generation = getattr(service, "_http_bridge_quarantine_generation_counter", None)
+    if generation is None:
+        generation = max((entry.generation for entry in registry.values()), default=0)
+    generation += 1
+    service._http_bridge_quarantine_generation_counter = generation
+    return generation
+
+
 def _prune_http_bridge_quarantine_registry(
     registry: dict[_HTTPBridgeSessionKey, _HTTPBridgeQuarantineEntry],
     now: float,
@@ -124,7 +136,7 @@ def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *
     entry.quarantined_until = max(entry.quarantined_until, now + _HTTP_BRIDGE_QUARANTINE_TTL_SECONDS)
     entry.last_touched_monotonic = now
     entry.reason = reason
-    entry.generation += 1
+    entry.generation = _next_http_bridge_quarantine_generation(service, registry)
     _prune_http_bridge_quarantine_registry(registry, now)
     session.quarantined = True
     if already_quarantined:

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -81,6 +81,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_durable_lease_ttl_seconds,
     _http_bridge_is_previous_response_owner_unavailable,
     _http_bridge_key_strength,
+    _http_bridge_pending_response_events_seen,
     _http_bridge_precreated_retry_failure_error,
     _http_bridge_prewarm_enabled,
     _http_bridge_request_budget_seconds,
@@ -2816,20 +2817,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 # circuit strike. Explicit values remain authoritative for
                 # reader-failure callers whose pending deque was already
                 # drained before entering this shared boundary.
-                response_events_seen = max(
-                    (
-                        max(
-                            request_state.response_event_count,
-                            int(
-                                request_state.response_id is not None
-                                or request_state.latency_response_created_ms is not None
-                                or request_state.downstream_visible
-                            ),
-                        )
-                        for request_state in retired_request_states
-                    ),
-                    default=0,
-                )
+                response_events_seen = _http_bridge_pending_response_events_seen(retired_request_states)
             if retry_circuit_attempt_selection is None:
                 retry_circuit_attempt_selection = _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
                     retired_request_states

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -3206,6 +3206,14 @@ class _HTTPBridgeRequestSubmitMixin:
             model_class=_extract_model_class(session.request_model) if session.request_model else None,
         )
         reconnect_reader_kwargs = {"restart_reader": True} if restart_reader else {}
+        # Only an account-neutral replay that proved it carries no account-scoped
+        # state asks to rebind. Every other reconnect keeps its existing call
+        # shape, because nothing about how it picks an account has changed.
+        reconnect_rebind_kwargs = (
+            {"allow_account_rebind": True}
+            if account_neutral_recovery and fresh_hard_request_account_switch_allowed
+            else {}
+        )
         try:
             if retry_jitter_seconds > 0:
                 logger.info(
@@ -3248,11 +3256,20 @@ class _HTTPBridgeRequestSubmitMixin:
                     **reconnect_reader_kwargs,
                 )
             elif require_preferred_reconnect:
+                # The branch above already released this request's
+                # account-scoped lease because a fresh hard replay may land on
+                # a replacement account. Binding the same account here would
+                # contradict that and pin the replay to an account that just
+                # went silent, so keep the old owner only as a preference.
                 await self._reconnect_http_bridge_session(
                     session,
                     request_state=request_state,
-                    require_same_account=account_neutral_recovery or account_bound_replay,
+                    require_same_account=(
+                        (account_neutral_recovery or account_bound_replay)
+                        and not fresh_hard_request_account_switch_allowed
+                    ),
                     require_preferred_account=True,
+                    **reconnect_rebind_kwargs,
                     **reconnect_reader_kwargs,
                 )
             elif clean_close_hard_continuation or clean_close_hard_continuity_anchor:
@@ -3269,6 +3286,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 await self._reconnect_http_bridge_session(
                     session,
                     request_state=request_state,
+                    **reconnect_rebind_kwargs,
                     **reconnect_reader_kwargs,
                 )
             if request_state.account_response_create_lease is None:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1947,6 +1947,7 @@ class _HTTPBridgeStreamingMixin:
             else dict(headers)
         )
         fresh_replay_excluded_account_ids: set[str] = set()
+        model_transition_owner_conflict_fork_attempted = False
         unanchored_fork_spill_attempted = False
 
         def durable_full_resend_allows_account_neutral_replay() -> bool:
@@ -2005,6 +2006,83 @@ class _HTTPBridgeStreamingMixin:
                     durable_full_resend_fresh_payload
                 )
             return durable_full_resend_is_account_neutral
+
+        def switch_model_transition_to_account_neutral_fork(exc: ProxyResponseError) -> bool:
+            nonlocal account_neutral_recovery
+            nonlocal affinity
+            nonlocal bridge_session_key
+            nonlocal downstream_turn_state
+            nonlocal force_local_recovery_creation
+            nonlocal incoming_turn_state_header
+            nonlocal model_transition_owner_conflict_fork_attempted
+            nonlocal preferred_account_has_continuity_provenance
+            nonlocal request_state
+            nonlocal session_creation_headers
+            nonlocal session_header_fallback_key
+
+            error_code, _error_message = _proxy_error_code_message(exc)
+            if (
+                durable_model_transition_lookup is None
+                or error_code != "continuity_owner_conflict"
+                or model_transition_owner_conflict_fork_attempted
+                or forwarded_request
+                or not _http_bridge_payload_is_account_neutral_fresh_replay(effective_payload)
+                or request_state.previous_response_id is not None
+                or rewritten_file_account_id is not None
+            ):
+                return False
+            reused_parent_turn_state = (
+                incoming_turn_state_header is not None and downstream_turn_state == incoming_turn_state_header
+            )
+            failed_owner_id = request_state.preferred_account_id
+            _log_http_bridge_event(
+                "model_transition_owner_conflict_fork",
+                bridge_session_key,
+                account_id=failed_owner_id,
+                model=effective_payload.model,
+                detail="outcome=retry_without_previous_model_owner",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                owner_check_applied=True,
+            )
+            if failed_owner_id is not None:
+                fresh_replay_excluded_account_ids.add(failed_owner_id)
+            session_creation_headers = without_http_bridge_session_affinity_headers(session_creation_headers)
+            incoming_turn_state_header = None
+            session_header_fallback_key = None
+            affinity = _AffinityPolicy()
+            replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
+            # Pin the child lane hard instead of inheriting the implicit
+            # default: this fork keeps the client's own payload rather than a
+            # proved full-resend projection like the model-transition fresh
+            # resend above, so once the lane owns upstream turn state there is
+            # no verified replay text that would make a later soft reroute to a
+            # third account safe.
+            bridge_session_key = _HTTPBridgeSessionKey(
+                replay_kind,
+                replay_key,
+                bridge_session_key.api_key_id,
+                strength="hard",
+            )
+            account_neutral_recovery = True
+            force_local_recovery_creation = True
+            model_transition_owner_conflict_fork_attempted = True
+            # request_state was prepared for the parent lane before the
+            # creation loop, and `continue` re-enters the loop without
+            # rebuilding it. Reset the parent-derived continuity fields so the
+            # submit, retry, and clean-close paths classify the child as the
+            # account-neutral fresh request it is: a stale hard anchor here
+            # would block a later fresh account switch and let a clean close
+            # treat the parent turn alias as this lane's continuation.
+            request_state.affinity_policy = affinity
+            request_state.hard_continuity_anchor = False
+            request_state.preferred_account_id = None
+            request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
+            preferred_account_has_continuity_provenance = False
+            if reused_parent_turn_state:
+                request_state.session_id = None
+                downstream_turn_state = None
+            return True
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
             return (
@@ -2205,6 +2283,8 @@ class _HTTPBridgeStreamingMixin:
                     defer_account_health_writes=request_state.api_key_reservation is not None,
                 )
             except ProxyResponseError as exc:
+                if switch_model_transition_to_account_neutral_fork(exc):
+                    continue
                 if not owner_unavailable_allows_account_neutral_replay(exc):
                     exc_code, _exc_message = _proxy_error_code_message(exc)
                     if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -109,7 +109,7 @@ from app.modules.proxy._service.http_bridge.owner_forwarding import (
     _owner_forward_failure_allows_local_recovery,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
-    _http_bridge_session_key_quarantined,
+    _http_bridge_session_key_quarantine_generation,
 )
 from app.modules.proxy._service.http_bridge.service_stubs import (
     _build_rewritten_stream_response_failed_event,
@@ -1352,6 +1352,8 @@ class _HTTPBridgeStreamingMixin:
         # dispatch genuinely goes unanchored instead of rebuilding the same
         # wedged reattach through the session-state side door.
         fresh_reattach_anchor_suppressed_quarantined = False
+        fresh_reattach_quarantine_clear_key: _HTTPBridgeSessionKey | None = None
+        fresh_reattach_quarantine_clear_generation: int | None = None
 
         def classify_durable_full_resend(
             lookup: DurableBridgeLookup,
@@ -1421,6 +1423,12 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
                 )
+                # The durable recovery-attempt fence keys persisted
+                # ``http_bridge_recovery_attempts`` rows. Hash the same
+                # unprojected body main has always hashed: a projected body
+                # would mint a different fingerprint, so a row written
+                # before a restart would stop matching and the one-shot
+                # replay fence would silently open once.
                 _fresh_state, fresh_replay_text = prepare_bridge_request(
                     _http_bridge_payload_without_previous_response_id(payload)
                 )
@@ -1585,6 +1593,12 @@ class _HTTPBridgeStreamingMixin:
                     replay_kind,
                     replay_key,
                     bridge_session_key.api_key_id,
+                    # This is a one-shot fresh recovery dispatch after the
+                    # original hard key was quarantined. Keep the
+                    # account-neutral marker for replay guards, but do not hash
+                    # the random recovery key through durable hard-owner
+                    # routing before the wedged upstream proof can run.
+                    strength="soft",
                 )
                 force_local_recovery_creation = True
             durable_lookup = None
@@ -1611,13 +1625,21 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
             )
-            if payload_looks_like_full_resend and _http_bridge_session_key_quarantined(self, bridge_session_key):
+            quarantine_generation = (
+                _http_bridge_session_key_quarantine_generation(self, bridge_session_key)
+                if payload_looks_like_full_resend
+                else None
+            )
+            if quarantine_generation is not None:
                 # The previous attach on this key proved silent/wedged
                 # (#1534). The client's own payload already carries the full
                 # conversation, so send it unanchored on the fresh path
-                # instead of rebuilding the same reattach. Delta-only
-                # payloads keep the anchor: it is their only way to convey
-                # prior context (same boundary as the fenced anchor clear).
+                # instead of rebuilding the same reattach. Only cross accounts
+                # once the sealed durable full-resend proof matches this
+                # payload; otherwise keep the durable owner while dropping the
+                # poisoned anchor. Delta-only payloads keep the anchor: it is
+                # their only way to convey prior context (same boundary as the
+                # fenced anchor clear).
                 # Evaluated independently of the fresh-reattach eligibility
                 # above: even when that gate is already false (for example a
                 # conversation-scoped payload, a live alias session, or an
@@ -1627,6 +1649,35 @@ class _HTTPBridgeStreamingMixin:
                 # paths below.
                 fresh_reattach_can_use_durable_anchor = False
                 fresh_reattach_anchor_suppressed_quarantined = True
+                if (
+                    durable_full_resend_proof is not None
+                    and durable_full_resend_proof.matches(payload, durable_lookup)
+                    and durable_full_resend_fresh_payload is not None
+                    and durable_full_resend_is_account_neutral is True
+                ):
+                    effective_payload = durable_full_resend_fresh_payload
+                    untrimmed_effective_payload = durable_full_resend_fresh_payload
+                    fresh_reattach_quarantine_clear_key = bridge_session_key
+                    fresh_reattach_quarantine_clear_generation = quarantine_generation
+                    # Name the recovery key after the body this dispatch
+                    # actually sends, not after the recovery-attempt fence
+                    # fingerprint: the two hash different bodies and must
+                    # not be conflated.
+                    _quarantine_replay_state, quarantine_replay_text = prepare_bridge_request(
+                        durable_full_resend_fresh_payload
+                    )
+                    del _quarantine_replay_state
+                    replay_nonce = durable_bridge_hash(quarantine_replay_text)
+                    replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(replay_nonce)
+                    bridge_session_key = _HTTPBridgeSessionKey(
+                        replay_kind,
+                        replay_key,
+                        bridge_session_key.api_key_id,
+                        strength="soft",
+                    )
+                    force_local_recovery_creation = True
+                    incoming_session_header = None
+                    session_header_fallback_key = None
                 _log_http_bridge_event(
                     "fresh_reattach_anchor_skipped_quarantined",
                     bridge_session_key,
@@ -1731,6 +1782,8 @@ class _HTTPBridgeStreamingMixin:
         request_state, text_data = prepare_bridge_request(effective_payload)
         request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
         request_state.affinity_policy = affinity
+        request_state.quarantine_clear_key = fresh_reattach_quarantine_clear_key
+        request_state.quarantine_clear_generation = fresh_reattach_quarantine_clear_generation
         _apply_http_bridge_downstream_turn_state(
             request_state,
             downstream_turn_state=downstream_turn_state,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1511,18 +1511,29 @@ class _HTTPBridgeStreamingMixin:
             if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
             else None
         )
+        durable_model_transition_uses_fresh_replay = (
+            durable_model_transition_lookup is not None
+            and not forwarded_request
+            and rewritten_file_account_id is None
+            and durable_full_resend_fresh_payload is not None
+            and durable_full_resend_has_safe_fresh_context
+            and durable_full_resend_is_account_neutral is True
+        )
         durable_model_transition_requires_owner = durable_model_transition_lookup is not None and (
-            payload.previous_response_id is not None
-            or bridge_session_key.strength == "hard"
-            or (
-                bridge_session_key.affinity_kind == "prompt_cache"
-                and _http_bridge_request_stage(
-                    headers=headers,
-                    payload=payload,
-                    durable_lookup=durable_model_transition_lookup,
+            not durable_model_transition_uses_fresh_replay
+            and (
+                payload.previous_response_id is not None
+                or bridge_session_key.strength == "hard"
+                or (
+                    bridge_session_key.affinity_kind == "prompt_cache"
+                    and _http_bridge_request_stage(
+                        headers=headers,
+                        payload=payload,
+                        durable_lookup=durable_model_transition_lookup,
+                    )
+                    == "follow_up"
+                    and durable_model_transition_lookup.latest_turn_state is not None
                 )
-                == "follow_up"
-                and durable_model_transition_lookup.latest_turn_state is not None
             )
         )
         if durable_model_transition_lookup is not None:
@@ -1536,7 +1547,36 @@ class _HTTPBridgeStreamingMixin:
                 model_class=_extract_model_class(payload.model) if payload.model else None,
                 owner_check_applied=durable_model_transition_requires_owner,
             )
-            if is_http_bridge_account_neutral_replay(
+            if durable_model_transition_uses_fresh_replay:
+                replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
+                bridge_session_key = _HTTPBridgeSessionKey(
+                    replay_kind,
+                    replay_key,
+                    bridge_session_key.api_key_id,
+                    strength="soft",
+                )
+                affinity = _AffinityPolicy()
+                incoming_turn_state_header = None
+                incoming_session_header = None
+                session_header_fallback_key = None
+                effective_payload = durable_full_resend_fresh_payload
+                untrimmed_effective_payload = durable_full_resend_fresh_payload
+                force_local_recovery_creation = True
+                preferred_account_has_continuity_provenance = False
+                _log_http_bridge_event(
+                    "model_transition_fresh_resend",
+                    bridge_session_key,
+                    account_id=durable_model_transition_lookup.account_id,
+                    model=payload.model,
+                    detail=(
+                        "outcome=account_neutral_full_resend_without_owner,"
+                        f"previous_model={durable_model_transition_lookup.model}"
+                    ),
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(payload.model) if payload.model else None,
+                    owner_check_applied=False,
+                )
+            elif is_http_bridge_account_neutral_replay(
                 kind=durable_model_transition_lookup.canonical_kind,
                 key=durable_model_transition_lookup.canonical_key,
             ):
@@ -1719,6 +1759,7 @@ class _HTTPBridgeStreamingMixin:
             durable_lookup.account_id
             if (
                 durable_lookup is not None
+                and not durable_model_transition_uses_fresh_replay
                 and (
                     request_state.previous_response_id is not None
                     or bridge_session_key.strength == "hard"
@@ -1735,6 +1776,7 @@ class _HTTPBridgeStreamingMixin:
             request_state.preferred_account_id is None
             and durable_model_transition_lookup is not None
             and durable_model_transition_requires_owner
+            and not durable_model_transition_uses_fresh_replay
         ):
             request_state.preferred_account_id = durable_model_transition_lookup.account_id
         local_previous_response_owner: str | None = None
@@ -1856,6 +1898,7 @@ class _HTTPBridgeStreamingMixin:
 
         def durable_full_resend_allows_account_neutral_replay() -> bool:
             nonlocal durable_full_resend_fresh_payload
+            nonlocal durable_full_resend_has_safe_fresh_context
             nonlocal durable_full_resend_is_account_neutral
             nonlocal durable_full_resend_retains_prior_output
 
@@ -1881,7 +1924,17 @@ class _HTTPBridgeStreamingMixin:
                     stored_count=eligibility_projection.stored_prefix_count,
                     canonical_lite_developer_index=eligibility_projection.canonical_lite_developer_index,
                 )
-                if not durable_full_resend_retains_prior_output:
+                durable_full_resend_has_safe_fresh_context = durable_full_resend_retains_prior_output or (
+                    durable_lookup is not None
+                    and durable_lookup.latest_pending_tool_calls is not None
+                    and responses_input_suffix_matches_pending_tool_calls(
+                        eligibility_projection.input_items,
+                        stored_count=eligibility_projection.stored_prefix_count,
+                        pending_tool_calls=durable_lookup.latest_pending_tool_calls,
+                        canonical_lite_developer_index=eligibility_projection.canonical_lite_developer_index,
+                    )
+                )
+                if not durable_full_resend_has_safe_fresh_context:
                     return False
                 replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                     cast(list[JsonValue], payload.input),
@@ -1892,7 +1945,7 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_fresh_payload = _http_bridge_payload_without_previous_response_id(
                     payload
                 ).model_copy(update={"input": replay_projection.input_items})
-            if not durable_full_resend_retains_prior_output:
+            if not durable_full_resend_has_safe_fresh_context:
                 return False
             if durable_full_resend_is_account_neutral is None:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
@@ -2813,16 +2866,16 @@ class _HTTPBridgeStreamingMixin:
                     previous_request_state.proxy_injected_anchor_had_full_resend_payload
                 )
                 request_state.fresh_upstream_request_text = fresh_upstream_request_text
-                # The trim branch only fires when the untrimmed payload
-                # is a true full resend whose prefix exactly matches the
-                # already-stored context, so the unanchored request text
-                # is a safe fresh-turn replay target regardless of
-                # whether the anchor came from the durable or
-                # session-level injection path. Injection-only re-prepares
-                # keep the replay-safety decision made when the anchor was
-                # injected.
+                # The trim branch proves the upstream submission can omit the
+                # stored prefix, but it does not by itself prove that dropping
+                # the injected anchor is safe. Keep the original anchor site's
+                # decision unless this was a durable full-resend proof with a
+                # verified safe fresh suffix. Session-level anchors may still be
+                # compacted follow-ups whose prior context only exists behind
+                # previous_response_id.
                 request_state.fresh_upstream_request_is_retry_safe = (
-                    (durable_full_resend_anchor_count is None or durable_full_resend_has_safe_fresh_context)
+                    previous_request_state.fresh_upstream_request_is_retry_safe
+                    or (durable_full_resend_anchor_count is not None and durable_full_resend_has_safe_fresh_context)
                     if store_context_trim_applied
                     else previous_request_state.fresh_upstream_request_is_retry_safe
                 )
@@ -2937,6 +2990,7 @@ class _HTTPBridgeStreamingMixin:
                     owner_check_applied=True,
                 )
                 replacement_preferred_account_id = request_state.preferred_account_id
+                replacement_excluded_account_ids = set(request_state.excluded_account_ids)
                 if request_state.previous_response_id is not None and replacement_preferred_account_id is None:
                     replacement_preferred_account_id = session.account.id
                 elif replacement_preferred_account_id is None:
@@ -2949,9 +3003,8 @@ class _HTTPBridgeStreamingMixin:
                     # impossible (fallback_on_preferred_account_unavailable is
                     # False for exactly this pinned case below) and would
                     # keep poisoning every later recovery call on this
-                    # request, since excluded_account_ids persists on
-                    # request_state.
-                    request_state.excluded_account_ids.add(session.account.id)
+                    # request.
+                    replacement_excluded_account_ids.add(session.account.id)
                 while True:
                     try:
                         replacement_session = await self._get_or_create_http_bridge_session(
@@ -2984,7 +3037,7 @@ class _HTTPBridgeStreamingMixin:
                             request_usage_budget=request_state.request_usage_budget,
                             request_deadline=request_deadline,
                             session_header_fallback_key=session_header_fallback_key,
-                            exclude_account_ids=request_state.excluded_account_ids or None,
+                            exclude_account_ids=replacement_excluded_account_ids or None,
                             deferred_account_backoff_lifecycle=request_state.deferred_account_backoff_lifecycle,
                             defer_account_health_writes=request_state.api_key_reservation is not None,
                         )

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1750,6 +1750,8 @@ class _HTTPBridgeStreamingMixin:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
+        assert effective_payload is not None
+        assert untrimmed_effective_payload is not None
         account_neutral_recovery = is_http_bridge_account_neutral_replay(
             kind=bridge_session_key.affinity_kind,
             key=bridge_session_key.affinity_key,
@@ -2032,13 +2034,16 @@ class _HTTPBridgeStreamingMixin:
             nonlocal session_creation_headers
             nonlocal session_header_fallback_key
 
+            model_transition_payload = effective_payload
+            if model_transition_payload is None:
+                return False
             error_code, _error_message = _proxy_error_code_message(exc)
             if (
                 durable_model_transition_lookup is None
                 or error_code != "continuity_owner_conflict"
                 or model_transition_owner_conflict_fork_attempted
                 or forwarded_request
-                or not _http_bridge_payload_is_account_neutral_fresh_replay(effective_payload)
+                or not _http_bridge_payload_is_account_neutral_fresh_replay(model_transition_payload)
                 or request_state.previous_response_id is not None
                 or rewritten_file_account_id is not None
             ):
@@ -2051,10 +2056,12 @@ class _HTTPBridgeStreamingMixin:
                 "model_transition_owner_conflict_fork",
                 bridge_session_key,
                 account_id=failed_owner_id,
-                model=effective_payload.model,
+                model=model_transition_payload.model,
                 detail="outcome=retry_without_previous_model_owner",
                 cache_key_family=bridge_session_key.affinity_kind,
-                model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                model_class=_extract_model_class(model_transition_payload.model)
+                if model_transition_payload.model
+                else None,
                 owner_check_applied=True,
             )
             if failed_owner_id is not None:
@@ -3433,6 +3440,7 @@ class _HTTPBridgeStreamingMixin:
             if durable_recovery_fresh_replay:
                 pass
             elif should_attempt_context_overflow_fresh_turn_recovery:
+                assert untrimmed_effective_payload is not None
                 if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
                     bridge_durable_recover_total.labels(path="context_overflow_fresh_turn").inc()
                 _log_http_bridge_event(
@@ -3510,6 +3518,9 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_stage = "reattach"
                 retry_preferred_account_id = request_state.preferred_account_id
                 allow_previous_response_recovery_rebind = True
+
+            if retry_payload is None:
+                raise
 
             try:
                 while True:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1360,6 +1360,8 @@ class _HTTPBridgeStreamingMixin:
         fresh_reattach_anchor_suppressed_quarantined = False
         fresh_reattach_quarantine_clear_key: _HTTPBridgeSessionKey | None = None
         fresh_reattach_quarantine_clear_generation: int | None = None
+        fresh_reattach_quarantine_clear_session_id: str | None = None
+        fresh_reattach_quarantine_clear_owner_epoch: int | None = None
 
         def classify_durable_full_resend(
             lookup: DurableBridgeLookup,
@@ -1671,6 +1673,8 @@ class _HTTPBridgeStreamingMixin:
                     untrimmed_effective_payload = durable_full_resend_fresh_payload
                     fresh_reattach_quarantine_clear_key = bridge_session_key
                     fresh_reattach_quarantine_clear_generation = quarantine_generation
+                    fresh_reattach_quarantine_clear_session_id = durable_lookup.session_id
+                    fresh_reattach_quarantine_clear_owner_epoch = durable_lookup.owner_epoch
                     # Name the recovery key after the body this dispatch
                     # actually sends, not after the recovery-attempt fence
                     # fingerprint: the two hash different bodies and must
@@ -1798,6 +1802,8 @@ class _HTTPBridgeStreamingMixin:
         request_state.affinity_policy = affinity
         request_state.quarantine_clear_key = fresh_reattach_quarantine_clear_key
         request_state.quarantine_clear_generation = fresh_reattach_quarantine_clear_generation
+        request_state.quarantine_clear_session_id = fresh_reattach_quarantine_clear_session_id
+        request_state.quarantine_clear_owner_epoch = fresh_reattach_quarantine_clear_owner_epoch
         _apply_http_bridge_downstream_turn_state(
             request_state,
             downstream_turn_state=downstream_turn_state,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1346,6 +1346,12 @@ class _HTTPBridgeStreamingMixin:
         durable_full_resend_fresh_bridge_proof: _VerifiedDurableFullResend | None = None
         force_local_recovery_creation = False
         payload_looks_like_full_resend = _http_bridge_payload_looks_like_full_resend(payload)
+        durable_model_transition_lookup = (
+            durable_lookup
+            if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
+            else None
+        )
+        durable_model_transition_uses_fresh_replay = False
         # Set when the quarantine check below suppresses the durable-anchor
         # injection for a full-resend payload; the session hydration and the
         # session-level anchor injection further down must honor it so the
@@ -1423,6 +1429,13 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
                 )
+                durable_model_transition_uses_fresh_replay = (
+                    durable_model_transition_lookup is not None
+                    and not forwarded_request
+                    and rewritten_file_account_id is None
+                    and durable_full_resend_has_safe_fresh_context
+                    and durable_full_resend_is_account_neutral is True
+                )
                 # The durable recovery-attempt fence keys persisted
                 # ``http_bridge_recovery_attempts`` rows. Hash the same
                 # unprojected body main has always hashed: a projected body
@@ -1451,6 +1464,16 @@ class _HTTPBridgeStreamingMixin:
                                 and durable_lookup.lease_is_active(now=utcnow())
                             )
                             if not owner_is_current:
+                                recovery_claim_model = (
+                                    durable_lookup.model
+                                    if durable_model_transition_uses_fresh_replay
+                                    else payload.model
+                                )
+                                recovery_claim_latest_response_id = (
+                                    durable_lookup.latest_response_id
+                                    if durable_model_transition_uses_fresh_replay
+                                    else None
+                                )
                                 claimed_session = await self._durable_bridge.claim_live_session(
                                     session_key_kind=durable_lookup.canonical_kind,
                                     session_key_value=durable_lookup.canonical_key,
@@ -1458,10 +1481,10 @@ class _HTTPBridgeStreamingMixin:
                                     instance_id=claim_instance_id,
                                     lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
                                     account_id=durable_lookup.account_id,
-                                    model=payload.model,
+                                    model=recovery_claim_model,
                                     service_tier=None,
                                     latest_turn_state=durable_lookup.latest_turn_state,
-                                    latest_response_id=None,
+                                    latest_response_id=recovery_claim_latest_response_id,
                                     owner_process_epoch=http_bridge_owner_process_epoch(),
                                     # Revalidate the stale lookup under the
                                     # row lock; an active owner that appeared
@@ -1477,6 +1500,8 @@ class _HTTPBridgeStreamingMixin:
                                         ),
                                     )
                                 claim_owner_epoch = claimed_session.owner_epoch
+                                if durable_model_transition_uses_fresh_replay:
+                                    durable_model_transition_lookup = claimed_session
                             claimed = await self._durable_bridge.mark_recovery_attempt_replayed(
                                 session_id=durable_lookup.session_id,
                                 api_key_id=bridge_session_key.api_key_id,
@@ -1514,19 +1539,6 @@ class _HTTPBridgeStreamingMixin:
                             ),
                         )
         durable_anchor_trimmable = durable_full_resend_anchor_count is not None
-        durable_model_transition_lookup = (
-            durable_lookup
-            if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
-            else None
-        )
-        durable_model_transition_uses_fresh_replay = (
-            durable_model_transition_lookup is not None
-            and not forwarded_request
-            and rewritten_file_account_id is None
-            and durable_full_resend_fresh_payload is not None
-            and durable_full_resend_has_safe_fresh_context
-            and durable_full_resend_is_account_neutral is True
-        )
         durable_model_transition_requires_owner = durable_model_transition_lookup is not None and (
             not durable_model_transition_uses_fresh_replay
             and (

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import replace
 from typing import Any, TypeVar, cast
 
@@ -49,6 +49,7 @@ from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.time import utcnow
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
 )
@@ -72,6 +73,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
     _clear_http_bridge_quarantine,
+    _clear_http_bridge_quarantine_key,
     _record_http_bridge_quarantine_eventless_timeout,
     _record_http_bridge_quarantine_wedged_pending,
 )
@@ -195,6 +197,7 @@ from app.modules.proxy.affinity import (
     _extract_model_class,
 )
 from app.modules.proxy.continuity import is_http_bridge_account_neutral_replay
+from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_epoch
 from app.modules.proxy.helpers import (
     _normalize_error_code,
     is_upstream_model_capacity_error,
@@ -208,6 +211,74 @@ from app.modules.proxy.tool_call_dedupe import (
 )
 
 logger = logging.getLogger("app.modules.proxy.service")
+
+
+async def _advance_http_bridge_quarantine_clear_key(
+    service: Any,
+    *,
+    key: Any,
+    api_key_id: str | None,
+    account_id: str,
+    response_id: str,
+    input_item_count: int | None,
+    input_full_fingerprint: str | None,
+    pending_tool_calls: Mapping[str, str] | None,
+) -> bool:
+    lookup = await service._durable_bridge.lookup_request_targets(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=api_key_id,
+        turn_state=None,
+        session_header=None,
+        previous_response_id=None,
+    )
+    if lookup is None:
+        return False
+    settings = _service_get_settings()
+    instance_id = settings.http_responses_session_bridge_instance_id
+    active_lookup = lookup
+    if not active_lookup.lease_is_active(now=utcnow()) or active_lookup.owner_instance_id != instance_id:
+        claimed_lookup = await service._durable_bridge.claim_live_session(
+            session_key_kind=key.affinity_kind,
+            session_key_value=key.affinity_key,
+            api_key_id=api_key_id,
+            instance_id=instance_id,
+            lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+            account_id=active_lookup.account_id,
+            model=active_lookup.model,
+            service_tier=None,
+            latest_turn_state=active_lookup.latest_turn_state,
+            latest_response_id=active_lookup.latest_response_id,
+            allow_takeover=False,
+            owner_process_epoch=http_bridge_owner_process_epoch(),
+        )
+        if claimed_lookup.owner_instance_id != instance_id:
+            return False
+        active_lookup = claimed_lookup
+    if active_lookup.account_id != account_id:
+        rebound = await service._durable_bridge.rebind_session_account(
+            session_id=active_lookup.session_id,
+            api_key_id=api_key_id,
+            instance_id=instance_id,
+            owner_epoch=active_lookup.owner_epoch,
+            account_id=account_id,
+            clear_continuity=True,
+        )
+        if not rebound:
+            return False
+    advanced = await service._durable_bridge.renew_live_session(
+        session_id=active_lookup.session_id,
+        api_key_id=api_key_id,
+        instance_id=instance_id,
+        owner_epoch=active_lookup.owner_epoch,
+        lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+        latest_response_id=response_id,
+        latest_input_item_count=input_item_count,
+        latest_input_full_fingerprint=input_full_fingerprint,
+        latest_pending_tool_calls=pending_tool_calls,
+    )
+    return advanced is not None
+
 
 _HTTP_BRIDGE_RECOVERY_SETTLEMENT_RETRY_DELAYS = (
     0.25,
@@ -2783,6 +2854,38 @@ class _HTTPBridgeUpstreamEventsMixin:
         ):
             await self._clear_http_bridge_retry_circuit(session)
             _clear_http_bridge_quarantine(self, session)
+            if terminal_request_state.quarantine_clear_key is not None:
+                quarantine_advanced = False
+                if response_id is not None:
+                    try:
+                        quarantine_advanced = await _advance_http_bridge_quarantine_clear_key(
+                            self,
+                            key=terminal_request_state.quarantine_clear_key,
+                            api_key_id=session.key.api_key_id,
+                            account_id=session.account.id,
+                            response_id=response_id,
+                            input_item_count=(
+                                terminal_request_state.input_item_count
+                                if terminal_request_state.input_item_count > 0
+                                else None
+                            ),
+                            input_full_fingerprint=(
+                                terminal_request_state.input_full_fingerprint
+                                if terminal_request_state.input_item_count > 0
+                                else None
+                            ),
+                            pending_tool_calls=_durable_pending_tool_call_manifest(terminal_request_state, payload),
+                        )
+                    except Exception:
+                        logger.warning("Failed to advance quarantined HTTP bridge continuity", exc_info=True)
+                if quarantine_advanced:
+                    _clear_http_bridge_quarantine_key(
+                        self,
+                        terminal_request_state.quarantine_clear_key,
+                        account_id=session.account.id,
+                        model=session.request_model,
+                        generation=terminal_request_state.quarantine_clear_generation,
+                    )
 
         normalize_error_event = (
             terminal_request_state is None or terminal_request_state.enforce_openai_sdk_contract

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -74,6 +74,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 from app.modules.proxy._service.http_bridge.quarantine import (
     _clear_http_bridge_quarantine,
     _clear_http_bridge_quarantine_key,
+    _http_bridge_session_key_quarantine_generation,
     _record_http_bridge_quarantine_eventless_timeout,
     _record_http_bridge_quarantine_wedged_pending,
 )
@@ -223,7 +224,15 @@ async def _advance_http_bridge_quarantine_clear_key(
     input_item_count: int | None,
     input_full_fingerprint: str | None,
     pending_tool_calls: Mapping[str, str] | None,
+    quarantine_generation: int | None,
 ) -> bool:
+    def generation_matches() -> bool:
+        if quarantine_generation is None:
+            return True
+        return _http_bridge_session_key_quarantine_generation(service, key) == quarantine_generation
+
+    if not generation_matches():
+        return False
     lookup = await service._durable_bridge.lookup_request_targets(
         session_key_kind=key.affinity_kind,
         session_key_value=key.affinity_key,
@@ -233,6 +242,8 @@ async def _advance_http_bridge_quarantine_clear_key(
         previous_response_id=None,
     )
     if lookup is None:
+        return False
+    if not generation_matches():
         return False
     settings = _service_get_settings()
     instance_id = settings.http_responses_session_bridge_instance_id
@@ -255,6 +266,8 @@ async def _advance_http_bridge_quarantine_clear_key(
         if claimed_lookup.owner_instance_id != instance_id:
             return False
         active_lookup = claimed_lookup
+    if not generation_matches():
+        return False
     if active_lookup.account_id != account_id:
         rebound = await service._durable_bridge.rebind_session_account(
             session_id=active_lookup.session_id,
@@ -266,6 +279,8 @@ async def _advance_http_bridge_quarantine_clear_key(
         )
         if not rebound:
             return False
+    if not generation_matches():
+        return False
     advanced = await service._durable_bridge.renew_live_session(
         session_id=active_lookup.session_id,
         api_key_id=api_key_id,
@@ -277,7 +292,14 @@ async def _advance_http_bridge_quarantine_clear_key(
         latest_input_full_fingerprint=input_full_fingerprint,
         latest_pending_tool_calls=pending_tool_calls,
     )
-    return advanced is not None
+    return (
+        advanced is not None
+        and advanced.session_id == active_lookup.session_id
+        and advanced.owner_instance_id == instance_id
+        and advanced.owner_epoch == active_lookup.owner_epoch
+        and advanced.account_id == account_id
+        and advanced.latest_response_id == response_id
+    )
 
 
 _HTTP_BRIDGE_RECOVERY_SETTLEMENT_RETRY_DELAYS = (
@@ -2875,6 +2897,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 else None
                             ),
                             pending_tool_calls=_durable_pending_tool_call_manifest(terminal_request_state, payload),
+                            quarantine_generation=terminal_request_state.quarantine_clear_generation,
                         )
                     except Exception:
                         logger.warning("Failed to advance quarantined HTTP bridge continuity", exc_info=True)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -225,6 +225,8 @@ async def _advance_http_bridge_quarantine_clear_key(
     input_full_fingerprint: str | None,
     pending_tool_calls: Mapping[str, str] | None,
     quarantine_generation: int | None,
+    expected_session_id: str | None = None,
+    expected_owner_epoch: int | None = None,
 ) -> bool:
     def generation_matches() -> bool:
         if quarantine_generation is None:
@@ -242,6 +244,10 @@ async def _advance_http_bridge_quarantine_clear_key(
         previous_response_id=None,
     )
     if lookup is None:
+        return False
+    if expected_session_id is not None and lookup.session_id != expected_session_id:
+        return False
+    if expected_owner_epoch is not None and lookup.owner_epoch != expected_owner_epoch:
         return False
     if not generation_matches():
         return False
@@ -2900,6 +2906,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                             ),
                             pending_tool_calls=_durable_pending_tool_call_manifest(terminal_request_state, payload),
                             quarantine_generation=terminal_request_state.quarantine_clear_generation,
+                            expected_session_id=terminal_request_state.quarantine_clear_session_id,
+                            expected_owner_epoch=terminal_request_state.quarantine_clear_owner_epoch,
                         )
                     except Exception:
                         logger.warning("Failed to advance quarantined HTTP bridge continuity", exc_info=True)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -292,6 +292,8 @@ async def _advance_http_bridge_quarantine_clear_key(
         latest_input_full_fingerprint=input_full_fingerprint,
         latest_pending_tool_calls=pending_tool_calls,
     )
+    if not generation_matches():
+        return False
     return (
         advanced is not None
         and advanced.session_id == active_lookup.session_id

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -921,11 +921,11 @@ class _StreamingMixin(_StreamingRetryMixin):
                         event_type,
                     ) = _facade()._build_rewritten_stream_response_failed_event(
                         response_id=response_id,
-                        error_code="stream_incomplete",
+                        error_code=_facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE,
                         error_message=_facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
                     )
                     status = "error"
-                    error_code = "stream_incomplete"
+                    error_code = _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE
                     error_message = _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE
                     settlement.record_success = False
                     settlement.account_health_error = False

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -988,6 +988,8 @@ class _WebSocketRequestState:
     skip_request_log: bool = False
     previous_response_id: str | None = None
     session_id: str | None = None
+    quarantine_clear_key: _HTTPBridgeSessionKey | None = None
+    quarantine_clear_generation: int | None = None
     # Session headers provide locality, but only a previous response or
     # explicit turn-state header guarantees continuity for stale recovery.
     hard_continuity_anchor: bool = False

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -990,6 +990,8 @@ class _WebSocketRequestState:
     session_id: str | None = None
     quarantine_clear_key: _HTTPBridgeSessionKey | None = None
     quarantine_clear_generation: int | None = None
+    quarantine_clear_session_id: str | None = None
+    quarantine_clear_owner_epoch: int | None = None
     # Session headers provide locality, but only a previous response or
     # explicit turn-state header guarantees continuity for stale recovery.
     hard_continuity_anchor: bool = False

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1386,7 +1386,7 @@ def _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
     request_state: _WebSocketRequestState,
 ) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
     rewritten_event_payload = response_failed_event(
-        "stream_incomplete",
+        _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE,
         _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
         error_type="server_error",
         response_id=_websocket_downstream_response_id(request_state),

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5989,7 +5989,7 @@ class _WebSocketMixin:
                 "account_health_error_handled",
                 False,
             )
-        if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
+        if request_state.suppressed_duplicate_tool_call:
             settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5989,7 +5989,10 @@ class _WebSocketMixin:
                 "account_health_error_handled",
                 False,
             )
-        if request_state.suppressed_duplicate_tool_call:
+        if (
+            request_state.suppressed_duplicate_tool_call
+            and error_code == _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE
+        ):
             settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"

--- a/app/modules/proxy/continuity.py
+++ b/app/modules/proxy/continuity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from hashlib import sha256
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
@@ -65,6 +65,46 @@ def without_http_bridge_session_affinity_headers(headers: Mapping[str, str]) -> 
 class _ReconnectPreferredOwner(Protocol):
     preferred_account_id: str | None
     file_required_preferred_account: bool
+
+
+class _AccountNeutralReplayKey(Protocol):
+    affinity_kind: str
+    affinity_key: str
+
+
+class AccountNeutralOwnerBinding(NamedTuple):
+    """How a reconnect must treat the account that opened an account-neutral replay."""
+
+    owner_bound: bool
+    rebind_allowed: bool
+
+
+def resolve_account_neutral_owner_binding(
+    key: _AccountNeutralReplayKey,
+    request_state: _ReconnectPreferredOwner,
+    allow_account_rebind: bool,
+) -> AccountNeutralOwnerBinding:
+    """Decide whether an account-neutral replay still binds its opening account.
+
+    A server-namespaced replay key can be continued by any account, but most
+    reconnects also resume account-scoped upstream state, so the opening account
+    stays bound by default. Only a caller that has proven its request carries no
+    such state -- no continuity anchor, no account-scoped file, nothing streamed
+    yet -- passes ``allow_account_rebind``, and only then may the reconnect land
+    on a replacement account. Deriving that here from the key alone would
+    override the caller, which is how a fresh replay stayed pinned to an account
+    that had gone silent.
+
+    ``owner_bound`` and ``rebind_allowed`` are not opposites: a key that was
+    never account-neutral is neither, so a caller that allows a rebind cannot
+    loosen owner requirements on an ordinary account-bound session.
+    """
+
+    if not is_http_bridge_account_neutral_replay(kind=key.affinity_kind, key=key.affinity_key):
+        return AccountNeutralOwnerBinding(owner_bound=False, rebind_allowed=False)
+    if allow_account_rebind and not request_state.file_required_preferred_account:
+        return AccountNeutralOwnerBinding(owner_bound=False, rebind_allowed=True)
+    return AccountNeutralOwnerBinding(owner_bound=True, rebind_allowed=False)
 
 
 def resolve_reconnect_preferred_account_id(

--- a/app/modules/proxy/continuity.py
+++ b/app/modules/proxy/continuity.py
@@ -68,8 +68,13 @@ class _ReconnectPreferredOwner(Protocol):
 
 
 class _AccountNeutralReplayKey(Protocol):
-    affinity_kind: str
-    affinity_key: str
+    # Read-only members: session keys are frozen dataclasses, and a plain
+    # attribute declaration would demand a writable one.
+    @property
+    def affinity_kind(self) -> str: ...
+
+    @property
+    def affinity_key(self) -> str: ...
 
 
 class AccountNeutralOwnerBinding(NamedTuple):

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -15,11 +15,10 @@ _TOOL_CALL_TYPE_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _TOOL_CALL_TYPES = frozenset(_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
-_ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset(
-    {"reasoning", "tool_search_call", "tool_search_output", "web_search_call"}
-)
+_ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset({"reasoning", "web_search_call"})
 _INTERNAL_CHAT_MESSAGE_METADATA_FIELD = "internal_chat_message_metadata_passthrough"
 _ACCOUNT_NEUTRAL_INTERNAL_CHAT_MESSAGE_METADATA_FIELDS = frozenset({"turn_id"})
 _ACCOUNT_NEUTRAL_TOOL_TYPES = frozenset({"custom", "function", "web_search", "web_search_preview"})
@@ -39,6 +38,7 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "additional_tools",
         "apply_patch_call",
         "apply_patch_call_output",
+        "compaction",
         "custom_tool_call",
         "custom_tool_call_output",
         "function_call",
@@ -47,6 +47,8 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "input_image",
         "input_text",
         "message",
+        "tool_search_call",
+        "tool_search_output",
     }
 )
 _ACCOUNT_NEUTRAL_MESSAGE_CONTENT_TYPES = frozenset(
@@ -65,6 +67,7 @@ _ACCOUNT_NEUTRAL_CONTENT_FIELDS = {
 }
 _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     "additional_tools": frozenset({"role", "tools", "type"}),
+    "compaction": frozenset({"encrypted_content", "id", "status", "type"}),
     "apply_patch_call": frozenset(
         {
             "call_id",
@@ -92,6 +95,22 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     ),
     "function_call_output": frozenset(
         {"call_id", "caller", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "output", "status", "type"}
+    ),
+    "tool_search_call": frozenset(
+        {"arguments", "call_id", "caller", "execution", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "status", "type"}
+    ),
+    "tool_search_output": frozenset(
+        {
+            "call_id",
+            "caller",
+            "execution",
+            "id",
+            _INTERNAL_CHAT_MESSAGE_METADATA_FIELD,
+            "output",
+            "status",
+            "tools",
+            "type",
+        }
     ),
 }
 _ACCOUNT_NEUTRAL_ITEM_STATUSES = frozenset({"completed", "failed"})
@@ -176,6 +195,8 @@ def project_responses_input_for_account_neutral_fresh_replay(
 
     if stored_count <= 0 or stored_count > len(input_items):
         return None
+    if not _stored_prefix_compaction_boundary_is_safe(input_items, stored_count=stored_count):
+        return None
 
     projected_items: list[JsonValue] = []
     projected_stored_count = 0
@@ -207,6 +228,14 @@ def project_responses_input_for_account_neutral_fresh_replay(
         stored_prefix_count=projected_stored_count,
         canonical_lite_developer_index=canonical_lite_developer_index,
     )
+
+
+def _stored_prefix_compaction_boundary_is_safe(input_items: list[JsonValue], *, stored_count: int) -> bool:
+    stored_prefix = input_items[:stored_count]
+    for item in stored_prefix[:-1]:
+        if isinstance(item, dict) and item.get("type") == "compaction" and _compaction_item_is_self_contained(item):
+            return False
+    return True
 
 
 def _is_canonical_lite_tool_bundle(item: JsonValue) -> bool:
@@ -245,6 +274,8 @@ def _project_account_neutral_replay_item(
     ):
         return None
 
+    if item_type == "compaction":
+        return item
     if "id" not in item:
         return item
     projected_item = dict(item)
@@ -269,6 +300,10 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         item_type = item_type_value if isinstance(item_type_value, str) else None
         if not _input_item_has_only_known_fields(item, item_type):
             return False
+        if item_type == "compaction":
+            if not _compaction_item_is_self_contained(item):
+                return False
+            continue
         call_id_value = item.get("call_id")
         call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
         if item_type in _TOOL_CALL_TYPES:
@@ -324,8 +359,10 @@ def responses_input_suffix_retains_prior_output(
     if prefix_state is None:
         return False
     pending_suffix_calls, seen_suffix_call_ids = prefix_state
-    retained_output_seen = False
+    compact_context_prefix = _input_prefix_ends_with_self_contained_compaction(input_items[:stored_count])
+    retained_output_seen = compact_context_prefix
     retained_output_is_final_answer = False
+    settled_suffix_call_types: set[str] = set()
     fresh_followup_seen = False
     fresh_followup_count = 0
     fresh_followup_is_user_message = False
@@ -364,6 +401,17 @@ def responses_input_suffix_retains_prior_output(
             if pending_suffix_calls[0] != (call_type, call_id):
                 return False
             pending_suffix_calls.popleft()
+            settled_suffix_call_types.add(call_type)
+            if (
+                compact_context_prefix
+                and not pending_suffix_calls
+                and settled_suffix_call_types == {"tool_search_call"}
+            ):
+                retained_output_seen = True
+                retained_output_is_final_answer = False
+                fresh_followup_seen = False
+                fresh_followup_count = 0
+                fresh_followup_is_user_message = False
             continue
         if item_type in (None, "message") and item.get("role") == "assistant":
             if pending_suffix_calls or not _is_retained_response_message(item):
@@ -394,6 +442,17 @@ def responses_input_suffix_retains_prior_output(
             continue
         return False
     return retained_output_seen and fresh_followup_seen and not pending_suffix_calls
+
+
+def _input_prefix_ends_with_self_contained_compaction(input_items: list[JsonValue]) -> bool:
+    if not input_items:
+        return False
+    last_item = input_items[-1]
+    return (
+        isinstance(last_item, dict)
+        and last_item.get("type") == "compaction"
+        and _compaction_item_is_self_contained(last_item)
+    )
 
 
 def responses_input_suffix_matches_pending_tool_calls(
@@ -628,6 +687,9 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("arguments"), str)
     if item_type == "custom_tool_call":
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("input"), str)
+    if item_type == "tool_search_call":
+        arguments = item.get("arguments")
+        return isinstance(arguments, dict) and item.get("execution") in (None, "client")
     operation = item.get("operation")
     patch = item.get("patch")
     input_value = item.get("input")
@@ -638,6 +700,10 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
     if "patch" in item:
         return _is_nonblank_string(patch)
     return _is_nonblank_string(input_value)
+
+
+def _compaction_item_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return item.get("status") in (None, "completed") and _is_nonblank_string(item.get("encrypted_content"))
 
 
 def _caller_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
@@ -677,6 +743,13 @@ def _apply_patch_operation_is_self_contained(operation: JsonValue | None) -> boo
 def _tool_output_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) -> bool:
     if item.get("status") not in (None, "completed", "failed"):
         return False
+    if item_type == "tool_search_output":
+        if item.get("execution") not in (None, "client"):
+            return False
+        if "tools" in item and not _tools_are_account_neutral(item.get("tools")):
+            return False
+        if _tool_search_output_tools_are_self_contained(item):
+            return True
     output = item.get("output")
     if isinstance(output, str):
         return True
@@ -689,6 +762,15 @@ def _tool_output_is_self_contained(item_type: str, item: Mapping[str, JsonValue]
             isinstance(part, dict) and _input_content_part_is_self_contained(part, allow_output=False)
             for part in output
         )
+    )
+
+
+def _tool_search_output_tools_are_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return (
+        item.get("execution") == "client"
+        and "tools" in item
+        and _tools_are_account_neutral(item.get("tools"))
+        and item.get("output") in (None, "")
     )
 
 
@@ -933,6 +1015,13 @@ def _input_items_have_valid_account_neutral_shape(input_items: list[JsonValue]) 
             if not _input_content_part_is_self_contained(item, allow_output=False):
                 return False
             continue
+        if item_type == "tool_search_output":
+            execution = item.get("execution")
+            if execution is not None and execution != "client":
+                return False
+            if "tools" in item and not _tools_are_account_neutral(item.get("tools")):
+                return False
+            continue
         if item_type == "additional_tools":
             if item.get("role") != "developer" or not _tools_are_account_neutral(item.get("tools")):
                 return False
@@ -1017,6 +1106,8 @@ def _contains_account_scoped_input_state(value: JsonValue) -> bool:
                 return True
             if item_type == "additional_tools" and not _tools_are_account_neutral(current.get("tools")):
                 return True
+            if item_type == "compaction" and _compaction_item_is_self_contained(current):
+                continue
             if (
                 isinstance(item_type, str)
                 and (item_type.endswith("_call") or item_type.endswith("_call_output"))

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -876,6 +876,7 @@ _WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE = "account_auth_invalidated"
 _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE = (
     "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely."
 )
+_SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE = "duplicate_tool_call_replay_suppressed"
 _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 _WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
 _SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE = "security_work_authorization_required"

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -222,6 +222,9 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_payload_without_previous_response_id as _http_bridge_payload_without_previous_response_id,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
+    _http_bridge_pending_response_events_seen as _http_bridge_pending_response_events_seen,
+)
+from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_precreated_retry_failure_error as _http_bridge_precreated_retry_failure_error,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
@@ -2594,19 +2597,11 @@ def _service_tier_from_event_payload(payload: dict[str, JsonValue] | None) -> st
 
 
 def _effective_service_tier(requested_service_tier: str | None, actual_service_tier: str | None) -> str | None:
-    if isinstance(actual_service_tier, str):
-        return actual_service_tier
-    if isinstance(requested_service_tier, str):
-        return requested_service_tier
-    return None
+    return actual_service_tier if isinstance(actual_service_tier, str) else requested_service_tier
 
 
 def _normalize_service_tier_value(value: JsonValue) -> str | None:
     if not isinstance(value, str):
         return None
     stripped = value.strip()
-    if not stripped:
-        return None
-    if stripped.lower() == "fast":
-        return "priority"
-    return stripped
+    return "priority" if stripped.lower() == "fast" else stripped or None

--- a/openspec/changes/fence-http-bridge-quarantine-recovery/.openspec.yaml
+++ b/openspec/changes/fence-http-bridge-quarantine-recovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/fence-http-bridge-quarantine-recovery/.openspec.yaml
+++ b/openspec/changes/fence-http-bridge-quarantine-recovery/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: spec-driven
-created: 2026-08-21
+created: 2026-08-20

--- a/openspec/changes/fence-http-bridge-quarantine-recovery/proposal.md
+++ b/openspec/changes/fence-http-bridge-quarantine-recovery/proposal.md
@@ -1,0 +1,24 @@
+# Fence HTTP bridge quarantine recovery
+
+## Why
+
+HTTP bridge quarantine is intentionally bounded and session-scoped. PR #1862 restores a recovery path that does more than clear the in-memory quarantine entry: when a replacement request completes and produces a usable response id, it also advances the original durable session row so later continuations can reuse the recovered anchor.
+
+That durable write is useful, but the current contract still says quarantine clearing never writes the durable row. The implementation also needs sharper fences: a stale quarantine generation must not advance durable continuity after the same key was quarantined again, and a fenced `renew_live_session` call must not be treated as success unless the returned snapshot proves the intended row was updated.
+
+## What Changes
+
+- Update the `responses-api-compat` quarantine contract so a completed recovery response may rebind and renew the original durable session row.
+- Require that durable recovery is fenced by the captured quarantine generation before durable mutation.
+- Require that the renewal snapshot matches the expected session id, owner instance, owner epoch, account id, and recovered response id before clearing quarantine.
+- Keep the existing boundaries: no account-health write, no account-selection change, TTL cleanup stays in-memory, and a stale generation leaves the newer quarantine and durable owner/anchor intact.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: HTTP bridge quarantine recovery may perform a fenced durable ownership transfer when a replacement response completes, and must prove the durable renewal before clearing the quarantine entry.

--- a/openspec/changes/fence-http-bridge-quarantine-recovery/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fence-http-bridge-quarantine-recovery/specs/responses-api-compat/spec.md
@@ -1,0 +1,63 @@
+# responses-api-compat Delta
+
+## MODIFIED Requirements
+
+### Requirement: Silent HTTP bridge sessions are quarantined from re-attach and reuse
+
+When an HTTP bridge session proves silent/wedged, the proxy MUST quarantine its session key for a bounded window so later requests stop attaching to it. A session proves silent/wedged when either (a) a pending request being failed or retired carried a proxy-injected `previous_response_id`, had sent `response.create`, observed upstream response events, and never had `response.created` assigned, or (b) the session key hits two consecutive eventless `missing_response_created_timeout` retires. This holds for every path that fails or retires the request — partial stale-holder cleanup, the reader-failure funnel, and direct all-stale session retirement alike. The quarantine MUST be evaluated only when a request is already being failed or its session retired — never against a live owned turn — so a stream whose `response.created` was observed (including deferred-reasoning streams with long event gaps) MUST NOT be quarantined, and mere event silence during an owned live turn MUST NOT trigger quarantine by itself.
+
+While a session key is quarantined: an existing session under that key MUST NOT be selected for reuse (a new request detaches it and proceeds on a fresh session), and for durable-anchor selection a quarantined session that is still open MUST count as absent, exactly as if it were already gone. The quarantine registry verdict is authoritative for the key: any session under the key while the quarantine window is active — including a freshly created replacement whose own completion has not yet cleared the quarantine — is equally excluded from reuse and equally absent for anchor selection. A fresh reattach whose incoming payload already looks like a full conversation resend MUST NOT receive a proxy-injected durable anchor through any injection point — the fresh-reattach injection, session-state hydration of the durable anchor, or the session-level injection — so the dispatch goes upstream genuinely unanchored with the client's own untrimmed payload. A payload that does not look like a full resend (a genuine delta-only continuation) MUST still receive the durable anchor, because it has no other way to convey prior conversation state.
+
+Quarantine state MUST be bounded and self-recovering: it is in-memory and session-scoped, expires by TTL (a live session that outlives its quarantine window MUST become reusable again), is cleared when a response completes on the same session key, and MUST NOT write account health or alter account selection. When a replacement request completes on a quarantined key and produces a usable response id, recovery MAY rebind and renew the original durable session row so the recovered response id becomes the durable continuity anchor. That durable recovery MUST be fenced by the quarantine generation captured when the replacement request was prepared, and MUST NOT perform durable mutations if the current quarantine generation differs before the mutation. The proxy MUST treat `renew_live_session` as successful only when its returned snapshot matches the expected durable session id, owner instance, owner epoch, account id, and recovered response id.
+
+#### Scenario: Repeated eventless timeouts quarantine the key
+
+- **GIVEN** a session key whose pending request already retired once with the eventless `missing_response_created_timeout`
+- **WHEN** a subsequent attach on the same key retires with the same eventless timeout before any response completes on the key
+- **THEN** the session key is quarantined with reason `repeated_eventless_timeout`
+- **AND** the first timeout alone does not quarantine the key
+
+#### Scenario: Deferred-reasoning live turn is never quarantined
+
+- **GIVEN** an owned live turn whose `response.created` was observed and whose events flow with long gaps (deferred reasoning)
+- **WHEN** its stream later fails or its session is retired
+- **THEN** the session key is not quarantined
+- **AND** later requests keep the existing reuse and anchor-injection behavior
+
+#### Scenario: Delta-only payloads keep their anchor while quarantined
+
+- **GIVEN** a quarantined session key — including one whose quarantined session is still open with other active requests
+- **WHEN** a later request arrives whose payload does not look like a full conversation resend
+- **THEN** the still-open quarantined session counts as absent for durable-anchor selection
+- **AND** the durable anchor is still injected for that request, preserving the client's only way to convey prior context
+
+#### Scenario: Quarantine is bounded and self-clearing
+
+- **GIVEN** a quarantined session key
+- **WHEN** a response completes on that session key, or the quarantine TTL elapses
+- **THEN** the quarantine (and its eventless strike counter) is cleared
+- **AND** a session that survived the quarantine window is reusable again instead of staying rejected forever
+- **AND** account health and account selection are not written by this path
+
+#### Scenario: Completed replacement response advances durable recovery
+
+- **GIVEN** generation N of a quarantined key dispatched a replacement request
+- **AND** that replacement response completes with response id `resp_recovered`
+- **WHEN** the original durable session row is still owned by the expected bridge instance and owner epoch
+- **THEN** the proxy may rebind the original durable row to the replacement account and renew it with `resp_recovered`
+- **AND** quarantine is cleared only after the renewal snapshot confirms the expected session id, owner instance, owner epoch, account id, and response id
+
+#### Scenario: Foreign renewal snapshot does not clear quarantine
+
+- **GIVEN** a completed replacement response attempts durable quarantine recovery
+- **WHEN** `renew_live_session` returns a snapshot for a foreign owner, epoch, account, or response id
+- **THEN** the recovery is not reported as successful
+- **AND** quarantine remains uncleared
+
+#### Scenario: Newer quarantine generation blocks stale durable recovery
+
+- **GIVEN** a generation N replacement response is still recovering
+- **AND** the same key is quarantined again at generation N+1 before durable mutation
+- **WHEN** generation N recovery resumes
+- **THEN** it does not rebind or renew the durable row
+- **AND** the generation N+1 quarantine and durable owner/anchor survive

--- a/openspec/changes/fence-http-bridge-quarantine-recovery/tasks.md
+++ b/openspec/changes/fence-http-bridge-quarantine-recovery/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Spec
+
+- [x] 1.1 Add a `responses-api-compat` delta that permits durable quarantine recovery on completed replacement responses.
+- [x] 1.2 Require generation fencing before durable mutation and renewal-snapshot validation before clearing quarantine.
+
+## 2. Implementation
+
+- [x] 2.1 Thread the captured quarantine generation into durable recovery.
+- [x] 2.2 Reject stale generations before durable rebind or renewal.
+- [x] 2.3 Validate the renewal snapshot's session id, owner instance, owner epoch, account id, and response id before reporting recovery success.
+
+## 3. Coverage
+
+- [x] 3.1 Add a regression where a foreign renewal snapshot returns and quarantine recovery is not reported as successful.
+- [x] 3.2 Add a regression where generation N+1 quarantine lands while generation N recovery is in flight, proving the newer owner/anchor survives.
+
+## 4. Verification
+
+- [ ] 4.1 Run the added tests and touched test module.
+- [x] 4.2 Run `ruff check .`.
+- [x] 4.3 Run OpenSpec validation.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/.openspec.yaml
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The durable full-resend reconciliation in the sibling change handles a
+verified complete replay. A model transition is a separate path: the request
+has no previous-response anchor to replay, but the durable lookup still binds
+the old model's owner. When a stale hard alias disagrees, blindly selecting a
+new account would be unsafe, while retrying the same alias produces a stable
+502 `continuity_owner_conflict` loop.
+
+## Decision
+
+Keep the recovery gate inside the HTTP bridge creation loop. Inspect the typed
+error code and continue only when it is `continuity_owner_conflict`; do not
+reuse the broader owner-unavailable predicate. Reject forwarded requests so a
+replica cannot create a local lane after an origin forwarding failure. Validate
+the effective Responses payload with the existing account-neutral replay
+classifier, which rejects `previous_response_id`, conversation state,
+account-scoped hosted references such as `input_file.file_id`, hosted/MCP call
+items, and any input item that is not self-contained. That classifier is shared
+with the post-compaction recovery work, so its admitted shapes can widen over
+time: a completed `compaction` item carrying its own encrypted content and
+client-executed `tool_search_*` items are now accepted as self-contained, while
+a compaction placeholder without that content still fails closed. File-owner
+resolution and previous-response checks remain explicit defensive gates.
+
+On success, strip session/turn aliases, replace the request key with a
+server-namespaced account-neutral key, exclude the failed owner, clear the
+preferred owner/provenance, and force local creation. Persisted hard aliases
+are not rewritten.
+
+The request state itself is reset to the child's own identity. It was prepared
+for the parent lane before the creation loop, and the retry re-enters that loop
+without rebuilding it, so the fork clears the parent affinity policy, the hard
+continuity anchor, and a reused parent turn state. Leaving those set would let
+the submit and clean-close paths treat the account-neutral child as the old
+owner-bound turn: a stale anchor blocks the pre-output account switch that the
+neutrality proof already permits, and a clean close would recover it as a
+continuation of the parent turn alias.
+
+The child lane key is pinned `hard` rather than inheriting the implicit
+strength default. The sibling model-transition fresh-resend path may use a
+`soft` key because it substitutes a proved full-resend projection that any
+account can serve at any point. This fork forwards the client's own payload
+unchanged, so once the child lane owns upstream turn state there is no verified
+replay text that would make a later soft reroute to a third account safe.
+
+## Negative Controls
+
+- A forwarded request with the same owner conflict must return the original
+  `continuity_owner_conflict` without a second creation attempt.
+- A fresh payload containing an unpinned `input_file.file_id` must also return
+  the original conflict without account-neutral forking.
+- A post-compaction payload whose `compaction` item only references the owner's
+  compacted context — no encrypted content of its own, or still in progress —
+  must return the original conflict instead of forking, because the prior turns
+  exist only behind the previous owner.
+- A second conflict on the child lane must surface the original error instead of
+  forking again.
+- The forked child request must not keep the parent's affinity policy, hard
+  continuity anchor, or reused parent turn state.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+An HTTP bridge model transition can resolve a durable model owner while a
+legacy hard alias resolves to a different account. The bridge then returns
+`continuity_owner_conflict` before dispatch even when the request is a fresh,
+account-neutral payload that can safely start a model-transition child lane.
+Forwarded requests and payloads that still depend on account-scoped state must
+remain fail-closed.
+
+## What Changes
+
+- Permit a model-transition child lane only for the exact
+  `continuity_owner_conflict` error.
+- Require a local request, no `previous_response_id`, no resolved file owner,
+  and a payload proven account-neutral by the existing replay-safety validator.
+- Clear session/turn aliases, exclude the conflicting owner, and create a
+  server-namespaced account-neutral lane, pinned `hard`, without changing
+  persisted aliases.
+- Keep forwarded requests, unpinned hosted files, post-compaction payloads whose
+  compacted context is not carried in the request, and other owner failures
+  fail-closed.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: model-transition owner conflicts may use a
+  proof-gated account-neutral child lane.
+- `sticky-session-operations`: the hard-owner conflict exception is limited to
+  that exact fresh model-transition case.
+
+## Impact
+
+- Affected code: HTTP bridge model-transition recovery and unit coverage.
+- No schema, setting, dependency, or live deployment change.
+- Rollback is a source revert; the existing fail-closed path remains the
+  fallback for every request that does not satisfy the proof.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge model-transition owner conflicts use a guarded child lane
+
+The service MUST use a guarded account-neutral child lane when a hard
+continuity lookup identifies a durable owner for an incompatible model and
+bridge creation returns `continuity_owner_conflict`; it may retry on that new
+server-namespaced lane only when the
+request is local (not forwarded), has no `previous_response_id`, has no
+resolved file owner, and the effective payload passes the existing
+account-neutral fresh-replay validator. The child lane MUST clear session and
+turn aliases, reset the request's parent-derived affinity policy, hard
+continuity anchor, and reused parent turn state, exclude the conflicting owner,
+force local creation, and remain owner-bound (`hard`) once created so a later
+capacity failure cannot reroute the same request to a third account. The service MUST attempt this child lane at
+most once per request and MUST preserve the original conflict for every other
+owner error or payload shape.
+
+#### Scenario: Neutral model transition conflict forks locally
+
+- **GIVEN** a durable hard continuity key belongs to account A for the old model
+- **AND** the requested model is incompatible with that durable session
+- **AND** the effective payload is account-neutral and has no previous-response
+  or resolved file owner
+- **AND** bridge creation returns `continuity_owner_conflict`
+- **WHEN** the request is local to the current replica
+- **THEN** the service creates one server-namespaced account-neutral child lane
+- **AND** that child lane key is owner-bound (`hard`)
+- **AND** it excludes account A and does not forward the request
+- **AND** the child request carries no parent affinity policy, hard continuity
+  anchor, or reused parent turn state
+- **AND** it leaves the original hard aliases unchanged
+
+#### Scenario: Forwarded model transition conflict remains fail-closed
+
+- **GIVEN** the same durable model-transition conflict occurs for a forwarded
+  request
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not create an account-neutral child lane
+
+#### Scenario: Account-bound payload remains fail-closed
+
+- **GIVEN** the effective model-transition payload contains an account-scoped
+  hosted reference such as an unpinned `input_file.file_id`
+- **WHEN** bridge creation returns `continuity_owner_conflict`
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not retry on another account
+
+#### Scenario: Post-compaction payload without carried compact context stays fail-closed
+
+- **GIVEN** the effective model-transition payload contains a `compaction` item
+  that is not self-contained, such as a placeholder with no encrypted content or
+  a compaction still in progress
+- **WHEN** bridge creation returns `continuity_owner_conflict`
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not fork the request onto an account that never held the
+  compacted context
+
+#### Scenario: Child lane conflict is not forked again
+
+- **GIVEN** the guarded child lane was already created for this request
+- **WHEN** creation on that lane also returns `continuity_owner_conflict`
+- **THEN** the service returns that error to the caller
+- **AND** it does not create a further account-neutral lane

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
@@ -1,0 +1,171 @@
+## MODIFIED Requirements
+
+### Requirement: Hard continuity remains owner-bound and bounded
+
+Requests that depend on `previous_response_id`, hard turn-state, nonblank `conversation`, account-scoped `input_file.file_id` pins, live or durable bridge ownership, replay/reattach state, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. A resolved required owner MUST override bare process-session locality and MUST be selected without consulting or rewriting that soft mapping. A `previous_response_id` is a stored-object continuation reference and remains owner-bound even when the same request also carries a session header, `prompt_cache_key`, or another soft locality key. If independently resolved hard sources identify different accounts, if live durable referenced-file pins identify different accounts, or if a request has partial live durable file-pin coverage, the service MUST fail closed before upstream dispatch. A request for which no referenced file has a live durable pin MUST preserve opaque `file_id` compatibility and proceed without inventing ownership evidence. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
+
+Every HTTP, compact, direct WebSocket, and HTTP-bridge transport MUST resolve explicit turn state against both live and durable bridge aliases. Live, durable, previous-response, file, and explicit turn-state evidence MUST be compared independently; source ordering MUST NOT choose the first match when distinct sessions or accounts resolve. A reused direct WebSocket MUST repeat nonblank `conversation` ownership validation for each response-create frame because the existing socket account proves only the current route. Single-account routing MUST constrain effective routing without narrowing the ownership-candidate pool used by that validation.
+
+When an HTTP-bridge owner is on another replica, the origin MUST forward its resolved durable file owner in authenticated full-context metadata. The receiving owner MUST perform its own fresh shared-database lookup and MUST require that durable result to match the forwarded owner. A missing or conflicting receiver-side durable owner MUST fail closed before account selection or upstream invocation. A retired direct WebSocket's upstream turn-state token MUST NOT be sent to a different account selected for a later movable bare-session request.
+
+A nonblank `conversation` without a dedicated resolved owner MUST proceed only when an explicit hard Codex mapping proves ownership or exactly one account remains in the model/API-key/security-scoped selection pool before transient additional-quota availability, retry exclusions, runtime health, budget, or account-cap filtering. A temporarily quota-filtered, excluded, unhealthy, or capped candidate MUST remain part of this ambiguity check because it may be the actual owner. A bare process-session mapping MUST NOT prove conversation ownership.
+
+The sole exception to the hard-owner conflict rule is the proof-gated HTTP
+bridge model-transition child lane defined by `responses-api-compat`. It
+applies only to a local request that fails with the exact
+`continuity_owner_conflict` error, carries no `previous_response_id` and no
+resolved file owner, and whose effective payload passes the account-neutral
+fresh-replay validator. That child lane MUST clear session and turn aliases,
+exclude the failed owner for that request only, and leave persisted hard
+mappings unchanged. Every other hard-owner conflict MUST still fail closed.
+
+#### Scenario: Previous-response owner queue is saturated
+
+- **WHEN** a `/v1/responses` follow-up requires a previous-response owner
+- **AND** the owner session queue or account cap is saturated
+- **THEN** the service fails closed with `hard_affinity_saturated`, `previous_response_owner_unavailable`, or the applicable stable `account_stream_cap` / `account_response_create_cap` code
+- **AND** it does not route to an unrelated account that lacks continuity state
+
+#### Scenario: File-pinned request owner is capped
+
+- **WHEN** a `/v1/responses` request references an `input_file.file_id` pinned to an owner account
+- **AND** the owner account is at its account stream or response-create cap
+- **THEN** the service returns a local account-cap overload for the owner
+- **AND** it does not route the file reference to another account
+
+#### Scenario: File-pinned request owner overrides process-session locality
+
+- **GIVEN** a request carries a bare process-session header mapped to account A
+- **AND** its `input_file.file_id` is durably pinned to account B
+- **WHEN** the request is routed
+- **THEN** account B is treated as the required owner
+- **AND** the process-session mapping is neither consulted as an owner nor rewritten
+
+#### Scenario: File-pinned request owner overrides thread locality
+
+- **GIVEN** a request carries a `thread-id` whose bounded mapping points to account A
+- **AND** its `input_file.file_id` is durably pinned to account B
+- **WHEN** the request is routed
+- **THEN** account B is treated as the required owner
+- **AND** the thread mapping is neither consulted as an owner nor rewritten
+
+#### Scenario: Conflicting hard owners fail closed
+
+- **GIVEN** a turn state, previous response, bridge, or input file resolves to account A
+- **AND** another hard source on the same request resolves to account B
+- **AND** the request is not the guarded model-transition child-lane case
+- **WHEN** the request is routed
+- **THEN** the service fails with `continuity_owner_conflict` before upstream dispatch
+- **AND** source ordering does not choose either owner
+
+#### Scenario: Partial or cross-account file pins fail closed
+
+- **GIVEN** a request references multiple account-scoped input files
+- **AND** at least one file has a live durable owner pin
+- **AND** another file has no live durable owner pin or the live pins resolve to different accounts
+- **WHEN** the request is routed
+- **THEN** the service fails with `file_owner_unavailable` or `continuity_owner_conflict`
+- **AND** it does not route the files using a soft affinity account
+
+#### Scenario: Opaque file IDs with no live durable pins preserve compatibility
+
+- **GIVEN** a request references one or more `input_file.file_id` values
+- **AND** none of those IDs has a live durable owner pin
+- **WHEN** the request is routed
+- **THEN** the service forwards the opaque file references under ordinary unpinned routing
+- **AND** it does not invent a hard owner or fail solely because durable pin metadata is absent
+
+#### Scenario: Ambiguous conversation fails closed
+
+- **GIVEN** a request carries nonblank `conversation` continuity and only bare process-session affinity
+- **AND** more than one account is eligible
+- **WHEN** no dedicated or hard-mapping owner can be resolved
+- **THEN** the request fails with a stable owner-unavailable error before upstream dispatch
+
+#### Scenario: Account-cap pressure does not manufacture a conversation owner
+
+- **GIVEN** two accounts remain in the model/API-key/security-scoped selection pool
+- **AND** one account is temporarily at its local account cap
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the uncapped account is not treated as the unique owner
+
+#### Scenario: Retry or additional-quota filtering does not manufacture a conversation owner
+
+- **GIVEN** two accounts remain in the model/API-key/security-scoped selection pool
+- **AND** retry exclusion or transient additional-quota availability removes one from the effective routing pool
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the remaining effective account is not treated as the unique owner
+
+#### Scenario: Account status does not manufacture a conversation owner
+
+- **GIVEN** two accounts are in the model/API-key/security ownership pool
+- **AND** one account is paused, requires reauthentication, deactivated, or otherwise unavailable for routing
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the active account is not treated as the unique owner
+
+#### Scenario: Preferred file owner does not manufacture a conversation owner
+
+- **GIVEN** a request carries nonblank `conversation` continuity and a file durably pinned to account B
+- **AND** another account remains in the model/API-key/security ownership pool
+- **WHEN** no dedicated conversation owner can be resolved
+- **THEN** file ownership does not narrow the conversation ambiguity check to account B
+- **AND** the request fails closed before upstream dispatch
+
+#### Scenario: Bridge turn state is owner-bound across transports
+
+- **GIVEN** an HTTP bridge registered a turn-state alias for account A
+- **WHEN** the alias is reused through compact, plain HTTP streaming, or direct WebSocket transport
+- **THEN** each transport treats account A as the required owner
+- **AND** it does not fall back to unrelated sticky affinity
+
+#### Scenario: Independent bridge aliases conflict
+
+- **GIVEN** a live or durable turn-state alias resolves to one bridge session
+- **AND** a previous-response alias on the same request resolves to a distinct session or account
+- **WHEN** the request is routed
+- **THEN** the service fails with `continuity_owner_conflict`
+- **AND** alias lookup order does not select either session
+
+#### Scenario: Reused WebSocket revalidates conversation ownership
+
+- **GIVEN** a direct upstream WebSocket is already open on account A
+- **AND** a later response-create frame carries nonblank `conversation`
+- **WHEN** more than one account remains in the ownership-candidate pool
+- **THEN** the later frame fails with a stable owner-unavailable error before upstream send
+- **AND** the existing socket account is not treated as ownership proof
+
+#### Scenario: Single-account routing does not manufacture conversation ownership
+
+- **GIVEN** single-account routing selects account A
+- **AND** multiple accounts remain in the model/API-key/security ownership pool
+- **WHEN** a request carries nonblank `conversation` without dedicated owner evidence
+- **THEN** the request remains ambiguous and fails closed
+- **AND** only the effective routing states are constrained to account A
+
+#### Scenario: Remote bridge owner revalidates forwarded file ownership
+
+- **GIVEN** origin replica A durably resolves an input file to account A
+- **AND** the request's HTTP bridge owner runs on replica B
+- **WHEN** replica A forwards the request to replica B with authenticated file-owner metadata
+- **THEN** replica B MUST freshly resolve the shared durable pin
+- **AND** it MUST accept the forwarded owner only when both owner values match
+- **AND** a missing, conflicting, tampered, or legacy-unbound proof MUST be rejected before upstream invocation
+
+#### Scenario: Retired WebSocket turn state does not cross accounts
+
+- **GIVEN** a closed upstream WebSocket on account A supplied an account-scoped turn-state token
+- **AND** a later movable bare-session frame or marked self-contained goal restart selects account B
+- **WHEN** the proxy opens the replacement WebSocket
+- **THEN** it removes account A's stale turn-state token before connect
+- **AND** account B never receives that token
+
+#### Scenario: Guarded model-transition exception does not rewrite hard mappings
+
+- **GIVEN** a request satisfies the account-neutral model-transition child-lane
+  proof
+- **WHEN** the child lane is created
+- **THEN** persisted hard aliases remain unchanged
+- **AND** the failed owner is excluded only for that request

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
@@ -1,0 +1,21 @@
+## 1. Contract
+
+- [x] 1.1 Define the exact conflict, local-request, payload-neutrality, and
+  owner-preservation gates.
+- [x] 1.2 Add the sticky-session exception without weakening unrelated hard
+  owner conflicts.
+
+## 2. Implementation
+
+- [x] 2.1 Add the guarded account-neutral model-transition child-lane path.
+- [x] 2.2 Pin the child lane key strength explicitly instead of relying on the
+  implicit default.
+- [x] 2.3 Reset the child request state's parent-derived affinity policy,
+  continuity anchor, and reused parent turn state.
+- [x] 2.4 Add positive and forwarded/unpinned-file/post-compaction negative
+  regressions plus the single-retry bound.
+
+## 3. Verification
+
+- [x] 3.1 Run model-transition unit and existing HTTP bridge integration tests.
+- [x] 3.2 Run Ruff, type checks, and strict OpenSpec validation.

--- a/openspec/changes/recover-post-compact-bridge-replays/proposal.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/proposal.md
@@ -1,0 +1,28 @@
+# Recover post-compact HTTP bridge replays
+
+## Why
+
+Post-compaction Codex turns can carry a compact context item, completed
+tool-search call/output side effects, and a fresh user message. When the HTTP
+bridge treats a session-level compact-anchor trim as a generically safe fresh
+replay, later recovery may drop the durable context or tool-search side effects
+that make the follow-up self-contained.
+
+## What Changes
+
+- Treat completed `compaction` items with encrypted content as self-contained
+  account-neutral replay context.
+- Preserve completed `tool_search_call` / `tool_search_output` pairs when
+  projecting a compacted fresh replay payload.
+- Preserve compact context when projecting a fresh replay payload, while removing
+  response-owned ids.
+- Keep session-level compact-anchor trim safety separate from durable full-resend
+  proof; trimming a stored prefix does not automatically make an unanchored
+  replay safe.
+- Retire stale response-create gate holders with evidence about whether upstream
+  response events were already observed, so wedged bridge sessions take the
+  existing recovery/quarantine path.
+
+## Impact
+
+Post-compaction follow-up turns recover with the compact context preserved.

--- a/openspec/changes/recover-post-compact-bridge-replays/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/specs/responses-api-compat/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Post-compact bridge replays preserve compact context
+
+codex-lb MUST treat completed post-compaction replay context as self-contained when an HTTP bridge or Responses WebSocket request must recover a follow-up turn after compaction. A projected fresh replay payload MUST retain that compact context while removing response-owned bookkeeping ids.
+
+Trimming a stored prefix because a session-level compact anchor was injected
+MUST NOT by itself mark the unanchored request safe to replay. The proxy may
+mark the unanchored request replay-safe only when the original anchor site had
+already made that decision or when a durable full-resend proof shows the fresh
+suffix is self-contained.
+
+Account-neutral recovery MAY select another eligible account after the previous
+owner has been excluded or proved silent. Requests that explicitly require a
+preferred previous-response owner MUST continue to fail closed when that owner
+is unavailable.
+
+#### Scenario: id-free completed compaction and tool-search context survives fresh replay projection
+
+- **GIVEN** a follow-up payload starts with a completed `compaction` item whose
+  encrypted content is non-empty
+- **AND** that compaction item does not carry an `id`
+- **AND** the payload also carries a completed `tool_search_call` /
+  `tool_search_output` pair followed by a fresh user message
+- **WHEN** codex-lb projects an account-neutral fresh replay payload
+- **THEN** the projected payload includes the compaction item
+- **AND** it preserves the completed tool-search pair without response-owned ids
+- **AND** the projected payload is eligible for account-neutral replay
+
+#### Scenario: session-level compact trim does not fabricate replay safety
+
+- **GIVEN** a session-level compact anchor trimmed a stored prefix from a
+  follow-up request
+- **AND** the original request state was not already known to be safe as an
+  unanchored fresh replay
+- **WHEN** the bridge records the retained fresh request text
+- **THEN** codex-lb does not mark that retained request as retry-safe solely
+  because the trim happened
+
+#### Scenario: account-neutral recovery can leave a silent owner
+
+- **GIVEN** an account-neutral HTTP bridge recovery request excludes the previous
+  owner account after it failed to acknowledge `response.create`
+- **WHEN** another eligible account is available
+- **THEN** codex-lb reconnects on that replacement account and sends the retained
+  request there
+
+#### Scenario: required previous-response owner still fails closed
+
+- **GIVEN** a follow-up request explicitly requires its preferred
+  previous-response owner account
+- **WHEN** that owner is unavailable
+- **THEN** codex-lb returns the previous-response-owner-unavailable failure
+  instead of silently rebinding the request to another account

--- a/openspec/changes/recover-post-compact-bridge-replays/tasks.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Accept compact context and tool-search call/output pairs in account-neutral replay safety checks.
+- [x] Preserve completed compaction items in projected fresh replay payloads without retaining response-owned ids.
+- [x] Keep session-level trim safety from overriding the original replay-safety decision unless a durable full-resend proof exists.
+- [x] Allow account-neutral bridge recovery to select another eligible account after the silent owner is excluded.
+- [x] Keep explicit required-owner continuity failures fail-closed.
+- [x] Pass response-event evidence into stale response-create gate retirement.
+- [x] Add replay-safety and HTTP bridge regression coverage for post-compact recovery.

--- a/openspec/changes/repair-retired-identity-warmup-stamp/proposal.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Local August 14, 2026 builds could stamp SQLite databases at the retired
+`20260814_020000_merge_identity_and_warmup_heads` merge id even when the
+current mainline file-pin, sticky-abandonment-scope, pending-deletion,
+API-key reasoning-policy, and model-source-embeddings lineage had never run.
+Those databases also kept two artifacts current main no longer owns:
+`idx_accounts_chatgpt_account_id` and
+`quota_planner_decisions.lease_expires_at`. Current main therefore treats the
+stamp as schema-ahead and a drift check on the live clone reports eleven schema
+diffs.
+
+## What Changes
+
+- Auto-remap the retired merge stamp to the current pre-repair Alembic head so
+  upgrade can continue through normal `python -m app.db.migrate upgrade`.
+- Add one forward-only repair migration that replays the guarded current-main
+  migrations needed by the stamped-local shape and drops the two stale
+  artifacts when present.
+- Cover the representative SQLite shape with a regression test that proves the
+  repair converges to the current ORM schema.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `database-migrations`: retired local merge stamps upgrade cleanly to the
+  current schema without manual restamping.

--- a/openspec/changes/repair-retired-identity-warmup-stamp/specs/database-migrations/spec.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/specs/database-migrations/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Retired identity/warmup merge stamps repair to current schema
+
+The system MUST upgrade a database stamped at
+`20260814_020000_merge_identity_and_warmup_heads` by the retired local merge
+build to the current Alembic head without manual restamping. Startup or CLI
+remap MAY rewrite that retired stamp to the canonical pre-repair revision, but
+the subsequent upgrade MUST execute a forward repair that converges the schema
+to ORM metadata. The repaired schema MUST add the file-pin,
+sticky-abandonment-scope, pending-deletion, API-key reasoning-policy, and
+model-source-embeddings objects current main expects, and MUST remove the
+retired `idx_accounts_chatgpt_account_id` index and
+`quota_planner_decisions.lease_expires_at` column if they are still present.
+
+#### Scenario: A SQLite clone stamped at the retired merge head upgrades cleanly
+
+- **GIVEN** a SQLite database stamped at `20260814_020000_merge_identity_and_warmup_heads`
+- **AND** the schema still lacks `file_account_pins`, pending-deletion markers, API-key reasoning policy, model-source embeddings, and sticky abandonment scope
+- **AND** the retired `idx_accounts_chatgpt_account_id` index and `quota_planner_decisions.lease_expires_at` column are still present
+- **WHEN** startup or `python -m app.db.migrate upgrade` runs to head
+- **THEN** the upgrade completes without manual stamp surgery
+- **AND** `python -m app.db.migrate check` reports no schema drift

--- a/openspec/changes/repair-retired-identity-warmup-stamp/tasks.md
+++ b/openspec/changes/repair-retired-identity-warmup-stamp/tasks.md
@@ -1,0 +1,9 @@
+## 1. Repair Path
+
+- [x] 1.1 Remap `20260814_020000_merge_identity_and_warmup_heads` to the current pre-repair Alembic revision
+- [x] 1.2 Add a forward-only repair migration that replays the missing current-main migrations and removes `idx_accounts_chatgpt_account_id` plus `quota_planner_decisions.lease_expires_at` when present
+
+## 2. Validation
+
+- [x] 2.1 Add a regression test for the representative SQLite drift shape stamped at the retired merge head
+- [x] 2.2 Validate OpenSpec and the focused migration tests

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/.openspec.yaml
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/proposal.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/proposal.md
@@ -1,0 +1,14 @@
+# Report suppressed duplicate tool-call terminals
+
+## Why
+
+A duplicate side-effect tool-call replay cannot safely continue, but every
+transport still needs to settle the request and report the same retryable
+outcome.
+
+## What Changes
+
+- Emit a specific failed terminal instead of misclassifying the replay as an
+  incomplete upstream stream.
+- Keep settlement, durable operation persistence, and account-health fencing
+  aligned across direct SSE, the HTTP bridge, and WebSocket clients.

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/specs/responses-api-compat/spec.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Suppressed duplicate side-effect replays receive a retryable terminal failure
+
+When a replayed side-effecting tool call is suppressed and its upstream turn subsequently reports `response.completed`, the proxy MUST deliver a `response.failed` terminal with code `duplicate_tool_call_replay_suppressed`; it MUST use the downstream response id, treat the request as non-success, persist a terminal durable HTTP-bridge operation when that transport is used, and MUST NOT penalize the upstream account for the intentionally fenced replay.
+
+#### Scenario: HTTP bridge client receives a terminal failure
+
+- **GIVEN** an HTTP bridge request suppresses a replayed side-effecting tool call
+- **WHEN** the upstream emits `response.completed` for that replay
+- **THEN** the client receives `response.failed` with code `duplicate_tool_call_replay_suppressed`
+- **AND** the bridge operation is terminal rather than left pending
+- **AND** the request is recorded as non-success
+
+#### Scenario: WebSocket and direct SSE have equivalent terminal semantics
+
+- **GIVEN** either a WebSocket or direct SSE request suppresses a replayed side-effecting tool call
+- **WHEN** the upstream emits `response.completed` for that replay
+- **THEN** the client receives the same `response.failed` code
+- **AND** the upstream account is not penalized for the intentionally suppressed replay

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Emit the explicit duplicate-tool-call replay failure from all terminal paths.
+- [x] 1.2 Preserve non-success settlement and account-health fencing.
+
+## 2. Validation
+
+- [x] 2.1 Run focused HTTP bridge and WebSocket regression tests.
+- [x] 2.2 Run strict OpenSpec validation.

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
@@ -5,5 +5,5 @@
 
 ## 2. Validation
 
-- [x] 2.1 Run focused HTTP bridge and WebSocket regression tests.
+- [x] 2.1 Run focused direct-SSE, HTTP bridge, and WebSocket regression tests.
 - [x] 2.2 Run strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7594,7 +7594,7 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
         # Scope the soft-affinity key to this test's account so a parallel or
         # ordered integration run cannot inherit another instance's durable
         # owner and turn the reconnect assertion into a 409 race.
-        "prompt_cache_key": f"http-bridge-reconnect-thread-{account_id}",
+        "prompt_cache_key": f"http-bridge-reconnect-thread-{account_id}-{time.monotonic_ns()}",
     }
     first = await asyncio.wait_for(async_client.post("/v1/responses", json=payload), timeout=_TEST_SYNC_TIMEOUT_SECONDS)
     second = await asyncio.wait_for(
@@ -7682,6 +7682,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
+    prompt_cache_key = f"http-bridge-previous-response-reconnect-{account_id}-{time.monotonic_ns()}"
     first = await asyncio.wait_for(
         async_client.post(
             "/v1/responses",
@@ -7689,7 +7690,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
                 "model": "gpt-5.1",
                 "instructions": "Return exactly OK.",
                 "input": "hello",
-                "prompt_cache_key": "http-bridge-previous-response-reconnect",
+                "prompt_cache_key": prompt_cache_key,
             },
         ),
         timeout=_TEST_SYNC_TIMEOUT_SECONDS,
@@ -7704,7 +7705,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
                 "model": "gpt-5.1",
                 "instructions": "Return exactly OK.",
                 "input": "hello-again",
-                "prompt_cache_key": "http-bridge-previous-response-reconnect",
+                "prompt_cache_key": prompt_cache_key,
                 "previous_response_id": first_body["id"],
             },
         ),
@@ -7761,6 +7762,7 @@ async def test_v1_responses_http_bridge_classifies_responses_lite_developer_inte
         "acc_http_bridge_preserve_fresh_reattach",
         "http-bridge-preserve-fresh-reattach@example.com",
     )
+    scenario_key = f"{account_id}-{time.monotonic_ns()}"
     account = await _get_account(account_id)
     first_upstream = _ClosingInterruptedCustomToolUpstreamWebSocket("resp_preserve_source")
     replay_upstream = _FakeBridgeUpstreamWebSocket("resp_preserve_replay")
@@ -7811,7 +7813,7 @@ async def test_v1_responses_http_bridge_classifies_responses_lite_developer_inte
     monkeypatch.setattr(service._durable_bridge, "release_live_session", delay_predecessor_release)
     monkeypatch.setattr(service._durable_bridge, "claim_live_session", observe_replacement_claim)
 
-    session_headers = {"x-codex-session-id": "fresh-reattach-full-resend"}
+    session_headers = {"x-codex-session-id": f"fresh-reattach-full-resend-{scenario_key}"}
     historical_input = [
         *([leading_input_item] if leading_input_item is not None else []),
         {
@@ -15341,7 +15343,7 @@ async def test_v1_responses_http_bridge_quarantines_reattach_that_streams_withou
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
-    session_headers = {"x-codex-session-id": "quarantine-silent-reattach"}
+    session_headers = {"x-codex-session-id": f"quarantine-silent-reattach-{account_id}-{time.monotonic_ns()}"}
     historical_input = [
         {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},
         {
@@ -15513,9 +15515,10 @@ async def test_v1_responses_http_bridge_quarantined_unsafe_full_resend_dispatche
     # The turn-state header makes the bridge session a true Codex continuity
     # session (``session.codex_session``), which is what arms the session-level
     # anchor injection this regression guards against.
+    scenario_key = f"{account_id}-{time.monotonic_ns()}"
     session_headers = {
-        "x-codex-session-id": "quarantine-unsafe-suffix-reattach",
-        "x-codex-turn-state": "quarantine-unsafe-suffix-turn",
+        "x-codex-session-id": f"quarantine-unsafe-suffix-reattach-{scenario_key}",
+        "x-codex-turn-state": f"quarantine-unsafe-suffix-turn-{scenario_key}",
     }
     historical_input = [
         {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -13488,6 +13488,162 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
 
 @pytest.mark.asyncio
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
+
+    service = get_proxy_service_for_app(app_instance)
+    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
+    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
+    replacement_account = cast(
+        Account,
+        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    replacement_upstream = _RecordingUpstreamWebSocket()
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
+        headers={"x-codex-turn-state": "stale-turn-state"},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=first_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-account-neutral-precreated-retry",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    session.pending_requests.append(request_state)
+    reconnect_calls: list[dict[str, object]] = []
+
+    async def fake_reconnect(
+        self,
+        target_session,
+        *,
+        request_state,
+        restart_reader=False,
+        require_same_account=False,
+        require_preferred_account=False,
+    ):
+        del self, restart_reader
+        reconnect_calls.append(
+            {
+                "require_same_account": require_same_account,
+                "require_preferred_account": require_preferred_account,
+                "preferred_account_id": target_session.account.id,
+                "excluded_account_ids": set(request_state.excluded_account_ids),
+            }
+        )
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    assert reconnect_calls == [
+        {
+            "require_same_account": True,
+            "require_preferred_account": True,
+            "preferred_account_id": "acct-silent",
+            "excluded_account_ids": set(),
+        }
+    ]
+    assert request_state.preferred_account_id == "acct-silent"
+    assert session.account.id == "acct-replacement"
+    assert replacement_upstream.sent_text == [request_state.request_text]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_required_owner_still_fails_when_owner_unavailable(app_instance, monkeypatch):
+    service = get_proxy_service_for_app(app_instance)
+    owner_account = cast(
+        Account,
+        SimpleNamespace(id="acct-owner-required", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey("prompt_cache", "required-owner-reconnect", None),
+        headers={},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=owner_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-required-owner-reconnect",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    request_state.preferred_account_id = owner_account.id
+    selection_calls: list[dict[str, object]] = []
+
+    async def fake_select_account_with_budget_for_stream(self, deadline, **kwargs):
+        del self, deadline
+        selection_calls.append(
+            {
+                "preferred_account_id": kwargs.get("preferred_account_id"),
+                "preferred_account_is_continuity_owner": kwargs.get("preferred_account_is_continuity_owner"),
+                "fallback_on_preferred_account_unavailable": kwargs.get("fallback_on_preferred_account_unavailable"),
+            }
+        )
+        return AccountSelection(
+            account=None,
+            error_message="Required continuity owner account no longer exists",
+            error_code=CONTINUITY_OWNER_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_for_stream",
+        fake_select_account_with_budget_for_stream,
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(
+            session,
+            request_state=request_state,
+            require_preferred_account=True,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "previous_response_owner_unavailable"
+    assert selection_calls == [
+        {
+            "preferred_account_id": owner_account.id,
+            "preferred_account_is_continuity_owner": False,
+            "fallback_on_preferred_account_unavailable": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailable(
     async_client,
     app_instance,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -287,6 +287,40 @@ def _install_bridge_settings_with_limits(
     )
 
 
+def _make_integration_proxy_service() -> proxy_module.ProxyService:
+    request_logs = SimpleNamespace(
+        add_log=AsyncMock(),
+        find_latest_owner_record_for_response_id=AsyncMock(return_value=None),
+        find_latest_account_id_for_response_id=AsyncMock(return_value=None),
+        find_latest_response_id_for_session_id=AsyncMock(return_value=None),
+    )
+    capability_lineage = SimpleNamespace(
+        is_required=AsyncMock(return_value=False),
+        require=AsyncMock(return_value=("test-marker",)),
+    )
+
+    class _RepoContext:
+        def __init__(self) -> None:
+            self._repos = SimpleNamespace(
+                accounts=AsyncMock(),
+                usage=AsyncMock(),
+                request_logs=request_logs,
+                sticky_sessions=AsyncMock(),
+                api_keys=AsyncMock(),
+                additional_usage=AsyncMock(),
+                capability_lineage=capability_lineage,
+            )
+
+        async def __aenter__(self):
+            return self._repos
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            del exc_type, exc, tb
+            return False
+
+    return proxy_module.ProxyService(lambda: _RepoContext())
+
+
 class _FakeUpstreamMessage:
     def __init__(
         self,
@@ -13490,10 +13524,11 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
 
 @pytest.mark.asyncio
-async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(monkeypatch):
     from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
 
-    service = get_proxy_service_for_app(app_instance)
+    service = _make_integration_proxy_service()
+    _install_bridge_settings(monkeypatch, enabled=True)
     recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
     first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
     replacement_account = cast(
@@ -13529,38 +13564,60 @@ async def test_retry_account_neutral_precreated_request_switches_from_silent_acc
         request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
     )
     session.pending_requests.append(request_state)
-    reconnect_calls: list[dict[str, object]] = []
+    selection_calls: list[dict[str, object]] = []
 
-    async def fake_reconnect(
+    async def fake_select_account_with_budget_for_stream(
         self,
-        target_session,
-        *,
-        request_state,
-        restart_reader=False,
-        require_same_account=False,
-        require_preferred_account=False,
+        deadline,
+        **kwargs,
     ):
-        del self, restart_reader
-        reconnect_calls.append(
+        del self, deadline
+        selection_calls.append(
             {
-                "require_same_account": require_same_account,
-                "require_preferred_account": require_preferred_account,
-                "preferred_account_id": target_session.account.id,
-                "excluded_account_ids": set(request_state.excluded_account_ids),
+                "preferred_account_id": kwargs.get("preferred_account_id"),
+                "preferred_account_is_continuity_owner": kwargs.get("preferred_account_is_continuity_owner"),
+                "fallback_on_preferred_account_unavailable": kwargs.get("fallback_on_preferred_account_unavailable"),
+                "excluded_account_ids": set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set()),
             }
         )
-        target_session.account = replacement_account
-        target_session.upstream = replacement_upstream
+        return AccountSelection(account=replacement_account, error_message=None, error_code=None)
 
-    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds=0.0):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_open_upstream_websocket_with_budget(
+        self,
+        account,
+        headers,
+        *,
+        timeout_seconds,
+        request_state=None,
+    ):
+        del self, headers, timeout_seconds, request_state
+        assert account is replacement_account
+        return replacement_upstream
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_for_stream",
+        fake_select_account_with_budget_for_stream,
+    )
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_open_upstream_websocket_with_budget",
+        fake_open_upstream_websocket_with_budget,
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", AsyncMock(return_value=True))
 
     assert await service._retry_http_bridge_precreated_request(session) is True
 
-    assert reconnect_calls == [
+    assert selection_calls == [
         {
-            "require_same_account": True,
-            "require_preferred_account": True,
             "preferred_account_id": "acct-silent",
+            "preferred_account_is_continuity_owner": False,
+            "fallback_on_preferred_account_unavailable": True,
             "excluded_account_ids": set(),
         }
     ]

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1908,3 +1908,120 @@ async def test_file_account_pins_migration_upgrade_and_downgrade(tmp_path):
             assert await conn.run_sync(_schema_state) is not None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_file_account_pins_migration_repairs_existing_table_missing_index(tmp_path):
+    from sqlalchemy import inspect as sa_inspect
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'partial-file-account-pins.sqlite'}"
+    parent_revision = "20260806_000000_add_anonymous_telemetry"
+    pin_revision = "20260813_000000_add_file_account_pins"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "CREATE TABLE file_account_pins ("
+                    "file_id VARCHAR NOT NULL PRIMARY KEY, "
+                    "account_id VARCHAR NOT NULL, "
+                    "expires_at DATETIME NOT NULL)"
+                )
+            )
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pin_revision, bootstrap_legacy=False))
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pin_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            indexes = await conn.run_sync(
+                lambda sync_conn: {index["name"] for index in sa_inspect(sync_conn).get_indexes("file_account_pins")}
+            )
+        assert indexes == {"ix_file_account_pins_expires_at"}
+        await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert check_schema_drift(db_url) == ()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_retired_identity_and_warmup_merge_stamp_repairs_to_head(tmp_path):
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'retired-identity-warmup-repair.sqlite'}"
+    pre_repair_head = "20260816_000000_add_model_source_embeddings"
+    retired_merge_revision = "20260814_020000_merge_identity_and_warmup_heads"
+    expected_drift_checks = (
+        ("add_table", "file_account_pins"),
+        ("add_index", "ix_file_account_pins_expires_at"),
+        ("add_column", "accounts', Column('delete_requested_at'"),
+        ("add_column", "accounts', Column('delete_history_requested'"),
+        ("remove_index", "idx_accounts_chatgpt_account_id"),
+        ("add_index", "idx_accounts_delete_requested_at"),
+        ("add_column", "api_keys', Column('allowed_reasoning_efforts'"),
+        ("add_constraint", "ck_api_keys_reasoning_policy_exclusive"),
+        ("add_column", "model_sources', Column('supports_embeddings'"),
+        ("remove_column", "quota_planner_decisions', Column('lease_expires_at'"),
+        ("add_column", "sticky_sessions', Column('continuity_abandonment_scope'"),
+    )
+
+    def _schema_state(sync_conn):
+        inspector = sa_inspect(sync_conn)
+        return {
+            "has_file_account_pins": inspector.has_table("file_account_pins"),
+            "account_columns": {column["name"] for column in inspector.get_columns("accounts")},
+            "account_indexes": {index["name"] for index in inspector.get_indexes("accounts")},
+            "api_key_columns": {column["name"] for column in inspector.get_columns("api_keys")},
+            "api_key_checks": {
+                constraint["name"]
+                for constraint in inspector.get_check_constraints("api_keys")
+                if constraint.get("name")
+            },
+            "model_source_columns": {column["name"] for column in inspector.get_columns("model_sources")},
+            "quota_columns": {column["name"] for column in inspector.get_columns("quota_planner_decisions")},
+            "sticky_columns": {column["name"] for column in inspector.get_columns("sticky_sessions")},
+        }
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, pre_repair_head, bootstrap_legacy=False))
+    await to_thread.run_sync(
+        lambda: command.downgrade(_build_alembic_config(db_url), "20260806_000000_add_anonymous_telemetry")
+    )
+
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("CREATE INDEX IF NOT EXISTS idx_accounts_chatgpt_account_id ON accounts (chatgpt_account_id)")
+            )
+            await conn.execute(text("ALTER TABLE quota_planner_decisions ADD COLUMN lease_expires_at DATETIME"))
+            await conn.execute(
+                text("UPDATE alembic_version SET version_num = :revision"),
+                {"revision": retired_merge_revision},
+            )
+
+        drift = check_schema_drift(db_url)
+        assert len(drift) == len(expected_drift_checks)
+        for action, marker in expected_drift_checks:
+            assert any(action in diff and marker in diff for diff in drift)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert check_schema_drift(db_url) == ()
+
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state["has_file_account_pins"] is True
+        assert "delete_requested_at" in state["account_columns"]
+        assert "delete_history_requested" in state["account_columns"]
+        assert "idx_accounts_chatgpt_account_id" not in state["account_indexes"]
+        assert "idx_accounts_delete_requested_at" in state["account_indexes"]
+        assert "allowed_reasoning_efforts" in state["api_key_columns"]
+        assert "ck_api_keys_reasoning_policy_exclusive" in state["api_key_checks"]
+        assert "supports_embeddings" in state["model_source_columns"]
+        assert "lease_expires_at" not in state["quota_columns"]
+        assert "continuity_abandonment_scope" in state["sticky_columns"]
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -665,6 +665,72 @@ async def test_proxy_compact_normalizes_summary_output_for_codex_remote_v2(async
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_output_item_with_skill_context(async_client, monkeypatch):
+    email = "compact-skill-recovery@example.com"
+    raw_account_id = "acc_compact_skill_recovery"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen: dict[str, ResponsesCompactRequest] = {}
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen["payload"] = payload
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "id": "cmp_skill_recovery",
+                    "encrypted_content": "enc_skill_recovery",
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "Compact the conversation.",
+        "input": [
+            {"type": "message", "role": "user", "content": "hello"},
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "<skill>\n"
+                            "<name>grill-me</name>\n"
+                            "<path>/home/kom/.codex/skills/grill-me/SKILL.md</path>\n"
+                            "---\n"
+                            "name: grill-me\n"
+                            "---\n"
+                            "Ask one question at a time.\n"
+                            "</skill>"
+                        ),
+                    }
+                ],
+            },
+        ],
+    }
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    output = response.json()["output"]
+    assert output == [
+        {
+            "id": "cmp_skill_recovery",
+            "type": "compaction",
+            "encrypted_content": "enc_skill_recovery",
+        }
+    ]
+    assert "<name>grill-me</name>" in json.dumps(seen["payload"].to_payload())
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_headers_include_monthly_only_credits(async_client, monkeypatch):
     email = "compact-monthly@example.com"
     raw_account_id = "acc_compact_monthly"

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -1880,6 +1880,54 @@ async def test_durable_bridge_release_without_draining_marks_session_closed(
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_ownerless_active_row_can_be_reclaimed_without_takeover(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="prompt_cache",
+        session_key_value="ownerless-reclaim",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="test-process-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    released = await coordinator.release_live_session(
+        session_id=claimed.session_id,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        draining=True,
+    )
+
+    assert released is not None
+    assert released.owner_instance_id is None
+
+    reclaimed = await coordinator.claim_live_session(
+        session_key_kind="prompt_cache",
+        session_key_value="ownerless-reclaim",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=False,
+    )
+
+    assert reclaimed.session_id == claimed.session_id
+    assert reclaimed.owner_instance_id == "instance-b"
+    assert reclaimed.owner_epoch == claimed.owner_epoch + 1
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_takeover_clears_stale_recovery_anchor_for_fresh_session(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -2398,6 +2398,89 @@ def test_compact_trimming_preserves_codex_goal_context_anchor_from_middle():
     assert dumped_input[-1] == input_items[-1]
 
 
+def test_compact_trimming_does_not_anchor_active_skill_context_from_middle():
+    skill_context = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "<skill>\n"
+                    "<name>grill-me</name>\n"
+                    "<path>/home/kom/.codex/skills/grill-me/SKILL.md</path>\n"
+                    "---\n"
+                    "name: grill-me\n"
+                    "---\n"
+                    "Ask one question at a time and keep the interview mode active.\n"
+                    "</skill>"
+                ),
+            }
+        ],
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        skill_context,
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert dumped_input[0] == input_items[0]
+    assert dumped_input[-1] == input_items[-1]
+    assert skill_context not in dumped_input
+    assert input_items[1] not in dumped_input
+    assert input_items[3] not in dumped_input
+
+
+def test_compact_trimming_does_not_anchor_plain_skill_catalog_mentions():
+    catalog_context = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "<skills_instructions>\n"
+                    "- grill-me: Interview the user one question at a time.\n"
+                    "</skills_instructions>"
+                ),
+            }
+        ],
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        catalog_context,
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert catalog_context not in dumped_input
+    assert dumped_input[0] == input_items[0]
+    assert dumped_input[-1] == input_items[-1]
+
+
 def test_compact_trimming_preserves_non_message_developer_directive_from_middle():
     developer_directive = {
         "type": "future_directive",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -2398,8 +2398,8 @@ def test_compact_trimming_preserves_codex_goal_context_anchor_from_middle():
     assert dumped_input[-1] == input_items[-1]
 
 
-def test_compact_trimming_does_not_anchor_active_skill_context_from_middle():
-    skill_context = {
+def test_compact_trimming_preserves_active_skill_context_anchor_from_middle():
+    active_skill_context = {
         "type": "message",
         "role": "user",
         "content": [
@@ -2409,21 +2409,32 @@ def test_compact_trimming_does_not_anchor_active_skill_context_from_middle():
                     "<skill>\n"
                     "<name>grill-me</name>\n"
                     "<path>/home/kom/.codex/skills/grill-me/SKILL.md</path>\n"
-                    "---\n"
-                    "name: grill-me\n"
-                    "---\n"
-                    "Ask one question at a time and keep the interview mode active.\n"
+                    "Active objective: review every TODO row with one question at a time.\n"
                     "</skill>"
                 ),
             }
         ],
     }
+    plan_call = {
+        "type": "function_call",
+        "name": "update_plan",
+        "call_id": "call_plan",
+        "arguments": '{"plan":[{"step":"return to grill-me managed TODO queue","status":"in_progress"}]}',
+    }
+    plan_output = {
+        "type": "function_call_output",
+        "call_id": "call_plan",
+        "output": "Plan updated",
+    }
     input_items = [
         {"role": "user", "content": "initial instructions"},
         {"role": "assistant", "content": "x" * 300_000},
-        skill_context,
-        {"role": "assistant", "content": "y" * 500_000},
-        {"role": "user", "content": "latest request"},
+        active_skill_context,
+        {"role": "assistant", "content": "y" * 300_000},
+        plan_call,
+        {"role": "assistant", "content": "z" * 300_000},
+        plan_output,
+        {"role": "user", "content": "continue the managed grill queue"},
     ]
     payload = {
         "model": "gpt-5.1",
@@ -2437,10 +2448,13 @@ def test_compact_trimming_does_not_anchor_active_skill_context_from_middle():
 
     assert isinstance(dumped_input, list)
     assert dumped_input[0] == input_items[0]
+    assert active_skill_context in dumped_input
+    assert plan_call in dumped_input
+    assert plan_output in dumped_input
     assert dumped_input[-1] == input_items[-1]
-    assert skill_context not in dumped_input
     assert input_items[1] not in dumped_input
     assert input_items[3] not in dumped_input
+    assert input_items[5] not in dumped_input
 
 
 def test_compact_trimming_does_not_anchor_plain_skill_catalog_mentions():
@@ -2477,6 +2491,52 @@ def test_compact_trimming_does_not_anchor_plain_skill_catalog_mentions():
 
     assert isinstance(dumped_input, list)
     assert catalog_context not in dumped_input
+    assert dumped_input[0] == input_items[0]
+    assert dumped_input[-1] == input_items[-1]
+
+
+def test_compact_trimming_does_not_promote_skill_catalog_or_checklist_prose():
+    skills_catalog = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "<skills_instructions>\n"
+                    "## Skills\n"
+                    "- grill-me: Interview the user one question at a time.\n"
+                    "</skills_instructions>"
+                ),
+            }
+        ],
+    }
+    checklist_prose = {
+        "type": "message",
+        "role": "assistant",
+        "content": "TODO review: [ ] first row, [ ] second row, [ ] third row.",
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        skills_catalog,
+        checklist_prose,
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "continue"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert skills_catalog not in dumped_input
+    assert checklist_prose not in dumped_input
     assert dumped_input[0] == input_items[0]
     assert dumped_input[-1] == input_items[-1]
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -59,6 +59,7 @@ from app.modules.proxy.durable_bridge_coordinator import DurableBridgeLookup, Du
 from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeAliasRegistration,
     DurableBridgeAliasRegistrationReceipt,
+    durable_bridge_hash,
 )
 from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_epoch
 from app.modules.proxy.http_bridge_event_batcher import TerminalOperationEventAppendResult
@@ -13698,6 +13699,7 @@ async def test_stream_via_http_bridge_preserves_context_after_owner_unavailable(
     retained_output = {
         "type": "message",
         "role": "assistant",
+        "id": "msg_response_owned",
         "content": [{"type": "output_text", "text": "two"}],
     }
     input_items = [*prefix_items]
@@ -30869,6 +30871,53 @@ def test_http_bridge_quarantine_clear_restores_session_reusability() -> None:
     assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is False
 
 
+def test_http_bridge_quarantine_clear_generation_rejects_stale_recovery() -> None:
+    service = SimpleNamespace()
+    session = _make_bridge_session(key_value="quarantine-clear-generation")
+
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="reattach_missing_response_created",
+    )
+    first_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(
+        service,
+        session.key,
+    )
+    assert first_generation is not None
+
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="repeated_eventless_timeout",
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, session.key) != (
+        first_generation
+    )
+
+    http_bridge_quarantine_module._clear_http_bridge_quarantine_key(
+        service,
+        session.key,
+        account_id="acc-late-recovery",
+        model="gpt-5.6-sol",
+        generation=first_generation,
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is True
+
+    current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(
+        service,
+        session.key,
+    )
+    http_bridge_quarantine_module._clear_http_bridge_quarantine_key(
+        service,
+        session.key,
+        account_id="acc-current-recovery",
+        model="gpt-5.6-sol",
+        generation=current_generation,
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is False
+
+
 def test_http_bridge_session_reusable_for_lookup_excludes_quarantined() -> None:
     service = SimpleNamespace()
     session = _make_bridge_session(key_value="quarantine-reuse")
@@ -31239,41 +31288,47 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     unanchored instead of restoring the wedged durable anchor through session
     hydration and session-level injection."""
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    historical_input = [
-        {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},
-        {
-            "type": "additional_tools",
-            "role": "developer",
-            "tools": [{"type": "custom", "name": "shell"}],
-        },
-        {
-            "type": "message",
-            "role": "developer",
-            "content": [{"type": "input_text", "text": "canonical Lite instructions"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "first question"}]},
-        {
-            "type": "custom_tool_call",
-            "call_id": "call_historical_shell",
-            "name": "shell",
-            "input": "printf historical",
-        },
-        {"role": "developer", "content": [{"type": "input_text", "text": "historical control"}]},
-        {
-            "type": "custom_tool_call_output",
-            "call_id": "call_historical_shell",
-            "output": "historical",
-        },
-    ]
-    # Full resend with a trimmable durable prefix and a fresh suffix that does
-    # NOT retain the prior output (plain user turn).
+    historical_input = [{"role": "user", "content": "one"}]
+    retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "id": "msg_response_owned",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    projected_retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    retains_prior_output = True
+    account_neutral_payload = True
+    expected_account_neutral = True
+    fresh_suffix = (
+        [
+            retained_output,
+            {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+        ]
+        if retains_prior_output
+        else [{"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]}]
+    )
+    expected_projected_input = (
+        [
+            *historical_input,
+            projected_retained_output,
+            {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+        ]
+        if retains_prior_output
+        else [{"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]}]
+    )
+    # Full resend with a trimmable durable prefix. Only the variant retaining
+    # prior output is safe to replay account-neutrally.
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.6-sol",
             "instructions": "test",
             "input": [
                 *historical_input,
-                {"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]},
+                *fresh_suffix,
             ],
         }
     )
@@ -31303,8 +31358,7 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
         quarantined_session,
         reason="reattach_missing_response_created",
     )
-    fresh_session = _make_bridge_session(key=bridge_key, key_value=bridge_key.affinity_key)
-    fresh_session.codex_session = True
+    fresh_session: proxy_service._HTTPBridgeSession | None = None
 
     prepared_payloads: list[proxy_service.ResponsesRequest] = []
 
@@ -31333,17 +31387,25 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
         request_state.previous_response_id = prepared_payload.previous_response_id
         return request_state, json.dumps(dict(prepared_payload.to_payload()), separators=(",", ":"))
 
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, object]] = []
+    captured_request_states: list[proxy_service._WebSocketRequestState] = []
+
     async def fake_get_or_create(
         key: proxy_service._HTTPBridgeSessionKey,
         **kwargs: object,
     ) -> proxy_service._HTTPBridgeSession:
-        del kwargs
-        assert key == bridge_key
+        nonlocal fresh_session
+        captured_keys.append(key)
+        captured_kwargs.append(dict(kwargs))
+        fresh_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        fresh_session.codex_session = True
         return fresh_session
 
     dispatched_text: list[str] = []
 
     async def fake_stream_events(*args: object, **kwargs: object):
+        captured_request_states.append(cast(proxy_service._WebSocketRequestState, kwargs["request_state"]))
         dispatched_text.append(cast(str, kwargs["text_data"]))
         yield 'data: {"type":"response.completed"}\n\n'
 
@@ -31369,6 +31431,12 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    account_neutral_classifier = Mock(return_value=account_neutral_payload)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_payload_is_account_neutral_fresh_replay",
+        account_neutral_classifier,
+    )
     # The bypass shape: a live (alias) session makes the fresh-reattach
     # durable-anchor gate false before the quarantine is ever consulted.
     monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=True))
@@ -31390,14 +31458,350 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     chunks = [chunk async for chunk in stream]
 
     assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert (captured_keys[0] != bridge_key) is expected_account_neutral
+    assert captured_keys[0].strength == ("soft" if expected_account_neutral else "hard")
+    assert (
+        is_http_bridge_account_neutral_replay(
+            kind=captured_keys[0].affinity_kind,
+            key=captured_keys[0].affinity_key,
+        )
+        is expected_account_neutral
+    )
+    assert captured_kwargs[0]["headers"] == (
+        {} if expected_account_neutral else {"x-codex-session-id": bridge_key.affinity_key}
+    )
+    assert captured_kwargs[0]["preferred_account_id"] == (None if expected_account_neutral else "acc-bridge")
     assert len(dispatched_text) == 1
     dispatched_payload = json.loads(dispatched_text[0])
     # Genuinely unanchored: the suppressed durable anchor did not come back
     # through session hydration or session-level injection, and the client's
     # payload was not prefix-trimmed against the durable stored context.
     assert "previous_response_id" not in dispatched_payload
-    assert len(dispatched_payload["input"]) == len(historical_input) + 1
+    assert dispatched_payload["input"] == expected_projected_input
+    assert fresh_session is not None
     assert fresh_session.last_completed_response_id is None
+    assert len(captured_request_states) == 1
+    assert (captured_request_states[0].quarantine_clear_key == bridge_key) is expected_account_neutral
+    assert (captured_request_states[0].quarantine_clear_generation is not None) is expected_account_neutral
+    expected_replay_kind, expected_replay_key = make_http_bridge_account_neutral_replay_key(
+        durable_bridge_hash(dispatched_text[0])
+    )
+    if expected_account_neutral:
+        assert captured_keys[0].affinity_kind == expected_replay_kind
+        assert captured_keys[0].affinity_key == expected_replay_key
+    if retains_prior_output:
+        account_neutral_classifier.assert_called_once()
+    else:
+        account_neutral_classifier.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_quarantined_full_resend_recovery_fence_survives_restart_fingerprint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The quarantine demotion must not re-key the durable recovery fence.
+
+    ``durable_recovery_attempt_fingerprint`` is the primary key of persisted
+    ``http_bridge_recovery_attempts`` rows, so it must keep hashing the
+    unprojected request body. A row journalled before a restart has to still
+    match after it, otherwise the one-shot replay fence silently opens once.
+    The quarantine recovery key is named after the projected body that this
+    dispatch actually sends, which is a different hash on purpose.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    historical_input = [{"role": "user", "content": "one"}]
+    retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "id": "msg_response_owned",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "test",
+            "input": [
+                *historical_input,
+                retained_output,
+                {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+            ],
+        }
+    )
+    bridge_key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-fence-restart", None)
+    prefix_fingerprint = http_bridge_streaming_module._fingerprint_input_items(
+        cast(list[Any], payload.input)[: len(historical_input)]
+    )
+    # The restart shape: the durable row survived, but its owner's lease died
+    # with the process that wrote the recovery-attempt row.
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-quarantine-fence",
+        canonical_kind=bridge_key.affinity_kind,
+        canonical_key=bridge_key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-bridge",
+        owner_instance_id="instance-before-restart",
+        owner_epoch=4,
+        lease_expires_at=proxy_service.utcnow() - timedelta(seconds=120),
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state=None,
+        latest_response_id="resp_wedged_anchor",
+        model="gpt-5.6-sol",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=prefix_fingerprint,
+    )
+    quarantined_session = _make_bridge_session(key=bridge_key, key_value=bridge_key.affinity_key)
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        quarantined_session,
+        reason="reattach_missing_response_created",
+    )
+
+    def render_bridge_text(rendered_payload: proxy_service.ResponsesRequest) -> str:
+        return json.dumps(dict(rendered_payload.to_payload()), separators=(",", ":"))
+
+    # What a pre-restart process journalled: the hash of the unprojected body.
+    persisted_fence_fingerprint = durable_bridge_hash(
+        render_bridge_text(http_bridge_streaming_module._http_bridge_payload_without_previous_response_id(payload))
+    )
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+        **prepare_kwargs: object,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip, prepare_kwargs
+        request_state = proxy_service._WebSocketRequestState(
+            request_id="req-quarantine-fence",
+            model=prepared_payload.model,
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=time.monotonic(),
+            event_queue=asyncio.Queue(),
+            transport="http",
+        )
+        request_state.previous_response_id = prepared_payload.previous_response_id
+        return request_state, render_bridge_text(prepared_payload)
+
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: object,
+    ) -> proxy_service._HTTPBridgeSession:
+        del kwargs
+        captured_keys.append(key)
+        fresh_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        fresh_session.codex_session = True
+        return fresh_session
+
+    dispatched_text: list[str] = []
+
+    async def fake_stream_events(*args: object, **kwargs: object):
+        del args
+        dispatched_text.append(cast(str, kwargs["text_data"]))
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    dashboard_settings = SimpleNamespace(
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=1800,
+    )
+    runtime_config = SimpleNamespace(
+        enabled=True,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=1800.0,
+        max_sessions=8,
+        queue_limit=4,
+        prompt_cache_idle_ttl_seconds=120.0,
+        gateway_safe_mode=False,
+    )
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=dashboard_settings)),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_service_get_settings", _make_app_settings)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+
+    claim_instance_id = _make_app_settings().http_responses_session_bridge_instance_id
+    claimed_lookup = replace(
+        durable_lookup,
+        owner_instance_id=claim_instance_id,
+        owner_epoch=durable_lookup.owner_epoch + 1,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+    )
+    lookup_recovery_attempt = AsyncMock(return_value=SimpleNamespace(request_fingerprint=persisted_fence_fingerprint))
+    mark_recovery_attempt_replayed = AsyncMock(return_value=True)
+    monkeypatch.setattr(service._durable_bridge, "lookup_recovery_attempt", lookup_recovery_attempt)
+    monkeypatch.setattr(service._durable_bridge, "claim_live_session", AsyncMock(return_value=claimed_lookup))
+    monkeypatch.setattr(service._durable_bridge, "mark_recovery_attempt_replayed", mark_recovery_attempt_replayed)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_payload_is_account_neutral_fresh_replay",
+        Mock(return_value=True),
+    )
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    stream = service._stream_http_bridge_or_retry(
+        payload,
+        {"x-codex-session-id": bridge_key.affinity_key},
+        codex_session_affinity=True,
+        propagate_http_errors=True,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        suppress_text_done_events=False,
+    )
+    chunks = [chunk async for chunk in stream]
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+
+    # The fence looked the persisted row up under the fingerprint that row was
+    # written with, so the one-shot replay guard still holds after the restart.
+    lookup_recovery_attempt.assert_awaited_once_with(
+        session_id=durable_lookup.session_id,
+        request_fingerprint=persisted_fence_fingerprint,
+    )
+    mark_recovery_attempt_replayed.assert_awaited_once_with(
+        session_id=durable_lookup.session_id,
+        api_key_id=None,
+        instance_id=claim_instance_id,
+        owner_epoch=claimed_lookup.owner_epoch,
+        request_fingerprint=persisted_fence_fingerprint,
+    )
+
+    # Negative control. The body this recovery actually dispatches is the
+    # projected one, and its hash is NOT the fence fingerprint. Hashing the
+    # projected body into ``durable_recovery_attempt_fingerprint`` is exactly
+    # the regression this test pins shut: the lookup above would have missed
+    # the persisted row and handed out a second "first" replay.
+    assert len(dispatched_text) == 1
+    dispatched_payload = json.loads(dispatched_text[0])
+    assert dispatched_payload["input"] == [
+        *historical_input,
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "two"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+    ]
+    projected_body_fingerprint = durable_bridge_hash(dispatched_text[0])
+    assert projected_body_fingerprint != persisted_fence_fingerprint
+    fence_await = lookup_recovery_attempt.await_args
+    assert fence_await is not None
+    assert fence_await.kwargs["request_fingerprint"] != projected_body_fingerprint
+
+    # The poisoned hard key was not reused for the recovery dispatch.
+    assert len(captured_keys) == 1
+    assert captured_keys[0] != bridge_key
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rebinds_and_updates_original_continuity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-original", None)
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-original",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-old",
+        owner_instance_id=None,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() - timedelta(seconds=60),
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        model="gpt-5.6-sol",
+    )
+    claimed_lookup = replace(
+        lookup,
+        owner_instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=lookup.owner_epoch + 1,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+    )
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=lookup),
+        claim_live_session=AsyncMock(return_value=claimed_lookup),
+        rebind_session_account=AsyncMock(return_value=True),
+        renew_live_session=AsyncMock(
+            return_value=replace(claimed_lookup, account_id="acc-new", latest_response_id="resp-new")
+        ),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", _make_app_settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-new",
+        response_id="resp-new",
+        input_item_count=3,
+        input_full_fingerprint="fp-new",
+        pending_tool_calls={"call_1": "function_call"},
+    )
+
+    assert advanced is True
+    service._durable_bridge.lookup_request_targets.assert_awaited_once_with(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=None,
+        turn_state=None,
+        session_header=None,
+        previous_response_id=None,
+    )
+    service._durable_bridge.claim_live_session.assert_awaited_once_with(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=None,
+        instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        lease_ttl_seconds=pytest.approx(http_bridge_helpers_module._http_bridge_durable_lease_ttl_seconds()),
+        account_id="acc-old",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        allow_takeover=False,
+        owner_process_epoch=http_bridge_owner_process_epoch(),
+    )
+    service._durable_bridge.rebind_session_account.assert_awaited_once_with(
+        session_id=claimed_lookup.session_id,
+        api_key_id=None,
+        instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=claimed_lookup.owner_epoch,
+        account_id="acc-new",
+        clear_continuity=True,
+    )
+    service._durable_bridge.renew_live_session.assert_awaited_once()
+    renew_kwargs = service._durable_bridge.renew_live_session.await_args.kwargs
+    assert renew_kwargs == {
+        "session_id": claimed_lookup.session_id,
+        "api_key_id": None,
+        "instance_id": _make_app_settings().http_responses_session_bridge_instance_id,
+        "owner_epoch": claimed_lookup.owner_epoch,
+        "lease_ttl_seconds": renew_kwargs["lease_ttl_seconds"],
+        "latest_response_id": "resp-new",
+        "latest_input_item_count": 3,
+        "latest_input_full_fingerprint": "fp-new",
+        "latest_pending_tool_calls": {"call_1": "function_call"},
+    }
+    assert renew_kwargs["lease_ttl_seconds"] > 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2586,8 +2586,10 @@ async def test_response_create_gate_timeout_retires_old_pending_without_upstream
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2695,8 +2697,10 @@ async def test_response_create_gate_timeout_retires_closed_anchored_pending_with
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2786,8 +2790,10 @@ async def test_response_create_gate_timeout_retires_old_precreated_request_after
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2888,7 +2894,9 @@ async def test_response_create_gate_timeout_does_not_retire_active_response_prog
         retire_session: proxy_service._HTTPBridgeSession,
         *,
         detail: str,
+        response_events_seen: int | None = None,
     ) -> None:
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -24134,18 +24142,19 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("unsafe_replay_input", "replace_retired_gate", "stored_model"),
+    ("unsafe_replay_input", "replace_retired_gate", "stored_model", "pending_manifest_replay"),
     [
-        (None, False, None),
-        (None, False, "gpt-5.3"),
-        (None, True, None),
-        ("conversation", False, None),
-        ("file", False, None),
-        ("missing_prior_output", False, None),
-        ("orphan_output", False, None),
-        ("response_owned_developer", False, None),
-        ("response_owned_stored_developer", False, None),
-        ("missing_owner", False, None),
+        pytest.param(None, False, None, False, id="retained-output"),
+        pytest.param(None, False, "gpt-5.3", False, id="retained-output-stored-model"),
+        pytest.param(None, True, None, False, id="retained-output-replace-retired-gate"),
+        pytest.param(None, False, None, True, id="pending-tool-manifest"),
+        pytest.param("conversation", False, None, False, id="conversation"),
+        pytest.param("file", False, None, False, id="file"),
+        pytest.param("missing_prior_output", False, None, False, id="missing-prior-output"),
+        pytest.param("orphan_output", False, None, False, id="orphan-output"),
+        pytest.param("response_owned_developer", False, None, False, id="response-owned-developer"),
+        pytest.param("response_owned_stored_developer", False, None, False, id="response-owned-stored-developer"),
+        pytest.param("missing_owner", False, None, False, id="missing-owner"),
     ],
 )
 async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_when_owner_is_unavailable(
@@ -24153,6 +24162,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     unsafe_replay_input: str | None,
     replace_retired_gate: bool,
     stored_model: str | None,
+    pending_manifest_replay: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     account_neutral_classifier = Mock(
@@ -24207,16 +24217,14 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         )
     elif unsafe_replay_input == "orphan_output":
         historical_input.append({"type": "function_call_output", "call_id": "call_missing", "output": "orphan output"})
-    historical_input.append(
-        {
-            "type": "function_call",
-            "id": "fc_owner",
-            "call_id": "call_old",
-            "name": "lookup",
-            "arguments": "{}",
-            "internal_chat_message_metadata_passthrough": owner_metadata,
-        }
-    )
+    retained_boundary_call: proxy_service.JsonValue = {
+        "type": "function_call",
+        "id": "fc_owner",
+        "call_id": "call_old",
+        "name": "lookup",
+        "arguments": "{}",
+        "internal_chat_message_metadata_passthrough": owner_metadata,
+    }
     retained_boundary_output: proxy_service.JsonValue = {
         "type": "function_call_output",
         "call_id": "call_old",
@@ -24228,6 +24236,21 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         "content": [{"type": "input_text", "text": "next question"}],
         "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
     }
+    pending_tool_loop: list[proxy_service.JsonValue] = [
+        {
+            "type": "function_call",
+            "call_id": "call_pending",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
     retained_prior_output: proxy_service.JsonValue = {
         "type": "message",
         "id": "msg_owner",
@@ -24252,6 +24275,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
             "call_id": "call_search",
             "execution": "client",
             "status": "completed",
+            "output": "found docs",
             "tools": [],
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
@@ -24268,10 +24292,17 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         "instructions": "hi",
         "input": [
             *historical_input,
+            retained_boundary_call,
             retained_boundary_output,
             *completed_search_bookkeeping,
-            *([] if unsafe_replay_input == "missing_prior_output" else [retained_prior_output]),
-            new_input,
+            *(
+                pending_tool_loop
+                if pending_manifest_replay
+                else [
+                    *([] if unsafe_replay_input == "missing_prior_output" else [retained_prior_output]),
+                    new_input,
+                ]
+            ),
             *(
                 [
                     {
@@ -24290,6 +24321,16 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     if unsafe_replay_input == "conversation":
         payload_data["conversation"] = "conv_owner_scoped"
     payload = proxy_service.ResponsesRequest.model_validate(payload_data)
+    stored_context_items = (
+        [
+            *historical_input,
+            retained_boundary_call,
+            retained_boundary_output,
+            *completed_search_bookkeeping,
+        ]
+        if pending_manifest_replay
+        else historical_input
+    )
     durable_lookup = proxy_service.DurableBridgeLookup(
         session_id="durable-owner-unavailable",
         canonical_kind="session_header",
@@ -24302,9 +24343,10 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         state=HttpBridgeSessionState.ACTIVE,
         latest_turn_state="sid-owner-unavailable",
         latest_response_id="resp_completed_anchor",
-        latest_input_item_count=len(historical_input),
-        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        latest_input_item_count=len(stored_context_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_context_items),
         model=stored_model,
+        latest_pending_tool_calls={"call_pending": "function_call"} if pending_manifest_replay else None,
     )
     owner_unavailable = ProxyResponseError(
         502,
@@ -24339,9 +24381,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     replacement_session = _make_bridge_session(key=session.key, key_value=session.key.affinity_key)
     get_or_create = AsyncMock(
         side_effect=(
-            [owner_unavailable, session, replacement_session]
-            if replace_retired_gate
-            else [owner_unavailable, capacity_unavailable, session]
+            [owner_unavailable, session, replacement_session] if replace_retired_gate else [owner_unavailable, session]
         )
     )
     captured_request_states: list[proxy_service._WebSocketRequestState] = []
@@ -24452,13 +24492,13 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     chunks = [chunk async for chunk in stream]
 
     assert chunks == ['data: {"type":"response.completed"}\n\n']
-    assert get_or_create.await_count == 3
+    assert get_or_create.await_count == (3 if replace_retired_gate else 2)
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]
-    third_call = get_or_create.await_args_list[2]
+    third_call = get_or_create.await_args_list[2] if replace_retired_gate else None
     assert first_call.kwargs["previous_response_id"] is None
-    assert first_call.kwargs["preferred_account_id"] == "acc-owner"
-    assert first_call.kwargs["allow_forward_to_owner"] is True
+    assert first_call.kwargs["preferred_account_id"] == (None if stored_model else "acc-owner")
+    assert first_call.kwargs["allow_forward_to_owner"] is (False if stored_model else True)
     assert second_call.kwargs["previous_response_id"] is None
     assert second_call.kwargs["preferred_account_id"] is None
     assert second_call.kwargs["durable_lookup"] is None
@@ -24466,29 +24506,30 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         kind=second_call.args[0].affinity_kind,
         key=second_call.args[0].affinity_key,
     )
-    assert second_call.args[0] == third_call.args[0]
+    if third_call is not None:
+        assert second_call.args[0] == third_call.args[0]
     assert second_call.args[0] != first_call.args[0]
     assert second_call.kwargs["affinity"] == proxy_service._AffinityPolicy()
     assert second_call.kwargs["session_header_fallback_key"] is None
-    assert second_call.kwargs["exclude_account_ids"] == {"acc-owner"}
+    assert second_call.kwargs["exclude_account_ids"] == (None if stored_model else {"acc-owner"})
     assert second_call.kwargs["allow_forward_to_owner"] is False
     assert all(key.lower() != "x-codex-turn-state" for key in second_call.kwargs["headers"])
-    assert third_call.kwargs["previous_response_id"] is None
-    assert third_call.kwargs["preferred_account_id"] is None
-    assert third_call.kwargs["durable_lookup"] is None
+    if third_call is not None:
+        assert third_call.kwargs["previous_response_id"] is None
+        assert third_call.kwargs["preferred_account_id"] is None
+        assert third_call.kwargs["durable_lookup"] is None
     # When the fresh-replay session's own gate later times out (session.account
     # is "acc-fallback"), the next replacement must also exclude it — a
     # "replacement" that could legally reselect the account that just proved
     # stuck isn't a replacement at all.
-    assert third_call.kwargs["exclude_account_ids"] == (
-        {"acc-owner", "acc-fallback"} if replace_retired_gate else {"acc-owner"}
-    )
-    assert third_call.kwargs["allow_forward_to_owner"] is False
+    if third_call is not None:
+        assert third_call.kwargs["exclude_account_ids"] == {"acc-owner", "acc-fallback"}
+        assert third_call.kwargs["allow_forward_to_owner"] is False
     assert captured_request_states[0].previous_response_id is None
     assert captured_request_states[0].enforce_openai_sdk_contract is False
     replay_payload = json.loads(captured_text_data[0])
     assert "previous_response_id" not in replay_payload
-    assert replay_payload["input"] == [
+    expected_replay_input = [
         {
             "role": "user",
             "content": [{"type": "input_text", "text": "old question"}],
@@ -24508,19 +24549,44 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
         {
-            "type": "message",
-            "role": "assistant",
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
             "status": "completed",
-            "phase": "final_answer",
-            "content": [{"type": "output_text", "text": "old answer"}],
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
         {
-            "role": "user",
-            "content": [{"type": "input_text", "text": "next question"}],
-            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
         },
     ]
+    if pending_manifest_replay:
+        expected_replay_input.extend(pending_tool_loop)
+    else:
+        expected_replay_input.extend(
+            [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "old answer"}],
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "next question"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+                },
+            ]
+        )
+    assert replay_payload["input"] == expected_replay_input
     assert "encrypted_content" not in captured_text_data[0]
     assert all("id" not in item for item in replay_payload["input"])
     account_neutral_classifier.assert_called_once()
@@ -24803,6 +24869,393 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
     assert all(call["previous_response_id"] is None for call in creation_calls)
     assert all(call["preferred_account_id"] == "acc-model-owner" for call in creation_calls)
     assert all(call["preferred_account_has_continuity_provenance"] is True for call in creation_calls)
+
+
+@pytest.mark.asyncio
+async def test_durable_model_transition_full_resend_uses_account_neutral_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_metadata: proxy_service.JsonValue = {"turn_id": "turn-owner"}
+    historical_input: list[proxy_service.JsonValue] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_owner",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "hi",
+            "input": [
+                *historical_input,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_old",
+                    "output": "old output",
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "type": "message",
+                    "id": "msg_owner",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "old answer"}],
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "next question"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+                },
+            ],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-full-resend",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id="instance-a",
+        owner_epoch=18,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_parent",
+        latest_response_id="resp_model_parent",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        model="gpt-5.4-mini",
+    )
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, Any]] = []
+    captured_text_data: list[str] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured_keys.append(key)
+        captured_kwargs.append(kwargs)
+        session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        session.account = cast(Any, SimpleNamespace(id="acc-fresh", status=AccountStatus.ACTIVE))
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        **_kwargs: Any,
+    ):
+        assert request_state.previous_response_id is None
+        assert request_state.preferred_account_id is None
+        captured_text_data.append(text_data)
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "authorization": "Bearer test-token",
+                "x-codex-session-id": "shared-root",
+                "x-codex-turn-state": "http_turn_child",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+    assert captured_keys[0].strength == "soft"
+    assert captured_kwargs[0]["durable_lookup"] is None
+    assert captured_kwargs[0]["previous_response_id"] is None
+    assert captured_kwargs[0]["preferred_account_id"] is None
+    assert captured_kwargs[0]["preferred_account_has_continuity_provenance"] is False
+    assert captured_kwargs[0]["allow_forward_to_owner"] is False
+    assert captured_kwargs[0]["headers"] == {"authorization": "Bearer test-token"}
+    replay_payload = json.loads(captured_text_data[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["model"] == "gpt-5.3-codex-spark"
+    assert replay_payload["input"][-1]["content"] == [{"type": "input_text", "text": "next question"}]
+    assert all("id" not in item for item in replay_payload["input"])
+
+
+@pytest.mark.asyncio
+async def test_durable_model_transition_full_resend_pending_tool_context_uses_account_neutral_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_metadata: proxy_service.JsonValue = {"turn_id": "turn-owner"}
+    stored_context_items: list[proxy_service.JsonValue] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_owner",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "old output",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "id": "tsc_owner",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+    ]
+    pending_tool_loop: list[proxy_service.JsonValue] = [
+        {
+            "type": "function_call",
+            "id": "fc_pending",
+            "call_id": "call_pending",
+            "name": "lookup_pending",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "hi",
+            "input": [*stored_context_items, *pending_tool_loop],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-pending-tool",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id="instance-a",
+        owner_epoch=18,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_parent",
+        latest_response_id="resp_model_parent",
+        latest_input_item_count=len(stored_context_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_context_items),
+        latest_pending_tool_calls={"call_pending": "function_call"},
+        model="gpt-5.4-mini",
+    )
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, Any]] = []
+    captured_text_data: list[str] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured_keys.append(key)
+        captured_kwargs.append(kwargs)
+        session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        session.account = cast(Any, SimpleNamespace(id="acc-fresh", status=AccountStatus.ACTIVE))
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        **_kwargs: Any,
+    ):
+        assert request_state.previous_response_id is None
+        assert request_state.preferred_account_id is None
+        captured_text_data.append(text_data)
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "authorization": "Bearer test-token",
+                "x-codex-session-id": "shared-root",
+                "x-codex-turn-state": "http_turn_child",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+    assert captured_keys[0].strength == "soft"
+    assert captured_kwargs[0]["durable_lookup"] is None
+    assert captured_kwargs[0]["previous_response_id"] is None
+    assert captured_kwargs[0]["preferred_account_id"] is None
+    assert captured_kwargs[0]["preferred_account_has_continuity_provenance"] is False
+    assert captured_kwargs[0]["allow_forward_to_owner"] is False
+    replay_payload = json.loads(captured_text_data[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["model"] == "gpt-5.3-codex-spark"
+    assert replay_payload["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "old output",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_pending",
+            "name": "lookup_pending",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
+    assert all("id" not in item for item in replay_payload["input"])
 
 
 @pytest.mark.asyncio
@@ -30743,13 +31196,37 @@ async def test_retire_stale_pending_http_bridge_session_quarantines_wedged_reatt
     await service._retire_stale_pending_http_bridge_session(
         session,
         detail="response_create_gate_timeout_stuck_pending",
-        response_events_seen=wedged.response_event_count,
     )
 
     assert session.quarantined is expect_quarantined
     assert (
         http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is expect_quarantined
     )
+
+
+@pytest.mark.asyncio
+async def test_retire_stale_pending_http_bridge_session_recomputes_event_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    eventful = _make_wedged_reattach_request_state(request_id="req-direct-retire-eventful")
+    eventful.response_id = "resp_eventful_direct_retire"
+    eventful.latency_response_created_ms = 700
+    session = _make_bridge_session(
+        key_value="quarantine-direct-retire-eventful",
+        pending_requests=deque([eventful]),
+        queued_request_count=1,
+    )
+    record_failure = AsyncMock()
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
+    monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
+
+    await service._retire_stale_pending_http_bridge_session(
+        session,
+        detail="response_create_gate_timeout_stuck_pending",
+    )
+
+    record_failure.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25261,6 +25261,496 @@ async def test_durable_model_transition_full_resend_pending_tool_context_uses_ac
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_forks_account_neutral_model_transition_after_owner_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_keys.append(key)
+        creation_calls.append(kwargs)
+        if len(creation_calls) == 1:
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **_kwargs: Any,
+    ):
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(creation_calls) == 2
+    assert creation_keys[0].affinity_kind in {"session_header", "turn_state_header"}
+    assert is_http_bridge_account_neutral_replay(
+        kind=creation_keys[1].affinity_kind,
+        key=creation_keys[1].affinity_key,
+    )
+    # The child lane stays owner-bound so a later capacity failure cannot soft
+    # reroute this request onto a third account.
+    assert creation_keys[1].strength == "hard"
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["preferred_account_has_continuity_provenance"] is False
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_limits_model_transition_owner_conflict_fork_to_one_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        _key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_calls.append(kwargs)
+        raise owner_conflict
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        ):
+            pass
+
+    assert exc_info.value is owner_conflict
+    assert len(creation_calls) == 2
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_not_rebind_parent_turn_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    stream_downstream_turn_states: list[str | None] = []
+    stream_request_states: list[Any] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        if kwargs["preferred_account_id"] == "acc-model-owner":
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **kwargs: Any,
+    ):
+        stream_downstream_turn_states.append(kwargs["downstream_turn_state"])
+        stream_request_states.append(kwargs["request_state"])
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_parent",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert stream_downstream_turn_states == [None]
+    # The child lane must not inherit the parent's continuity identity: a stale
+    # hard anchor or parent affinity policy would make the submit and
+    # clean-close paths treat this account-neutral fork as the old owner-bound
+    # turn.
+    (child_request_state,) = stream_request_states
+    assert child_request_state.session_id is None
+    assert child_request_state.hard_continuity_anchor is False
+    assert child_request_state.affinity_policy.key is None
+    assert child_request_state.affinity_policy.codex_session_source is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("forwarded_request", "input_items"),
+    [
+        (
+            True,
+            [{"role": "user", "content": "continue on the new model"}],
+        ),
+        (
+            False,
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "continue on the new model"},
+                        {"type": "input_file", "file_id": "file-unpinned"},
+                    ],
+                }
+            ],
+        ),
+        # Negative controls for the widened account-neutral classifier (#1849):
+        # a `compaction` item is admitted only when it carries its own
+        # completed encrypted content. A placeholder that merely references the
+        # owner's compacted context, or one still being produced, keeps the
+        # prior turns behind the old owner, so forking would silently drop
+        # them.
+        (
+            False,
+            [
+                {"type": "compaction", "id": "cmpct_model_parent"},
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue on the new model"}],
+                },
+            ],
+        ),
+        (
+            False,
+            [
+                {
+                    "type": "compaction",
+                    "status": "in_progress",
+                    "encrypted_content": "gAAAAABopaque",
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue on the new model"}],
+                },
+            ],
+        ),
+    ],
+    ids=[
+        "forwarded-request",
+        "unpinned-input-file",
+        "post-compaction-placeholder",
+        "post-compaction-in-progress",
+    ],
+)
+async def test_stream_via_http_bridge_keeps_model_transition_owner_conflict_fail_closed_for_unsafe_fork(
+    monkeypatch: pytest.MonkeyPatch,
+    forwarded_request: bool,
+    input_items: list[dict[str, Any]],
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": input_items,
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-unsafe-fork",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_keys.append(key)
+        creation_calls.append(kwargs)
+        raise owner_conflict
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+            forwarded_request=forwarded_request,
+        ):
+            pass
+
+    assert exc_info.value is owner_conflict
+    assert len(creation_calls) == 1
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
+    assert not is_http_bridge_account_neutral_replay(
+        kind=creation_keys[0].affinity_kind,
+        key=creation_keys[0].affinity_key,
+    )
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_preserves_verified_replay_kind_for_durable_model_transition(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -32669,6 +32669,55 @@ async def test_advance_http_bridge_quarantine_clear_key_rejects_stale_generation
 
 
 @pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rejects_successor_durable_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-successor-owner", None)
+    settings = _make_app_settings()
+    successor_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-successor",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-successor",
+        owner_instance_id=settings.http_responses_session_bridge_instance_id,
+        owner_epoch=12,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-successor",
+        model="gpt-5.6-sol",
+    )
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=successor_lookup),
+        claim_live_session=AsyncMock(),
+        rebind_session_account=AsyncMock(),
+        renew_live_session=AsyncMock(),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", lambda: settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-stale-recovery",
+        response_id="resp-stale-recovery",
+        input_item_count=3,
+        input_full_fingerprint="fp-stale-recovery",
+        pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=None,
+        expected_session_id="durable-dispatch-owner",
+        expected_owner_epoch=7,
+    )
+
+    assert advanced is False
+    service._durable_bridge.claim_live_session.assert_not_awaited()
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.renew_live_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_advance_http_bridge_quarantine_clear_key_rejects_generation_reused_after_prune(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25034,6 +25034,235 @@ async def test_durable_model_transition_full_resend_uses_account_neutral_replay(
 
 
 @pytest.mark.asyncio
+async def test_durable_model_transition_recovery_claim_keeps_parent_model_anchor_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_metadata: proxy_service.JsonValue = {"turn_id": "turn-owner"}
+    historical_input: list[proxy_service.JsonValue] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_owner",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "hi",
+            "input": [
+                *historical_input,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_old",
+                    "output": "old output",
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "type": "message",
+                    "id": "msg_owner",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "old answer"}],
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "next question"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+                },
+            ],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-recovery-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id="instance-before-restart",
+        owner_epoch=18,
+        lease_expires_at=datetime.now(timezone.utc) - timedelta(seconds=120),
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state="http_turn_parent",
+        latest_response_id="resp_model_parent",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        model="gpt-5.4-mini",
+    )
+    parent_row = {
+        "model": durable_lookup.model,
+        "latest_response_id": durable_lookup.latest_response_id,
+        "owner_epoch": durable_lookup.owner_epoch,
+        "owner_instance_id": durable_lookup.owner_instance_id,
+        "state": durable_lookup.state,
+    }
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, Any]] = []
+    release_calls: list[dict[str, Any]] = []
+
+    async def fake_claim_live_session(**kwargs: Any) -> proxy_service.DurableBridgeLookup:
+        parent_row["owner_epoch"] = cast(int, parent_row["owner_epoch"]) + 1
+        parent_row["owner_instance_id"] = kwargs["instance_id"]
+        parent_row["state"] = HttpBridgeSessionState.ACTIVE
+        parent_row["model"] = kwargs["model"]
+        if kwargs["latest_response_id"] is not None:
+            parent_row["latest_response_id"] = kwargs["latest_response_id"]
+        return replace(
+            durable_lookup,
+            owner_instance_id=cast(str, parent_row["owner_instance_id"]),
+            owner_epoch=cast(int, parent_row["owner_epoch"]),
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+            state=cast(HttpBridgeSessionState, parent_row["state"]),
+            model=cast(str | None, parent_row["model"]),
+            latest_response_id=cast(str | None, parent_row["latest_response_id"]),
+        )
+
+    async def fake_mark_recovery_attempt_replayed(**kwargs: Any) -> bool:
+        assert kwargs["session_id"] == durable_lookup.session_id
+        assert kwargs["owner_epoch"] == parent_row["owner_epoch"]
+        return True
+
+    async def fake_release_live_session(**kwargs: Any) -> proxy_service.DurableBridgeLookup:
+        release_calls.append(kwargs)
+        assert kwargs["session_id"] == durable_lookup.session_id
+        assert kwargs["owner_epoch"] == parent_row["owner_epoch"]
+        parent_row["owner_instance_id"] = None
+        parent_row["state"] = HttpBridgeSessionState.CLOSED
+        return replace(
+            durable_lookup,
+            owner_instance_id=None,
+            owner_epoch=cast(int, parent_row["owner_epoch"]),
+            lease_expires_at=datetime.now(timezone.utc),
+            state=HttpBridgeSessionState.CLOSED,
+            model=cast(str | None, parent_row["model"]),
+            latest_response_id=cast(str | None, parent_row["latest_response_id"]),
+        )
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured_keys.append(key)
+        captured_kwargs.append(kwargs)
+        session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        session.account = cast(Any, SimpleNamespace(id="acc-fresh", status=AccountStatus.ACTIVE))
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        **_kwargs: Any,
+    ):
+        assert request_state.recovery_attempt_claimed is True
+        assert request_state.previous_response_id is None
+        replay_payload = json.loads(text_data)
+        assert replay_payload["model"] == payload.model
+        assert "previous_response_id" not in replay_payload
+        await service._durable_bridge.release_live_session(
+            session_id=request_state.recovery_attempt_session_id,
+            instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+            owner_epoch=request_state.recovery_attempt_owner_epoch,
+            draining=False,
+        )
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(
+        service._durable_bridge,
+        "lookup_recovery_attempt",
+        AsyncMock(return_value=SimpleNamespace(request_fingerprint="existing-recovery-fence")),
+    )
+    monkeypatch.setattr(service._durable_bridge, "claim_live_session", AsyncMock(side_effect=fake_claim_live_session))
+    monkeypatch.setattr(
+        service._durable_bridge,
+        "mark_recovery_attempt_replayed",
+        AsyncMock(side_effect=fake_mark_recovery_attempt_replayed),
+    )
+    monkeypatch.setattr(
+        service._durable_bridge,
+        "release_live_session",
+        AsyncMock(side_effect=fake_release_live_session),
+    )
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "authorization": "Bearer test-token",
+                "x-codex-session-id": "shared-root",
+                "x-codex-turn-state": "http_turn_child",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+    assert captured_kwargs[0]["durable_lookup"] is None
+    assert captured_kwargs[0]["previous_response_id"] is None
+    assert release_calls == [
+        {
+            "session_id": durable_lookup.session_id,
+            "instance_id": _make_app_settings().http_responses_session_bridge_instance_id,
+            "owner_epoch": parent_row["owner_epoch"],
+            "draining": False,
+        }
+    ]
+    assert (parent_row["model"], parent_row["latest_response_id"]) == ("gpt-5.4-mini", "resp_model_parent")
+    assert parent_row["model"] != payload.model
+
+
+@pytest.mark.asyncio
 async def test_durable_model_transition_full_resend_pending_tool_context_uses_account_neutral_replay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -32245,6 +32245,7 @@ async def test_advance_http_bridge_quarantine_clear_key_rebinds_and_updates_orig
         input_item_count=3,
         input_full_fingerprint="fp-new",
         pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=None,
     )
 
     assert advanced is True
@@ -32292,6 +32293,150 @@ async def test_advance_http_bridge_quarantine_clear_key_rebinds_and_updates_orig
         "latest_pending_tool_calls": {"call_1": "function_call"},
     }
     assert renew_kwargs["lease_ttl_seconds"] > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot_overrides", "case_id"),
+    [
+        ({"owner_instance_id": "bridge-instance-foreign"}, "foreign-instance"),
+        ({"owner_epoch": 8}, "foreign-epoch"),
+        ({"account_id": "acc-foreign"}, "foreign-account"),
+        ({"latest_response_id": "resp-foreign"}, "foreign-response"),
+    ],
+    ids=["foreign-instance", "foreign-epoch", "foreign-account", "foreign-response"],
+)
+async def test_advance_http_bridge_quarantine_clear_key_rejects_unconfirmed_renewal_snapshot(
+    snapshot_overrides: dict[str, Any],
+    case_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del case_id
+    service = SimpleNamespace()
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-renew-fence", None)
+    settings = _make_app_settings()
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-renew-fence",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-bridge",
+        owner_instance_id=settings.http_responses_session_bridge_instance_id,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        model="gpt-5.6-sol",
+    )
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=lookup),
+        claim_live_session=AsyncMock(),
+        rebind_session_account=AsyncMock(),
+        renew_live_session=AsyncMock(
+            return_value=replace(
+                lookup,
+                **{"latest_response_id": "resp-new", **snapshot_overrides},
+            )
+        ),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", lambda: settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-bridge",
+        response_id="resp-new",
+        input_item_count=3,
+        input_full_fingerprint="fp-new",
+        pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=None,
+    )
+
+    assert advanced is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.renew_live_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rejects_stale_generation_before_durable_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    session = _make_bridge_session(key_value="quarantine-stale-generation-durable")
+    key = session.key
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="reattach_missing_response_created",
+    )
+    first_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert first_generation is not None
+    settings = _make_app_settings()
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-stale-generation",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-old",
+        owner_instance_id=settings.http_responses_session_bridge_instance_id,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        model="gpt-5.6-sol",
+    )
+    durable_state = {"account_id": "acc-newer", "latest_response_id": "resp-newer"}
+
+    async def lookup_after_newer_quarantine(**_kwargs: Any) -> DurableBridgeLookup:
+        http_bridge_quarantine_module._quarantine_http_bridge_session(
+            service,
+            session,
+            reason="repeated_eventless_timeout",
+        )
+        return lookup
+
+    async def rebind_session_account(**kwargs: Any) -> bool:
+        durable_state["account_id"] = kwargs["account_id"]
+        return True
+
+    async def renew_live_session(**kwargs: Any) -> DurableBridgeLookup:
+        durable_state["latest_response_id"] = kwargs["latest_response_id"]
+        return replace(
+            lookup,
+            account_id=durable_state["account_id"],
+            latest_response_id=durable_state["latest_response_id"],
+        )
+
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(side_effect=lookup_after_newer_quarantine),
+        claim_live_session=AsyncMock(),
+        rebind_session_account=AsyncMock(side_effect=rebind_session_account),
+        renew_live_session=AsyncMock(side_effect=renew_live_session),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", lambda: settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-recovered-old",
+        response_id="resp-recovered-old",
+        input_item_count=3,
+        input_full_fingerprint="fp-recovered-old",
+        pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=first_generation,
+    )
+
+    assert advanced is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.renew_live_session.assert_not_awaited()
+    assert durable_state == {"account_id": "acc-newer", "latest_response_id": "resp-newer"}
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, key) is True
+    current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert current_generation != first_generation
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25120,7 +25120,7 @@ async def test_durable_model_transition_recovery_claim_keeps_parent_model_anchor
         return replace(
             durable_lookup,
             owner_instance_id=cast(str, parent_row["owner_instance_id"]),
-            owner_epoch=cast(int, parent_row["owner_epoch"]),
+            owner_epoch=parent_row["owner_epoch"],
             lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
             state=cast(HttpBridgeSessionState, parent_row["state"]),
             model=cast(str | None, parent_row["model"]),
@@ -32663,6 +32663,72 @@ async def test_advance_http_bridge_quarantine_clear_key_rejects_stale_generation
     service._durable_bridge.rebind_session_account.assert_not_awaited()
     service._durable_bridge.renew_live_session.assert_not_awaited()
     assert durable_state == {"account_id": "acc-newer", "latest_response_id": "resp-newer"}
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, key) is True
+    current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert current_generation != first_generation
+
+
+@pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rejects_generation_changed_during_renew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    session = _make_bridge_session(key_value="quarantine-stale-generation-after-renew")
+    key = session.key
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="reattach_missing_response_created",
+    )
+    first_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert first_generation is not None
+    settings = _make_app_settings()
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-stale-generation-after-renew",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-bridge",
+        owner_instance_id=settings.http_responses_session_bridge_instance_id,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        model="gpt-5.6-sol",
+    )
+
+    async def renew_live_session(**_kwargs: Any) -> DurableBridgeLookup:
+        http_bridge_quarantine_module._quarantine_http_bridge_session(
+            service,
+            session,
+            reason="repeated_eventless_timeout",
+        )
+        return replace(lookup, latest_response_id="resp-recovered-old")
+
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=lookup),
+        claim_live_session=AsyncMock(),
+        rebind_session_account=AsyncMock(),
+        renew_live_session=AsyncMock(side_effect=renew_live_session),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", lambda: settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-bridge",
+        response_id="resp-recovered-old",
+        input_item_count=3,
+        input_full_fingerprint="fp-recovered-old",
+        pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=first_generation,
+    )
+
+    assert advanced is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.renew_live_session.assert_awaited_once()
     assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, key) is True
     current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
     assert current_generation != first_generation

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -32669,6 +32669,93 @@ async def test_advance_http_bridge_quarantine_clear_key_rejects_stale_generation
 
 
 @pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rejects_generation_reused_after_prune(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    session = _make_bridge_session(key_value="quarantine-pruned-generation")
+    key = session.key
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="reattach_missing_response_created",
+    )
+    first_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert first_generation is not None
+
+    entry = http_bridge_quarantine_module._http_bridge_quarantine_registry(service)[key]
+    now = time.monotonic()
+    entry.quarantined_until = now - 1.0
+    entry.last_touched_monotonic = now - http_bridge_quarantine_module._HTTP_BRIDGE_QUARANTINE_TTL_SECONDS - 1.0
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, key) is False
+    assert key not in http_bridge_quarantine_module._http_bridge_quarantine_registry(service)
+
+    replacement = _make_bridge_session(key=key)
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        replacement,
+        reason="repeated_eventless_timeout",
+    )
+
+    settings = _make_app_settings()
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-pruned-generation",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-newer",
+        owner_instance_id=settings.http_responses_session_bridge_instance_id,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-newer",
+        model="gpt-5.6-sol",
+    )
+    durable_state = {"account_id": lookup.account_id, "latest_response_id": lookup.latest_response_id}
+
+    async def rebind_session_account(**kwargs: Any) -> bool:
+        durable_state["account_id"] = kwargs["account_id"]
+        return True
+
+    async def renew_live_session(**kwargs: Any) -> DurableBridgeLookup:
+        durable_state["latest_response_id"] = kwargs["latest_response_id"]
+        return replace(
+            lookup,
+            account_id=durable_state["account_id"],
+            latest_response_id=durable_state["latest_response_id"],
+        )
+
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=lookup),
+        claim_live_session=AsyncMock(),
+        rebind_session_account=AsyncMock(side_effect=rebind_session_account),
+        renew_live_session=AsyncMock(side_effect=renew_live_session),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", lambda: settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-stale-recovery",
+        response_id="resp-stale-recovery",
+        input_item_count=3,
+        input_full_fingerprint="fp-stale-recovery",
+        pending_tool_calls={"call_1": "function_call"},
+        quarantine_generation=first_generation,
+    )
+
+    assert advanced is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.renew_live_session.assert_not_awaited()
+    assert durable_state == {"account_id": "acc-newer", "latest_response_id": "resp-newer"}
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, key) is True
+    current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, key)
+    assert current_generation != first_generation
+
+
+@pytest.mark.asyncio
 async def test_advance_http_bridge_quarantine_clear_key_rejects_generation_changed_during_renew(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -17138,10 +17138,10 @@ async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_
     assert terminal_event["type"] == "response.failed"
     terminal_response = cast(dict[str, JsonValue], terminal_event["response"])
     terminal_error = cast(dict[str, JsonValue], terminal_response["error"])
-    assert terminal_error["code"] == "stream_incomplete"
+    assert terminal_error["code"] == "duplicate_tool_call_replay_suppressed"
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["status"] == "error"
-    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert request_logs.calls[0]["error_code"] == "duplicate_tool_call_replay_suppressed"
 
 
 @pytest.mark.asyncio
@@ -44258,6 +44258,95 @@ async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
     assert forwarded_created is not None
     assert proxy_service.parse_sse_data_json(forwarded_created) == replay_created_payload
     assert event_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_duplicate_tool_call_replay_emits_retryable_terminal_failure():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_duplicate_terminal",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_bridge_duplicate_terminal",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-duplicate-terminal", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_duplicate_terminal"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_bridge_duplicate_terminal",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": ""}),
+            "call_id": "call_first",
+        },
+    }
+    replay_payload = {
+        **tool_payload,
+        "response_id": "resp_bridge_duplicate_terminal_replay",
+        "item": {**tool_payload["item"], "call_id": "call_replayed"},
+    }
+    replay_created_payload = {
+        "type": "response.created",
+        "response": {"id": "resp_bridge_duplicate_terminal_replay", "status": "in_progress"},
+    }
+    completed_payload = {
+        "type": "response.completed",
+        "response": {"id": "resp_bridge_duplicate_terminal_replay", "status": "completed", "output": []},
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(tool_payload, separators=(",", ":")))
+    session.upstream_control = proxy_service._WebSocketUpstreamControl()
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_created_payload, separators=(",", ":")))
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_payload, separators=(",", ":")))
+    await service._process_http_bridge_upstream_text(session, json.dumps(completed_payload, separators=(",", ":")))
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    first = await event_queue.get()
+    created = await event_queue.get()
+    terminal_block = await event_queue.get()
+    assert isinstance(first, str)
+    assert isinstance(created, str)
+    assert isinstance(terminal_block, str)
+    assert proxy_service.parse_sse_data_json(first) == tool_payload
+    assert proxy_service.parse_sse_data_json(created) == replay_created_payload
+    terminal = proxy_service.parse_sse_data_json(terminal_block)
+    assert isinstance(terminal, dict)
+    assert terminal["type"] == "response.failed"
+    terminal_response = terminal["response"]
+    assert isinstance(terminal_response, dict)
+    terminal_error = terminal_response["error"]
+    assert isinstance(terminal_error, dict)
+    assert terminal_error["code"] == "duplicate_tool_call_replay_suppressed"
+    assert await event_queue.get() is None
+    assert request_state.error_http_status_override == 502
+    assert session.upstream_control.reconnect_requested is True
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[-1]["status"] == "error"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -25097,6 +25097,115 @@ async def test_websocket_terminal_hands_log_off_before_health_and_isolates_healt
 
 
 @pytest.mark.asyncio
+async def test_websocket_duplicate_tool_suppression_still_penalizes_genuine_terminal_failure(
+    monkeypatch,
+):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_duplicate_terminal_failure")
+    handle_stream_error = AsyncMock()
+    write_request_log = AsyncMock()
+    settle_stream = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_stream)
+
+    payload: dict[str, JsonValue] = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_duplicate_terminal_failure",
+            "error": {"code": "rate_limit_exceeded", "message": "slow down"},
+            "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+        },
+    }
+    event = parse_sse_event(f"data: {json.dumps(payload)}\n\n")
+    assert event is not None
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_duplicate_terminal_failure",
+        response_id="resp_ws_duplicate_terminal_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=asyncio.get_running_loop().time(),
+        suppressed_duplicate_tool_call=True,
+    )
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    await service._finalize_websocket_request_state(
+        request_state,
+        account=account,
+        account_id_value=account.id,
+        event=event,
+        event_type="response.failed",
+        payload=payload,
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    handle_stream_error.assert_awaited_once_with(
+        account,
+        {"message": "slow down"},
+        "rate_limit_exceeded",
+    )
+    assert upstream_control.reconnect_requested is True
+    write_request_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_synthetic_duplicate_terminal_skips_health_penalty(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_duplicate_completed")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_duplicate_completed",
+        response_id="resp_ws_duplicate_completed",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        suppressed_duplicate_tool_call=True,
+    )
+    pending_requests = deque([request_state])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "response.completed",
+        "response": {
+            "id": request_state.response_id,
+            "status": "completed",
+            "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    downstream_payload = json.loads(downstream_text)
+    assert downstream_payload["type"] == "response.failed"
+    assert downstream_payload["response"]["error"]["code"] == "duplicate_tool_call_replay_suppressed"
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["error_code"] == "duplicate_tool_call_replay_suppressed"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("settlement_committed", "request_log_handoff_fails", "expected_warning"),
     [
@@ -44347,6 +44456,7 @@ async def test_http_bridge_duplicate_tool_call_replay_emits_retryable_terminal_f
     assert session.upstream_control.reconnect_requested is True
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[-1]["status"] == "error"
+    assert request_logs.calls[-1]["error_code"] == "duplicate_tool_call_replay_suppressed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_items_are_self_contained_fresh_replay,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -151,6 +152,310 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
 
 
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_replay_projection_preserves_owner_bound_compaction_id_to_fail_closed() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "id": "cmp_owner_a",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "id": "cmp_owner_a",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
+
+
+def test_account_neutral_replay_projection_accepts_compaction_without_owner_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
+
+
+def test_account_neutral_replay_projection_rejects_compaction_before_later_raw_prefix_bookkeeping() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "web_search_call",
+            "id": "ws_owner_a",
+            "action": {"type": "search", "query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "output": "result",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+
+    assert project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=2) is None
+
+
+def test_account_neutral_replay_projection_preserves_post_compact_tool_search_context_without_owner_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "tool_search_call",
+            "id": "tsc_owner_a",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb post compact replay"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "id": "tso_owner_a",
+            "call_id": "call_search",
+            "output": "replay fix candidate",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.stored_prefix_count == 1
+    assert projection.input_items == [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb post compact replay"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "replay fix candidate",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+    assert (
+        responses_input_suffix_retains_prior_output(
+            projection.input_items,
+            stored_count=projection.stored_prefix_count,
+        )
+        is True
+    )
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
+
+
+def test_account_neutral_fresh_replay_rejects_post_compact_mixed_tool_suffix_before_user_followup() -> None:
+    input_items: list[JsonValue] = [
+        {"type": "compaction", "status": "completed", "encrypted_content": "encrypted-compact-context"},
+        {
+            "type": "function_call",
+            "call_id": "call_function",
+            "name": "lookup",
+            "arguments": "{}",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb post compact replay"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {"type": "function_call_output", "call_id": "call_function", "output": "result", "status": "completed"},
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "search result",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_suffix_retains_prior_output(input_items, stored_count=1) is False
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
+
+
+def test_account_neutral_fresh_replay_accepts_tools_only_client_tool_search_output() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
+
+
+@pytest.mark.parametrize(
+    "tool_search_output",
+    [
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "server",
+            "status": "completed",
+            "tools": [],
+            "output": "Found codex-lb",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [{"type": "file_search", "vector_store_ids": ["vs_owner"]}],
+            "output": "Found codex-lb",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [{"type": "function", "name": "lookup", "namespace": "private"}],
+            "output": "Found codex-lb",
+        },
+    ],
+)
+def test_account_neutral_fresh_replay_rejects_account_scoped_tool_search_output(
+    tool_search_output: dict[str, JsonValue],
+) -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        tool_search_output,
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is False
+
+
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
     metadata = {"turn_id": "turn_owner_a"}
     input_items: list[JsonValue] = [
@@ -195,8 +500,10 @@ def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() 
         },
         {
             "type": "tool_search_output",
+            "id": "tso_owner_a",
             "call_id": "call_search",
             "execution": "client",
+            "output": "search result",
             "status": "completed",
             "tools": [],
             "internal_chat_message_metadata_passthrough": metadata,
@@ -248,6 +555,23 @@ def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() 
             "call_id": "call_boundary",
             "output": "/workspace",
             "status": "completed",
+            "internal_chat_message_metadata_passthrough": metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "github"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "output": "search result",
+            "status": "completed",
+            "tools": [],
             "internal_chat_message_metadata_passthrough": metadata,
         },
         {


### PR DESCRIPTION
Five pull requests were squash-merged into `main` earlier today outside the maintainer's merge triage round. That was my mistake: merging into `main` is the maintainer's call, not a contributor's. #1858 reverted all five in a single commit, and `main` is back to the tree it had before them (`6d5f9f83`), byte-identical.

This PR re-offers the exact same content as one branch, so it can be merged on the maintainer's own schedule instead of mine.

## What is in here

The five original squash commits, replayed in their original order onto the reverted `main`:

| Commit | Originally |
|---|---|
| `fix(proxy): absorb replay-safe compaction recovery` | #1849 |
| `fix(proxy): report suppressed duplicate tool-call terminals` | #1706 |
| `fix(db): repair retired identity/warmup migration stamp` | #1847 |
| `fix(proxy): demote quarantined bridge reattach keys` | #1730 |
| `fix(proxy): guard model-transition owner-conflict fork` | #1619 |

They are kept as five separate commits rather than squashed into one, so each change stays reviewable on its own and `git log` keeps pointing at the original PR that discussed it.

## Nothing was added or lost

The tree of this branch's head is `31f9ca989163c446c31f1eb67308fa1eb937a9fa`, which is exactly the tree of `52092bc91fd81d7a18655eab403f02ff6895dd80` — the state `main` had after the five merges. No rebase fixups, no edits, no additions. The replay was conflict-free, which is expected: `main`'s tree after the revert is identical to the tree those commits were originally written against.

## Migrations

`fix(db): repair retired identity/warmup migration stamp` reintroduces `20260820_000000_repair_retired_identity_and_warmup_stamp`. Anything that was re-parented onto that revision while it was briefly on `main` has been re-pointed at the correct head in its own branch, so the single-head invariant in `app/db/migrate.py` holds both with and without this PR.

## Review

The five changes were each reviewed on their original PRs; those discussions are still the substantive record. This PR is the delivery vehicle, not a new proposal. If any one of the five should not land, it can be dropped from this branch on request rather than reverted afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recovery for interrupted and post-compaction conversations, preserving safe context and tool-search activity.
  * Added guarded failover for model-transition ownership conflicts.
  * Added clearer terminal errors for suppressed duplicate tool-call replays across streaming transports.
  * Strengthened session quarantine handling to protect newer recovery state.
* **Bug Fixes**
  * Improved repair of partially applied database migrations.
  * Refined service-tier normalization and account-neutral replay behavior.
* **Tests**
  * Expanded coverage for recovery, failover, replay safety, migrations, and duplicate tool-call handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->