### PR TITLE
fix(proxy): recover stale previous response anchors

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -82,10 +82,8 @@ def is_previous_response_not_found_message(message: str | None) -> bool:
 def _is_invalid_previous_response_id_message(message: str | None) -> bool:
     if message is None:
         return False
-    normalized = " ".join(message.lower().split())
-    if normalized.endswith("."):
-        normalized = normalized[:-1]
-    return normalized == "invalid `previous_response_id`"
+    normalized = " ".join(message.casefold().replace("`", "").split()).removesuffix(".").rstrip()
+    return normalized == "invalid previous_response_id"
 
 
 def previous_response_id_from_not_found_message(message: str | None) -> str | None:
@@ -106,11 +104,13 @@ def previous_response_id_from_not_found_message(message: str | None) -> str | No
 def is_previous_response_not_found_error(
     *,
     code: str | None,
-    param: str | None,
+    param: object,
     message: str | None,
 ) -> bool:
     if code == PREVIOUS_RESPONSE_NOT_FOUND_CODE:
         return True
+    if param is not None and not isinstance(param, str):
+        return False
     if code != "invalid_request_error":
         return False
     if param is None:
@@ -131,7 +131,7 @@ def response_failed_event(
     incomplete_details: dict[str, str] | None = None,
 ) -> ResponseFailedEvent:
     error = openai_error(code, message, error_type, resets_at=resets_at)["error"]
-    if error_param:
+    if error_param is not None:
         error["param"] = error_param
     if created_at is None:
         created_at = int(time.time())

--- a/app/db/alembic/versions/20260821_000000_add_retry_circuit_admission_generation.py
+++ b/app/db/alembic/versions/20260821_000000_add_retry_circuit_admission_generation.py
@@ -1,0 +1,49 @@
+"""add retry-circuit admission generation
+
+Revision ID: 20260821_000000_add_retry_circuit_admission_generation
+Revises: 20260816_000000_add_model_source_embeddings
+Create Date: 2026-08-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260821_000000_add_retry_circuit_admission_generation"
+down_revision = "20260816_000000_add_model_source_embeddings"
+branch_labels = None
+depends_on = None
+
+_TABLE = "http_bridge_retry_circuits"
+_COLUMN = "admission_generation"
+
+
+def _columns(bind) -> set[str]:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN in _columns(bind):
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                _COLUMN,
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN not in _columns(bind):
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column(_COLUMN)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2104,6 +2104,12 @@ class HttpBridgeRetryCircuit(Base):
     )
     last_detail: Mapped[str | None] = mapped_column(String(255), nullable=True)
     updated_at_epoch: Mapped[float] = mapped_column(Float, nullable=False)
+    admission_generation: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text("0"),
+    )
 
 
 _PRIMARY_WINDOW_INDEX_EXPR = func.coalesce(UsageHistory.window, literal_column("'primary'"))

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -677,15 +677,16 @@ def _normalize_http_bridge_error_event(
                     error_message_value = stripped
             param_value = payload_error.get("param")
             if isinstance(param_value, str):
-                stripped = param_value.strip()
-                if stripped:
-                    error_param_value = stripped
+                error_param_value = param_value.strip()
 
     if isinstance(payload, dict):
         raw_error = payload.get("error")
         if not isinstance(raw_error, dict):
             raw_error = _websocket_top_level_error_payload(payload)
         if isinstance(raw_error, dict):
+            if "param" in raw_error:
+                raw_param = raw_error.get("param")
+                error_param_value = raw_param.strip() if isinstance(raw_param, str) else ""
             plan_type = raw_error.get("plan_type")
             if isinstance(plan_type, str):
                 rate_limit_metadata["plan_type"] = plan_type
@@ -2795,7 +2796,32 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
             "server_indefinite_recovery",
         }
     param_value = error.get("param")
-    param = param_value.strip() if isinstance(param_value, str) and param_value.strip() else None
+    if "param" in error and not isinstance(param_value, str):
+        return False
+    param = param_value.strip() if isinstance(param_value, str) else None
+    message_value = error.get("message")
+    message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else None
+    return _is_previous_response_not_found_error(code=code, param=param, message=message)
+
+
+def _http_bridge_is_explicit_previous_response_rejection(exc: ProxyResponseError) -> bool:
+    payload = exc.payload
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return False
+    code_value = error.get("code")
+    raw_code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else None
+    type_value = error.get("type")
+    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else None
+    code = _normalize_error_code(raw_code, error_type)
+    if code == "bridge_previous_response_not_found":
+        return True
+    param_value = error.get("param")
+    if "param" in error and not isinstance(param_value, str):
+        return False
+    param = param_value.strip() if isinstance(param_value, str) else None
     message_value = error.get("message")
     message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else None
     return _is_previous_response_not_found_error(code=code, param=param, message=message)
@@ -3131,6 +3157,7 @@ for _helper_name in (
     "_http_bridge_continuity_lost_error_envelope",
     "_http_bridge_owner_lookup_unavailable_error_envelope",
     "_http_bridge_should_attempt_local_previous_response_recovery",
+    "_http_bridge_is_explicit_previous_response_rejection",
     "_http_bridge_is_previous_response_owner_unavailable",
     "_http_bridge_should_attempt_soft_affinity_reroute",
     "_http_bridge_is_context_overflow_error",

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -543,6 +543,7 @@ class _HTTPBridgeMixin(
             preserve_internal_fork_key = key.affinity_kind in {
                 "internal_unanchored_parallel",
                 "internal_model_parallel",
+                "internal_request_parallel",
             }
             require_preferred_account = preferred_account_id is not None and (
                 previous_response_id is not None

--- a/app/modules/proxy/_service/http_bridge/quarantine.py
+++ b/app/modules/proxy/_service/http_bridge/quarantine.py
@@ -39,6 +39,7 @@ _HTTP_BRIDGE_QUARANTINE_REPEATED_EVENTLESS_REASON = "repeated_eventless_timeout"
 
 @dataclass(slots=True)
 class _HTTPBridgeQuarantineEntry:
+    generation: int = 0
     quarantined_until: float = 0.0
     consecutive_eventless_timeouts: int = 0
     last_touched_monotonic: float = 0.0
@@ -100,6 +101,17 @@ def _http_bridge_session_key_quarantined(service: Any, key: _HTTPBridgeSessionKe
     return entry is not None and entry.quarantined_until > now
 
 
+def _http_bridge_quarantine_generation(service: Any, key: _HTTPBridgeSessionKey) -> int | None:
+    """Return the active quarantine generation observed for one recovery."""
+    registry = _http_bridge_quarantine_registry(service)
+    now = time.monotonic()
+    _prune_http_bridge_quarantine_registry(registry, now)
+    entry = registry.get(key)
+    if entry is None or entry.quarantined_until <= now:
+        return None
+    return entry.generation
+
+
 def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *, reason: str) -> None:
     """Quarantine a bridge session that has proven silent/wedged.
 
@@ -110,6 +122,7 @@ def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *
     registry = _http_bridge_quarantine_registry(service)
     entry = registry.setdefault(session.key, _HTTPBridgeQuarantineEntry())
     already_quarantined = entry.quarantined_until > now
+    entry.generation += 1
     entry.quarantined_until = max(entry.quarantined_until, now + _HTTP_BRIDGE_QUARANTINE_TTL_SECONDS)
     entry.last_touched_monotonic = now
     entry.reason = reason
@@ -169,21 +182,35 @@ def _record_http_bridge_quarantine_eventless_timeout(service: Any, session: _HTT
     )
 
 
-def _clear_http_bridge_quarantine(service: Any, session: _HTTPBridgeSession) -> None:
-    """A completed response on this key disproves the wedge; drop all state."""
+def _clear_http_bridge_quarantine(
+    service: Any,
+    session: _HTTPBridgeSession,
+    *,
+    additional_key: _HTTPBridgeSessionKey | None = None,
+    additional_key_generation: int | None = None,
+) -> None:
+    """A completed response disproves the current and recovery-origin wedges."""
     registry = _http_bridge_quarantine_registry(service)
     session.quarantined = False
-    entry = registry.pop(session.key, None)
-    if entry is None:
-        return
-    if entry.quarantined_until <= time.monotonic():
-        return
-    _log_http_bridge_event(
-        "session_quarantine_cleared",
-        session.key,
-        account_id=session.account.id,
-        model=session.request_model,
-        detail=f"reason={entry.reason}",
-        cache_key_family=session.key.affinity_kind,
-        model_class=_extract_model_class(session.request_model) if session.request_model else None,
-    )
+    keys = (session.key,) if additional_key is None or additional_key == session.key else (session.key, additional_key)
+    for key in keys:
+        entry = registry.pop(key, None)
+        if (
+            key == additional_key
+            and key != session.key
+            and (additional_key_generation is None or entry is None or entry.generation != additional_key_generation)
+        ):
+            if entry is not None:
+                registry[key] = entry
+            continue
+        if entry is None or entry.quarantined_until <= time.monotonic():
+            continue
+        _log_http_bridge_event(
+            "session_quarantine_cleared",
+            key,
+            account_id=session.account.id,
+            model=session.request_model,
+            detail=f"reason={entry.reason}",
+            cache_key_family=key.affinity_kind,
+            model_class=_extract_model_class(session.request_model) if session.request_model else None,
+        )

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -939,12 +939,12 @@ class _HTTPBridgeRequestSubmitMixin:
             and request_state.response_event_count == 0
             and request_state.replay_count == 0
         )
-        allow_server_anchored_replay = _http_bridge_server_anchored_replay_enabled(request_state)
-        if not await self._http_bridge_precreated_retry_allowed(
+        retry_allowed = await self._http_bridge_precreated_retry_allowed(
             session,
-            allow_proof_gated_continuity_replay=allow_proof_gated_continuity_replay or allow_server_anchored_replay,
+            allow_proof_gated_continuity_replay=allow_proof_gated_continuity_replay,
             allow_operation_fenced_continuity_replay=allow_operation_fenced_continuity_replay,
-        ):
+        )
+        if not retry_allowed:
             retry_after_seconds = max(
                 1,
                 math.ceil(await self._http_bridge_precreated_retry_cooldown_seconds(session)),
@@ -1293,7 +1293,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         "The recovery checkpoint was already consumed; retry the request.",
                     ),
                 )
-            if not operation.created:
+            if not operation.created and not getattr(operation, "rebound", False):
                 if operation.state in {"completed", "incomplete"}:
                     if getattr(operation, "event_spool_complete", False):
                         get_operation_events = getattr(self._durable_bridge, "get_operation_events", None)
@@ -1414,6 +1414,13 @@ class _HTTPBridgeRequestSubmitMixin:
             request_state.operation_registered = True
             request_state.operation_rebind_required = False
             request_state.operation_created = operation.created
+            request_state.operation_rebound = getattr(operation, "rebound", False)
+            request_state.operation_rebound_from_session_id = getattr(operation, "rebound_from_session_id", None)
+            request_state.operation_rebound_from_account_id = getattr(operation, "rebound_from_account_id", None)
+            request_state.operation_rebound_from_model = getattr(operation, "rebound_from_model", None)
+            request_state.operation_rebound_from_parent_response_id = getattr(
+                operation, "rebound_from_parent_response_id", None
+            )
             request_state.operation_persisted_response_id = (
                 None if request_state.operation_recovery_claimed else getattr(operation, "response_id", None)
             )
@@ -1422,7 +1429,9 @@ class _HTTPBridgeRequestSubmitMixin:
 
         async def _cleanup_unsubmitted_recovery_claim() -> None:
             if (
-                not request_state.operation_recovery_claimed and not request_state.operation_created
+                not request_state.operation_recovery_claimed
+                and not request_state.operation_created
+                and not request_state.operation_rebound
             ) or request_state.operation_dispatched:
                 return
             await self._cleanup_http_bridge_submit_interruption(
@@ -1886,6 +1895,48 @@ class _HTTPBridgeRequestSubmitMixin:
                                     "bridge_continuity_persistence_failed",
                                     "The recovery checkpoint was consumed before dispatch; retry the request.",
                                 ),
+                            )
+                    if (
+                        request_state.verified_stale_anchor_replay
+                        and request_state.verified_stale_anchor_retry_circuit_generation_captured
+                    ):
+                        circuit_key = request_state.verified_stale_anchor_retry_circuit_key
+                        generation_claimed = bool(
+                            circuit_key is not None
+                            and await self._claim_http_bridge_retry_circuit_generation(
+                                key=circuit_key,
+                                captured=request_state.verified_stale_anchor_retry_circuit_generation_captured,
+                                generation=request_state.verified_stale_anchor_retry_circuit_generation,
+                            )
+                        )
+                        if not generation_claimed:
+                            suppressed_retry_after_seconds = max(
+                                1,
+                                math.ceil(
+                                    await self._http_bridge_retry_circuit_cooldown_seconds_for_key(
+                                        circuit_key or session.key,
+                                    )
+                                ),
+                            )
+                            _log_http_bridge_event(
+                                "stale_anchor_replay_generation_suppressed",
+                                circuit_key or session.key,
+                                account_id=session.account.id,
+                                model=session.request_model,
+                                detail="circuit_generation_advanced_before_dispatch_claim",
+                                cache_key_family=(circuit_key or session.key).affinity_kind,
+                                model_class=(
+                                    _extract_model_class(session.request_model) if session.request_model else None
+                                ),
+                            )
+                            raise ProxyResponseError(
+                                503,
+                                openai_error(
+                                    "upstream_request_timeout",
+                                    "HTTP responses session bridge is cooling down after repeated upstream "
+                                    "timeouts; retry shortly.",
+                                ),
+                                retry_after_seconds=suppressed_retry_after_seconds,
                             )
                     async with session.pending_lock:
                         session.pending_requests.append(request_state)
@@ -2409,7 +2460,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 request_state.operation_fingerprint = None
                 request_state.operation_parent_response_id = None
         elif (
-            request_state.operation_created
+            (request_state.operation_created or request_state.operation_rebound)
             and request_state.operation_registered
             and request_state.operation_id is not None
             and not request_state.operation_dispatched
@@ -2419,7 +2470,15 @@ class _HTTPBridgeRequestSubmitMixin:
             rollback_operation = getattr(self._durable_bridge, "rollback_operation_before_dispatch", None)
             if callable(rollback_operation):
                 try:
-                    rolled_back = await rollback_operation(
+                    rolled_back = await _call_with_supported_optional_kwargs(
+                        rollback_operation,
+                        optional_kwargs={
+                            "restore_rebound": request_state.operation_rebound,
+                            "rebound_from_session_id": request_state.operation_rebound_from_session_id,
+                            "rebound_from_account_id": request_state.operation_rebound_from_account_id,
+                            "rebound_from_model": request_state.operation_rebound_from_model,
+                            "rebound_from_parent_response_id": request_state.operation_rebound_from_parent_response_id,
+                        },
                         operation_id=request_state.operation_id,
                         session_id=session.durable_session_id,
                         instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
@@ -2435,9 +2494,16 @@ class _HTTPBridgeRequestSubmitMixin:
                 if rolled_back:
                     request_state.operation_registered = False
                     request_state.operation_created = False
-                    request_state.operation_id = None
-                    request_state.operation_fingerprint = None
-                    request_state.operation_parent_response_id = None
+                    if request_state.operation_rebound:
+                        # The failed durable row was restored rather than
+                        # deleted. Preserve its identity so a capacity/gate
+                        # retry must rebind that exact fence before send.
+                        request_state.operation_rebind_required = True
+                        request_state.operation_rebound = False
+                    else:
+                        request_state.operation_id = None
+                        request_state.operation_fingerprint = None
+                        request_state.operation_parent_response_id = None
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
         if request_state.response_create_gate is not None:
             if gate_acquired or request_state.response_create_gate_acquired:
@@ -3006,10 +3072,25 @@ class _HTTPBridgeRequestSubmitMixin:
         )
 
         def request_is_retryable(request_state: _WebSocketRequestState) -> bool:
+            transport_only_unanchored_replay = bool(
+                request_state.precreated_replay_reason is None
+                and (
+                    request_state.verified_stale_anchor_replay
+                    or (
+                        request_state.previous_response_id is not None
+                        and not request_state.proxy_injected_previous_response_id
+                        and request_state.fresh_upstream_request_is_retry_safe
+                        and request_state.fresh_upstream_request_text
+                    )
+                )
+            )
+            if transport_only_unanchored_replay:
+                return False
             if _websocket_request_can_replay_before_visible_output(request_state):
                 return True
             if (
                 clean_close_retry_max_count <= 0
+                or request_state.verified_stale_anchor_replay
                 or request_state.replay_count != 1
                 or request_state.response_event_count != 0
                 or request_state.clean_close_replay_count >= clean_close_retry_max_count
@@ -3027,7 +3108,6 @@ class _HTTPBridgeRequestSubmitMixin:
 
         fresh_hard_request_account_switch_candidate = False
         proof_gated_continuity_replay_candidate = False
-        server_anchored_replay_candidate = False
         if session.key.strength == "hard":
             async with session.pending_lock:
                 retryable_candidates = [
@@ -3052,13 +3132,10 @@ class _HTTPBridgeRequestSubmitMixin:
                         and candidate.response_event_count == 0
                         and candidate.replay_count == 0
                     )
-                    server_anchored_replay_candidate = _http_bridge_server_anchored_replay_enabled(candidate)
         if not await self._http_bridge_precreated_retry_allowed(
             session,
             allow_fresh_hard_account_switch=fresh_hard_request_account_switch_candidate,
-            allow_proof_gated_continuity_replay=(
-                proof_gated_continuity_replay_candidate or server_anchored_replay_candidate
-            ),
+            allow_proof_gated_continuity_replay=proof_gated_continuity_replay_candidate,
         ):
             return False
 

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeResponseCreateAttempt,
     _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
+    _HTTPBridgeSessionKey,
 )
 from app.modules.proxy.durable_bridge_repository import DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS
 
@@ -23,6 +25,7 @@ _HTTP_BRIDGE_RETRY_CIRCUIT_BASE_BACKOFF_SECONDS = 60.0
 _HTTP_BRIDGE_RETRY_CIRCUIT_MAX_BACKOFF_SECONDS = 600.0
 _HTTP_BRIDGE_RETRY_CIRCUIT_CLEAN_CLOSE_MAX_BACKOFF_SECONDS = 30.0
 _HTTP_BRIDGE_RETRY_CIRCUIT_HALF_OPEN_LEASE_SECONDS = 600.0
+_HTTP_BRIDGE_RETRY_CIRCUIT_CLAIM_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_DETAILS = frozenset(
     {
         "stream_incomplete",
@@ -100,6 +103,134 @@ def _record_http_bridge_retry_circuit_duplicate_suppressed(
 
 
 class _HTTPBridgeRetryCircuitMixin:
+    async def _http_bridge_retry_circuit_generation(
+        self: Any,
+        session: _HTTPBridgeSession,
+    ) -> tuple[bool, tuple[int, float, int, float, int, float, float] | None]:
+        return await self._http_bridge_retry_circuit_generation_for_key(session.key)
+
+    async def _http_bridge_retry_circuit_generation_for_key(
+        self: Any,
+        key: _HTTPBridgeSessionKey,
+    ) -> tuple[bool, tuple[int, float, int, float, int, float, float] | None]:
+        try:
+            persisted = await self._durable_bridge.lookup_retry_circuit(
+                session_key_kind=key.affinity_kind,
+                session_key_value=key.affinity_key,
+                api_key_id=key.api_key_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to inspect HTTP bridge retry circuit generation bridge_kind=%s bridge_key=%s",
+                key.affinity_kind,
+                _hash_identifier(key.affinity_key),
+                exc_info=True,
+            )
+            return False, None
+        async with self._http_bridge_retry_circuit_lock:
+            state = self._http_bridge_retry_circuits.get(key)
+            if state is None and persisted is None:
+                return True, None
+            persisted_updated_at_epoch = max(
+                state.persisted_updated_at_epoch if state is not None else 0.0,
+                persisted.updated_at_epoch if persisted is not None else 0.0,
+            )
+            persisted_consecutive_failures = persisted.consecutive_failures if persisted is not None else 0
+            durable_cooldown_until_epoch = persisted.cooldown_until_epoch if persisted is not None else 0.0
+            local_consecutive_failures = state.consecutive_failures if state is not None else 0
+            last_failure_monotonic = state.last_failure_monotonic if state is not None else 0.0
+            local_cooldown_until = state.cooldown_until if state is not None else 0.0
+            return True, (
+                getattr(persisted, "admission_generation", 0) if persisted is not None else 0,
+                persisted_updated_at_epoch,
+                persisted_consecutive_failures,
+                durable_cooldown_until_epoch,
+                local_consecutive_failures,
+                last_failure_monotonic,
+                local_cooldown_until,
+            )
+
+    async def _http_bridge_retry_circuit_generation_is_not_newer(
+        self: Any,
+        *,
+        key: _HTTPBridgeSessionKey,
+        captured: bool,
+        generation: tuple[int, float, int, float, int, float, float] | None,
+    ) -> bool:
+        if not captured:
+            return False
+        load_succeeded, current_generation = await self._http_bridge_retry_circuit_generation_for_key(key)
+        if not load_succeeded:
+            return False
+        if generation is None:
+            return current_generation is None
+        if current_generation is None:
+            return True
+        return all(
+            current <= captured_value for current, captured_value in zip(current_generation, generation, strict=True)
+        )
+
+    async def _claim_http_bridge_retry_circuit_generation(
+        self: Any,
+        *,
+        key: _HTTPBridgeSessionKey,
+        captured: bool,
+        generation: tuple[int, float, int, float, int, float, float] | None,
+    ) -> bool:
+        """Atomically linearize replay admission against the captured circuit."""
+        if not captured:
+            return False
+        expected_admission_generation = generation[0] if generation is not None else 0
+        expected_persisted_updated_at = generation[1] if generation is not None else 0.0
+        expected_persisted_failures = generation[2] if generation is not None else 0
+        expected_persisted_cooldown = generation[3] if generation is not None else 0.0
+        expected_local_failures = generation[4] if generation is not None else 0
+        expected_last_failure = generation[5] if generation is not None else 0.0
+        expected_local_cooldown = generation[6] if generation is not None else 0.0
+        claim_generation = getattr(self._durable_bridge, "claim_retry_circuit_generation", None)
+        if not callable(claim_generation):
+            return False
+
+        # Keep local failure recording behind the same lock until the durable
+        # CAS commits. Cross-replica failures serialize at the row CAS; local
+        # failures serialize here before they can mutate their in-memory base.
+        async with self._http_bridge_retry_circuit_lock:
+            state = self._http_bridge_retry_circuits.get(key)
+            if state is not None and (
+                state.consecutive_failures > expected_local_failures
+                or state.last_failure_monotonic > expected_last_failure
+                or state.cooldown_until > expected_local_cooldown
+            ):
+                return False
+            try:
+                claimed = await asyncio.wait_for(
+                    claim_generation(
+                        session_key_kind=key.affinity_kind,
+                        session_key_value=key.affinity_key,
+                        api_key_id=key.api_key_id,
+                        expected_updated_at_epoch=(
+                            expected_persisted_updated_at if expected_persisted_updated_at > 0 else None
+                        ),
+                        expected_admission_generation=expected_admission_generation,
+                        expected_consecutive_failures=expected_persisted_failures,
+                        expected_cooldown_until_epoch=expected_persisted_cooldown,
+                    ),
+                    timeout=_HTTP_BRIDGE_RETRY_CIRCUIT_CLAIM_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to claim HTTP bridge retry circuit generation bridge_kind=%s bridge_key=%s",
+                    key.affinity_kind,
+                    _hash_identifier(key.affinity_key),
+                    exc_info=True,
+                )
+                return False
+            if claimed is None:
+                return False
+            self._http_bridge_retry_circuit_loaded_keys.add(key)
+            self._http_bridge_retry_circuit_persisted_keys.add(key)
+            return True
+
     async def _http_bridge_retry_circuit_current_count(self: Any, session: _HTTPBridgeSession) -> int:
         async with self._http_bridge_retry_circuit_lock:
             current_state = self._http_bridge_retry_circuits.get(session.key)
@@ -458,6 +589,20 @@ class _HTTPBridgeRetryCircuitMixin:
             if state is None:
                 return 0.0
             return max(0.0, state.cooldown_until - now)
+
+    async def _http_bridge_retry_circuit_cooldown_seconds_for_key(
+        self: Any,
+        key: _HTTPBridgeSessionKey,
+    ) -> float:
+        """Return the source-key cooldown used to suppress a replacement."""
+        load_succeeded, generation = await self._http_bridge_retry_circuit_generation_for_key(key)
+        if not load_succeeded or generation is None:
+            return 0.0
+        return max(
+            0.0,
+            generation[3] - time.time(),
+            generation[6] - time.monotonic(),
+        )
 
     async def _record_http_bridge_retry_circuit_failure(
         self: Any,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -76,6 +76,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_durable_lease_ttl_seconds,
     _http_bridge_durable_lookup_allows_turn_state_takeover,
     _http_bridge_is_context_overflow_error,
+    _http_bridge_is_explicit_previous_response_rejection,
     _http_bridge_is_previous_response_owner_unavailable,
     _http_bridge_models_compatible,
     _http_bridge_owner_lookup_unavailable_error_envelope,
@@ -109,6 +110,7 @@ from app.modules.proxy._service.http_bridge.owner_forwarding import (
     _owner_forward_failure_allows_local_recovery,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
+    _http_bridge_quarantine_generation,
     _http_bridge_session_key_quarantined,
 )
 from app.modules.proxy._service.http_bridge.service_stubs import (
@@ -231,6 +233,7 @@ from app.modules.proxy.helpers import (
     _normalize_error_code,
 )
 from app.modules.proxy.replay_safety import (
+    AccountNeutralReplayProjection,
     project_responses_input_for_account_neutral_fresh_replay,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
@@ -255,6 +258,19 @@ def _http_bridge_continuity_bound_without_safe_replay(request_state: _WebSocketR
 def _http_bridge_durable_recovery_predecessor_proven(request_state: _WebSocketRequestState) -> bool:
     """Return whether the operation has a durable predecessor anchor."""
     return request_state.previous_response_id is not None or request_state.operation_parent_response_id is not None
+
+
+def _http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+    session: _HTTPBridgeSession,
+    request_state: _WebSocketRequestState,
+) -> bool:
+    """Return whether anchor removal can preserve durable single settlement."""
+    return bool(
+        request_state.operation_registered
+        and request_state.operation_id is not None
+        and session.durable_session_id is not None
+        and session.durable_owner_epoch is not None
+    )
 
 
 class _VerifiedDurableFullResend:
@@ -1335,13 +1351,7 @@ class _HTTPBridgeStreamingMixin:
         durable_full_resend_fresh_payload: ResponsesRequest | None = None
         durable_full_resend_is_account_neutral: bool | None = None
         durable_full_resend_has_safe_fresh_context = False
-        durable_full_resend_retains_prior_output = False
-        durable_recovery_attempt_fingerprint: str | None = None
-        durable_recovery_attempt_available = False
-        durable_recovery_attempt_claimed = False
-        durable_recovery_attempt_session_id: str | None = None
-        durable_recovery_attempt_owner_epoch: int | None = None
-        durable_recovery_fresh_replay = False
+        durable_full_resend_retains_required_context_cache: bool | None = None
         durable_full_resend_proof = _verify_durable_full_resend(payload, durable_lookup)
         durable_full_resend_fresh_bridge_proof: _VerifiedDurableFullResend | None = None
         force_local_recovery_creation = False
@@ -1352,6 +1362,24 @@ class _HTTPBridgeStreamingMixin:
         # dispatch genuinely goes unanchored instead of rebuilding the same
         # wedged reattach through the session-state side door.
         fresh_reattach_anchor_suppressed_quarantined = False
+
+        def replay_projection_retains_required_context(
+            replay_projection: AccountNeutralReplayProjection,
+            lookup: DurableBridgeLookup,
+        ) -> bool:
+            return responses_input_suffix_retains_prior_output(
+                replay_projection.input_items,
+                stored_count=replay_projection.stored_prefix_count,
+                canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
+            ) or (
+                lookup.latest_pending_tool_calls is not None
+                and responses_input_suffix_matches_pending_tool_calls(
+                    replay_projection.input_items,
+                    stored_count=replay_projection.stored_prefix_count,
+                    pending_tool_calls=lookup.latest_pending_tool_calls,
+                    canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
+                )
+            )
 
         def classify_durable_full_resend(
             lookup: DurableBridgeLookup,
@@ -1379,19 +1407,7 @@ class _HTTPBridgeStreamingMixin:
             )
             safe_fresh_context = False
             if replay_projection is not None:
-                safe_fresh_context = responses_input_suffix_retains_prior_output(
-                    replay_projection.input_items,
-                    stored_count=replay_projection.stored_prefix_count,
-                    canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-                ) or (
-                    lookup.latest_pending_tool_calls is not None
-                    and responses_input_suffix_matches_pending_tool_calls(
-                        replay_projection.input_items,
-                        stored_count=replay_projection.stored_prefix_count,
-                        pending_tool_calls=lookup.latest_pending_tool_calls,
-                        canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-                    )
-                )
+                safe_fresh_context = replay_projection_retains_required_context(replay_projection, lookup)
             return stored_count, lookup.latest_input_full_fingerprint, safe_fresh_context
 
         if durable_lookup is not None:
@@ -1405,29 +1421,25 @@ class _HTTPBridgeStreamingMixin:
             and durable_full_resend_anchor_count is not None
             and isinstance(payload.input, list)
         ):
+            durable_full_resend_retains_required_context_cache = durable_full_resend_has_safe_fresh_context
             replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                 cast(list[JsonValue], payload.input),
                 stored_count=durable_full_resend_anchor_count,
             )
             if replay_projection is not None:
-                durable_full_resend_retains_prior_output = responses_input_suffix_retains_prior_output(
-                    replay_projection.input_items,
-                    stored_count=replay_projection.stored_prefix_count,
-                    canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-                )
                 durable_full_resend_fresh_payload = _http_bridge_payload_without_previous_response_id(
                     payload
                 ).model_copy(update={"input": replay_projection.input_items})
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
                 )
-                _fresh_state, fresh_replay_text = prepare_bridge_request(
-                    _http_bridge_payload_without_previous_response_id(payload)
-                )
-                del _fresh_state
-                durable_recovery_attempt_fingerprint = durable_bridge_hash(fresh_replay_text)
-                if durable_lookup is not None and durable_full_resend_is_account_neutral:
+                if durable_lookup is not None:
                     try:
+                        _fresh_state, fresh_replay_text = prepare_bridge_request(
+                            _http_bridge_payload_without_previous_response_id(payload)
+                        )
+                        del _fresh_state
+                        durable_recovery_attempt_fingerprint = durable_bridge_hash(fresh_replay_text)
                         existing_attempt = await self._durable_bridge.lookup_recovery_attempt(
                             session_id=durable_lookup.session_id,
                             request_fingerprint=durable_recovery_attempt_fingerprint,
@@ -1436,68 +1448,18 @@ class _HTTPBridgeStreamingMixin:
                             durable_lookup.state != HttpBridgeSessionState.ACTIVE
                             or not durable_lookup.lease_is_active(now=utcnow())
                         ):
-                            claim_instance_id = _service_get_settings().http_responses_session_bridge_instance_id
-                            claim_owner_epoch = durable_lookup.owner_epoch
-                            owner_is_current = (
-                                durable_lookup.owner_instance_id == claim_instance_id
-                                and durable_lookup.lease_is_active(now=utcnow())
+                            raise ProxyResponseError(
+                                502,
+                                openai_error(
+                                    "bridge_continuity_persistence_failed",
+                                    "A prior HTTP response outcome is ambiguous; retry after its recovery "
+                                    "state settles.",
+                                ),
                             )
-                            if not owner_is_current:
-                                claimed_session = await self._durable_bridge.claim_live_session(
-                                    session_key_kind=durable_lookup.canonical_kind,
-                                    session_key_value=durable_lookup.canonical_key,
-                                    api_key_id=bridge_session_key.api_key_id,
-                                    instance_id=claim_instance_id,
-                                    lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
-                                    account_id=durable_lookup.account_id,
-                                    model=payload.model,
-                                    service_tier=None,
-                                    latest_turn_state=durable_lookup.latest_turn_state,
-                                    latest_response_id=None,
-                                    owner_process_epoch=http_bridge_owner_process_epoch(),
-                                    # Revalidate the stale lookup under the
-                                    # row lock; an active owner that appeared
-                                    # after the lookup must not be displaced.
-                                    allow_takeover=False,
-                                )
-                                if claimed_session.owner_instance_id != claim_instance_id:
-                                    raise ProxyResponseError(
-                                        502,
-                                        openai_error(
-                                            "bridge_continuity_persistence_failed",
-                                            "HTTP responses recovery ownership changed; retry the request.",
-                                        ),
-                                    )
-                                claim_owner_epoch = claimed_session.owner_epoch
-                            claimed = await self._durable_bridge.mark_recovery_attempt_replayed(
-                                session_id=durable_lookup.session_id,
-                                api_key_id=bridge_session_key.api_key_id,
-                                instance_id=claim_instance_id,
-                                owner_epoch=claim_owner_epoch,
-                                request_fingerprint=durable_recovery_attempt_fingerprint,
-                            )
-                            if not claimed:
-                                raise ProxyResponseError(
-                                    502,
-                                    openai_error(
-                                        "bridge_continuity_persistence_failed",
-                                        "HTTP responses recovery ownership changed; retry the request.",
-                                    ),
-                                )
-                            durable_recovery_attempt_claimed = True
-                            durable_recovery_attempt_available = False
-                            durable_recovery_attempt_session_id = durable_lookup.session_id
-                            durable_recovery_attempt_owner_epoch = claim_owner_epoch
-                        elif existing_attempt is None:
-                            # No prior attempt owns this fingerprint. The
-                            # request-submit path will journal it immediately
-                            # before dispatch, and an ambiguous transport
-                            # outcome may then consume the one replay fence.
-                            durable_recovery_attempt_available = True
                     except ProxyResponseError:
                         raise
                     except Exception:
-                        logger.warning("Failed to claim HTTP bridge recovery attempt", exc_info=True)
+                        logger.warning("Failed to inspect HTTP bridge recovery attempt", exc_info=True)
                         raise ProxyResponseError(
                             502,
                             openai_error(
@@ -1853,36 +1815,43 @@ class _HTTPBridgeStreamingMixin:
         )
         fresh_replay_excluded_account_ids: set[str] = set()
         unanchored_fork_spill_attempted = False
+        verified_stale_anchor_generation_captured = False
+        verified_stale_anchor_circuit_key: _HTTPBridgeSessionKey | None = None
+        verified_stale_anchor_generation: tuple[int, float, int, float, int, float, float] | None = None
+        verified_stale_anchor_quarantine_generation: int | None = None
 
-        def durable_full_resend_allows_account_neutral_replay() -> bool:
-            nonlocal durable_full_resend_fresh_payload
-            nonlocal durable_full_resend_is_account_neutral
-            nonlocal durable_full_resend_retains_prior_output
+        def durable_full_resend_retains_required_context() -> bool:
+            nonlocal durable_full_resend_retains_required_context_cache
 
             if (
-                forwarded_request
-                or rewritten_file_account_id is not None
-                or durable_full_resend_anchor_count is None
+                durable_full_resend_anchor_count is None
                 or durable_full_resend_anchor_fingerprint is None
+                or not isinstance(payload.input, list)
             ):
                 return False
-            if durable_full_resend_fresh_payload is None:
-                if not isinstance(payload.input, list):
-                    return False
+            if durable_full_resend_retains_required_context_cache is None:
                 eligibility_projection = project_responses_input_for_account_neutral_fresh_replay(
                     cast(list[JsonValue], payload.input),
                     stored_count=durable_full_resend_anchor_count,
                     preserve_developer_message_ids=True,
                 )
-                if eligibility_projection is None:
+                if eligibility_projection is None or durable_lookup is None:
                     return False
-                durable_full_resend_retains_prior_output = responses_input_suffix_retains_prior_output(
-                    eligibility_projection.input_items,
-                    stored_count=eligibility_projection.stored_prefix_count,
-                    canonical_lite_developer_index=eligibility_projection.canonical_lite_developer_index,
+                durable_full_resend_retains_required_context_cache = replay_projection_retains_required_context(
+                    eligibility_projection,
+                    durable_lookup,
                 )
-                if not durable_full_resend_retains_prior_output:
-                    return False
+            return bool(durable_full_resend_retains_required_context_cache)
+
+        def durable_full_resend_allows_account_neutral_replay() -> bool:
+            nonlocal durable_full_resend_fresh_payload
+            nonlocal durable_full_resend_is_account_neutral
+
+            if rewritten_file_account_id is not None or not durable_full_resend_retains_required_context():
+                return False
+            if durable_full_resend_fresh_payload is None:
+                assert isinstance(payload.input, list)
+                assert durable_full_resend_anchor_count is not None
                 replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                     cast(list[JsonValue], payload.input),
                     stored_count=durable_full_resend_anchor_count,
@@ -1892,8 +1861,6 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_fresh_payload = _http_bridge_payload_without_previous_response_id(
                     payload
                 ).model_copy(update={"input": replay_projection.input_items})
-            if not durable_full_resend_retains_prior_output:
-                return False
             if durable_full_resend_is_account_neutral is None:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
@@ -1906,7 +1873,12 @@ class _HTTPBridgeStreamingMixin:
                 and durable_full_resend_allows_account_neutral_replay()
             )
 
-        def switch_to_account_neutral_replay() -> None:
+        def switch_to_account_neutral_replay(
+            *,
+            event: str = "owner_unavailable_fresh_resend",
+            detail: str = "outcome=projected_plaintext_full_resend_without_anchor",
+            preserve_operation: bool = False,
+        ) -> None:
             nonlocal account_neutral_recovery
             nonlocal affinity
             nonlocal bridge_session_key
@@ -1932,7 +1904,7 @@ class _HTTPBridgeStreamingMixin:
             nonlocal text_data
             nonlocal untrimmed_effective_payload
 
-            preserve_operation_identity = durable_recovery_attempt_claimed or durable_recovery_fresh_replay
+            preserve_operation_identity = preserve_operation
             prior_operation_id = request_state.operation_id if preserve_operation_identity else None
             prior_operation_fingerprint = request_state.operation_fingerprint if preserve_operation_identity else None
             prior_operation_parent_response_id = (
@@ -1949,11 +1921,11 @@ class _HTTPBridgeStreamingMixin:
             )
             failed_owner_id = request_state.preferred_account_id
             _log_http_bridge_event(
-                "owner_unavailable_fresh_resend",
+                event,
                 bridge_session_key,
                 account_id=failed_owner_id,
                 model=payload.model,
-                detail="outcome=projected_plaintext_full_resend_without_anchor",
+                detail=detail,
                 cache_key_family=bridge_session_key.affinity_kind,
                 model_class=_extract_model_class(payload.model) if payload.model else None,
             )
@@ -2007,13 +1979,7 @@ class _HTTPBridgeStreamingMixin:
             dead_owner_process_epoch_mismatch = False
             file_required_preferred_account = False
 
-        if durable_recovery_attempt_claimed:
-            switch_to_account_neutral_replay()
-            request_state.recovery_attempt_fingerprint = durable_recovery_attempt_fingerprint
-            request_state.recovery_attempt_session_id = durable_recovery_attempt_session_id
-            request_state.recovery_attempt_owner_epoch = durable_recovery_attempt_owner_epoch
-            request_state.recovery_attempt_claimed = True
-        elif (
+        if (
             dead_owner_anchor
             and durable_lookup is not None
             and durable_lookup.state == HttpBridgeSessionState.ACTIVE
@@ -2853,43 +2819,84 @@ class _HTTPBridgeStreamingMixin:
         )
         try:
             yielded_any = False
-            durable_recovery_fresh_replay = False
-            retry_request_state: _WebSocketRequestState | None = None
 
-            async def release_recovery_origin_lease() -> None:
-                if durable_recovery_attempt_session_id is None or durable_recovery_attempt_owner_epoch is None:
-                    return
-                try:
-                    await self._durable_bridge.release_live_session(
-                        session_id=durable_recovery_attempt_session_id,
-                        instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
-                        owner_epoch=durable_recovery_attempt_owner_epoch,
-                        draining=False,
-                    )
-                except Exception:
-                    logger.warning("Failed to release HTTP bridge recovery origin lease", exc_info=True)
-
-            async def rollback_pre_dispatch_recovery_claim() -> None:
-                if not (
-                    (durable_recovery_fresh_replay or durable_recovery_attempt_claimed)
-                    and (retry_request_state is None or not retry_request_state.recovery_attempt_dispatched)
-                    and durable_recovery_attempt_fingerprint is not None
-                    and durable_recovery_attempt_session_id is not None
-                    and durable_recovery_attempt_owner_epoch is not None
+            async def reset_previous_response_recovery_operation_spool(
+                recovery_session: "_HTTPBridgeSession",
+                recovery_request_state: _WebSocketRequestState,
+                *,
+                required: bool = True,
+            ) -> None:
+                if not _http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+                    recovery_session,
+                    recovery_request_state,
                 ):
-                    return
-                try:
-                    rolled_back = await self._durable_bridge.rollback_recovery_attempt_replayed(
-                        session_id=durable_recovery_attempt_session_id,
-                        api_key_id=bridge_session_key.api_key_id,
-                        instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
-                        owner_epoch=durable_recovery_attempt_owner_epoch,
-                        request_fingerprint=durable_recovery_attempt_fingerprint,
+                    if not required:
+                        return
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "bridge_continuity_persistence_failed",
+                            "HTTP response recovery operation fence is unavailable; retry the request.",
+                        ),
                     )
-                    if rolled_back:
-                        await release_recovery_origin_lease()
-                except Exception:
-                    logger.warning("Failed to roll back pre-dispatch HTTP bridge recovery claim", exc_info=True)
+                reset_operation_event_spool = getattr(self._durable_bridge, "reset_operation_event_spool", None)
+                if not callable(reset_operation_event_spool):
+                    if not required:
+                        return
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "bridge_continuity_persistence_failed",
+                            "HTTP response recovery spool reset is unavailable; retry the request.",
+                        ),
+                    )
+                assert recovery_request_state.operation_id is not None
+                assert recovery_session.durable_session_id is not None
+                assert recovery_session.durable_owner_epoch is not None
+                reset_ok = await reset_operation_event_spool(
+                    operation_id=recovery_request_state.operation_id,
+                    session_id=recovery_session.durable_session_id,
+                    instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
+                    owner_epoch=recovery_session.durable_owner_epoch,
+                )
+                if not reset_ok:
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "bridge_continuity_persistence_failed",
+                            "HTTP response recovery spool could not be reset; retry the request.",
+                        ),
+                    )
+
+            async def capture_verified_stale_anchor_circuit_generation(
+                recovery_session: "_HTTPBridgeSession",
+            ) -> None:
+                nonlocal verified_stale_anchor_generation
+                nonlocal verified_stale_anchor_generation_captured
+                nonlocal verified_stale_anchor_circuit_key
+
+                load_succeeded, generation = await self._http_bridge_retry_circuit_generation(recovery_session)
+                if not load_succeeded:
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "bridge_continuity_persistence_failed",
+                            "HTTP response recovery circuit generation is unavailable; retry the request.",
+                        ),
+                    )
+                verified_stale_anchor_generation = generation
+                verified_stale_anchor_generation_captured = True
+                verified_stale_anchor_circuit_key = recovery_session.key
+
+            def capture_verified_stale_anchor_quarantine_generation(
+                recovery_session: "_HTTPBridgeSession",
+            ) -> None:
+                nonlocal verified_stale_anchor_quarantine_generation
+
+                verified_stale_anchor_quarantine_generation = _http_bridge_quarantine_generation(
+                    self,
+                    recovery_session.key,
+                )
 
             async for event_block in session_events:
                 yield event_block
@@ -3139,66 +3146,25 @@ class _HTTPBridgeStreamingMixin:
                     except Exception:
                         pass
                 return
-            if (
-                durable_recovery_attempt_available
-                and durable_recovery_attempt_fingerprint is not None
-                and _http_bridge_error_is_ambiguous_transport(exc)
-                and request_state.response_event_count == 0
-                and request_state.previous_response_id is not None
-                and session.durable_session_id is not None
-                and session.durable_owner_epoch is not None
+            explicit_previous_response_rejection = (
+                effective_payload.previous_response_id is not None
+                and _http_bridge_is_explicit_previous_response_rejection(exc)
+            )
+            if explicit_previous_response_rejection and (
+                request_state.replay_count > 0
+                or request_state.response_event_count > 0
+                or request_state.downstream_visible
             ):
-                try:
-                    marked = await self._durable_bridge.mark_recovery_attempt_replayed(
-                        session_id=session.durable_session_id,
-                        api_key_id=bridge_session_key.api_key_id,
-                        instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
-                        owner_epoch=session.durable_owner_epoch,
-                        request_fingerprint=durable_recovery_attempt_fingerprint,
-                    )
-                except Exception:
-                    marked = False
-                    logger.warning("Failed to fence HTTP bridge recovery attempt", exc_info=True)
-                if marked:
-                    durable_recovery_fresh_replay = True
-                    recovery_origin_session_id = request_state.recovery_attempt_session_id or session.durable_session_id
-                    recovery_origin_owner_epoch = (
-                        request_state.recovery_attempt_owner_epoch or session.durable_owner_epoch
-                    )
-                    durable_recovery_attempt_session_id = recovery_origin_session_id
-                    durable_recovery_attempt_owner_epoch = recovery_origin_owner_epoch
-                    _log_http_bridge_event(
-                        "durable_recovery_fresh_replay",
-                        bridge_session_key,
-                        account_id=session.account.id,
-                        model=effective_payload.model,
-                        detail="outcome=new_account_neutral_upstream_session",
-                        cache_key_family=bridge_session_key.affinity_kind,
-                        model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
-                        owner_check_applied=True,
-                    )
-                    await self._reset_http_bridge_session_after_local_terminal_error(
-                        session,
-                        error_code="stream_incomplete",
-                        error_message="Upstream websocket closed before response.completed",
-                        # Keep the origin lease fenced while the replacement
-                        # session is admitted and the one-shot journal is
-                        # either rolled back or settled. Releasing it here
-                        # would make both transitions fail their owner fence.
-                        preserve_durable_lease=True,
-                    )
-                    switch_to_account_neutral_replay()
-                    request_state.recovery_attempt_fingerprint = durable_recovery_attempt_fingerprint
-                    request_state.recovery_attempt_session_id = recovery_origin_session_id
-                    request_state.recovery_attempt_owner_epoch = recovery_origin_owner_epoch
-                    recovery_path = "durable_recovery_fresh_replay"
-                    retry_payload = effective_payload
-                    retry_previous_response_id = None
-                    retry_request_stage = "durable_recovery"
-                    retry_preferred_account_id = None
-                    allow_previous_response_recovery_rebind = False
-                else:
-                    durable_recovery_attempt_available = False
+                raise ProxyResponseError(
+                    502,
+                    openai_error(
+                        "bridge_continuity_persistence_failed",
+                        "A prior HTTP response replay has an ambiguous outcome; retry later.",
+                    ),
+                ) from exc
+            verified_stale_anchor_operation_fenced = _http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+                session, request_state
+            )
             is_context_overflow = _http_bridge_is_context_overflow_error(exc)
             should_rollover_after_context_overflow = _http_bridge_should_rollover_after_context_overflow(
                 exc,
@@ -3207,6 +3173,27 @@ class _HTTPBridgeStreamingMixin:
             should_attempt_previous_response_recovery = (
                 effective_payload.previous_response_id is not None
                 and _http_bridge_should_attempt_local_previous_response_recovery(exc)
+            )
+            previous_response_rejected_same_owner_full_resend = bool(
+                explicit_previous_response_rejection
+                and verified_stale_anchor_operation_fenced
+                and request_state.response_event_count == 0
+                and request_state.replay_count == 0
+                and durable_full_resend_retains_required_context()
+            )
+            previous_response_rejected_full_resend = (
+                explicit_previous_response_rejection
+                and verified_stale_anchor_operation_fenced
+                and request_state.response_event_count == 0
+                and request_state.replay_count == 0
+                and durable_full_resend_allows_account_neutral_replay()
+            )
+            previous_response_rejected_full_resend_without_operation_fence = bool(
+                explicit_previous_response_rejection
+                and not verified_stale_anchor_operation_fenced
+                and request_state.response_event_count == 0
+                and request_state.replay_count == 0
+                and durable_full_resend_retains_required_context()
             )
             should_attempt_context_overflow_fresh_turn_recovery = (
                 is_context_overflow
@@ -3217,7 +3204,6 @@ class _HTTPBridgeStreamingMixin:
                 not should_attempt_previous_response_recovery
                 and not should_rollover_after_context_overflow
                 and not should_attempt_context_overflow_fresh_turn_recovery
-                and not durable_recovery_fresh_replay
             ):
                 if is_context_overflow:
                     _log_http_bridge_event(
@@ -3232,9 +3218,15 @@ class _HTTPBridgeStreamingMixin:
                     )
                 raise
 
-            if durable_recovery_fresh_replay:
-                pass
-            elif should_attempt_context_overflow_fresh_turn_recovery:
+            if previous_response_rejected_full_resend_without_operation_fence:
+                raise ProxyResponseError(
+                    502,
+                    openai_error(
+                        "bridge_continuity_persistence_failed",
+                        "HTTP response recovery operation fence is unavailable; retry the request.",
+                    ),
+                ) from exc
+            if should_attempt_context_overflow_fresh_turn_recovery:
                 if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
                     bridge_durable_recover_total.labels(path="context_overflow_fresh_turn").inc()
                 _log_http_bridge_event(
@@ -3275,6 +3267,68 @@ class _HTTPBridgeStreamingMixin:
                     error_message="Upstream websocket closed before response.completed",
                 )
                 raise
+            elif previous_response_rejected_full_resend:
+                await capture_verified_stale_anchor_circuit_generation(session)
+                capture_verified_stale_anchor_quarantine_generation(session)
+                await reset_previous_response_recovery_operation_spool(session, request_state)
+                await self._reset_http_bridge_session_after_local_terminal_error(
+                    session,
+                    error_code="stream_incomplete",
+                    error_message="Upstream websocket closed before response.completed",
+                )
+                switch_to_account_neutral_replay(
+                    event="previous_response_recover_fresh_resend",
+                    detail="outcome=stale_anchor_rejected_account_neutral_replay",
+                    preserve_operation=True,
+                )
+                recovery_path = "local_previous_response_fresh_replay"
+                retry_payload = effective_payload
+                retry_previous_response_id = None
+                retry_request_stage = "stale_anchor_recover"
+                retry_preferred_account_id = None
+                allow_previous_response_recovery_rebind = False
+            elif previous_response_rejected_same_owner_full_resend:
+                # The owner-pinned replacement does not bypass the source
+                # circuit: its unique internal key avoids that admission path.
+                # Retain the origin key only for independent quarantine cleanup.
+                verified_stale_anchor_circuit_key = session.key
+                capture_verified_stale_anchor_quarantine_generation(session)
+                if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
+                    bridge_durable_recover_total.labels(path="local_previous_response_same_owner_fresh_replay").inc()
+                _log_http_bridge_event(
+                    "previous_response_recover_same_owner_fresh_resend",
+                    bridge_session_key,
+                    account_id=session.account.id,
+                    model=effective_payload.model,
+                    detail="outcome=stale_anchor_rejected_same_owner_unanchored_replay",
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                    owner_check_applied=True,
+                )
+                retry_payload = _http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)
+                retry_injected_input = _http_bridge_interrupted_tool_outputs_input(
+                    session,
+                    payload=retry_payload,
+                    request_id=request_id,
+                )
+                if retry_injected_input is not None:
+                    retry_payload = retry_payload.model_copy(update={"input": retry_injected_input})
+                retry_preferred_account_id = request_state.preferred_account_id or session.account.id
+                bridge_session_key = _HTTPBridgeSessionKey(
+                    "internal_request_parallel",
+                    f"stale-owner-replay:{uuid4().hex}",
+                    bridge_session_key.api_key_id,
+                )
+                await reset_previous_response_recovery_operation_spool(session, request_state)
+                await self._reset_http_bridge_session_after_local_terminal_error(
+                    session,
+                    error_code="stream_incomplete",
+                    error_message="Upstream websocket closed before response.completed",
+                )
+                recovery_path = "local_previous_response_same_owner_fresh_replay"
+                retry_previous_response_id = None
+                retry_request_stage = "stale_anchor_recover"
+                allow_previous_response_recovery_rebind = False
             else:
                 if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
                     bridge_durable_recover_total.labels(path="local_previous_response_error").inc()
@@ -3377,7 +3431,6 @@ class _HTTPBridgeStreamingMixin:
                         continue
                     break
             except BaseException:
-                await rollback_pre_dispatch_recovery_claim()
                 raise
             _record_bridge_reattach(path=recovery_path, outcome="success")
 
@@ -3408,34 +3461,37 @@ class _HTTPBridgeStreamingMixin:
                     retry_payload,
                     reservation=retry_api_key_reservation,
                 )
-                if (
-                    recovery_path == "local_previous_response_error"
-                    and request_state.operation_registered
-                    and request_state.operation_id is not None
-                    and session.durable_session_id is not None
-                    and session.durable_owner_epoch is not None
-                ):
-                    reset_operation_event_spool = getattr(self._durable_bridge, "reset_operation_event_spool", None)
-                    if callable(reset_operation_event_spool):
-                        reset_ok = await reset_operation_event_spool(
-                            operation_id=request_state.operation_id,
-                            session_id=session.durable_session_id,
-                            instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
-                            owner_epoch=session.durable_owner_epoch,
-                        )
-                        if not reset_ok:
-                            raise ProxyResponseError(
-                                502,
-                                openai_error(
-                                    "bridge_continuity_persistence_failed",
-                                    "HTTP response recovery spool could not be reset; retry the request.",
-                                ),
-                            )
+                local_previous_response_recovery = recovery_path in {
+                    "local_previous_response_error",
+                    "local_previous_response_fresh_replay",
+                    "local_previous_response_same_owner_fresh_replay",
+                }
+                if recovery_path == "local_previous_response_error":
+                    await reset_previous_response_recovery_operation_spool(
+                        session,
+                        request_state,
+                        required=False,
+                    )
                 # A recovery request is the one bounded server-side replay;
                 # prevent a second cooldown bypass if this fresh socket also
                 # fails before response.created.
-                if recovery_path == "local_previous_response_error":
+                if local_previous_response_recovery:
                     retry_request_state.replay_count = max(1, request_state.replay_count + 1)
+                retry_request_state.verified_stale_anchor_replay = recovery_path in {
+                    "local_previous_response_fresh_replay",
+                    "local_previous_response_same_owner_fresh_replay",
+                }
+                if retry_request_state.verified_stale_anchor_replay:
+                    retry_request_state.verified_stale_anchor_retry_circuit_generation_captured = (
+                        verified_stale_anchor_generation_captured
+                    )
+                    retry_request_state.verified_stale_anchor_retry_circuit_key = verified_stale_anchor_circuit_key
+                    retry_request_state.verified_stale_anchor_retry_circuit_generation = (
+                        verified_stale_anchor_generation
+                    )
+                    retry_request_state.verified_stale_anchor_quarantine_generation = (
+                        verified_stale_anchor_quarantine_generation
+                    )
                 # Keep the durable operation identity attached to the
                 # server-owned recovery attempt. Re-registering the same
                 # fingerprint would be interpreted as an already-dispatched
@@ -3447,17 +3503,12 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_state.operation_attempt_generation = request_state.operation_attempt_generation
                 retry_request_state.operation_persisted_response_id = request_state.operation_persisted_response_id
                 retry_request_state.operation_rebind_required = request_state.operation_rebind_required
-                if recovery_path == "local_previous_response_error":
+                if local_previous_response_recovery:
                     # The prior response.failed/error made the operation
                     # terminal. Re-enter record_operation so its owner fence
                     # atomically moves it back to submitted before send.
                     retry_request_state.operation_rebind_required = True
                 retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
-                if durable_recovery_fresh_replay and durable_recovery_attempt_fingerprint is not None:
-                    retry_request_state.recovery_attempt_fingerprint = durable_recovery_attempt_fingerprint
-                    retry_request_state.recovery_attempt_session_id = request_state.recovery_attempt_session_id
-                    retry_request_state.recovery_attempt_owner_epoch = request_state.recovery_attempt_owner_epoch
-                    retry_request_state.recovery_attempt_claimed = True
                 _apply_http_bridge_downstream_turn_state(
                     retry_request_state,
                     downstream_turn_state=downstream_turn_state,
@@ -3486,7 +3537,6 @@ class _HTTPBridgeStreamingMixin:
                     except Exception:
                         pass
             except BaseException:
-                await rollback_pre_dispatch_recovery_claim()
                 if retry_reservation_reacquired and retry_api_key_reservation is not None:
                     retry_lifecycle = (
                         retry_request_state.deferred_account_backoff_lifecycle
@@ -3791,6 +3841,7 @@ class _HTTPBridgeStreamingMixin:
             if (
                 session.key.strength != "hard"
                 or not continuity_bound_without_safe_replay()
+                or request_state.verified_stale_anchor_replay
                 or request_state.response_id is not None
                 or request_state.response_event_count > 0
             ):
@@ -3957,6 +4008,7 @@ class _HTTPBridgeStreamingMixin:
             initial_retry_cooldown_seconds > 0
             and session.key.strength == "hard"
             and continuity_bound_without_safe_replay()
+            and not request_state.verified_stale_anchor_replay
             and request_state.response_id is None
             and request_state.response_event_count == 0
             and event_queue.empty()

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -2781,8 +2781,14 @@ class _HTTPBridgeUpstreamEventsMixin:
             and terminal_request_state.request_kind != "prewarm"
             and not terminal_request_state.skip_request_log
         ):
-            await self._clear_http_bridge_retry_circuit(session)
-            _clear_http_bridge_quarantine(self, session)
+            if not terminal_request_state.verified_stale_anchor_replay:
+                await self._clear_http_bridge_retry_circuit(session)
+            _clear_http_bridge_quarantine(
+                self,
+                session,
+                additional_key=terminal_request_state.verified_stale_anchor_retry_circuit_key,
+                additional_key_generation=terminal_request_state.verified_stale_anchor_quarantine_generation,
+            )
 
         normalize_error_event = (
             terminal_request_state is None or terminal_request_state.enforce_openai_sdk_contract

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1019,6 +1019,18 @@ class _WebSocketRequestState:
     # on, and dropping the anchor there would silently turn a continuation into
     # a context-free fresh turn.
     fresh_upstream_request_is_retry_safe: bool = False
+    # Set only on the internally constructed one-shot request that replaces an
+    # explicitly rejected stale anchor with a verified full-history payload.
+    # It may bypass an older hard-key retry circuit without deleting that
+    # circuit or weakening admission for ordinary client retries.
+    verified_stale_anchor_replay: bool = False
+    # Snapshot of the hard-key circuit observed when the stale-anchor replay
+    # was authorized. ``captured=True`` with ``generation=None`` proves that no
+    # circuit existed; a newer local/durable failure must suppress submit.
+    verified_stale_anchor_retry_circuit_generation_captured: bool = False
+    verified_stale_anchor_retry_circuit_key: _HTTPBridgeSessionKey | None = None
+    verified_stale_anchor_retry_circuit_generation: tuple[int, float, int, float, int, float, float] | None = None
+    verified_stale_anchor_quarantine_generation: int | None = None
     # Stable fingerprint used by the durable recovery-attempt journal. It is
     # populated only for a proof-gated fresh replay candidate.
     recovery_attempt_fingerprint: str | None = None
@@ -1049,6 +1061,11 @@ class _WebSocketRequestState:
     # pre-dispatch admission failure may remove that row; an existing row
     # represents an ambiguous upstream attempt and must remain fenced.
     operation_created: bool = False
+    operation_rebound: bool = False
+    operation_rebound_from_session_id: str | None = None
+    operation_rebound_from_account_id: str | None = None
+    operation_rebound_from_model: str | None = None
+    operation_rebound_from_parent_response_id: str | None = None
     operation_replay: bool = False
     operation_dispatched: bool = False
     # Immutable durable attempt generation. Recovery claims increment the
@@ -1727,8 +1744,8 @@ def _openai_error_envelope_from_response_failed_payload(
 
     envelope = openai_error(code, message, error_type)
     param_value = error_payload.get("param")
-    if isinstance(param_value, str) and param_value.strip():
-        envelope["error"]["param"] = param_value.strip()
+    if "param" in error_payload:
+        envelope["error"]["param"] = param_value.strip() if isinstance(param_value, str) else ""
     error_detail = envelope["error"]
     plan_type = error_payload.get("plan_type")
     if plan_type is not None:

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -760,11 +760,15 @@ def _websocket_event_error_param(event_type: str | None, payload: dict[str, Json
     error = _websocket_event_error_payload(event_type, payload)
     if not isinstance(error, dict):
         return None
+    if "param" not in error:
+        return None
     param_value = error.get("param")
     if not isinstance(param_value, str):
-        return None
-    stripped = param_value.strip()
-    return stripped or None
+        # Preserve field presence as a fail-closed, non-matching value. The
+        # upstream classifier must distinguish an absent param from a present
+        # value with the wrong JSON type.
+        return ""
+    return param_value.strip()
 
 
 def _websocket_event_error_message(event_type: str | None, payload: dict[str, JsonValue] | None) -> str | None:
@@ -958,6 +962,8 @@ def _prepare_websocket_request_state_for_auth_replay(
     *,
     current_account_id: str | None = None,
 ) -> str | None:
+    if request_state.verified_stale_anchor_replay:
+        return None
     if request_state.last_downstream_sequence_number is not None:
         return None
     can_switch_account = _websocket_auth_request_can_switch_account(request_state)
@@ -1100,10 +1106,13 @@ def _websocket_top_level_error_payload(payload: dict[str, JsonValue]) -> dict[st
     if payload.get("type") != "error":
         return None
     error: dict[str, JsonValue] = {}
-    for error_field in ("code", "message", "param"):
+    for error_field in ("code", "message"):
         value = payload.get(error_field)
         if isinstance(value, str) and value.strip():
             error[error_field] = value.strip()
+    if "param" in payload:
+        param = payload.get("param")
+        error["param"] = param.strip() if isinstance(param, str) else ""
     error_type = payload.get("error_type")
     if isinstance(error_type, str) and error_type.strip():
         error["type"] = error_type.strip()

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -275,6 +275,28 @@ class DurableBridgeSessionCoordinator:
                 expected_updated_at_epoch=expected_updated_at_epoch,
             )
 
+    async def claim_retry_circuit_generation(
+        self,
+        *,
+        session_key_kind: str,
+        session_key_value: str,
+        api_key_id: str | None,
+        expected_updated_at_epoch: float | None,
+        expected_admission_generation: int,
+        expected_consecutive_failures: int,
+        expected_cooldown_until_epoch: float,
+    ) -> DurableBridgeRetryCircuitSnapshot | None:
+        async with self._session() as session:
+            return await DurableBridgeRepository(session).claim_retry_circuit_generation(
+                session_key_kind=session_key_kind,
+                session_key_value=session_key_value,
+                api_key_scope=durable_bridge_api_key_scope(api_key_id),
+                expected_updated_at_epoch=expected_updated_at_epoch,
+                expected_admission_generation=expected_admission_generation,
+                expected_consecutive_failures=expected_consecutive_failures,
+                expected_cooldown_until_epoch=expected_cooldown_until_epoch,
+            )
+
     async def purge_retry_circuit(
         self,
         *,
@@ -754,6 +776,11 @@ class DurableBridgeSessionCoordinator:
         session_id: str,
         instance_id: str,
         owner_epoch: int,
+        restore_rebound: bool = False,
+        rebound_from_session_id: str | None = None,
+        rebound_from_account_id: str | None = None,
+        rebound_from_model: str | None = None,
+        rebound_from_parent_response_id: str | None = None,
     ) -> bool:
         async with self._session() as session:
             return await DurableBridgeRepository(session).rollback_operation_before_dispatch(
@@ -761,6 +788,11 @@ class DurableBridgeSessionCoordinator:
                 session_id=session_id,
                 instance_id=instance_id,
                 owner_epoch=owner_epoch,
+                restore_rebound=restore_rebound,
+                rebound_from_session_id=rebound_from_session_id,
+                rebound_from_account_id=rebound_from_account_id,
+                rebound_from_model=rebound_from_model,
+                rebound_from_parent_response_id=rebound_from_parent_response_id,
             )
 
     async def get_operation_by_fingerprint(

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -160,6 +160,7 @@ class DurableBridgeRetryCircuitSnapshot:
     cooldown_until_epoch: float
     last_detail: str | None
     updated_at_epoch: float
+    admission_generation: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,6 +189,11 @@ class DurableBridgeOperationSnapshot:
     request_text: str | None = None
     event_spool_complete: bool = True
     created: bool = False
+    rebound: bool = False
+    rebound_from_session_id: str | None = None
+    rebound_from_account_id: str | None = None
+    rebound_from_model: str | None = None
+    rebound_from_parent_response_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -461,6 +467,72 @@ class DurableBridgeRepository:
         async with sqlite_writer_section():
             await self._session.execute(statement)
             await self._session.commit()
+
+    async def claim_retry_circuit_generation(
+        self,
+        *,
+        session_key_kind: str,
+        session_key_value: str,
+        api_key_scope: str,
+        expected_updated_at_epoch: float | None,
+        expected_admission_generation: int,
+        expected_consecutive_failures: int,
+        expected_cooldown_until_epoch: float,
+    ) -> DurableBridgeRetryCircuitSnapshot | None:
+        """Linearize replay admission against a retry-circuit generation.
+
+        ``admission_generation`` is independent from the failure observation
+        timestamp. A failure committed first makes this claim fail; a delayed
+        failure committed afterward still sees its original ``updated_at``
+        baseline and is merged after the already-admitted dispatch.
+        """
+        values = {
+            "session_key_kind": session_key_kind,
+            "session_key_hash": durable_bridge_hash(session_key_value),
+            "api_key_scope": api_key_scope,
+            "consecutive_failures": 0,
+            "cooldown_until_epoch": 0.0,
+            "last_detail": None,
+            "updated_at_epoch": time.time(),
+            "admission_generation": 1,
+        }
+        dialect = self._session.get_bind().dialect.name
+        async with sqlite_writer_section():
+            if expected_updated_at_epoch is None:
+                if expected_admission_generation != 0:
+                    return None
+                if dialect == "postgresql":
+                    statement = pg_insert(HttpBridgeRetryCircuit).values(**values).on_conflict_do_nothing()
+                elif dialect == "sqlite":
+                    statement = sqlite_insert(HttpBridgeRetryCircuit).values(**values).on_conflict_do_nothing()
+                else:
+                    raise RuntimeError(
+                        f"DurableBridgeRepository retry circuit claim unsupported for dialect={dialect!r}"
+                    )
+            else:
+                statement = (
+                    update(HttpBridgeRetryCircuit)
+                    .where(
+                        HttpBridgeRetryCircuit.session_key_kind == session_key_kind,
+                        HttpBridgeRetryCircuit.session_key_hash == durable_bridge_hash(session_key_value),
+                        HttpBridgeRetryCircuit.api_key_scope == api_key_scope,
+                        HttpBridgeRetryCircuit.admission_generation == expected_admission_generation,
+                        HttpBridgeRetryCircuit.updated_at_epoch == expected_updated_at_epoch,
+                        HttpBridgeRetryCircuit.consecutive_failures == expected_consecutive_failures,
+                        HttpBridgeRetryCircuit.cooldown_until_epoch == expected_cooldown_until_epoch,
+                    )
+                    .values(admission_generation=expected_admission_generation + 1)
+                )
+            result = await self._session.execute(statement)
+            if getattr(result, "rowcount", 0) != 1:
+                await self._session.rollback()
+                return None
+            await self._session.commit()
+        return await self.get_retry_circuit(
+            session_key_kind=session_key_kind,
+            session_key_value=session_key_value,
+            api_key_scope=api_key_scope,
+        )
 
     async def delete_retry_circuit(
         self,
@@ -1226,6 +1298,10 @@ class DurableBridgeRepository:
                     ).where(HttpBridgeSessionRecord.api_key_scope == api_key_scope)
                 operation = await self._session.scalar(fingerprint_statement.with_for_update())
             if operation is not None:
+                rebound_from_session_id = operation.session_id if operation.state == "failed" else None
+                rebound_from_account_id = operation.account_id if operation.state == "failed" else None
+                rebound_from_model = operation.model if operation.state == "failed" else None
+                rebound_from_parent_response_id = operation.parent_response_id if operation.state == "failed" else None
                 if recovery_attempt_consumed:
                     # A REPLAYED recovery checkpoint is immutable. Return the
                     # existing row for safe transcript replay or fail-closed
@@ -1330,7 +1406,14 @@ class DurableBridgeRepository:
                 if request_text is not None and operation.request_text is None:
                     operation.request_text = request_text
                     operation.updated_at = utcnow()
-                snapshot = _to_operation_snapshot(operation, created=rebound)
+                snapshot = _to_operation_snapshot(
+                    operation,
+                    rebound=rebound,
+                    rebound_from_session_id=rebound_from_session_id,
+                    rebound_from_account_id=rebound_from_account_id,
+                    rebound_from_model=rebound_from_model,
+                    rebound_from_parent_response_id=rebound_from_parent_response_id,
+                )
                 await self._session.commit()
                 return snapshot
             operation = HttpBridgeOperationRecord(
@@ -1539,8 +1622,13 @@ class DurableBridgeRepository:
         session_id: str,
         instance_id: str,
         owner_epoch: int,
+        restore_rebound: bool = False,
+        rebound_from_session_id: str | None = None,
+        rebound_from_account_id: str | None = None,
+        rebound_from_model: str | None = None,
+        rebound_from_parent_response_id: str | None = None,
     ) -> bool:
-        """Remove a newly-created operation that never reached upstream."""
+        """Undo an operation transition that never reached upstream."""
         async with sqlite_writer_section():
             owner_exists = await self._session.scalar(
                 select(HttpBridgeSessionRecord.id)
@@ -1573,7 +1661,17 @@ class DurableBridgeRepository:
             if has_events is not None:
                 await self._session.rollback()
                 return False
-            await self._session.delete(operation)
+            if restore_rebound:
+                operation.state = "failed"
+                operation.event_spool_complete = False
+                if rebound_from_session_id is not None:
+                    operation.session_id = rebound_from_session_id
+                    operation.account_id = rebound_from_account_id
+                    operation.model = rebound_from_model
+                    operation.parent_response_id = rebound_from_parent_response_id
+                operation.updated_at = utcnow()
+            else:
+                await self._session.delete(operation)
             await self._session.commit()
         return True
 
@@ -3112,6 +3210,11 @@ def _to_operation_snapshot(
     row: HttpBridgeOperationRecord,
     *,
     created: bool = False,
+    rebound: bool = False,
+    rebound_from_session_id: str | None = None,
+    rebound_from_account_id: str | None = None,
+    rebound_from_model: str | None = None,
+    rebound_from_parent_response_id: str | None = None,
 ) -> DurableBridgeOperationSnapshot:
     return DurableBridgeOperationSnapshot(
         operation_id=row.operation_id,
@@ -3126,6 +3229,11 @@ def _to_operation_snapshot(
         request_text=row.request_text,
         event_spool_complete=bool(row.event_spool_complete),
         created=created,
+        rebound=rebound,
+        rebound_from_session_id=rebound_from_session_id,
+        rebound_from_account_id=rebound_from_account_id,
+        rebound_from_model=rebound_from_model,
+        rebound_from_parent_response_id=rebound_from_parent_response_id,
     )
 
 
@@ -3140,4 +3248,5 @@ def _to_retry_circuit_snapshot(row: HttpBridgeRetryCircuit | None) -> DurableBri
         cooldown_until_epoch=row.cooldown_until_epoch,
         last_detail=row.last_detail,
         updated_at_epoch=row.updated_at_epoch,
+        admission_generation=row.admission_generation,
     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -168,6 +168,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_admission_timeout_seconds,
+    _http_bridge_is_explicit_previous_response_rejection,  # noqa: F401
     _http_bridge_should_attempt_local_previous_response_recovery,  # noqa: F401
 )
 from app.modules.proxy._service.http_bridge.helpers import (

--- a/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/design.md
+++ b/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/design.md
@@ -10,10 +10,14 @@ This route already has a working transparent server-side replay for `previous_re
 - Make stale-anchor continuity loss recoverable by unmodified Codex clients on the WebSocket route.
 - Preserve the hygiene intent of masking: no raw upstream error envelope and no missing response id downstream.
 - Preserve semantic classification: clients can still tell stale-anchor loss apart from quota, policy, auth, and generic invalid-request failures.
+- Prevent verified HTTP full resends from re-entering the same rejecting owner
+  after an explicit stale-anchor error.
 
 **Non-Goals:**
-- No client changes, no HTTP bridge changes, no public `/v1` changes, no routing changes.
+- No client changes and no public `/v1` masking changes.
 - `upstream_unavailable` and suppressed-duplicate `stream_incomplete` are out of scope (follow-up).
+- No account switch based only on a transport close with zero observed events;
+  that send remains ambiguous and can have at-least-once side effects.
 
 ## Decisions
 
@@ -21,8 +25,150 @@ This route already has a working transparent server-side replay for `previous_re
 - **Refine the masking requirements to their intent.** The masking spirit is "do not leak the raw upstream error object or internal ids," not "never emit the bare code." Change the requirements from forbidding `previous_response_not_found` outright to forbidding the raw envelope and id, while permitting the sanitized canonical code on the Codex-native route.
 - **Deliver as an application-level error, not a transport close.** The client full-resend cascade (five full-payload resends, then a sticky WebSocket->HTTP downgrade) is triggered by transport signals (`1009` close, `413`), per the ingress-budget ops notes, not by an application-level `previous_response_not_found`. An application-level canonical code triggers the client's controlled single full-context retry instead.
 - **Keep public `/v1/responses` on `stream_incomplete`.** OpenAI-compatible clients do not expect the Codex continuity code; the canonical-code signal is scoped to the Codex-native route.
+- **Recognize the parameter-less ChatGPT backend variant narrowly.** Treat
+  `code = "invalid_request_error"` plus the normalized message
+  `Invalid previous_response_id` as continuity loss only when `param` is absent
+  or equals `previous_response_id`. Do not classify other generic invalid
+  requests, and keep the existing canonical `previous_response_not_found`
+  fast path unchanged.
+- **Parameter-less classification is exact, not substring-based.** The broad
+  `previous response` + `not found` message matcher remains valid only when
+  upstream explicitly sets `param=previous_response_id`. With no parameter,
+  only the normalized `Invalid previous_response_id` sentence is accepted so
+  missing-tool-output errors cannot enter stale-anchor replay.
+- **Use explicit rejection plus the existing full-resend proof for HTTP
+  migration.** A classified `previous_response_not_found` proves that the
+  anchored attempt was rejected before execution. If the incoming payload also
+  passes `durable_full_resend_allows_account_neutral_replay()`—including prior
+  output retention, prefix fingerprint, and file-neutrality checks—the recovery
+  may strip the anchor, clear stale affinity headers, exclude the rejecting
+  owner, and reuse the existing one-shot account-neutral replay path. The
+  durable operation identity is preserved and rebound so settlement remains
+  single-owner. A bare `stream_incomplete` or no-close-frame transport failure
+  is not sufficient proof and keeps the existing fail-closed circuit behavior.
+- **Separate replay safety from account-migration safety.** Prefix verification
+  and retained fresh request text prove that the rejected anchored request can
+  be replayed without the anchor. The stricter account-neutral projection only
+  decides whether that replay may move to another account. If migration is
+  unsafe because retained tool/file history is owner-bound, codex-lb must still
+  use the verified fresh body on the same owner rather than rebuilding another
+  socket with the stale anchor. Both paths remain one-shot and preserve the
+  durable operation fence; delta-only requests remain fail-closed.
+- **Preserve the obsolete anchored-request circuit.** The retry circuit is keyed
+  by the original hard session key and survives container replacement. An
+  account-neutral replacement uses a unique internal key, but its authorization
+  is still compare-and-set against the observed source-circuit generation. A
+  same-owner replacement uses a distinct owner-pinned internal key and therefore
+  never bypasses source-key admission. Neither path deletes the shared local or
+  durable circuit row. Eventless transport failures, delta-only requests, client
+  retries, and ordinary reconnects retain the existing circuit behavior.
+- **Do not reuse the broad anchored-recovery predicate as replay proof.**
+  `server_anchored_replay_once` intentionally treats eventless transport errors
+  as eligible for an at-least-once anchored retry. Anchor removal is stricter:
+  it requires an explicit classified stale-anchor rejection and the durable
+  full-resend retained-output proof. Prefix trimming alone is insufficient.
+- **Require the durable operation fence before anchor removal.** Both
+  account-neutral and same-owner stale-anchor replay require a registered
+  operation id plus the current durable session id and owner epoch. Resetting
+  the operation event spool is mandatory; a disabled ledger, missing reset
+  capability, or rejected owner fence falls back to the anchored fail-closed
+  path without dispatching an unanchored replacement.
+- **Preserve the old circuit after verified replay completion.** The verified
+  marker is carried through the replacement request's terminal event. A
+  successful verified replacement skips the ordinary success-driven circuit
+  clear, so the older circuit and any concurrent newer failure remain intact.
+  A later ordinary successful request still uses the existing settlement path.
+- **Transport recovery remains anchored.** The operation-journal branch must
+  not consume an ambiguous `stream_incomplete`, idle timeout, or request timeout
+  as authority to remove the anchor. Only the explicit stale-anchor classifier
+  may enter the unanchored replacement branches.
+- **Do not claim an inactive UNKNOWN journal.** An UNKNOWN row proves that an
+  earlier dispatch may have reached upstream, while an inactive lease only
+  proves that its owner is gone. Claiming that row cannot turn ambiguity into
+  an explicit rejection, so the request fails closed without anchor removal or
+  account migration.
+- **Require an unused replay budget.** All stale-anchor replacement predicates
+  require `replay_count == 0`. If an eventless replay already occurred, the
+  earlier attempt remains ambiguous even when the latest attempt explicitly
+  rejects its anchor, so no additional anchored or unanchored replacement is
+  dispatched, including delta-only and prefix-unverified requests.
+- **Do not claim the ambiguous-transport journal for explicit stale recovery.**
+  The terminal-event processor may deterministically settle the journal before
+  the streaming catch block runs. Explicit stale recovery therefore relies on
+  the already-required durable operation id/session/owner fence and mandatory
+  spool reset, not a second journal claim. This removes both double-claim races
+  and pre-dispatch rollback gaps around session reset.
+- **Preserve parameter presence.** A missing `param` remains eligible for the
+  exact `Invalid previous_response_id` variant, while present blank/whitespace
+  values normalize to `""` and fail classification rather than collapsing to
+  the absent case. This applies at raw bridge error parsing and at the shared
+  WebSocket event extractor before any canonical rewrite occurs.
+- **Use the shared safe-context proof.** Stale-anchor recovery accepts either
+  retained prior assistant output or an exact pending-tool-call manifest match,
+  matching `classify_durable_full_resend` rather than defining a narrower
+  second proof.
+- **Circuit and quarantine have separate success semantics.** A verified replay
+  completion skips only `_clear_http_bridge_retry_circuit`. It clears quarantine
+  for both the replacement key and the stored original hard key, because
+  completion disproves the recovery-origin wedge even though it must not erase
+  circuit evidence from concurrent failures.
+- **The verified replacement is the final transport attempt.** Its marker makes
+  the request ineligible for clean-close replay and every other pre-created
+  transport retry. `replay_count == 1` records the replacement itself, not a
+  budget for one more send.
+- **Claim only the approved account-neutral circuit generation.** At explicit
+  rejection time, capture the original hard-key circuit's durable row fields and
+  local failure state, including an explicit captured-absence state. Immediately
+  before queue publication, admission holds the local circuit lock and performs
+  a durable compare-and-set that advances only the independent integer
+  `admission_generation`, never the failure observation timestamp. A failure
+  committed first makes the claim fail; a failure committed afterward is ordered
+  after the already-admitted dispatch. This durable claim is the linearization
+  point, eliminating the former lookup-to-send race without hiding a delayed
+  failure from a replica with a skewed wall clock.
+- **Compare the original hard key, independent of cooldown.** The marker stores
+  the source `_HTTPBridgeSessionKey` as well as its generation. Account-neutral
+  admission claims durable/local state for that source key before considering
+  the replacement session. The comparison covers absent, below-threshold,
+  active, half-open, and expired states; any generation that won the CAS first
+  suppresses submit.
+- **Block every transport resend mechanism.** In addition to clean-close retry,
+  the shared auth-replay preparer rejects the verified marker before mutating
+  counters or request text.
+- **Preserve blank params through terminal normalization.** HTTP-bridge error
+  normalization emits `param=""` when the source field is present but blank,
+  and the common error envelope retains non-`None` empty params.
+- **Reject present non-string params.** Raw HTTP and WebSocket extraction keeps
+  the distinction between a missing `param` and a present value with the wrong
+  JSON type. The latter becomes a non-matching empty sentinel and cannot
+  authorize exact-message stale-anchor recovery.
+- **Inspect UNKNOWN journals for both replay variants.** Safe-context journal
+  lookup is not conditioned on account neutrality; owner-bound same-account
+  replay also fails closed when an inactive owner leaves an UNKNOWN attempt.
+- **Distinguish operation insertion from rebind.** Durable operation snapshots
+  expose separate `created` and `rebound` facts. Pre-dispatch cleanup may delete
+  only a genuinely inserted row; a rebound failed operation is restored to the
+  failed fence instead of deleting its durable identity.
+- **Restore rebound ownership, not only state.** The transient rebound snapshot
+  carries the prior session/account/model/parent fields. Pre-dispatch rollback
+  restores those fields so an undispatched replacement cannot retain ownership.
+- **Avoid same-owner circuit bypass.** Same-owner stale recovery receives a
+  unique `internal_request_parallel` key while remaining pinned to the proven
+  owner. That internal key is preserved even when the incoming header contains a
+  normal `http_turn_*` value. Account-neutral recovery keeps its unique key but
+  still uses the source-circuit CAS claim above. The original hard-key circuit is
+  preserved in both cases.
+- **Centralize transport-only replay denial.** The pre-created retry selector
+  rejects verified replacements and anchored safe-fresh candidates when no
+  explicit typed replay reason exists. Clean-close, auth, and generic eventless
+  transport paths cannot remove an anchor; non-transport model fallback keeps
+  its explicit reason and separate policy.
 
 ## Implementation guidance
+
+The eventual delivery is split into the canonical WebSocket signal PR and an
+HTTP recovery transaction PR as documented in `split-plan.md`; the HTTP PR is
+stacked on the canonical PR because shared classifier/normalization seams overlap.
 
 The mechanism this change touches is shared code, so this section exists to keep the change from growing beyond its intended scope. Each claim below was checked against the current codebase (and, where noted, against a failing test), not assumed.
 
@@ -31,6 +177,35 @@ The mechanism this change touches is shared code, so this section exists to keep
 - **The mid-stream (`response.failed`-shaped) path never had this second-layer problem.** `_sanitize_websocket_terminal_error_fields` (the third sanitizer, used for pending-request cleanup) and `_rewrite_websocket_continuity_corruption_event` (used for in-flight `previous_response_not_found` masking) both build their output via `response_failed_event(...)` directly and send it without passing through `_wrapped_websocket_error_event` at all — confirmed by all ~14 mid-stream tests passing on the first attempt, with only the two connect-failure tests failing. `_wrapped_websocket_error_event` is specific to the top-level `"type": "error"` wire shape used before a response/request is underway.
 - **This is provably safe to change without touching the HTTP bridge or public `/v1`, not merely assumed to be scoped correctly.** `_websocket_continuity_error_fields` is shared: it is called from `websocket/helpers.py` and from `streaming/helpers.py:645` (`_build_stream_incomplete_terminal_event_for_request`), which is in turn called from `http_bridge/upstream_events.py` and `http_bridge/service_stubs.py`. But every call site passes `request_state.expose_stale_previous_response_classifier`, and that field has exactly three set-sites, all in `websocket/mixin.py`, all set to `codex_session_affinity` (default `False` per `support.py:803`). Tracing `codex_session_affinity` to its callers in `api.py` confirms: `codex_session_affinity=True` is passed from exactly one place, the `responses_websocket` handler behind `@ws_router.websocket("/responses")` (`ws_router` prefix `/backend-api/codex`) — the Codex-native route. Every other entry point passes `False` explicitly (`v1_responses_websocket` behind `@v1_ws_router.websocket("/responses")`, prefix `/v1`; the `v1_responses` HTTP handler) or never sets the field at all (the HTTP bridge). The new code can only ever be emitted from the one route this change targets. The same fencing applies to the `_wrapped_websocket_error_event` fix above, since it is gated by the identical field/flag.
 - **No additional sanitization work is needed for the id/envelope.** `_websocket_downstream_response_id` (`websocket/helpers.py:571`), which supplies the `response_id` on the outgoing event regardless of which code is returned, already resolves to the current downstream/local id (`replay_downstream_response_id` or `response_id` or `request_id`) and never to `request_state.previous_response_id` (the stale anchor). "No raw envelope, no stale id, current id preserved" is an existing invariant of the surrounding code.
+- **The classifier is the shared seam for issue #1816.**
+  `is_previous_response_not_found_error` already gates direct WebSocket and
+  HTTP-bridge recovery. Extending that pure function for the exact
+  parameter-less envelope should activate the existing one-shot safe replay;
+  bridge/session code changes are only warranted if the externally failing
+  integration test proves the stale anchor is still reused.
+- **The live canary provided that external proof.** After the parameter-less
+  envelope was classified, `previous_response_recover_local` rebuilt another
+  owner-bound session with the same stale anchor. Two eventless failures on
+  each of two hard bridge keys then opened the 60-second retry circuit. The
+  implementation therefore extends only the explicit stale-error branch in
+  `_stream_via_http_bridge`; generic reader-failure handling remains unchanged.
+- **The first production deployment exposed the missing owner-bound half.**
+  Logs showed `store_context_input_trimmed` and a proof-gated cooldown bypass,
+  but `fresh_replay_available=false` in the stale-error diagnostic and no
+  `previous_response_recover_fresh_resend` event. The real nine-item payload
+  retained tool history that correctly failed account-neutral projection, so
+  the implementation must distinguish “safe to resend” from “safe to migrate”
+  and use the former for a same-owner unanchored replay.
+- **The second production deployment exposed durable circuit carry-over.** The
+  same-owner recovery event fired, but `submit_retry_circuit_suppressed` blocked
+  every fresh request because the prior hard-key circuit remained half-open in
+  durable storage. The integration test now seeds an expired two-failure
+  circuit and requires the explicit stale-anchor branch's internally marked
+  one-shot request to pass admission without deleting the durable row.
+- **The circuit regression uses an actually active row.** Its cooldown expires
+  in the future, so ordinary half-open admission cannot make the test pass. The
+  test also asserts that the local row remains and the durable clear API is not
+  called after the verified replacement completes.
 - **The test migration was mostly mechanical, with 2 tests needing a genuine behavioral fix, not a test update.** All matching assertions in `tests/integration/test_proxy_websocket_responses.py` funneled through one shared helper, `_assert_codex_previous_response_stale_error` (renamed `_assert_previous_response_not_found_error`), which asserts against the renamed constants dynamically, not hardcoded literal strings — updating the constants' values alone made that helper assert the new contract everywhere. A separate, per-test `"previous_response_not_found" not in json.dumps(...)` assertion existed at 18 call sites across 16 test functions (a leftover from the old contract, verified by diffing against the pre-change file) and needed individual attention: 5 were redundant with an existing `"<stale_id>" not in ...` check and were deleted; 8 (across 6 functions, including both `failed_2`/`failed_3` pairs in 2 of them) had no such check and were replaced with one using that test's own literal stale-anchor id, rather than a generic string; the remaining 5 (public `/v1` route or success-only replay paths) were outside this route's scope and untouched. `tests/unit/test_proxy_utils.py:22502` was strengthened to also assert the new code's absence on an unrelated (`missing_tool_output`) masking path, guarding against classifier cross-contamination. The 2 connect-failure tests initially failed for the structural reason above, not because their assertions were wrong.
 
 ## Rejected Alternatives

--- a/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/proposal.md
+++ b/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/proposal.md
@@ -10,7 +10,35 @@ The requirement `Codex WebSocket stale-anchor failures remain recoverable by a f
 
 This route already recovers transparently, without any client involvement, when the client's own payload happens to be a self-contained full resend (see `design.md`'s Context). The rename bug only reaches the client in the residual case that mechanism cannot cover — a delta-only continuation, exactly the shape pi/pi-ai reported — where codex-lb has no independently-reconstructable history to replay with and a client-actionable signal is the only remaining option.
 
-Reference: pi report [#1529](https://github.com/Soju06/codex-lb/issues/1529).
+The ChatGPT backend also emits an equivalent stale-anchor envelope that omits
+`param` and uses the generic `invalid_request_error` code with the message
+`Invalid previous_response_id.`. That shape currently bypasses the continuity
+classifier, so neither transparent replay nor the canonical client signal runs.
+
+The live canary exposed a second HTTP-bridge failure after classification was
+fixed: a verified full-history resend can receive an explicit stale-anchor
+rejection, rebind to the same owner account, then hit an eventless transport
+drop and open the hard-key retry circuit. Because the explicit stale-anchor
+error proves that the rejected attempt did not run, codex-lb can avoid that
+same-owner loop by using the already-verified account-neutral full-resend
+projection immediately after the rejection.
+
+The production replay then showed the complementary case: the incoming request
+was prefix-verified and trim-safe, but its retained tool history was not safe to
+migrate across accounts. That payload still has a safe recovery on the same
+owner: the explicit stale-anchor rejection proves the anchored attempt did not
+run, so codex-lb can drop only the rejected anchor and replay the retained full
+request once without changing accounts.
+
+The second production replay reached that same-owner branch but was rejected
+before submit because the hard-key retry circuit persisted across container
+replacement. A stale-anchor recovery changes the request from anchored to
+verified unanchored full history, so that internally constructed one-shot
+replay may bypass the old circuit without deleting shared circuit state.
+
+References: pi report [#1529](https://github.com/Soju06/codex-lb/issues/1529)
+and the parameter-less ChatGPT backend report
+[#1816](https://github.com/Soju06/codex-lb/issues/1816).
 
 ## What Changes
 
@@ -19,6 +47,52 @@ Reference: pi report [#1529](https://github.com/Soju06/codex-lb/issues/1529).
 - Public `/v1/responses` WebSocket clients keep the existing `stream_incomplete` masking; OpenAI-compatible clients do not expect the Codex continuity code.
 - Sibling requirements that currently assert `stream_incomplete` masking for the Codex-native WebSocket route (`Codex WebSocket top-level previous-response errors are masked`, `Codex WebSocket wrapped errors follow official client shape`) are reconciled so their Codex-native scenarios use the canonical `previous_response_not_found` signal while their public `/v1` scenarios keep `stream_incomplete`. This delta modifies the two authoritative requirements; the owner drives the dependent wording per the centralized-continuity requirement.
 - Add WebSocket-surface regression coverage asserting the client-visible code is `previous_response_not_found` with the stale `previous_response_id` and raw upstream envelope absent (the current response id may remain).
+- Classify the exact `invalid_request_error` + `Invalid previous_response_id.`
+  envelope as continuity loss when `param` is absent or names
+  `previous_response_id`, without broadening recovery to unrelated invalid
+  requests.
+- When the HTTP bridge receives an explicit stale-anchor rejection for a
+  verified, file-free, account-neutral full resend, remove the stale anchor,
+  exclude the rejecting owner account, and perform the existing bounded replay
+  on a fresh account-neutral bridge. Delta-only and unverified requests retain
+  the current fail-closed behavior; verified file/account-bound history may
+  replay only on the same owner.
+- When the same explicit rejection occurs for a prefix-verified full resend
+  that is not account-neutral (for example retained account-bound tool/file
+  history), remove the stale anchor and replay the retained full request once
+  on the same owner. Do not carry the rejected `previous_response_id` into the
+  replacement socket.
+- Allow only the internally marked, verified one-shot unanchored replay to pass
+  an older hard-key retry circuit. Do not delete local or durable circuit state;
+  transport-only failures and ordinary reconnects continue to observe it.
+- Require an attached durable operation identity plus live session/owner fence
+  before either stale-anchor replay may remove the anchor. If that fence or its
+  spool-reset operation is unavailable, retain the anchor and fail closed.
+- Do not let the verified replay's successful completion clear the pre-existing
+  hard-key circuit; a later ordinary successful request may settle it normally.
+- Treat an UNKNOWN recovery journal owned by an inactive durable session as an
+  ambiguous prior dispatch: fail closed instead of claiming it, removing the
+  anchor, or migrating accounts.
+- Permit stale-anchor replacement only when the current request has not already
+  used an eventless replay, regardless of whether the request carries a proven
+  full resend.
+- Keep explicit stale-anchor replacement independent from the ambiguous-
+  transport recovery journal. Deterministic terminal settlement may consume
+  that journal, while replacement ownership remains fenced by the durable
+  operation identity and mandatory spool reset.
+- Keep retry-circuit preservation independent from quarantine cleanup: a
+  verified successful response retains the circuit but still clears quarantine.
+- Reject present blank/whitespace `param` values instead of treating them as an
+  absent parameter, and accept an exact stored pending-tool manifest as the
+  same safe-context proof already used by durable full-resend classification.
+- Preserve blank/whitespace `param` values through every shared WebSocket and
+  HTTP-bridge extraction path so they cannot be rewritten into a canonical
+  stale-anchor error later in the pipeline.
+- Forbid clean-close and other transport retries of the internally verified
+  replacement; its single dispatch exhausts the replay budget.
+- Capture the hard-key retry-circuit generation when stale-anchor recovery is
+  authorized and bypass only that generation. A newer local or durable failure
+  appearing before submit must suppress the replacement.
 
 ## Capabilities
 
@@ -31,7 +105,12 @@ Reference: pi report [#1529](https://github.com/Soju06/codex-lb/issues/1529).
 ## Non-Goals
 
 - No change to `upstream_unavailable` (owner-account-unavailable) or suppressed-duplicate `stream_incomplete` signaling; those share the same delivery problem but are a follow-up.
-- No change to the HTTP bridge path, which is already client-recoverable.
+- No account migration based only on an eventless transport close; without an
+  explicit stale-anchor rejection, upstream acceptance remains ambiguous.
+- No conversion of an operation-journal transport recovery into an unanchored
+  replay unless the current failure is an explicit stale-anchor rejection.
 - No change to public `/v1/responses` masking (`stream_incomplete` is retained).
 - No client-side change; the fix targets the deviating proxy surface only.
-- No change to account selection, routing, retry decisions, or upstream payload shape.
+- No cross-account replay for uploaded files or payloads that fail the existing
+  durable full-resend proof.
+- No anchor removal for delta-only or prefix-unverified payloads.

--- a/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/specs/responses-api-compat/spec.md
@@ -28,6 +28,73 @@ When serving or consuming the Codex-native `/backend-api/codex/responses` WebSoc
 - **THEN** the client MUST NOT convert it into a stale-anchor full-context retry
 - **AND** codex-lb MUST preserve the original error class as much as safely possible
 
+#### Scenario: ChatGPT backend omits param on an invalid previous response id
+- **GIVEN** a request depends on a `previous_response_id`
+- **WHEN** upstream returns `code = "invalid_request_error"` with the message `Invalid previous_response_id.`
+- **AND** `param` is absent or equals `previous_response_id`
+- **THEN** codex-lb MUST classify the failure as stale-anchor continuity loss
+- **AND** the existing one-shot replay or sanitized canonical client signal MUST run
+- **AND** the same generic error with another `param` MUST NOT trigger continuity recovery
+- **AND** unrelated `invalid_request_error` messages MUST NOT trigger continuity recovery
+
+#### Scenario: Verified HTTP full resend escapes a rejecting owner
+- **GIVEN** an HTTP-bridge continuation carries a full input history that passes the existing durable full-resend and account-neutral projection checks
+- **AND** the projected request has no account-scoped file references
+- **WHEN** the continuity owner explicitly rejects its `previous_response_id` as not found before producing a response
+- **THEN** codex-lb MUST remove the rejected anchor and replay the verified full request at most once on a fresh account-neutral bridge
+- **AND** the rejecting owner account MUST be excluded from that replay
+- **AND** stale session and turn-state affinity headers MUST NOT be forwarded to the replacement bridge
+- **AND** the durable operation identity and settlement contract MUST remain attached to the replacement attempt
+- **AND** anchor removal MUST NOT occur unless a registered durable operation id and the current durable session owner fence are available
+- **AND** failure to reset the fenced operation spool MUST abort before the unanchored replacement is submitted
+- **AND** delta-only or unverified requests MUST fail closed
+- **AND** verified file/account-bound requests MUST NOT migrate accounts and MAY use only the same-owner replay described below
+- **AND** an eventless transport failure without an explicit stale-anchor rejection MUST NOT by itself authorize cross-account replay
+- **AND** no anchored or unanchored replacement MUST run when the request has already consumed an eventless replay, including delta-only and prefix-unverified requests
+- **AND** an UNKNOWN recovery journal on an inactive durable owner MUST fail closed without being claimed for anchor removal or account migration
+- **AND** explicit stale-anchor replacement MUST NOT depend on claiming the ambiguous-transport recovery journal
+- **AND** durable full-resend safety MAY be proven either by retained prior output or by an exact stored pending-tool-call manifest match
+
+#### Scenario: Verified owner-bound HTTP full resend drops only the rejected anchor
+- **GIVEN** an HTTP-bridge continuation carries a prefix-verified, trim-safe full input history
+- **AND** the retained request is not account-neutral because it contains account-bound tool or file history
+- **WHEN** the continuity owner explicitly rejects its `previous_response_id` as not found before producing a response
+- **THEN** codex-lb MUST remove the rejected anchor and replay the retained full request at most once on the same owner
+- **AND** the replacement upstream request MUST NOT contain the rejected `previous_response_id`
+- **AND** same-owner replay MUST use a unique owner-pinned internal key instead of bypassing the older hard-key retry circuit
+- **AND** account-neutral replay admission MUST atomically claim the authorized original hard-key circuit generation
+- **AND** local and durable retry-circuit state MUST NOT be deleted to authorize that replay
+- **AND** successful completion of that verified replay MUST NOT clear the pre-existing local or durable circuit state
+- **AND** successful completion MUST clear independent bridge quarantine state for both the replacement key and original hard key
+- **AND** the request MUST NOT migrate to another account
+- **AND** durable operation identity and settlement MUST remain attached to the replacement attempt
+- **AND** a missing operation ledger, operation id, durable session id, owner epoch, or spool-reset capability MUST retain the anchor and fail closed
+- **AND** delta-only or prefix-unverified requests MUST retain the existing fail-closed behavior
+- **AND** an eventless transport failure without an explicit stale-anchor rejection MUST NOT by itself authorize this replay
+- **AND** ordinary transport recovery without an explicit stale-anchor rejection MUST NOT bypass or clear the retry circuit
+- **AND** an operation-journal recovery after an ambiguous transport failure MUST NOT remove the anchor or migrate accounts
+- **AND** a request with a nonzero replay count MUST NOT dispatch another stale-anchor replacement
+- **AND** a present blank or whitespace-only `param` MUST NOT be treated as an absent parameter for stale-anchor classification
+- **AND** a present non-string or null `param` MUST NOT be treated as an absent parameter for stale-anchor classification
+- **AND** blank or whitespace-only parameter presence MUST survive every upstream event-normalization layer and MUST NOT be rewritten to the canonical continuity code
+- **AND** the verified replacement MUST NOT receive a clean-close or other transport-level resend after its first dispatch
+- **AND** account-neutral generation claim MUST apply only to the local/durable circuit generation observed when recovery was authorized
+- **AND** a circuit generation that wins the durable compare-and-set first MUST suppress the replacement before submit
+- **AND** generation claim MUST use the original hard session key even when account-neutral recovery creates a new soft key
+- **AND** generation claim MUST run for absent, below-threshold, expired, half-open, and active circuit states
+- **AND** generation claim MUST use a monotonic field independent from failure observation time so delayed clock-skewed failures remain mergeable
+- **AND** verified replacement MUST NOT enter authentication replay
+- **AND** HTTP-bridge terminal normalization MUST preserve a present empty parameter in the normalized error envelope
+- **AND** inactive-owner UNKNOWN journal inspection MUST apply to both account-neutral and owner-bound verified full resends
+- **AND** a pre-dispatch failure after rebinding an existing durable operation MUST restore that operation's failed fence and MUST NOT delete its row
+- **AND** a durable operation snapshot MUST distinguish newly inserted rows from rebound rows
+- **AND** generic eventless transport retry MUST NOT convert an anchored safe-fresh request into an unanchored replay without explicit stale-anchor rejection
+- **AND** rebound rollback MUST restore the prior session/account/model/parent ownership fields
+- **AND** a restored rebound operation MUST retain its durable identity and require a fresh rebind before any in-memory capacity or gate retry dispatches
+- **AND** successful replacement completion MUST clear the original-key quarantine only when it still matches the generation observed at recovery authorization
+- **AND** explicit stale-anchor rejection after any emitted response event or downstream-visible output MUST fail closed without anchored fallback dispatch
+- **AND** same-owner verified replay MUST use a unique internal key pinned to the proven owner rather than bypassing the original hard-key circuit
+
 ### Requirement: Direct WebSocket previous-response misses never leak raw upstream errors
 When a direct Responses WebSocket request depends on `previous_response_id`, the service MUST NOT send the raw upstream `previous_response_not_found` error envelope or the missing upstream response id to the downstream client. On the Codex-native `/backend-api/codex/responses` route the service MUST surface the sanitized canonical `error.code = "previous_response_not_found"` (raw envelope and id removed) so an unmodified Codex client recovers; on public `/v1/responses` the service MUST rewrite the failure to a retryable `stream_incomplete` continuity error. This applies to both `/v1/responses` and `/backend-api/codex/responses` WebSocket clients.
 
@@ -75,6 +142,14 @@ Top-level error normalization MUST NOT treat the event discriminator `type: "err
 - **AND** the event discriminator `type = "error"` is not used as the upstream error type
 
 #### Scenario: top-level previous-response miss surfaces the sanitized canonical code
+
+- **WHEN** a `/backend-api/codex/responses` WebSocket follow-up has `previous_response_id`
+- **AND** upstream emits a top-level `previous_response_not_found` wrapped-error frame using `status_code`
+- **THEN** the downstream event is a retryable stale-anchor failure carrying the sanitized canonical `previous_response_not_found` code
+- **AND** the downstream payload does not contain the raw upstream error envelope
+- **AND** the downstream payload does not expose the missing previous response id
+
+#### Scenario: top-level previous-response miss remains masked
 
 - **WHEN** a `/backend-api/codex/responses` WebSocket follow-up has `previous_response_id`
 - **AND** upstream emits a top-level `previous_response_not_found` wrapped-error frame using `status_code`

--- a/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/split-plan.md
+++ b/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/split-plan.md
@@ -1,0 +1,52 @@
+# Proposed PR split
+
+## PR 1: Canonical Codex WebSocket stale-anchor signal
+
+Scope:
+
+- Rename the sanitized Codex-native classifier to `previous_response_not_found`.
+- Preserve raw-envelope and stale-id masking.
+- Keep public `/v1/responses` masking on `stream_incomplete`.
+- Recognize only the exact parameter-less `Invalid previous_response_id` variant.
+- Preserve parameter presence through shared WebSocket normalization.
+
+Primary files/hunks:
+
+- `app/core/errors.py`
+- Codex-native WebSocket sanitizer/export hunks in `app/modules/proxy/service.py`
+- WebSocket helper/mixin hunks that expose the canonical sanitized classifier
+- `tests/unit/test_openai_errors.py`
+- Canonical-signal assertions in `tests/integration/test_proxy_websocket_responses.py`
+
+This PR must not include HTTP bridge account migration, circuit bypass, operation
+rebind, journal, quarantine, or transport-retry behavior.
+
+## PR 2: HTTP bridge stale-anchor recovery transaction
+
+Base: PR 1.
+
+Scope:
+
+- Explicit-rejection-only full-context replay.
+- Account-neutral versus same-owner replay safety.
+- Durable operation fencing and inserted-versus-rebound rollback semantics.
+- Original-hard-key circuit generation capture and send-adjacent revalidation.
+- Central denial of transport-only anchor removal and all verified redispatch.
+- Circuit preservation, quarantine cleanup, forwarding, and negative coverage.
+
+Primary files/hunks:
+
+- `app/modules/proxy/_service/http_bridge/**`
+- HTTP-specific request-state fields in `app/modules/proxy/_service/support.py`
+- Durable operation snapshot/repository/coordinator changes
+- `tests/unit/test_proxy_http_bridge.py`
+- `tests/unit/test_bridge_ring_lifecycle.py`
+- `tests/integration/test_http_responses_bridge.py`
+
+## Overlap handling
+
+`app/core/errors.py`, `app/modules/proxy/service.py`, and WebSocket helpers contain
+shared seams. PR 1 owns canonical classification and parameter-preserving error
+normalization. PR 2 must consume those APIs without reintroducing signal-shape
+changes. Build PR 2 on PR 1 rather than independently cherry-picking overlapping
+files.

--- a/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/tasks.md
+++ b/openspec/changes/recover-codex-ws-stale-anchor-with-canonical-code/tasks.md
@@ -17,3 +17,130 @@ See `design.md`'s Implementation guidance for the verified scope proof and for w
 - [x] 3.1 Renamed `_assert_codex_previous_response_stale_error` to `_assert_previous_response_not_found_error` in `tests/integration/test_proxy_websocket_responses.py`; it now checks `error["code"]`/`error["message"]` against the renamed constants plus `error.get("param") is None` (verified safe across every call path: none of the three sanitizer functions ever set `param` on their rewritten output). The per-call-site `"previous_response_not_found" not in json.dumps(...)` assertions (18 occurrences across 16 test functions, verified by diffing against the pre-change file) were individually triaged: 5 (one each in 5 functions) were redundant with an existing `"<stale_id>" not in ...` check on the same event and were deleted; 8 (across 6 functions — 4 with one occurrence, 2 with two, `..._for_same_anchor_followups_and_recovers` and `..._grouped_anonymous_stale_anchor_persists_diagnostics`) had no such check and were replaced with one using that test's own literal stale-anchor id (not a generic string). The remaining 5 occurrences (2 on the public `/v1` route, 3 on the transparent-full-resend-replay success path, which never surfaces an error at all) were outside this route's scope and left untouched. Renamed `test_backend_responses_websocket_never_exposes_raw_previous_response_not_found_to_client` to `..._never_exposes_raw_previous_response_id_to_client`, since the code itself is no longer raw-envelope-only after this change.
 - [x] 3.2 Confirmed public `/v1/responses` WebSocket clients still receive `stream_incomplete` (both existing `/v1` tests pass unmodified). Strengthened `tests/unit/test_proxy_utils.py:22502` to assert `"previous_response_not_found" not in emitted_text` (was `"codex_previous_response_stale"`, a string that can no longer appear anywhere), guarding against classifier cross-contamination on the unrelated `missing_tool_output` masking path.
 - [x] 3.3 `openspec validate --specs` passes; `tests/integration/test_proxy_websocket_responses.py` (75 passed), `tests/unit/test_proxy_utils.py` (904 passed), full `tests/unit` and `tests/integration` suites, Ruff, format, changed-file `ty`, and the proxy architecture check all pass.
+
+## 4. Parameter-less invalid previous-response variant (#1816)
+
+- [x] 4.1 Extend the change artifacts with the exact ChatGPT backend envelope:
+  `code=invalid_request_error`, message `Invalid previous_response_id.`, and no
+  `param`, while preserving fail-closed behavior for unrelated invalid requests.
+- [x] 4.2 Add failing unit and externally visible bridge/WebSocket regression
+  coverage for classification and one-shot replay without the stale anchor.
+- [x] 4.3 Extend `is_previous_response_not_found_error` narrowly so the exact
+  envelope reaches the existing continuity recovery path.
+- [x] 4.4 Prove public masking, retry bounds, and existing canonical error
+  behavior remain unchanged with the focused and related suites.
+- [x] 4.5 Build and canary the hotfix, then verify the live stale-anchor path
+  does not repeat the old anchor or enter a cooldown loop.
+
+## 5. Verified HTTP full-resend stale-owner escape
+
+- [x] 5.1 Extend the change artifacts with the live canary failure and require
+  account-neutral replay only after an explicit stale-anchor rejection plus the
+  existing durable full-resend/file-neutrality proof.
+- [x] 5.2 Add an externally visible `/backend-api/codex/responses` regression
+  proving the rejecting owner is excluded, the stale anchor and affinity
+  headers are removed, and the replacement account completes the turn.
+- [x] 5.3 Route the explicit stale-anchor recovery branch through the existing
+  account-neutral projection while preserving durable operation identity and
+  keeping delta/file-bound/transport-only failures unchanged.
+- [x] 5.4 Run focused bridge tests, related unit coverage, Ruff/format/type
+  checks, and strict OpenSpec validation.
+
+## 6. Owner-bound verified full-resend recovery
+
+- [x] 6.1 Record the production payload gap: prefix-verified full history can
+  be safe to replay while retained tool/file history makes account migration
+  unsafe.
+- [x] 6.2 Extend the external backend Responses regression with an owner-bound
+  tool-history variant that must retry on the same owner without the rejected
+  `previous_response_id`.
+- [x] 6.3 Split stale-anchor recovery into account-neutral migration and
+  same-owner unanchored replay while preserving one-shot and operation-fence
+  invariants.
+- [x] 6.4 Re-run focused/full related validation, rebuild ARM64, canary both
+  replay variants, redeploy, and verify production cooldown does not recur.
+
+## 7. Durable circuit admission for verified same-owner replay
+
+- [x] 7.1 Record the production carry-over where the same-owner recovery branch
+  ran but the prior hard-key durable circuit suppressed the unanchored submit.
+- [x] 7.2 Seed an expired two-failure circuit in the external owner-bound
+  regression and require successful verified replay without deleting it.
+- [x] 7.3 Admit only the internally marked stale-anchor + trim-verified replay
+  past the old circuit; retain local/durable state for other requests.
+- [x] 7.4 Re-run related validation, rebuild ARM64, canary, redeploy, and verify
+  the production hard key no longer emits cooldown suppression.
+
+## 8. rvw review hardening
+
+- [x] 8.1 Restrict parameter-less `invalid_request_error` classification to
+  the exact normalized invalid-previous-response message.
+- [x] 8.2 Require an explicit stale-anchor rejection plus durable retained-
+  output proof before either unanchored replay path; transport-only recovery
+  remains anchored/fail-closed.
+- [x] 8.3 Replace retry-circuit deletion with a tightly constrained internal
+  replay marker so concurrent replicas cannot lose newer circuit state.
+- [x] 8.4 Prevent the operation-journal ambiguous-transport path from removing
+  the anchor; only an explicit stale-anchor rejection may authorize unanchored
+  replay.
+- [x] 8.5 Require a registered operation id, durable session/owner fence, and
+  successful spool reset before either stale-anchor replay branch.
+- [x] 8.6 Preserve pre-existing local/durable circuit state when the internally
+  verified replay completes successfully.
+- [x] 8.7 Seed an active future-cooldown circuit and assert marker-only admission,
+  local retention, no durable clear, and transport-only anchored recovery.
+- [x] 8.8 Fail closed when an UNKNOWN recovery journal belongs to an inactive
+  durable owner; do not claim it for unanchored account-neutral replay.
+- [x] 8.9 Require `replay_count == 0` on all stale-anchor replacement branches.
+- [x] 8.10 Keep explicit stale-anchor replacement independent from recovery-
+  journal claims so deterministic settlement cannot race replacement ownership.
+- [x] 8.11 Preserve retry-circuit state independently while clearing quarantine
+  after a verified replay succeeds.
+- [x] 8.12 Fail closed on every explicit stale rejection after a prior replay,
+  including delta-only and prefix-unverified inputs.
+- [x] 8.13 Reject present blank/whitespace `param` values in the explicit
+  previous-response classifier.
+- [x] 8.14 Reuse the pending-tool-manifest safe-context proof for stale-anchor
+  replay eligibility.
+- [x] 8.15 Preserve whitespace `param` presence through shared bridge/WebSocket
+  extraction and prevent canonical stale rewriting.
+- [x] 8.16 Make verified stale-anchor replacements ineligible for clean-close
+  and all other transport-level redispatch.
+- [x] 8.17 Capture and compare retry-circuit generation so only the circuit
+  observed at authorization may be bypassed.
+- [x] 8.18 Preserve blank parameter presence through HTTP-bridge terminal
+  normalization and common error-envelope construction.
+- [x] 8.19 Compare authorization generation against the original hard key for
+  every circuit state, including below-threshold and expired rows.
+- [x] 8.20 Block verified stale-anchor replacements from auth replay.
+- [x] 8.21 Apply inactive UNKNOWN journal inspection to owner-bound safe-context
+  replay as well as account-neutral replay.
+- [x] 8.22 Separate durable operation `created` and `rebound` state and restore
+  rebound rows instead of deleting them on pre-dispatch failure.
+- [x] 8.23 Centralize denial of transport-only unanchored proof-gated replay.
+- [x] 8.24 Add failpoint regressions and run related full validation.
+- [x] 8.25 Create a clean commit boundary between canonical signaling and HTTP
+  recovery hardening before PR creation.
+- [x] 8.26 Restore prior durable ownership fields when an undispatched rebound
+  operation rolls back.
+- [x] 8.27 Move same-owner verified replay to a unique owner-pinned internal key
+  and remove its dependency on original circuit bypass.
+- [x] 8.28 Run related validation and obtain a clean rvw re-review.
+- [x] 8.29 Preserve owner-pinned internal keys in the presence of normal
+  `http_turn_*` headers and cover the production-shaped header path.
+- [x] 8.30 Linearize account-neutral replay admission with a durable
+  retry-circuit generation CAS and local failure lock.
+- [x] 8.31 Fail closed after any explicit stale rejection with a consumed replay
+  budget, including after partial response output.
+- [x] 8.32 Clear quarantine for the original hard key after a successful
+  replacement while retaining its retry-circuit evidence.
+- [x] 8.33 Reject present non-string/null error params across raw HTTP and
+  WebSocket normalization instead of collapsing them into absence.
+- [x] 8.34 Store replay admission generation independently from retry-circuit
+  failure timestamps and verify delayed clock-skewed failures still merge.
+- [x] 8.35 Preserve invalid-param presence through parsed nested errors and raw
+  `response.failed` envelopes without changing the shared error parser contract.
+- [x] 8.36 Keep restored rebound operation identity for capacity/gate retries
+  and force a durable rebind before dispatch.
+- [x] 8.37 Generation-fence original-key quarantine clearing and fail closed on
+  explicit stale rejection after any output.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -12,7 +12,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import anyio
 import pytest
@@ -36,7 +36,9 @@ from app.db.session import SessionLocal
 from app.dependencies import get_proxy_service_for_app
 from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service.http_bridge import quarantine as http_bridge_quarantine_module
+from app.modules.proxy._service.http_bridge import retry_circuit as http_bridge_retry_circuit_module
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
+from app.modules.proxy._service.http_bridge import upstream_events as http_bridge_upstream_events_module
 from app.modules.proxy._service.http_bridge.helpers import (
     _make_http_bridge_session_header_fallback_key,
     _release_http_bridge_unanchored_handoff,
@@ -725,6 +727,20 @@ class _PreviousResponseNotFoundUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
                 ),
             )
         )
+
+
+class _PreviousResponseNotFoundAfterOutputUpstreamWebSocket(_PreviousResponseNotFoundUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        await self._messages.put(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.reasoning_summary_text.delta", "delta": "partial"},
+                    separators=(",", ":"),
+                ),
+            )
+        )
+        await super().send_text(text)
 
 
 class _AnonymousPreviousResponseNotFoundWithInflightUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
@@ -13834,6 +13850,478 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_previous_response
     assert second.status_code == 200
     assert second.json()["output"][0]["content"][0]["text"] == "OK"
     assert connect_count == 2
+
+
+@pytest.mark.parametrize(
+    "replay_case",
+    [
+        "account-neutral",
+        "forwarded-account-neutral",
+        "owner-bound-tool-history",
+        "forwarded-owner-bound-tool-history",
+        "missing-prior-output",
+        "transport-only",
+        "operation-fence-unavailable",
+        "spool-reset-unavailable",
+        "prior-replay-ambiguous",
+        "inactive-unknown-journal",
+        "pending-tool-manifest",
+        "inactive-unknown-owner-bound-journal",
+        "newer-circuit-before-submit",
+        "account-neutral-newer-circuit-before-submit",
+        "circuit-advances-during-admission",
+        "prior-replay-ambiguous-after-event",
+        "stale-rejection-after-event-first-attempt",
+    ],
+)
+@pytest.mark.asyncio
+async def test_backend_responses_http_bridge_replays_verified_full_resend_after_stale_owner(
+    async_client,
+    app_instance,
+    monkeypatch,
+    replay_case,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_neutral = replay_case in {
+        "account-neutral",
+        "forwarded-account-neutral",
+        "pending-tool-manifest",
+        "account-neutral-newer-circuit-before-submit",
+    }
+    forwarded_receiver = replay_case.startswith("forwarded-")
+    operation_fence_unavailable = replay_case == "operation-fence-unavailable"
+    spool_reset_unavailable = replay_case == "spool-reset-unavailable"
+    prior_replay_ambiguous = replay_case == "prior-replay-ambiguous"
+    prior_replay_ambiguous_after_event = replay_case == "prior-replay-ambiguous-after-event"
+    stale_rejection_after_event_first_attempt = replay_case == "stale-rejection-after-event-first-attempt"
+    inactive_unknown_journal = replay_case in {
+        "inactive-unknown-journal",
+        "inactive-unknown-owner-bound-journal",
+    }
+    pending_tool_manifest = replay_case == "pending-tool-manifest"
+    newer_circuit_before_submit = replay_case in {
+        "newer-circuit-before-submit",
+        "account-neutral-newer-circuit-before-submit",
+    }
+    circuit_advances_during_admission = replay_case == "circuit-advances-during-admission"
+    transport_only = replay_case == "transport-only"
+    owner_bound_replay = replay_case in {
+        "owner-bound-tool-history",
+        "forwarded-owner-bound-tool-history",
+        "newer-circuit-before-submit",
+        "inactive-unknown-owner-bound-journal",
+        "circuit-advances-during-admission",
+    }
+    case = replay_case.replace("-", "_")
+    owner_account_id = await _import_account(
+        async_client,
+        f"acc_backend_stale_owner_{case}",
+        f"backend-stale-owner-{case}@example.com",
+    )
+    alternate_account_id = await _import_account(
+        async_client,
+        f"acc_backend_stale_alternate_{case}",
+        f"backend-stale-alternate-{case}@example.com",
+    )
+    owner_account = await _get_account(owner_account_id)
+    alternate_account = await _get_account(alternate_account_id)
+    owner_chatgpt_account_id = cast(str, owner_account.chatgpt_account_id)
+    alternate_chatgpt_account_id = cast(str, alternate_account.chatgpt_account_id)
+    owner_upstream = _FakeBridgeUpstreamWebSocket("resp_stale_owner")
+    if transport_only:
+        rejecting_upstream = _PrecreatedCloseUpstreamWebSocket("resp_transport_only")
+    elif prior_replay_ambiguous_after_event or stale_rejection_after_event_first_attempt:
+        rejecting_upstream = _PreviousResponseNotFoundAfterOutputUpstreamWebSocket()
+    else:
+        rejecting_upstream = _PreviousResponseNotFoundUpstreamWebSocket()
+    alternate_upstream = _FakeBridgeUpstreamWebSocket("resp_stale_alternate")
+    selection_calls: list[dict[str, object]] = []
+    connected_account_ids: list[str] = []
+    connect_headers_by_account: dict[str, dict[str, str]] = {}
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        selection_calls.append(dict(kwargs))
+        preferred_account_id = cast(str | None, kwargs.get("preferred_account_id"))
+        excluded_account_ids = cast(set[str], kwargs.get("exclude_account_ids") or set())
+        if owner_account.id in excluded_account_ids or preferred_account_id == alternate_account.id:
+            return AccountSelection(account=alternate_account, error_message=None, error_code=None)
+        return AccountSelection(account=owner_account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del access_token, base_url, session
+        connected_account_ids.append(account_id_header)
+        connect_headers_by_account[account_id_header] = dict(headers)
+        if account_id_header == owner_chatgpt_account_id:
+            return owner_upstream
+        assert account_id_header == alternate_chatgpt_account_id
+        return alternate_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    session_headers = {
+        "x-codex-session-id": f"backend-stale-owner-session-{case}",
+        "x-request-trace": "keep-me",
+    }
+    historical_input = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "first question"}],
+        }
+    ]
+    first_events = await _collect_sse_events(
+        async_client,
+        "/backend-api/codex/responses",
+        json_body={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": historical_input,
+            "stream": True,
+        },
+        headers=session_headers,
+    )
+    first_response_id = cast(str, first_events[-1]["response"]["id"])
+
+    service = get_proxy_service_for_app(app_instance)
+    async with service._http_bridge_lock:
+        session = next(iter(service._http_bridge_sessions.values()))
+        if owner_bound_replay or newer_circuit_before_submit or circuit_advances_during_admission:
+            cast(Any, service)._http_bridge_retry_circuits[session.key] = (
+                http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+                    consecutive_failures=2,
+                    cooldown_until=time.monotonic() + 60.0,
+                    last_detail="stream_incomplete",
+                    last_touched_monotonic=time.monotonic(),
+                    # This fixture injects an in-memory circuit directly;
+                    # no matching durable row was persisted.
+                    persisted_updated_at_epoch=0.0,
+                )
+            )
+            monkeypatch.setattr(service, "_load_http_bridge_retry_circuit", AsyncMock(return_value=True))
+        if operation_fence_unavailable:
+            monkeypatch.setattr(
+                http_bridge_streaming_module,
+                "_http_bridge_verified_stale_anchor_replay_is_operation_fenced",
+                lambda _session, _request_state: False,
+            )
+        if spool_reset_unavailable:
+            monkeypatch.setattr(service._durable_bridge, "reset_operation_event_spool", None)
+        if prior_replay_ambiguous or prior_replay_ambiguous_after_event:
+            original_prepare_http_bridge_request = service._prepare_http_bridge_request
+
+            def prepare_with_consumed_replay(*args, **kwargs):
+                prepared_state, prepared_text = original_prepare_http_bridge_request(*args, **kwargs)
+                prepared_payload = args[0]
+                if prepared_payload.previous_response_id is not None:
+                    prepared_state.replay_count = 1
+                return prepared_state, prepared_text
+
+            monkeypatch.setattr(service, "_prepare_http_bridge_request", prepare_with_consumed_replay)
+        if newer_circuit_before_submit:
+            original_reset_http_bridge_session = service._reset_http_bridge_session_after_local_terminal_error
+
+            async def reset_then_advance_circuit(*args, **kwargs):
+                await original_reset_http_bridge_session(*args, **kwargs)
+                state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+                state.persisted_updated_at_epoch += 1.0
+                state.last_failure_monotonic = time.monotonic() + 1.0
+
+            monkeypatch.setattr(
+                service,
+                "_reset_http_bridge_session_after_local_terminal_error",
+                reset_then_advance_circuit,
+            )
+        if circuit_advances_during_admission:
+            original_acquire_admission = service._acquire_request_state_response_create_admission
+
+            async def acquire_then_advance_circuit(*args, **kwargs):
+                await original_acquire_admission(*args, **kwargs)
+                state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+                state.consecutive_failures += 1
+                state.last_failure_monotonic = time.monotonic() + 1.0
+
+            monkeypatch.setattr(
+                service,
+                "_acquire_request_state_response_create_admission",
+                acquire_then_advance_circuit,
+            )
+        await _replace_http_bridge_upstream_reader(
+            service,
+            session,
+            cast(proxy_module.UpstreamWebSocket, rejecting_upstream),
+        )
+    durable_clear_retry_circuit = AsyncMock(return_value=True)
+    clear_http_bridge_quarantine = Mock()
+    monkeypatch.setattr(service._durable_bridge, "clear_retry_circuit", durable_clear_retry_circuit)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_clear_http_bridge_quarantine",
+        clear_http_bridge_quarantine,
+    )
+    if inactive_unknown_journal:
+        original_lookup_request_targets = service._durable_bridge.lookup_request_targets
+
+        async def lookup_inactive_unknown_target(**kwargs):
+            lookup = await original_lookup_request_targets(**kwargs)
+            assert lookup is not None
+            return replace(
+                lookup,
+                state=HttpBridgeSessionState.CLOSED,
+                lease_expires_at=datetime.now(timezone.utc),
+            )
+
+        monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", lookup_inactive_unknown_target)
+        monkeypatch.setattr(
+            service._durable_bridge,
+            "lookup_recovery_attempt",
+            AsyncMock(return_value=SimpleNamespace()),
+        )
+        claim_live_session = AsyncMock(side_effect=AssertionError("inactive UNKNOWN journal must not be claimed"))
+        mark_recovery_attempt_replayed = AsyncMock(
+            side_effect=AssertionError("inactive UNKNOWN journal must not be replayed")
+        )
+        monkeypatch.setattr(service._durable_bridge, "claim_live_session", claim_live_session)
+        monkeypatch.setattr(
+            service._durable_bridge,
+            "mark_recovery_attempt_replayed",
+            mark_recovery_attempt_replayed,
+        )
+    elif pending_tool_manifest:
+        original_lookup_request_targets = service._durable_bridge.lookup_request_targets
+
+        async def lookup_pending_tool_manifest(**kwargs):
+            lookup = await original_lookup_request_targets(**kwargs)
+            assert lookup is not None
+            return replace(
+                lookup,
+                latest_pending_tool_calls={"call_owner_bound": "function_call"},
+            )
+
+        monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", lookup_pending_tool_manifest)
+
+    full_resend = [
+        *historical_input,
+        *(
+            []
+            if not owner_bound_replay
+            else [
+                {
+                    "type": "function_call",
+                    "namespace": "collaboration",
+                    "call_id": "call_owner_bound",
+                    "name": "spawn_agent",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_owner_bound",
+                    "output": "completed",
+                },
+            ]
+        ),
+        *(
+            []
+            if replay_case in {"missing-prior-output", "pending-tool-manifest"}
+            else [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "first answer"}],
+                }
+            ]
+        ),
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "second question"}],
+        },
+    ]
+    if prior_replay_ambiguous or prior_replay_ambiguous_after_event:
+        full_resend = [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "second question"}],
+            }
+        ]
+    elif pending_tool_manifest:
+        full_resend = [
+            *historical_input,
+            {
+                "type": "function_call",
+                "call_id": "call_owner_bound",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_owner_bound",
+                "output": "completed",
+            },
+        ]
+    second_payload = {
+        "model": "gpt-5.1",
+        "instructions": "Return exactly OK.",
+        "input": full_resend,
+        "previous_response_id": first_response_id,
+        "stream": True,
+    }
+    expected_replay_input = proxy_module.ResponsesRequest.model_validate(second_payload).to_payload()["input"]
+    if inactive_unknown_journal:
+        failed_response = await async_client.post(
+            "/backend-api/codex/responses",
+            json=second_payload,
+            headers={**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+        )
+        assert failed_response.status_code == 502
+        assert failed_response.json()["error"]["code"] == "bridge_continuity_persistence_failed"
+        assert connected_account_ids == [owner_chatgpt_account_id]
+        assert len(owner_upstream.sent_text) == 1
+        assert rejecting_upstream.sent_text == []
+        assert alternate_upstream.sent_text == []
+        claim_live_session.assert_not_awaited()
+        mark_recovery_attempt_replayed.assert_not_awaited()
+        return
+    if account_neutral and newer_circuit_before_submit:
+        failed_response = await async_client.post(
+            "/backend-api/codex/responses",
+            json=second_payload,
+            headers={**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+        )
+        assert failed_response.status_code == 503
+        assert failed_response.json()["error"]["code"] == "upstream_request_timeout"
+        assert connected_account_ids == (
+            [owner_chatgpt_account_id, alternate_chatgpt_account_id]
+            if account_neutral
+            else [owner_chatgpt_account_id, owner_chatgpt_account_id]
+        )
+        assert len(owner_upstream.sent_text) == 1
+        assert alternate_upstream.sent_text == []
+        return
+    if operation_fence_unavailable or spool_reset_unavailable or prior_replay_ambiguous:
+        failed_response = await async_client.post(
+            "/backend-api/codex/responses",
+            json=second_payload,
+            headers={**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+        )
+        assert failed_response.status_code == 502
+        assert failed_response.json()["error"]["code"] == "bridge_continuity_persistence_failed"
+        assert connected_account_ids == [owner_chatgpt_account_id]
+        assert len(owner_upstream.sent_text) == 1
+        assert alternate_upstream.sent_text == []
+        return
+    if prior_replay_ambiguous_after_event or stale_rejection_after_event_first_attempt:
+        failed_events = await _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=second_payload,
+            headers={**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+        )
+        # The stream already emitted output, so the HTTP surface normalizes
+        # the fail-closed exception to stream_incomplete. The safety contract
+        # is that no anchored or unanchored replacement is dispatched.
+        assert failed_events[-1]["response"]["error"]["code"] == "stream_incomplete"
+        assert connected_account_ids == [owner_chatgpt_account_id]
+        assert len(owner_upstream.sent_text) == 1
+        assert alternate_upstream.sent_text == []
+        return
+    if forwarded_receiver:
+        forwarded_chunks = [
+            chunk
+            async for chunk in service.stream_http_responses(
+                proxy_module.ResponsesRequest.model_validate(second_payload),
+                {**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+                codex_session_affinity=True,
+                propagate_http_errors=True,
+                forwarded_request=True,
+                forwarded_affinity_kind="session_header",
+                forwarded_affinity_key=session_headers["x-codex-session-id"],
+            )
+        ]
+        second_events = [
+            event
+            for line in "".join(forwarded_chunks).splitlines()
+            if line.startswith("data: ") and line[6:] != "[DONE]"
+            if (event := json.loads(line[6:])).get("type") != "codex.keepalive"
+        ]
+    else:
+        second_events = await _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=second_payload,
+            headers={**session_headers, "x-codex-turn-state": f"http_turn_stale_{case}"},
+        )
+
+    assert len(rejecting_upstream.sent_text) == 1
+    if transport_only:
+        assert second_events[-1]["response"]["error"]["code"] == "stream_incomplete"
+        assert connected_account_ids == [owner_chatgpt_account_id]
+        assert len(owner_upstream.sent_text) == 1
+        assert alternate_upstream.sent_text == []
+        return
+    if account_neutral:
+        assert second_events[-1]["response"]["id"] == "resp_stale_alternate_1"
+        assert connected_account_ids == [owner_chatgpt_account_id, alternate_chatgpt_account_id]
+        assert len(alternate_upstream.sent_text) == 1
+        replay_payload = json.loads(alternate_upstream.sent_text[0])
+        replay_connect_headers = {
+            key.lower(): value for key, value in connect_headers_by_account[alternate_chatgpt_account_id].items()
+        }
+        assert not {"x-codex-session-id", "x-codex-turn-state"} & replay_connect_headers.keys()
+        replay_selection = next(
+            call
+            for call in selection_calls
+            if owner_account.id in cast(set[str], call.get("exclude_account_ids") or set())
+        )
+        assert replay_selection.get("preferred_account_id") is None
+    elif owner_bound_replay:
+        assert second_events[-1]["response"]["id"] == "resp_stale_owner_2"
+        assert connected_account_ids == [owner_chatgpt_account_id, owner_chatgpt_account_id]
+        assert alternate_upstream.sent_text == []
+        replay_payload = json.loads(owner_upstream.sent_text[-1])
+        replay_connect_headers = {
+            key.lower(): value for key, value in connect_headers_by_account[owner_chatgpt_account_id].items()
+        }
+        assert replay_connect_headers["x-codex-session-id"] == session_headers["x-codex-session-id"]
+        replay_selection = next(
+            call for call in selection_calls if call.get("preferred_account_id") == owner_account.id
+        )
+        assert owner_account.id not in cast(set[str], replay_selection.get("exclude_account_ids") or set())
+        assert "previous_response_id" not in replay_payload
+        assert replay_payload["input"] == expected_replay_input
+        retained_circuit = cast(Any, service)._http_bridge_retry_circuits[session.key]
+        if circuit_advances_during_admission:
+            assert retained_circuit.consecutive_failures >= 3
+        else:
+            assert retained_circuit.consecutive_failures == 2
+        assert retained_circuit.cooldown_until > time.monotonic()
+        durable_clear_retry_circuit.assert_not_awaited()
+        clear_http_bridge_quarantine.assert_called_once()
+    else:
+        assert second_events[-1]["response"]["id"] == "resp_stale_owner_2"
+        assert connected_account_ids == [owner_chatgpt_account_id, owner_chatgpt_account_id]
+        assert alternate_upstream.sent_text == []
+        replay_payload = json.loads(owner_upstream.sent_text[-1])
+        replay_connect_headers = {
+            key.lower(): value for key, value in connect_headers_by_account[owner_chatgpt_account_id].items()
+        }
+        assert replay_payload["previous_response_id"] == first_response_id
+    if account_neutral:
+        assert "previous_response_id" not in replay_payload
+        assert replay_payload["input"] == expected_replay_input
+    assert replay_connect_headers["x-request-trace"] == "keep-me"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -765,6 +765,65 @@ async def test_terminal_operation_event_exposes_failure_after_spooling(
 
 
 @pytest.mark.asyncio
+async def test_failed_operation_rebind_rollback_restores_row_instead_of_deleting(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-rebind-rollback", session_key_value="sid-rebind-rollback")
+        fingerprint = durable_bridge_hash("rebind-rollback")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        operation = await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-rebind-rollback",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-rebind-rollback",
+            model="gpt-5.6",
+            parent_response_id="resp-parent",
+        )
+        assert operation is not None
+        assert await repository.append_terminal_operation_event(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-rebind-rollback",
+            owner_epoch=claim.owner_epoch,
+            event_text='data: {"type":"response.failed"}\n\n',
+            max_bytes=1024,
+            state="failed",
+        )
+
+        rebound = await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-rebind-rollback",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-rebind-rollback",
+            model="gpt-5.6",
+            parent_response_id="resp-parent",
+        )
+        assert rebound is not None
+        assert rebound.created is False
+        assert rebound.rebound is True
+        assert await repository.rollback_operation_before_dispatch(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-rebind-rollback",
+            owner_epoch=claim.owner_epoch,
+            restore_rebound=True,
+        )
+        restored = await repository.get_operation(operation_id=operation_id)
+        assert restored is not None
+        assert restored.state == "failed"
+        assert restored.event_spool_complete is False
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
 async def test_terminal_failure_exposes_state_when_spool_overflows(
     async_session_factory: Callable[[], AsyncSession],
 ) -> None:

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -3270,6 +3270,80 @@ async def test_durable_bridge_retry_circuit_round_trip(
     assert cleared.last_detail is None
 
 
+@pytest.mark.asyncio
+async def test_durable_bridge_retry_circuit_generation_claim_is_compare_and_set(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await coordinator.persist_retry_circuit(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim",
+        api_key_id="key-claim",
+        consecutive_failures=2,
+        cooldown_until_epoch=1300.0,
+        last_detail="stream_incomplete",
+        updated_at_epoch=1200.0,
+    )
+
+    claimed = await coordinator.claim_retry_circuit_generation(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim",
+        api_key_id="key-claim",
+        expected_updated_at_epoch=1200.0,
+        expected_admission_generation=0,
+        expected_consecutive_failures=2,
+        expected_cooldown_until_epoch=1300.0,
+    )
+    assert claimed is not None
+    assert claimed.updated_at_epoch == 1200.0
+    assert claimed.admission_generation == 1
+    assert claimed.consecutive_failures == 2
+    assert claimed.cooldown_until_epoch == 1300.0
+
+    stale_claim = await coordinator.claim_retry_circuit_generation(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim",
+        api_key_id="key-claim",
+        expected_updated_at_epoch=1200.0,
+        expected_admission_generation=0,
+        expected_consecutive_failures=2,
+        expected_cooldown_until_epoch=1300.0,
+    )
+    assert stale_claim is None
+
+    absent_claim = await coordinator.claim_retry_circuit_generation(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim-absent",
+        api_key_id="key-claim",
+        expected_updated_at_epoch=None,
+        expected_admission_generation=0,
+        expected_consecutive_failures=0,
+        expected_cooldown_until_epoch=0.0,
+    )
+    assert absent_claim is not None
+    assert absent_claim.admission_generation == 1
+
+    await coordinator.persist_retry_circuit(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim",
+        api_key_id="key-claim",
+        consecutive_failures=3,
+        cooldown_until_epoch=1400.0,
+        last_detail="stream_incomplete",
+        # Simulate a delayed replica whose wall clock is behind the observed
+        # failure row. The admission claim must not disturb this base epoch.
+        updated_at_epoch=1100.0,
+        base_updated_at_epoch=1200.0,
+    )
+    after_delayed_failure = await coordinator.lookup_retry_circuit(
+        session_key_kind="session_header",
+        session_key_value="sid-retry-circuit-claim",
+        api_key_id="key-claim",
+    )
+    assert after_delayed_failure is not None
+    assert after_delayed_failure.consecutive_failures == 3
+    assert after_delayed_failure.admission_generation == 1
+
+
 def _lookup_with_lease(lease_expires_at):
     from app.db.models import HttpBridgeSessionState
     from app.modules.proxy.durable_bridge_coordinator import DurableBridgeLookup

--- a/tests/unit/test_openai_errors.py
+++ b/tests/unit/test_openai_errors.py
@@ -94,6 +94,43 @@ def test_previous_response_not_found_classifier_covers_openai_shapes():
     )
 
 
+def test_previous_response_not_found_classifier_covers_parameterless_invalid_anchor():
+    assert is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param=None,
+        message="Invalid `previous_response_id`.",
+    )
+    assert is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="previous_response_id",
+        message="Invalid previous_response_id.",
+    )
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="input",
+        message="Invalid previous_response_id.",
+    )
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param=None,
+        message="Invalid input.",
+    )
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param=None,
+        message="A required tool output from the previous response was not found.",
+    )
+
+
+def test_previous_response_not_found_classifier_rejects_non_string_param():
+    for param in (0, False, {}, []):
+        assert not is_previous_response_not_found_error(
+            code="invalid_request_error",
+            param=param,
+            message="Invalid previous_response_id.",
+        )
+
+
 def test_previous_response_id_from_not_found_message_extracts_anchor():
     assert (
         previous_response_id_from_not_found_message(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -50,6 +50,7 @@ from app.modules.proxy._service.http_bridge import request_submit as http_bridge
 from app.modules.proxy._service.http_bridge import retry_circuit as http_bridge_retry_circuit_module
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
 from app.modules.proxy._service.http_bridge import upstream_events as http_bridge_upstream_events_module
+from app.modules.proxy._service.websocket import helpers as websocket_helpers_module
 from app.modules.proxy.account_cache import clear_account_routing_unavailable, mark_account_routing_unavailable
 from app.modules.proxy.continuity import (
     is_http_bridge_account_neutral_replay,
@@ -477,6 +478,187 @@ def test_ambiguous_continuation_recovery_is_opt_in_and_requires_unobserved_ancho
     assert http_bridge_request_submit_module._http_bridge_client_full_history_recovery_enabled(request_state) is False
 
 
+@pytest.mark.parametrize(
+    ("code", "param", "message", "expected"),
+    [
+        ("previous_response_not_found", None, "missing", True),
+        ("bridge_previous_response_not_found", None, "missing", True),
+        ("invalid_request_error", None, "Invalid previous_response_id.", True),
+        ("invalid_request_error", "", "Invalid previous_response_id.", False),
+        ("invalid_request_error", "   ", "Invalid previous_response_id.", False),
+        ("stream_incomplete", None, "closed", False),
+        ("stream_idle_timeout", None, "timed out", False),
+        ("upstream_request_timeout", None, "timed out", False),
+        ("bridge_owner_unreachable", None, "owner unavailable", False),
+    ],
+)
+def test_http_bridge_explicit_previous_response_rejection_excludes_ambiguous_transport(
+    code: str,
+    param: str | None,
+    message: str,
+    expected: bool,
+) -> None:
+    error = proxy_service.openai_error(code, message)
+    if param is not None:
+        error["error"]["param"] = param
+
+    assert (
+        proxy_service._http_bridge_is_explicit_previous_response_rejection(
+            ProxyResponseError(400 if expected else 502, error)
+        )
+        is expected
+    )
+
+
+def test_http_bridge_explicit_previous_response_rejection_normalizes_error_type() -> None:
+    error = proxy_service.openai_error("upstream_error", "Previous response with id 'resp_missing' not found.")
+    error["error"]["type"] = "previous_response_not_found"
+    error["error"].pop("code")
+
+    assert proxy_service._http_bridge_is_explicit_previous_response_rejection(ProxyResponseError(400, error)) is True
+
+
+@pytest.mark.parametrize("param", ["", "   "])
+def test_previous_response_recovery_preserves_present_blank_param(param: str) -> None:
+    error = proxy_service.openai_error("invalid_request_error", "Invalid previous_response_id.")
+    error["error"]["param"] = param
+    exc = ProxyResponseError(400, error)
+
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
+    assert proxy_service._http_bridge_is_explicit_previous_response_rejection(exc) is False
+    assert (
+        websocket_helpers_module._websocket_event_error_param(
+            "error",
+            {
+                "type": "error",
+                "status": 400,
+                "error_type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "message": "Invalid previous_response_id.",
+                "param": param,
+            },
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize("param", [None, 0, False, {}, []])
+def test_previous_response_recovery_rejects_present_non_string_param(param: object) -> None:
+    error = proxy_service.openai_error("invalid_request_error", "Invalid previous_response_id.")
+    cast(Any, error["error"])["param"] = param
+    exc = ProxyResponseError(400, error)
+
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
+    assert proxy_service._http_bridge_is_explicit_previous_response_rejection(exc) is False
+    assert (
+        websocket_helpers_module._websocket_event_error_param(
+            "error",
+            cast(
+                dict[str, proxy_service.JsonValue],
+                {
+                    "type": "error",
+                    "code": "invalid_request_error",
+                    "message": "Invalid previous_response_id.",
+                    "param": param,
+                },
+            ),
+        )
+        == ""
+    )
+
+    _event_block, normalized_payload, _event, event_type = (
+        http_bridge_helpers_module._normalize_http_bridge_error_event(
+            event=None,
+            payload=cast(
+                dict[str, proxy_service.JsonValue],
+                {
+                    "type": "error",
+                    "status": 400,
+                    "error_type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Invalid previous_response_id.",
+                    "param": param,
+                },
+            ),
+            request_state=None,
+        )
+    )
+    assert event_type == "response.failed"
+    assert normalized_payload is not None
+    normalized_response = cast(dict[str, Any], normalized_payload["response"])
+    normalized_error = cast(dict[str, Any], normalized_response["error"])
+    assert normalized_error["param"] == ""
+    normalized_envelope = proxy_support_module._openai_error_envelope_from_response_failed_payload(normalized_payload)
+    assert normalized_envelope["error"]["param"] == ""
+
+    nested_payload = cast(
+        dict[str, proxy_service.JsonValue],
+        {
+            "type": "error",
+            "status": 400,
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "message": "Invalid previous_response_id.",
+                "param": param,
+            },
+        },
+    )
+    parsed_event = cast(
+        Any,
+        SimpleNamespace(
+            error=SimpleNamespace(
+                code="invalid_request_error",
+                type="invalid_request_error",
+                message="Invalid previous_response_id.",
+                param=None,
+            )
+        ),
+    )
+    _event_block, nested_normalized, _event, _event_type = (
+        http_bridge_helpers_module._normalize_http_bridge_error_event(
+            event=parsed_event,
+            payload=nested_payload,
+            request_state=None,
+        )
+    )
+    assert nested_normalized is not None
+    nested_response = cast(dict[str, Any], nested_normalized["response"])
+    nested_error = cast(dict[str, Any], nested_response["error"])
+    assert nested_error["param"] == ""
+
+    raw_failed_envelope = proxy_support_module._openai_error_envelope_from_response_failed_payload(
+        cast(
+            dict[str, proxy_service.JsonValue],
+            {
+                "type": "response.failed",
+                "response": {
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "invalid_request_error",
+                        "message": "Invalid previous_response_id.",
+                        "param": param,
+                    }
+                },
+            },
+        )
+    )
+    assert raw_failed_envelope["error"]["param"] == ""
+
+
+def test_parse_openai_error_retains_unrelated_error_with_nullable_param() -> None:
+    payload = proxy_service.openai_error("rate_limit_exceeded", "Retry later", error_type="rate_limit_error")
+    cast(Any, payload["error"])["param"] = None
+
+    parsed = proxy_service._parse_openai_error(payload)
+
+    assert parsed is not None
+    assert parsed.code == "rate_limit_exceeded"
+    assert parsed.type == "rate_limit_error"
+    assert parsed.message == "Retry later"
+    assert parsed.param is None
+
+
 def test_hard_continuity_operation_fence_requires_server_recovery_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -547,6 +729,46 @@ def test_http_bridge_durable_recovery_requires_predecessor_anchor() -> None:
 
     assert http_bridge_streaming_module._http_bridge_durable_recovery_predecessor_proven(fresh_turn) is False
     assert http_bridge_streaming_module._http_bridge_durable_recovery_predecessor_proven(anchored_turn) is True
+
+
+def test_verified_stale_anchor_replay_requires_complete_durable_operation_fence() -> None:
+    session = _make_bridge_session(key_value="verified-stale-operation-fence")
+    session.durable_session_id = "durable-verified-stale-operation-fence"
+    session.durable_owner_epoch = 7
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-verified-stale-operation-fence",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        operation_registered=True,
+        operation_id="op-verified-stale-operation-fence",
+    )
+
+    assert http_bridge_streaming_module._http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+        session,
+        request_state,
+    )
+    assert not http_bridge_streaming_module._http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+        session,
+        replace(request_state, operation_registered=False),
+    )
+    assert not http_bridge_streaming_module._http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+        session,
+        replace(request_state, operation_id=None),
+    )
+    session.durable_owner_epoch = None
+    assert not http_bridge_streaming_module._http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+        session,
+        request_state,
+    )
+    session.durable_owner_epoch = 7
+    session.durable_session_id = None
+    assert not http_bridge_streaming_module._http_bridge_verified_stale_anchor_replay_is_operation_fenced(
+        session,
+        request_state,
+    )
 
 
 @pytest.mark.asyncio
@@ -816,6 +1038,27 @@ def test_http_bridge_account_neutral_replay_rejects_namespaced_tool_call_history
                 },
                 {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
                 {"role": "user", "content": "next request"},
+            ],
+        }
+    )
+
+    assert http_bridge_streaming_module._http_bridge_payload_is_account_neutral_fresh_replay(payload) is False
+
+
+def test_http_bridge_account_neutral_replay_rejects_account_scoped_file_input() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "summarize the upload"},
+                        {"type": "input_file", "file_id": "file_account_scoped"},
+                    ],
+                },
+                {"role": "user", "content": "continue"},
             ],
         }
     )
@@ -21607,8 +21850,15 @@ async def test_http_bridge_capacity_retry_reclaims_unknown_operation_before_send
 
 
 @pytest.mark.asyncio
-async def test_submit_hard_turn_rolls_back_new_operation_before_retiring_session(
+@pytest.mark.parametrize(
+    ("operation_created", "operation_rebound", "restore_rebound"),
+    [(True, False, False), (False, True, True)],
+)
+async def test_submit_hard_turn_rolls_back_operation_before_retiring_session(
     monkeypatch: pytest.MonkeyPatch,
+    operation_created: bool,
+    operation_rebound: bool,
+    restore_rebound: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     session = _make_bridge_session(key_value="hard-turn-unsent-operation")
@@ -21632,7 +21882,8 @@ async def test_submit_hard_turn_rolls_back_new_operation_before_retiring_session
     )
     record_operation = AsyncMock(
         return_value=SimpleNamespace(
-            created=True,
+            created=operation_created,
+            rebound=operation_rebound,
             operation_id="operation-unsent",
             state="submitted",
             response_id=None,
@@ -21672,17 +21923,33 @@ async def test_submit_hard_turn_rolls_back_new_operation_before_retiring_session
 
     assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
     record_operation.assert_awaited_once()
-    rollback_operation.assert_awaited_once_with(
-        operation_id="operation-unsent",
-        session_id="durable-hard-turn-unsent-operation",
-        instance_id="instance-hard-turn-unsent-operation",
-        owner_epoch=3,
-    )
+    rollback_operation.assert_awaited_once()
+    rollback_call = rollback_operation.await_args
+    assert rollback_call is not None
+    rollback_kwargs = rollback_call.kwargs
+    assert rollback_kwargs == {
+        "operation_id": "operation-unsent",
+        "session_id": "durable-hard-turn-unsent-operation",
+        "instance_id": "instance-hard-turn-unsent-operation",
+        "owner_epoch": 3,
+        "restore_rebound": restore_rebound,
+        "rebound_from_session_id": None,
+        "rebound_from_account_id": None,
+        "rebound_from_model": None,
+        "rebound_from_parent_response_id": None,
+    }
     assert request_state.operation_created is False
+    assert request_state.operation_rebound is False
     assert request_state.operation_registered is False
-    assert request_state.operation_id is None
-    assert request_state.operation_fingerprint is None
-    assert request_state.operation_parent_response_id is None
+    assert request_state.operation_rebind_required is operation_rebound
+    if operation_rebound:
+        assert request_state.operation_id == "operation-unsent"
+        assert request_state.operation_fingerprint is not None
+        assert request_state.operation_parent_response_id is None
+    else:
+        assert request_state.operation_id is None
+        assert request_state.operation_fingerprint is None
+        assert request_state.operation_parent_response_id is None
 
 
 @pytest.mark.asyncio
@@ -26010,6 +26277,79 @@ async def test_retry_http_bridge_precreated_request_consumes_each_clean_close_on
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_rejects_verified_stale_anchor_clean_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-verified-stale-clean-close",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"full history"}',
+        transport="http",
+        replay_count=1,
+        verified_stale_anchor_replay=True,
+        account_response_create_lease=cast(Any, object()),
+    )
+    session = _make_bridge_session(
+        key_value="bridge-verified-stale-clean-close",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.last_upstream_close_code = 1000
+    session.last_upstream_close_generation = 3
+    send_text = AsyncMock()
+    session.upstream = cast(UpstreamWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock()))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+
+    assert websocket_helpers_module._prepare_websocket_request_state_for_auth_replay(request_state) is None
+    assert request_state.auth_replay_count == 0
+    assert request_state.replay_count == 1
+    assert await service._retry_http_bridge_precreated_request(session) is False
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_rejects_transport_only_anchor_removal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-transport-only-anchor-removal",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","previous_response_id":"resp-anchor"}',
+        transport="http",
+        previous_response_id="resp-anchor",
+        fresh_upstream_request_text='{"type":"response.create","input":"full history"}',
+        fresh_upstream_request_is_retry_safe=True,
+        account_response_create_lease=cast(Any, object()),
+    )
+    session = _make_bridge_session(
+        key_value="bridge-transport-only-anchor-removal",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.last_upstream_close_code = 1011
+    send_text = AsyncMock()
+    session.upstream = cast(UpstreamWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock()))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+
+    assert await service._retry_http_bridge_precreated_request(session) is False
+    assert request_state.previous_response_id == "resp-anchor"
+    assert request_state.replay_count == 0
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_model_fallback_excludes_rejected_hard_affinity_account(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -27460,6 +27800,241 @@ async def test_http_bridge_retry_circuit_allows_proof_gated_continuity_replay_du
         )
         is True
     )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_server_anchored_replay_does_not_bypass_submit_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-server-anchored-submit-cooldown")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-server-anchored-submit-cooldown",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        previous_response_id="resp-anchor",
+        request_text='{"type":"response.create","previous_response_id":"resp-anchor"}',
+    )
+    retry_allowed = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once"
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", retry_allowed)
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request_with_handoff(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+            request_scope_id="scope-server-anchored-submit-cooldown",
+            owned_unanchored_handoff=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    retry_allowed_call = retry_allowed.await_args
+    assert retry_allowed_call is not None
+    assert retry_allowed_call.kwargs["allow_proof_gated_continuity_replay"] is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_server_anchored_replay_does_not_bypass_precreated_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-server-anchored-precreated-cooldown",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        awaiting_response_created=True,
+        previous_response_id="resp-anchor",
+        request_text='{"type":"response.create","previous_response_id":"resp-anchor"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-server-anchored-precreated-cooldown",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    retry_allowed = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once"
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", retry_allowed)
+
+    assert await service._retry_http_bridge_precreated_request(session) is False
+    retry_allowed_call = retry_allowed.await_args
+    assert retry_allowed_call is not None
+    assert retry_allowed_call.kwargs["allow_proof_gated_continuity_replay"] is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_verified_stale_anchor_bypasses_only_captured_circuit_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-verified-generation")
+    now = time.monotonic()
+    state = http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+        consecutive_failures=2,
+        cooldown_until=now + 60.0,
+        last_detail="stream_incomplete",
+        last_touched_monotonic=now,
+        persisted_updated_at_epoch=7.0,
+        last_failure_monotonic=now,
+    )
+    cast(Any, service)._http_bridge_retry_circuits[hard_session.key] = state
+    monkeypatch.setattr(service._durable_bridge, "lookup_retry_circuit", AsyncMock(return_value=None))
+
+    load_succeeded, generation = await service._http_bridge_retry_circuit_generation(hard_session)
+    assert load_succeeded is True
+    assert generation == (0, 7.0, 0, 0.0, 2, now, now + 60.0)
+    assert (
+        await service._http_bridge_retry_circuit_generation_is_not_newer(
+            key=hard_session.key,
+            captured=True,
+            generation=generation,
+        )
+        is True
+    )
+
+    state.last_failure_monotonic = now + 1.0
+    assert (
+        await service._http_bridge_retry_circuit_generation_is_not_newer(
+            key=hard_session.key,
+            captured=True,
+            generation=generation,
+        )
+        is False
+    )
+
+    empty_session = _make_bridge_session(key_value="bridge-circuit-verified-generation-empty")
+    empty_load_succeeded, empty_generation = await service._http_bridge_retry_circuit_generation(empty_session)
+    assert empty_load_succeeded is True
+    assert empty_generation is None
+    cast(Any, service)._http_bridge_retry_circuits[empty_session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=1,
+            cooldown_until=0.0,
+            last_detail="stream_incomplete",
+            last_touched_monotonic=now,
+            last_failure_monotonic=now + 2.0,
+        )
+    )
+    assert (
+        await service._http_bridge_retry_circuit_generation_is_not_newer(
+            key=empty_session.key,
+            captured=True,
+            generation=empty_generation,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_verified_stale_anchor_claims_captured_generation_atomically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-generation-claim")
+    now = time.monotonic()
+    state = http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+        consecutive_failures=2,
+        cooldown_until=now + 60.0,
+        last_detail="stream_incomplete",
+        last_touched_monotonic=now,
+        persisted_updated_at_epoch=7.0,
+        last_failure_monotonic=now,
+    )
+    cast(Any, service)._http_bridge_retry_circuits[hard_session.key] = state
+    claimed = SimpleNamespace(updated_at_epoch=7.0, admission_generation=1)
+    claim_generation = AsyncMock(return_value=claimed)
+    monkeypatch.setattr(service._durable_bridge, "claim_retry_circuit_generation", claim_generation)
+
+    assert (
+        await service._claim_http_bridge_retry_circuit_generation(
+            key=hard_session.key,
+            captured=True,
+            generation=(0, 7.0, 2, 90.0, 2, now, now + 60.0),
+        )
+        is True
+    )
+    claim_generation.assert_awaited_once()
+    assert state.persisted_updated_at_epoch == 7.0
+
+    state.last_failure_monotonic = now + 1.0
+    assert (
+        await service._claim_http_bridge_retry_circuit_generation(
+            key=hard_session.key,
+            captured=True,
+            generation=(1, 7.0, 2, 90.0, 2, now, now + 60.0),
+        )
+        is False
+    )
+    claim_generation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_verified_stale_anchor_claim_times_out_and_releases_circuit_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-generation-timeout")
+    waiting = asyncio.Event()
+
+    async def never_claims(**_kwargs: Any) -> None:
+        await waiting.wait()
+
+    monkeypatch.setattr(service._durable_bridge, "claim_retry_circuit_generation", never_claims)
+    monkeypatch.setattr(http_bridge_retry_circuit_module, "_HTTP_BRIDGE_RETRY_CIRCUIT_CLAIM_TIMEOUT_SECONDS", 0.001)
+
+    assert (
+        await service._claim_http_bridge_retry_circuit_generation(
+            key=hard_session.key,
+            captured=True,
+            generation=None,
+        )
+        is False
+    )
+    async with cast(Any, service)._http_bridge_retry_circuit_lock:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_source_retry_circuit_cooldown_is_used_for_replacement_suppression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-source-cooldown")
+    now = time.monotonic()
+    cast(Any, service)._http_bridge_retry_circuits[hard_session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=2,
+            cooldown_until=now + 42.0,
+            last_touched_monotonic=now,
+        )
+    )
+    monkeypatch.setattr(service._durable_bridge, "lookup_retry_circuit", AsyncMock(return_value=None))
+
+    cooldown = await service._http_bridge_retry_circuit_cooldown_seconds_for_key(hard_session.key)
+
+    assert 41.0 < cooldown <= 42.0
 
 
 @pytest.mark.asyncio
@@ -30379,6 +30954,61 @@ def test_http_bridge_quarantine_cleared_by_completed_response(caplog: pytest.Log
         http_bridge_quarantine_module._clear_http_bridge_quarantine(service, session)
     assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is False
     assert "http_bridge_event event=session_quarantine_cleared" in caplog.text
+
+
+def test_http_bridge_quarantine_clear_also_removes_recovery_origin_key() -> None:
+    service = SimpleNamespace()
+    origin = _make_bridge_session(key_value="quarantine-recovery-origin")
+    replacement = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("internal_unanchored_parallel", "recovery-fork", None),
+        key_value="recovery-fork",
+    )
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        origin,
+        reason="repeated_eventless_timeout",
+    )
+    observed_generation = http_bridge_quarantine_module._http_bridge_quarantine_generation(service, origin.key)
+    assert observed_generation is not None
+
+    http_bridge_quarantine_module._clear_http_bridge_quarantine(
+        service,
+        replacement,
+        additional_key=origin.key,
+        additional_key_generation=observed_generation,
+    )
+
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, origin.key) is False
+
+
+def test_http_bridge_quarantine_recovery_clear_preserves_newer_origin_generation() -> None:
+    service = SimpleNamespace()
+    origin = _make_bridge_session(key_value="quarantine-origin-generation")
+    replacement = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("internal_unanchored_parallel", "recovery-generation", None),
+        key_value="recovery-generation",
+    )
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        origin,
+        reason="reattach_missing_response_created",
+    )
+    observed_generation = http_bridge_quarantine_module._http_bridge_quarantine_generation(service, origin.key)
+    assert observed_generation is not None
+
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        origin,
+        reason="repeated_eventless_timeout",
+    )
+    http_bridge_quarantine_module._clear_http_bridge_quarantine(
+        service,
+        replacement,
+        additional_key=origin.key,
+        additional_key_generation=observed_generation,
+    )
+
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, origin.key) is True
 
 
 def test_http_bridge_quarantine_expired_strike_is_not_resurrected() -> None:


### PR DESCRIPTION
## Summary

- Recover explicit stale `previous_response_id` rejection only with durable replay and operation-fence proof.
- Preserve retry-circuit, quarantine, account-ownership, and partial-output fail-closed invariants.
- Add durable admission-generation migration and HTTP bridge regressions.

## Validation

- `925 passed` — Soju main based related HTTP bridge, durable-session, lifecycle, and error suites
- Ruff, ty, proxy architecture, strict OpenSpec, and `git diff --check`
- Prior `rvw` review loop completed with 0 confirmed findings before this two-file Soju-main conflict resolution

## Issue coverage

Partial fix; no linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer stale-response recovery for WebSocket and HTTP requests.
  * Supports verified same-owner and account-neutral replay when eligible.
  * Preserves error parameters and standardizes stale-response signaling.
  * Adds generation-aware retry admission and recovery-state fencing.

* **Bug Fixes**
  * Prevents unsafe retries, duplicate processing, and replay after state changes.
  * Improves quarantine cleanup, rollback, and recovery-state handling.
  * Fails closed when required recovery state is unavailable.

* **Tests**
  * Expanded coverage for recovery, replay safety, retry admission, rollback, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->