### PR TITLE
fix(db): skip the SQLite startup scan after a clean shutdown

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -21,10 +21,15 @@ from sqlalchemy.pool import NullPool
 
 from app.core.config.settings import get_settings
 from app.db.sqlite_utils import (
+    IntegrityCheck,
     SqliteIntegrityCheckMode,
+    SqliteRunState,
     check_sqlite_integrity,
+    integrity_check_pragma_name,
     normalize_sqlite_url,
+    read_sqlite_runstate,
     sqlite_db_path_from_url,
+    write_sqlite_runstate,
 )
 
 if TYPE_CHECKING:
@@ -361,6 +366,77 @@ def _startup_sqlite_check_mode(raw_mode: str) -> SqliteIntegrityCheckMode | None
     if raw_mode == "off":
         return None
     return SqliteIntegrityCheckMode(raw_mode)
+
+
+def _sqlite_startup_check_required(sqlite_path: Path, *, mode: SqliteIntegrityCheckMode) -> bool:
+    """Decide whether this startup has to scan the whole SQLite file.
+
+    The scan reads every page, so its cost grows with the store and the
+    listener cannot bind until it returns. SQLite is already consistent after
+    a clean close, so the scan only earns its cost when the previous process
+    did not get to record one. Anything other than a recorded clean shutdown
+    (a crash, an OOM kill, a power loss, a first run, or an upgrade from a
+    build that never wrote the sidecar) still pays for the scan.
+    """
+    if read_sqlite_runstate(sqlite_path) is not SqliteRunState.CLEAN:
+        return True
+    logger.info(
+        "Skipping SQLite startup %s after a recorded clean shutdown path=%s",
+        integrity_check_pragma_name(mode),
+        sqlite_path,
+    )
+    return False
+
+
+def _run_startup_sqlite_check(sqlite_path: Path, *, mode: SqliteIntegrityCheckMode) -> IntegrityCheck:
+    """Run the startup scan, announcing it so the stall is never unexplained."""
+    pragma_name = integrity_check_pragma_name(mode)
+    try:
+        size_bytes = sqlite_path.stat().st_size
+    except OSError:
+        size_bytes = 0
+    logger.info(
+        "Running SQLite startup %s path=%s size_bytes=%s; the listener does not bind until it completes",
+        pragma_name,
+        sqlite_path,
+        size_bytes,
+    )
+    started_monotonic = time.monotonic()
+    integrity = check_sqlite_integrity(sqlite_path, mode=mode)
+    elapsed_seconds = time.monotonic() - started_monotonic
+    if integrity.ok:
+        logger.info(
+            "SQLite startup %s passed in %.1fs path=%s",
+            pragma_name,
+            elapsed_seconds,
+            sqlite_path,
+        )
+    return integrity
+
+
+def _mark_sqlite_running(sqlite_path: Path) -> None:
+    if not write_sqlite_runstate(sqlite_path, SqliteRunState.RUNNING):
+        logger.warning(
+            "Failed to record the SQLite run state path=%s; the next startup will re-run the integrity check",
+            sqlite_path,
+        )
+
+
+def mark_sqlite_shutdown_clean() -> None:
+    """Record that this process closed the SQLite store cleanly.
+
+    Call this after the engines are disposed. The next startup reads it and
+    skips the integrity scan, which is what keeps an operator restart from
+    paying a whole-file read that grows with the store.
+    """
+    sqlite_path = sqlite_db_path_from_url(normalize_sqlite_url(_settings.database_url))
+    if sqlite_path is None:
+        return
+    if not write_sqlite_runstate(sqlite_path, SqliteRunState.CLEAN):
+        logger.warning(
+            "Failed to record a clean SQLite shutdown path=%s; the next startup will run the integrity check",
+            sqlite_path,
+        )
 
 
 async def _shielded(awaitable: Awaitable[object]) -> None:
@@ -843,11 +919,11 @@ async def init_db() -> None:
     sqlite_path = sqlite_db_path_from_url(database_url)
     if sqlite_path is not None:
         check_mode = _startup_sqlite_check_mode(_settings.database_sqlite_startup_check_mode)
-        if check_mode is not None:
-            integrity = check_sqlite_integrity(sqlite_path, mode=check_mode)
+        if check_mode is not None and _sqlite_startup_check_required(sqlite_path, mode=check_mode):
+            integrity = _run_startup_sqlite_check(sqlite_path, mode=check_mode)
             if not integrity.ok:
                 details = integrity.details or "unknown error"
-                pragma_name = "quick_check" if check_mode == SqliteIntegrityCheckMode.QUICK else "integrity_check"
+                pragma_name = integrity_check_pragma_name(check_mode)
                 logger.error(
                     "SQLite %s failed path=%s details=%s",
                     pragma_name,
@@ -868,6 +944,9 @@ async def init_db() -> None:
                         "or restore a backup from the same directory."
                     )
                 raise RuntimeError(message)
+        # Record the run state even when the check is disabled, so turning it
+        # back on cannot trust a sidecar this build never maintained.
+        _mark_sqlite_running(sqlite_path)
 
     try:
         inspect_migration_state, run_startup_migrations, check_schema_drift = _load_migration_entrypoints()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -415,7 +415,13 @@ def _run_startup_sqlite_check(sqlite_path: Path, *, mode: SqliteIntegrityCheckMo
 
 
 def _mark_sqlite_running(sqlite_path: Path) -> None:
-    if not write_sqlite_runstate(sqlite_path, SqliteRunState.RUNNING):
+    try:
+        recorded = write_sqlite_runstate(sqlite_path, SqliteRunState.RUNNING)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not safely invalidate the SQLite run state at {sqlite_path}; refusing to start"
+        ) from exc
+    if not recorded:
         logger.warning(
             "Failed to record the SQLite run state path=%s; the next startup will re-run the integrity check",
             sqlite_path,

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1030,7 +1030,9 @@ async def init_db() -> None:
             raise
 
 
-async def close_db() -> None:
+async def close_db() -> bool:
+    """Dispose database engines and report whether SQLite teardown fully drained."""
+    sqlite_teardown_drained = True
     if _wedged_teardown_cleanup_tasks:
         # Abandoned wedged teardowns plus their deferred bookkeeping closes.
         # Drain until the registry is stable — an abandoned teardown that
@@ -1049,6 +1051,7 @@ async def close_db() -> None:
                     "drain; their connections were already reclaimed (issue #1682)",
                     len(_wedged_teardown_cleanup_tasks),
                 )
+                sqlite_teardown_drained = False
                 break
             await asyncio.wait(tuple(_wedged_teardown_cleanup_tasks), timeout=remaining)
             # Completion callbacks (deregistration and scheduling of the
@@ -1058,3 +1061,4 @@ async def close_db() -> None:
     await engine.dispose()
     if _background_engine is not None:
         await _background_engine.dispose()
+    return sqlite_teardown_drained

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -185,22 +185,29 @@ def _sqlite_file_identity(db_path: Path) -> dict[str, int] | None:
     }
 
 
-def _fsync_directory(directory: Path) -> None:
+def _fsync_directory(directory: Path) -> bool:
     """Persist a directory entry so a rename survives power loss.
 
-    Windows and some network filesystems refuse to open or sync a directory;
-    there the rename durability guarantee is the platform's to make.
+    Returns ``False`` only when a sync was attempted and failed, which means
+    the storage is unhealthy and the record must not be trusted.
+
+    A platform that does not allow a directory handle at all reports success.
+    Windows raises on ``os.open`` of a directory, so failing closed there
+    would mean no Windows deployment could ever record a clean shutdown;
+    rename durability on those platforms is the platform's guarantee to make,
+    not something this code can verify.
     """
     try:
         directory_fd = os.open(directory, os.O_RDONLY)
     except OSError:
-        return
+        return True
     try:
         os.fsync(directory_fd)
     except OSError:
-        pass
+        return False
     finally:
         os.close(directory_fd)
+    return True
 
 
 def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
@@ -235,7 +242,9 @@ def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
 
     The payload and the directory entry are both fsynced, so a power loss
     cannot retain an earlier ``clean`` record while losing the ``running``
-    transition that replaced it. In WAL mode the main database file can keep
+    transition that replaced it. A directory sync that is attempted and fails
+    is treated as a failed write, because a record whose durability could not
+    be established must not be trusted. In WAL mode the main database file can keep
     its size and mtime across a long run, so the sidecar cannot rely on the
     file identity alone to invalidate a lost transition.
 
@@ -253,7 +262,8 @@ def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp, target)
-        _fsync_directory(target.parent)
+        if not _fsync_directory(target.parent):
+            raise OSError("could not sync the run-state directory entry")
         return True
     except OSError:
         for cleanup in (tmp, target):

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -164,12 +164,43 @@ def sqlite_runstate_path(db_path: Path) -> Path:
 
 
 def _sqlite_file_identity(db_path: Path) -> dict[str, int] | None:
-    """Size and mtime of the database file, used to fence a stale sidecar."""
+    """Identify the database file well enough to detect that it was replaced.
+
+    Size and mtime alone are not enough: a restore that preserves timestamps
+    (``tar -x``, ``cp -p``, ``rsync -a``) can reproduce both. The inode and
+    device catch the replacement itself, and ctime catches an in-place
+    metadata change. Any of these shifting for a benign reason only costs an
+    extra scan, which is the safe direction.
+    """
     try:
         stat_result = db_path.stat()
     except OSError:
         return None
-    return {"size": stat_result.st_size, "mtime_ns": stat_result.st_mtime_ns}
+    return {
+        "dev": stat_result.st_dev,
+        "ino": stat_result.st_ino,
+        "size": stat_result.st_size,
+        "mtime_ns": stat_result.st_mtime_ns,
+        "ctime_ns": stat_result.st_ctime_ns,
+    }
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Persist a directory entry so a rename survives power loss.
+
+    Windows and some network filesystems refuse to open or sync a directory;
+    there the rename durability guarantee is the platform's to make.
+    """
+    try:
+        directory_fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(directory_fd)
 
 
 def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
@@ -187,7 +218,7 @@ def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
     """
     try:
         raw = sqlite_runstate_path(db_path).read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeError):
         return None
     try:
         record = json.loads(raw)
@@ -202,6 +233,12 @@ def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
 def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
     """Record ``state`` atomically. Returns ``False`` if it could not be recorded.
 
+    The payload and the directory entry are both fsynced, so a power loss
+    cannot retain an earlier ``clean`` record while losing the ``running``
+    transition that replaced it. In WAL mode the main database file can keep
+    its size and mtime across a long run, so the sidecar cannot rely on the
+    file identity alone to invalidate a lost transition.
+
     A failed write must never leave a stale ``clean`` sidecar behind, because
     that would tell the next startup to skip the integrity check for a store
     this process may have left mid-write. The fallback is to remove the
@@ -211,8 +248,12 @@ def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
     tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
     payload = json.dumps({"state": state.value, "identity": _sqlite_file_identity(db_path)})
     try:
-        tmp.write_text(payload, encoding="utf-8")
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(tmp, target)
+        _fsync_directory(target.parent)
         return True
     except OSError:
         for cleanup in (tmp, target):

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 import sqlite3
 import urllib.parse
 from collections.abc import Iterator
@@ -18,6 +20,13 @@ class IntegrityCheck:
 class SqliteIntegrityCheckMode(str, Enum):
     QUICK = "quick"
     FULL = "full"
+
+
+class SqliteRunState(str, Enum):
+    """How the previous process left the SQLite store."""
+
+    RUNNING = "running"
+    CLEAN = "clean"
 
 
 @contextmanager
@@ -143,3 +152,72 @@ def check_sqlite_integrity(
 
     details = "; ".join(str(row) for row in rows)
     return IntegrityCheck(ok=False, details=details)
+
+
+def integrity_check_pragma_name(mode: SqliteIntegrityCheckMode) -> str:
+    return "quick_check" if mode == SqliteIntegrityCheckMode.QUICK else "integrity_check"
+
+
+def sqlite_runstate_path(db_path: Path) -> Path:
+    """Sidecar file recording how the previous process left ``db_path``."""
+    return db_path.with_name(f"{db_path.name}.runstate")
+
+
+def _sqlite_file_identity(db_path: Path) -> dict[str, int] | None:
+    """Size and mtime of the database file, used to fence a stale sidecar."""
+    try:
+        stat_result = db_path.stat()
+    except OSError:
+        return None
+    return {"size": stat_result.st_size, "mtime_ns": stat_result.st_mtime_ns}
+
+
+def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
+    """Return the recorded run state, or ``None`` when it cannot be trusted.
+
+    ``None`` means "unknown" and callers MUST treat it as potentially
+    unclean. A missing sidecar covers both a first run and an upgrade from a
+    build that never wrote one, so the conservative reading is the only safe
+    one.
+
+    A ``clean`` record is honoured only while the database file still matches
+    the size and mtime captured when the record was written. Restoring a
+    backup or swapping the file in by hand therefore reads back as unknown
+    rather than inheriting the previous file's clean record.
+    """
+    try:
+        raw = sqlite_runstate_path(db_path).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        record = json.loads(raw)
+        state = SqliteRunState(record["state"])
+    except (ValueError, TypeError, KeyError):
+        return None
+    if state is SqliteRunState.CLEAN and record.get("identity") != _sqlite_file_identity(db_path):
+        return None
+    return state
+
+
+def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
+    """Record ``state`` atomically. Returns ``False`` if it could not be recorded.
+
+    A failed write must never leave a stale ``clean`` sidecar behind, because
+    that would tell the next startup to skip the integrity check for a store
+    this process may have left mid-write. The fallback is to remove the
+    sidecar entirely, which reads back as unknown and forces the check.
+    """
+    target = sqlite_runstate_path(db_path)
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    payload = json.dumps({"state": state.value, "identity": _sqlite_file_identity(db_path)})
+    try:
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, target)
+        return True
+    except OSError:
+        for cleanup in (tmp, target):
+            try:
+                cleanup.unlink(missing_ok=True)
+            except OSError:
+                pass
+        return False

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -185,22 +185,34 @@ def _sqlite_file_identity(db_path: Path) -> dict[str, int] | None:
     }
 
 
+# Windows cannot obtain a directory handle through ``os.open``: the underlying
+# CreateFileW call refuses a directory and the failure surfaces as EACCES,
+# which errno cannot tell apart from an ordinary permission denial. Decide by
+# platform instead, so that on POSIX every open failure can be treated as the
+# real failure it is.
+_DIRECTORY_FSYNC_SUPPORTED = os.name == "posix"
+
+
 def _fsync_directory(directory: Path) -> bool:
     """Persist a directory entry so a rename survives power loss.
 
-    Returns ``False`` only when a sync was attempted and failed, which means
-    the storage is unhealthy and the record must not be trusted.
+    Returns ``False`` whenever a sync was expected and did not happen, so the
+    caller can refuse to leave behind a record whose durability is unproven.
+    A missing path, a permission denial, descriptor exhaustion, and an I/O
+    error all count.
 
-    A platform that does not allow a directory handle at all reports success.
-    Windows raises on ``os.open`` of a directory, so failing closed there
-    would mean no Windows deployment could ever record a clean shutdown;
-    rename durability on those platforms is the platform's guarantee to make,
-    not something this code can verify.
+    Where a directory handle is not obtainable at all the sync is not
+    attempted and this reports success. There is nothing this code can verify
+    on such a platform, and failing closed would mean no Windows deployment
+    could ever record a clean shutdown; rename durability there is the
+    platform's guarantee to make.
     """
+    if not _DIRECTORY_FSYNC_SUPPORTED:
+        return True
     try:
         directory_fd = os.open(directory, os.O_RDONLY)
     except OSError:
-        return True
+        return False
     try:
         os.fsync(directory_fd)
     except OSError:

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -249,6 +249,20 @@ def read_sqlite_runstate(db_path: Path) -> SqliteRunState | None:
     return state
 
 
+def _invalidate_failed_sqlite_runstate(target: Path, tmp: Path) -> None:
+    """Remove an untrusted run-state write and persist that removal."""
+    cleanup_error: OSError | None = None
+    for cleanup in (tmp, target):
+        try:
+            cleanup.unlink(missing_ok=True)
+        except OSError as exc:
+            cleanup_error = cleanup_error or exc
+    if cleanup_error is not None:
+        raise OSError(f"could not remove failed SQLite run-state files for {target}") from cleanup_error
+    if not _fsync_directory(target.parent):
+        raise OSError(f"could not persist removal of failed SQLite run-state files for {target}")
+
+
 def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
     """Record ``state`` atomically. Returns ``False`` if it could not be recorded.
 
@@ -262,8 +276,10 @@ def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
 
     A failed write must never leave a stale ``clean`` sidecar behind, because
     that would tell the next startup to skip the integrity check for a store
-    this process may have left mid-write. The fallback is to remove the
-    sidecar entirely, which reads back as unknown and forces the check.
+    this process may have left mid-write. The fallback removes both the
+    temporary and target files, then syncs the directory entry. If that
+    invalidation cannot be confirmed, the error is raised so startup cannot
+    continue with an untrusted marker.
     """
     target = sqlite_runstate_path(db_path)
     tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
@@ -278,9 +294,5 @@ def write_sqlite_runstate(db_path: Path, state: SqliteRunState) -> bool:
             raise OSError("could not sync the run-state directory entry")
         return True
     except OSError:
-        for cleanup in (tmp, target):
-            try:
-                cleanup.unlink(missing_ok=True)
-            except OSError:
-                pass
+        _invalidate_failed_sqlite_runstate(target, tmp)
         return False

--- a/app/main.py
+++ b/app/main.py
@@ -181,7 +181,7 @@ def _log_abandoned_lease_release(task: asyncio.Task[None]) -> None:
         logger.warning("Abandoned scheduler leader lease release finished with error", exc_info=exc)
 
 
-async def _release_leader_lease_within(timeout: float) -> None:
+async def _release_leader_lease_within(timeout: float) -> bool:
     """Release the scheduler leader lease without ever pinning shutdown.
 
     ``release()`` uses a background DB session whose rollback/close shield and
@@ -201,10 +201,11 @@ async def _release_leader_lease_within(timeout: float) -> None:
             timeout,
         )
         release_task.add_done_callback(_log_abandoned_lease_release)
-        return
+        return False
     exc = release_task.exception()
     if exc is not None:
         logger.warning("Failed to release scheduler leader lease during shutdown", exc_info=exc)
+    return True
 
 
 async def _drain_proxy_persistence_tasks(
@@ -322,15 +323,16 @@ def _log_non_multiproc_metrics_bind_conflict(port: int) -> None:
     )
 
 
-async def _close_db_and_record_clean_shutdown() -> None:
+async def _close_db_and_record_clean_shutdown(*, leader_lease_release_completed: bool = True) -> None:
     """Dispose the database engines, then record the shutdown as clean.
 
-    The record is only reached once disposal returns. A cancellation or a
-    failed dispose must leave the run state unclean, because that is exactly
-    the incomplete shutdown the next startup's integrity scan is for.
+    The record is only reached once disposal returns and no database-using
+    leader-lease release task was abandoned. A cancellation, failed dispose,
+    or abandoned release must leave the run state unclean, because that is
+    exactly the incomplete shutdown the next startup's integrity scan is for.
     """
     sqlite_teardown_drained = await close_db()
-    if sqlite_teardown_drained:
+    if sqlite_teardown_drained and leader_lease_release_completed:
         mark_sqlite_shutdown_clean()
 
 
@@ -774,7 +776,7 @@ async def lifespan(app: FastAPI):
         # release path shields and awaits its own session teardown — is
         # enforced by abandoning the release task rather than awaiting a
         # potentially wedged cancellation, so shutdown always proceeds.
-        await _release_leader_lease_within(10)
+        leader_lease_release_completed = await _release_leader_lease_within(10)
         try:
             await close_http_client()
         finally:
@@ -788,7 +790,9 @@ async def lifespan(app: FastAPI):
             finally:
                 mark_process_dead()
                 try:
-                    await _close_db_and_record_clean_shutdown()
+                    await _close_db_and_record_clean_shutdown(
+                        leader_lease_release_completed=leader_lease_release_completed,
+                    )
                 finally:
                     shutdown_state.mark_lifespan_completed()
 

--- a/app/main.py
+++ b/app/main.py
@@ -228,7 +228,7 @@ async def _drain_proxy_persistence_tasks(
         return False
 
 
-async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
+async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> bool:
     # Closing admission is synchronous with producer checks on the event loop,
     # so no task can appear after the stable drain passes complete.
     close_control_plane_task_admission()
@@ -257,7 +257,7 @@ async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
                 clean_pass = False
 
         if not clean_pass:
-            return
+            return False
 
         clean_passes += 1
 
@@ -266,6 +266,7 @@ async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
         # HTTP clients and DB engines are torn down.
         if clean_passes < 2:
             await asyncio.sleep(0)
+    return True
 
 
 class _MetricsServer(Protocol):
@@ -323,16 +324,21 @@ def _log_non_multiproc_metrics_bind_conflict(port: int) -> None:
     )
 
 
-async def _close_db_and_record_clean_shutdown(*, leader_lease_release_completed: bool = True) -> None:
+async def _close_db_and_record_clean_shutdown(
+    *,
+    database_tasks_drained: bool = True,
+    leader_lease_release_completed: bool = True,
+) -> None:
     """Dispose the database engines, then record the shutdown as clean.
 
     The record is only reached once disposal returns and no database-using
-    leader-lease release task was abandoned. A cancellation, failed dispose,
-    or abandoned release must leave the run state unclean, because that is
-    exactly the incomplete shutdown the next startup's integrity scan is for.
+    persistence, control-plane, or leader-lease release task was abandoned. A
+    cancellation, failed dispose, or abandoned task must leave the run state
+    unclean, because that is exactly the incomplete shutdown the next startup's
+    integrity scan is for.
     """
     sqlite_teardown_drained = await close_db()
-    if sqlite_teardown_drained and leader_lease_release_completed:
+    if sqlite_teardown_drained and database_tasks_drained and leader_lease_release_completed:
         mark_sqlite_shutdown_clean()
 
 
@@ -680,7 +686,7 @@ async def lifespan(app: FastAPI):
         # requests writes their request logs, which enqueues more
         # persistence tasks that this drain must cover.
         remaining_drain_seconds = shutdown_state.remaining_drain_timeout_seconds() or 0.0
-        await _drain_proxy_persistence_tasks(
+        database_tasks_drained = await _drain_proxy_persistence_tasks(
             proxy_service,
             remaining_drain_seconds,
             failure_message="Failed to drain proxy persistence tasks during shutdown",
@@ -726,7 +732,8 @@ async def lifespan(app: FastAPI):
         # The replica heartbeat is already stopped/staled so this grace period
         # does not extend its active bridge-ring lifetime.
         remaining_drain_seconds = shutdown_state.remaining_drain_timeout_seconds() or 0.0
-        await _drain_detached_control_plane_tasks(remaining_drain_seconds)
+        control_plane_tasks_drained = await _drain_detached_control_plane_tasks(remaining_drain_seconds)
+        database_tasks_drained = database_tasks_drained and control_plane_tasks_drained
 
         # Start the single process-level lease-renewal keeper BEFORE stopping any
         # scheduler. Schedulers are stopped one at a time and only the final
@@ -791,6 +798,7 @@ async def lifespan(app: FastAPI):
                 mark_process_dead()
                 try:
                     await _close_db_and_record_clean_shutdown(
+                        database_tasks_drained=database_tasks_drained,
                         leader_lease_release_completed=leader_lease_release_completed,
                     )
                 finally:

--- a/app/main.py
+++ b/app/main.py
@@ -322,6 +322,17 @@ def _log_non_multiproc_metrics_bind_conflict(port: int) -> None:
     )
 
 
+async def _close_db_and_record_clean_shutdown() -> None:
+    """Dispose the database engines, then record the shutdown as clean.
+
+    The record is only reached once disposal returns. A cancellation or a
+    failed dispose must leave the run state unclean, because that is exactly
+    the incomplete shutdown the next startup's integrity scan is for.
+    """
+    await close_db()
+    mark_sqlite_shutdown_clean()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     import app.core.startup as startup_module
@@ -776,15 +787,9 @@ async def lifespan(app: FastAPI):
             finally:
                 mark_process_dead()
                 try:
-                    await close_db()
+                    await _close_db_and_record_clean_shutdown()
                 finally:
-                    try:
-                        # Only reachable on an orderly teardown. A crash or a
-                        # SIGKILL leaves the sidecar unclean, which is exactly
-                        # what makes the next startup re-scan the store.
-                        mark_sqlite_shutdown_clean()
-                    finally:
-                        shutdown_state.mark_lifespan_completed()
+                    shutdown_state.mark_lifespan_completed()
 
 
 def create_app() -> FastAPI:

--- a/app/main.py
+++ b/app/main.py
@@ -329,8 +329,9 @@ async def _close_db_and_record_clean_shutdown() -> None:
     failed dispose must leave the run state unclean, because that is exactly
     the incomplete shutdown the next startup's integrity scan is for.
     """
-    await close_db()
-    mark_sqlite_shutdown_clean()
+    sqlite_teardown_drained = await close_db()
+    if sqlite_teardown_drained:
+        mark_sqlite_shutdown_clean()
 
 
 @asynccontextmanager

--- a/app/main.py
+++ b/app/main.py
@@ -63,7 +63,14 @@ from app.core.timeout_invariants import validate_runtime_timeout_invariants
 from app.core.usage.refresh_scheduler import build_usage_refresh_scheduler
 from app.core.usage.reset_credits_refresh_scheduler import build_rate_limit_reset_credits_scheduler
 from app.core.utils.time import utcnow
-from app.db.session import SessionLocal, close_db, close_session, init_background_db, init_db
+from app.db.session import (
+    SessionLocal,
+    close_db,
+    close_session,
+    init_background_db,
+    init_db,
+    mark_sqlite_shutdown_clean,
+)
 from app.modules.accounts import api as accounts_api
 from app.modules.accounts.deletion import build_account_deletion_scheduler
 from app.modules.accounts.repository import AccountsRepository
@@ -771,7 +778,13 @@ async def lifespan(app: FastAPI):
                 try:
                     await close_db()
                 finally:
-                    shutdown_state.mark_lifespan_completed()
+                    try:
+                        # Only reachable on an orderly teardown. A crash or a
+                        # SIGKILL leaves the sidecar unclean, which is exactly
+                        # what makes the next startup re-scan the store.
+                        mark_sqlite_shutdown_clean()
+                    finally:
+                        shutdown_state.mark_lifespan_completed()
 
 
 def create_app() -> FastAPI:

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/proposal.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`init_db()` runs `PRAGMA quick_check` (or `integrity_check`) over the whole
+SQLite file before anything else, and the listener does not bind until it
+returns. The scan reads every page, so its cost grows with the store while
+the operator sees nothing at all: no log line marks the start, so a restart
+looks like a hang.
+
+On a 3.7 GB store this is 177 seconds of connection-refused on every
+restart, measured on a running deployment across two consecutive restarts
+(178 s and 181 s). The stall sits entirely ahead of Alembic, which then
+reports `Database schema already at head; skipping upgrade`, so migrations
+are not the cost and the check is paid in full even when nothing changed.
+
+SQLite is already consistent after a clean close. The scan defends against
+filesystem and hardware corruption, which does not correlate with an
+operator restart, so paying for it on every start buys nothing in the common
+case and turns every deploy into a multi-minute outage.
+
+## What Changes
+
+- Record how each process left the SQLite store in a `<db>.runstate`
+  sidecar: `running` once startup has begun, `clean` after the engines are
+  disposed during an orderly shutdown.
+- Skip the startup integrity scan only when the sidecar records a clean
+  shutdown. A crash, an OOM kill, a power loss, a first run, and an upgrade
+  from a build that never wrote a sidecar all still run the scan.
+- Announce the scan before it starts (path, mode, file size) and log its
+  duration when it passes, so the stall is attributable when it does happen.
+
+Failure modes resolve toward checking. An unwritable, missing, or
+unrecognized sidecar reads back as unknown, and a failed write removes the
+file rather than leaving a stale `clean` behind. A `clean` record also
+carries the database file's size and mtime and is discarded once either
+changes, so restoring a backup over the store cannot inherit the previous
+file's clean record.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-backends`: when the SQLite startup integrity check runs, and the
+  observability it emits.
+
+## Impact
+
+No new setting, no new dependency, no schema change, and no change for
+non-SQLite backends. The existing
+`CODEX_LB_DATABASE_SQLITE_STARTUP_CHECK_MODE` (`quick` / `full` / `off`)
+keeps its current meaning and default; this only removes redundant runs of
+the mode already selected. The added artifact is one small sidecar file next
+to the database.
+
+Operators who want the scan on every start regardless can still get it: the
+sidecar only ever suppresses a scan after this process itself recorded a
+clean close.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/proposal.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/proposal.md
@@ -28,12 +28,15 @@ case and turns every deploy into a multi-minute outage.
 - Announce the scan before it starts (path, mode, file size) and log its
   duration when it passes, so the stall is attributable when it does happen.
 
-Failure modes resolve toward checking. An unwritable, missing, or
-unrecognized sidecar reads back as unknown, and a failed write removes the
-file rather than leaving a stale `clean` behind. A `clean` record also
-carries the database file's size and mtime and is discarded once either
-changes, so restoring a backup over the store cannot inherit the previous
-file's clean record.
+Failure modes resolve toward checking. A sidecar that is missing,
+unwritable, undecodable, or unrecognized reads back as unknown, and a failed
+write removes the file rather than leaving a stale `clean` behind. A `clean`
+record carries the database file's device, inode, size, mtime, and ctime and
+is discarded once any of them changes, so even a timestamp-preserving restore
+cannot inherit the previous file's clean record. Both the record and its
+directory entry are fsynced, so a power loss cannot keep an earlier `clean`
+while losing the `running` transition. `clean` is recorded only after the
+engines actually finished disposing.
 
 ## Capabilities
 

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -38,12 +38,15 @@ a `running` record stays readable while the process writes to the store.
 Run-state transitions MUST be durable. The system MUST sync both the record's
 contents and the directory entry that names it, so a power loss cannot retain
 an earlier `clean` record while losing the `running` transition that replaced
-it. A sync that is attempted and fails MUST be treated as a failed write, so
-storage that cannot confirm durability leaves no trusted record. A platform
-that does not permit a directory handle at all MUST NOT be treated as a
-failure, because rename durability there is the platform's guarantee and
+it. Every directory-sync failure MUST be treated as a failed write, including
+a directory that cannot be opened, so storage that cannot confirm durability
+leaves no trusted record. The one exception is a platform that offers no
+directory handle at all, where the sync MUST be skipped and reported as
+success, because rename durability there is the platform's guarantee and
 failing closed would prevent those deployments from ever recording a clean
-shutdown. The file fence cannot substitute for this: in WAL mode the main database
+shutdown. That exception MUST be decided by platform rather than by the error
+the open reports, because Windows refuses a directory handle with the same
+`EACCES` an ordinary permission denial uses. The file fence cannot substitute for this: in WAL mode the main database
 file can keep its size and modification time across a long run, so a lost
 transition would leave a `clean` record that still matches.
 
@@ -97,6 +100,13 @@ requirement governs only whether the selected mode runs on a given startup.
 - **WHEN** the system records a run-state transition
 - **THEN** the write reports failure and no sidecar remains
 - **AND** the next startup runs the integrity check
+
+#### Scenario: A directory that cannot be opened fails the write closed
+
+- **GIVEN** a platform that supports directory handles
+- **AND** a run-state directory the process cannot open
+- **WHEN** the system records a run-state transition
+- **THEN** the write reports failure and no sidecar remains
 
 #### Scenario: Corrupt sidecar content does not abort startup
 

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -38,7 +38,12 @@ a `running` record stays readable while the process writes to the store.
 Run-state transitions MUST be durable. The system MUST sync both the record's
 contents and the directory entry that names it, so a power loss cannot retain
 an earlier `clean` record while losing the `running` transition that replaced
-it. The file fence cannot substitute for this: in WAL mode the main database
+it. A sync that is attempted and fails MUST be treated as a failed write, so
+storage that cannot confirm durability leaves no trusted record. A platform
+that does not permit a directory handle at all MUST NOT be treated as a
+failure, because rename durability there is the platform's guarantee and
+failing closed would prevent those deployments from ever recording a clean
+shutdown. The file fence cannot substitute for this: in WAL mode the main database
 file can keep its size and modification time across a long run, so a lost
 transition would leave a `clean` record that still matches.
 
@@ -85,6 +90,13 @@ requirement governs only whether the selected mode runs on a given startup.
   time
 - **THEN** the clean record reads as unknown
 - **AND** the configured integrity check runs against the restored file
+
+#### Scenario: Unverifiable durability leaves no trusted record
+
+- **GIVEN** storage whose directory sync fails
+- **WHEN** the system records a run-state transition
+- **THEN** the write reports failure and no sidecar remains
+- **AND** the next startup runs the integrity check
 
 #### Scenario: Corrupt sidecar content does not abort startup
 

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -58,7 +58,9 @@ finished disposing and all reclaimed SQLite teardown work finished within the
 bounded shutdown drain. A cancelled or failed disposal, or a drain that
 abandons pending teardown work at its deadline, MUST leave the run state
 unclean. If shutdown abandons a database-using scheduler leader-lease release
-task at its deadline, it MUST also leave the run state unclean.
+task at its deadline, it MUST also leave the run state unclean. The same rule
+MUST apply when the final proxy persistence drain or detached audit/fleet
+control-plane drain leaves database-using tasks pending at its deadline.
 
 The configured check mode (`quick`, `full`, `off`) keeps its meaning: this
 requirement governs only whether the selected mode runs on a given startup.
@@ -149,6 +151,14 @@ requirement governs only whether the selected mode runs on a given startup.
 
 - **GIVEN** shutdown abandons a database-using scheduler leader-lease release
   task at its bounded deadline
+- **WHEN** database disposal finishes
+- **THEN** the sidecar does not record a clean shutdown
+- **AND** the next startup runs the integrity check
+
+#### Scenario: Abandoned database tasks are not recorded as clean
+
+- **GIVEN** the final proxy persistence drain or detached control-plane drain
+  reaches its deadline with database-using tasks still pending
 - **WHEN** database disposal finishes
 - **THEN** the sidecar does not record a clean shutdown
 - **AND** the next startup runs the integrity check

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -51,7 +51,9 @@ file can keep its size and modification time across a long run, so a lost
 transition would leave a `clean` record that still matches.
 
 Recording `clean` MUST NOT be reachable unless the database engines actually
-finished disposing. A cancelled or failed disposal MUST leave the run state
+finished disposing and all reclaimed SQLite teardown work finished within the
+bounded shutdown drain. A cancelled or failed disposal, or a drain that
+abandons pending teardown work at its deadline, MUST leave the run state
 unclean.
 
 The configured check mode (`quick`, `full`, `off`) keeps its meaning: this
@@ -120,6 +122,14 @@ requirement governs only whether the selected mode runs on a given startup.
 - **GIVEN** a shutdown in which disposing the database engines raises or is
   cancelled
 - **WHEN** the lifespan teardown completes
+- **THEN** the sidecar does not record a clean shutdown
+- **AND** the next startup runs the integrity check
+
+#### Scenario: An abandoned teardown is not recorded as clean
+
+- **GIVEN** a reclaimed SQLite teardown task remains pending when the bounded
+  shutdown drain reaches its deadline
+- **WHEN** database disposal finishes
 - **THEN** the sidecar does not record a clean shutdown
 - **AND** the next startup runs the integrity check
 

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -21,7 +21,10 @@ sidecar MUST read as unknown rather than clean, so a first run and an upgrade
 from a build that never wrote one both still scan. Sidecar content that cannot be read, cannot be
 decoded, or is not recognized MUST also read as unknown, and MUST NOT
 propagate an error that aborts startup. A sidecar write that fails MUST
-remove the file rather than leave a stale `clean` behind.
+remove the temporary and target files rather than leave a stale `clean`
+behind, and MUST directory-sync that removal. If the removal or its
+durability cannot be confirmed for the startup `running` transition, startup
+MUST abort rather than continue with an untrusted marker.
 
 The run state MUST be recorded even when the check mode is `off`, so
 re-enabling the check cannot trust a state the disabled build never
@@ -54,7 +57,8 @@ Recording `clean` MUST NOT be reachable unless the database engines actually
 finished disposing and all reclaimed SQLite teardown work finished within the
 bounded shutdown drain. A cancelled or failed disposal, or a drain that
 abandons pending teardown work at its deadline, MUST leave the run state
-unclean.
+unclean. If shutdown abandons a database-using scheduler leader-lease release
+task at its deadline, it MUST also leave the run state unclean.
 
 The configured check mode (`quick`, `full`, `off`) keeps its meaning: this
 requirement governs only whether the selected mode runs on a given startup.
@@ -103,6 +107,14 @@ requirement governs only whether the selected mode runs on a given startup.
 - **THEN** the write reports failure and no sidecar remains
 - **AND** the next startup runs the integrity check
 
+#### Scenario: Unconfirmed run-state invalidation aborts startup
+
+- **GIVEN** the startup `running` transition fails while a prior sidecar exists
+- **AND** removing or directory-syncing that sidecar cannot be confirmed
+- **WHEN** the application starts
+- **THEN** startup aborts instead of continuing with a potentially trusted
+  stale `clean` marker
+
 #### Scenario: A directory that cannot be opened fails the write closed
 
 - **GIVEN** a platform that supports directory handles
@@ -129,6 +141,14 @@ requirement governs only whether the selected mode runs on a given startup.
 
 - **GIVEN** a reclaimed SQLite teardown task remains pending when the bounded
   shutdown drain reaches its deadline
+- **WHEN** database disposal finishes
+- **THEN** the sidecar does not record a clean shutdown
+- **AND** the next startup runs the integrity check
+
+#### Scenario: An abandoned leader-lease release is not recorded as clean
+
+- **GIVEN** shutdown abandons a database-using scheduler leader-lease release
+  task at its bounded deadline
 - **WHEN** database disposal finishes
 - **THEN** the sidecar does not record a clean shutdown
 - **AND** the next startup runs the integrity check

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -18,8 +18,9 @@ or a failed startup.
 
 Every state other than a recorded `clean` MUST run the check. A missing
 sidecar MUST read as unknown rather than clean, so a first run and an upgrade
-from a build that never wrote one both still scan. Unreadable or unrecognized
-sidecar content MUST also read as unknown. A sidecar write that fails MUST
+from a build that never wrote one both still scan. Sidecar content that cannot be read, cannot be
+decoded, or is not recognized MUST also read as unknown, and MUST NOT
+propagate an error that aborts startup. A sidecar write that fails MUST
 remove the file rather than leave a stale `clean` behind.
 
 The run state MUST be recorded even when the check mode is `off`, so
@@ -27,11 +28,23 @@ re-enabling the check cannot trust a state the disabled build never
 maintained.
 
 A `clean` record MUST be fenced to the database file it describes. The
-recorded state MUST capture the file's size and modification time, and a
-`clean` record MUST read as unknown once either no longer matches, so a
-restored backup or a hand-swapped file cannot inherit the previous file's
-clean record. The fence applies only to `clean`; a `running` record stays
-readable while the process writes to the store.
+recorded state MUST capture enough of the file's identity to detect that it
+was replaced, including its device and inode, not only its size and
+modification time: a restore that preserves timestamps (`tar -x`, `cp -p`,
+`rsync -a`) can reproduce both. A `clean` record MUST read as unknown once
+any captured attribute no longer matches. The fence applies only to `clean`;
+a `running` record stays readable while the process writes to the store.
+
+Run-state transitions MUST be durable. The system MUST sync both the record's
+contents and the directory entry that names it, so a power loss cannot retain
+an earlier `clean` record while losing the `running` transition that replaced
+it. The file fence cannot substitute for this: in WAL mode the main database
+file can keep its size and modification time across a long run, so a lost
+transition would leave a `clean` record that still matches.
+
+Recording `clean` MUST NOT be reachable unless the database engines actually
+finished disposing. A cancelled or failed disposal MUST leave the run state
+unclean.
 
 The configured check mode (`quick`, `full`, `off`) keeps its meaning: this
 requirement governs only whether the selected mode runs on a given startup.
@@ -68,9 +81,25 @@ requirement governs only whether the selected mode runs on a given startup.
 
 - **GIVEN** a SQLite store whose sidecar records a clean shutdown
 - **WHEN** the database file is replaced from a backup, leaving the sidecar
-  in place
+  in place, and the restore reproduces the recorded size and modification
+  time
 - **THEN** the clean record reads as unknown
 - **AND** the configured integrity check runs against the restored file
+
+#### Scenario: Corrupt sidecar content does not abort startup
+
+- **GIVEN** a sidecar whose bytes are not valid UTF-8
+- **WHEN** the application starts
+- **THEN** the run state reads as unknown
+- **AND** the configured integrity check runs instead of startup failing
+
+#### Scenario: A failed disposal is not recorded as clean
+
+- **GIVEN** a shutdown in which disposing the database engines raises or is
+  cancelled
+- **WHEN** the lifespan teardown completes
+- **THEN** the sidecar does not record a clean shutdown
+- **AND** the next startup runs the integrity check
 
 #### Scenario: A failed check leaves the state unclean
 

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/specs/database-backends/spec.md
@@ -1,0 +1,100 @@
+# database-backends Delta
+
+## ADDED Requirements
+
+### Requirement: The SQLite startup integrity check is skipped after a recorded clean shutdown
+
+The startup integrity check reads every page of the SQLite file and the
+listener MUST NOT bind until it returns, so its cost grows with the store.
+Because SQLite is already consistent after a clean close, the system MUST
+record how each process left the store and MUST run the startup check only
+when the previous process did not record a clean shutdown.
+
+The run state MUST be persisted in a sidecar next to the database file. The
+system MUST record `running` during startup and MUST record `clean` only
+after the database engines are disposed during an orderly shutdown. The
+`clean` record MUST NOT be reachable from a crash, a signal-killed process,
+or a failed startup.
+
+Every state other than a recorded `clean` MUST run the check. A missing
+sidecar MUST read as unknown rather than clean, so a first run and an upgrade
+from a build that never wrote one both still scan. Unreadable or unrecognized
+sidecar content MUST also read as unknown. A sidecar write that fails MUST
+remove the file rather than leave a stale `clean` behind.
+
+The run state MUST be recorded even when the check mode is `off`, so
+re-enabling the check cannot trust a state the disabled build never
+maintained.
+
+A `clean` record MUST be fenced to the database file it describes. The
+recorded state MUST capture the file's size and modification time, and a
+`clean` record MUST read as unknown once either no longer matches, so a
+restored backup or a hand-swapped file cannot inherit the previous file's
+clean record. The fence applies only to `clean`; a `running` record stays
+readable while the process writes to the store.
+
+The configured check mode (`quick`, `full`, `off`) keeps its meaning: this
+requirement governs only whether the selected mode runs on a given startup.
+
+#### Scenario: A clean shutdown skips the next scan
+
+- **GIVEN** a SQLite store whose sidecar records a clean shutdown
+- **WHEN** the application starts with the check mode enabled
+- **THEN** no integrity check runs
+- **AND** the sidecar is updated to record that a process is running
+
+#### Scenario: An unfinished previous process still scans
+
+- **GIVEN** a SQLite store whose sidecar records that a process was running
+- **WHEN** the application starts with the check mode enabled
+- **THEN** the configured integrity check runs
+
+#### Scenario: A missing sidecar still scans
+
+- **GIVEN** an existing SQLite store with no sidecar, as after an upgrade from
+  a build that never wrote one
+- **WHEN** the application starts with the check mode enabled
+- **THEN** the configured integrity check runs
+
+#### Scenario: A disabled check still records the run state
+
+- **GIVEN** a check mode of `off`
+- **WHEN** the application starts
+- **THEN** no integrity check runs
+- **AND** the sidecar records that a process is running, so a later startup
+  with the check enabled does not trust the earlier clean record
+
+#### Scenario: A restored database still scans
+
+- **GIVEN** a SQLite store whose sidecar records a clean shutdown
+- **WHEN** the database file is replaced from a backup, leaving the sidecar
+  in place
+- **THEN** the clean record reads as unknown
+- **AND** the configured integrity check runs against the restored file
+
+#### Scenario: A failed check leaves the state unclean
+
+- **GIVEN** a SQLite store that fails its startup integrity check
+- **WHEN** startup aborts with the corruption error
+- **THEN** the sidecar does not record a clean shutdown
+- **AND** the next startup runs the check again
+
+### Requirement: The SQLite startup integrity check is observable
+
+When the startup integrity check runs, the system MUST log that it is
+starting, including the database path, the check mode, and the file size, and
+MUST log the elapsed duration when the check passes. A multi-minute scan MUST
+NOT present as an unexplained stall with the listener unbound.
+
+#### Scenario: A long scan is attributable
+
+- **GIVEN** a SQLite store large enough for the check to take minutes
+- **WHEN** the application starts with the check mode enabled
+- **THEN** a log record precedes the scan naming the path, mode, and size
+- **AND** a log record on success reports how long the scan took
+
+#### Scenario: A skipped scan says so
+
+- **GIVEN** a SQLite store whose sidecar records a clean shutdown
+- **WHEN** the application starts with the check mode enabled
+- **THEN** a log record states that the check was skipped after a clean shutdown

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -12,9 +12,10 @@
   letting the error abort startup.
 - [x] 1.6 Fsync the record's contents before the rename and the directory
   entry after it, so a power loss cannot lose a `running` transition.
-- [x] 1.7 Treat a directory sync that is attempted and fails as a failed
-  write, while treating a platform that refuses a directory handle at all
-  (Windows) as success rather than a storage failure.
+- [x] 1.7 Treat every directory-sync failure as a failed write, including a
+  directory that cannot be opened, and skip the sync only on a platform that
+  offers no directory handle at all (Windows), decided by platform rather
+  than by the error the open reports.
 
 ## 2. Startup
 
@@ -42,7 +43,9 @@
 - [x] 4.3 Unit-test that a failed integrity check leaves the state unclean.
 - [x] 4.4 Unit-test the invalid-UTF-8 sidecar, the timestamp-preserving
   restore, that both syncs happen on a write, that a failed directory sync
-  fails the write closed, and both directory-sync outcomes.
+  fails the write closed, that an unopenable directory fails closed, and that
+  a platform without directory handles skips the sync. Drive the sync-failure
+  path through a stubbed handle so it runs on every platform.
 - [x] 4.5 Unit-test that a raised or cancelled `close_db()` does not record a
   clean shutdown.
 - [x] 4.6 Run Ruff check/format and `ty`.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -40,6 +40,9 @@
 - [x] 3.4 Treat an abandoned scheduler leader-lease release task as an
   incomplete shutdown, so its still-live database session cannot race with
   clean-state recording.
+- [x] 3.5 Propagate final proxy persistence and detached control-plane drain
+  outcomes into clean-state recording so timed-out database tasks leave the
+  run state unclean.
 
 ## 4. Verification
 
@@ -61,3 +64,5 @@
 - [x] 4.8 Unit-test durable failed-write invalidation, startup abort on
   unconfirmed invalidation, and clean-state suppression after an abandoned
   leader-lease release.
+- [x] 4.9 Unit-test that timed-out persistence and audit drains suppress the
+  clean marker.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -3,7 +3,9 @@
 - [x] 1.1 Add `SqliteRunState` plus `sqlite_runstate_path`,
   `read_sqlite_runstate`, and `write_sqlite_runstate` to `app/db/sqlite_utils.py`.
 - [x] 1.2 Write the sidecar atomically (temp file + `os.replace`) and remove
-  it when the write fails, so a stale `clean` can never survive.
+  both files with a directory sync when the write fails, so a stale `clean`
+  can never survive; abort the startup transition if that invalidation cannot
+  be confirmed.
 - [x] 1.3 Read unrecognized or unreadable content as unknown.
 - [x] 1.4 Fence a `clean` record to the database file's device, inode, size,
   mtime, and ctime, so a timestamp-preserving restore cannot inherit the
@@ -35,6 +37,9 @@
   `finally`.
 - [x] 3.3 Treat a bounded teardown drain that abandons pending SQLite work as
   incomplete, so it cannot record a clean shutdown.
+- [x] 3.4 Treat an abandoned scheduler leader-lease release task as an
+  incomplete shutdown, so its still-live database session cannot race with
+  clean-state recording.
 
 ## 4. Verification
 
@@ -53,3 +58,6 @@
 - [x] 4.6 Run Ruff check/format and `ty`.
 - [x] 4.7 Unit-test that a teardown drain reaching its deadline reports an
   incomplete shutdown and does not record a clean sidecar.
+- [x] 4.8 Unit-test durable failed-write invalidation, startup abort on
+  unconfirmed invalidation, and clean-state suppression after an abandoned
+  leader-lease release.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -1,0 +1,33 @@
+## 1. Run-state sidecar
+
+- [x] 1.1 Add `SqliteRunState` plus `sqlite_runstate_path`,
+  `read_sqlite_runstate`, and `write_sqlite_runstate` to `app/db/sqlite_utils.py`.
+- [x] 1.2 Write the sidecar atomically (temp file + `os.replace`) and remove
+  it when the write fails, so a stale `clean` can never survive.
+- [x] 1.3 Read unrecognized or unreadable content as unknown.
+- [x] 1.4 Fence a `clean` record to the database file's size and mtime, so
+  a restored backup cannot inherit the previous file's clean record.
+
+## 2. Startup
+
+- [x] 2.1 Skip the integrity scan in `init_db()` only when the sidecar
+  records `clean`.
+- [x] 2.2 Record `running` on every startup, including when the check mode is
+  `off`, so re-enabling the check cannot trust a state this build never wrote.
+- [x] 2.3 Log the scan before it starts with path, mode, and file size, and
+  log its elapsed duration on success.
+
+## 3. Shutdown
+
+- [x] 3.1 Add `mark_sqlite_shutdown_clean()` and call it from the lifespan
+  teardown after `close_db()`, guarded so it cannot block
+  `mark_lifespan_completed()`.
+
+## 4. Verification
+
+- [x] 4.1 Unit-test the sidecar round trip, the unknown-content read, and the
+  write-failure path that clears a stale `clean`.
+- [x] 4.2 Unit-test that `init_db()` skips the scan after a clean shutdown and
+  runs it for a missing sidecar, a `running` sidecar, and a disabled check.
+- [x] 4.3 Unit-test that a failed integrity check leaves the state unclean.
+- [x] 4.4 Run Ruff check/format and `ty`.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -12,6 +12,9 @@
   letting the error abort startup.
 - [x] 1.6 Fsync the record's contents before the rename and the directory
   entry after it, so a power loss cannot lose a `running` transition.
+- [x] 1.7 Treat a directory sync that is attempted and fails as a failed
+  write, while treating a platform that refuses a directory handle at all
+  (Windows) as success rather than a storage failure.
 
 ## 2. Startup
 
@@ -38,7 +41,8 @@
   runs it for a missing sidecar, a `running` sidecar, and a disabled check.
 - [x] 4.3 Unit-test that a failed integrity check leaves the state unclean.
 - [x] 4.4 Unit-test the invalid-UTF-8 sidecar, the timestamp-preserving
-  restore, and that both syncs happen on a write.
+  restore, that both syncs happen on a write, that a failed directory sync
+  fails the write closed, and both directory-sync outcomes.
 - [x] 4.5 Unit-test that a raised or cancelled `close_db()` does not record a
   clean shutdown.
 - [x] 4.6 Run Ruff check/format and `ty`.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -33,6 +33,8 @@
 - [x] 3.2 Extract `_close_db_and_record_clean_shutdown()` so the ordering is
   testable, and keep `mark_lifespan_completed()` in the unconditional
   `finally`.
+- [x] 3.3 Treat a bounded teardown drain that abandons pending SQLite work as
+  incomplete, so it cannot record a clean shutdown.
 
 ## 4. Verification
 
@@ -49,3 +51,5 @@
 - [x] 4.5 Unit-test that a raised or cancelled `close_db()` does not record a
   clean shutdown.
 - [x] 4.6 Run Ruff check/format and `ty`.
+- [x] 4.7 Unit-test that a teardown drain reaching its deadline reports an
+  incomplete shutdown and does not record a clean sidecar.

--- a/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
+++ b/openspec/changes/skip-clean-shutdown-sqlite-startup-check/tasks.md
@@ -5,8 +5,13 @@
 - [x] 1.2 Write the sidecar atomically (temp file + `os.replace`) and remove
   it when the write fails, so a stale `clean` can never survive.
 - [x] 1.3 Read unrecognized or unreadable content as unknown.
-- [x] 1.4 Fence a `clean` record to the database file's size and mtime, so
-  a restored backup cannot inherit the previous file's clean record.
+- [x] 1.4 Fence a `clean` record to the database file's device, inode, size,
+  mtime, and ctime, so a timestamp-preserving restore cannot inherit the
+  previous file's clean record.
+- [x] 1.5 Read content that cannot be decoded as UTF-8 as unknown rather than
+  letting the error abort startup.
+- [x] 1.6 Fsync the record's contents before the rename and the directory
+  entry after it, so a power loss cannot lose a `running` transition.
 
 ## 2. Startup
 
@@ -19,9 +24,11 @@
 
 ## 3. Shutdown
 
-- [x] 3.1 Add `mark_sqlite_shutdown_clean()` and call it from the lifespan
-  teardown after `close_db()`, guarded so it cannot block
-  `mark_lifespan_completed()`.
+- [x] 3.1 Add `mark_sqlite_shutdown_clean()` and record the clean state only
+  after `close_db()` returns, so a cancelled or failed disposal stays unclean.
+- [x] 3.2 Extract `_close_db_and_record_clean_shutdown()` so the ordering is
+  testable, and keep `mark_lifespan_completed()` in the unconditional
+  `finally`.
 
 ## 4. Verification
 
@@ -30,4 +37,8 @@
 - [x] 4.2 Unit-test that `init_db()` skips the scan after a clean shutdown and
   runs it for a missing sidecar, a `running` sidecar, and a disabled check.
 - [x] 4.3 Unit-test that a failed integrity check leaves the state unclean.
-- [x] 4.4 Run Ruff check/format and `ty`.
+- [x] 4.4 Unit-test the invalid-UTF-8 sidecar, the timestamp-preserving
+  restore, and that both syncs happen on a write.
+- [x] 4.5 Unit-test that a raised or cancelled `close_db()` does not record a
+  clean shutdown.
+- [x] 4.6 Run Ruff check/format and `ty`.

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -19,7 +19,13 @@ from sqlalchemy.pool import NullPool
 
 import app.db.session as session_module
 from app.db.models import Account, AccountStatus, Base
-from app.db.sqlite_utils import IntegrityCheck, SqliteIntegrityCheckMode
+from app.db.sqlite_utils import (
+    IntegrityCheck,
+    SqliteIntegrityCheckMode,
+    SqliteRunState,
+    read_sqlite_runstate,
+    write_sqlite_runstate,
+)
 
 
 @dataclass(slots=True)
@@ -1710,3 +1716,165 @@ async def test_close_db_bounds_the_wedged_teardown_drain(monkeypatch, caplog) ->
         session_module._wedged_teardown_cleanup_tasks.discard(stuck)
         never.set()
         await stuck
+
+
+def _stub_head_migration_state(monkeypatch) -> None:
+    monkeypatch.setattr(
+        session_module,
+        "_load_migration_entrypoints",
+        lambda: (
+            lambda _: _FakeMigrationState(
+                current_revision="head",
+                head_revision="head",
+                has_alembic_version_table=True,
+                has_legacy_migrations_table=False,
+                needs_upgrade=False,
+            ),
+            lambda _: (_ for _ in ()).throw(AssertionError("startup migrations should stay disabled")),
+            lambda _: (),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_db_skips_startup_check_after_recorded_clean_shutdown(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    write_sqlite_runstate(db_path, SqliteRunState.CLEAN)
+
+    def _check(_: Path, *, mode: SqliteIntegrityCheckMode = SqliteIntegrityCheckMode.FULL) -> IntegrityCheck:
+        raise AssertionError("a cleanly closed store must not pay for the whole-file scan")
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            database_migrate_on_startup=False,
+        ),
+    )
+    monkeypatch.setattr(session_module, "check_sqlite_integrity", _check)
+    _stub_head_migration_state(monkeypatch)
+
+    await session_module.init_db()
+
+    assert read_sqlite_runstate(db_path) is SqliteRunState.RUNNING
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "recorded_state",
+    [
+        pytest.param(None, id="no-sidecar-upgrade-or-first-run"),
+        pytest.param(SqliteRunState.RUNNING, id="previous-process-did-not-finish"),
+    ],
+)
+async def test_init_db_runs_startup_check_when_shutdown_was_not_clean(monkeypatch, tmp_path, recorded_state) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    if recorded_state is not None:
+        write_sqlite_runstate(db_path, recorded_state)
+    seen: list[SqliteIntegrityCheckMode] = []
+
+    def _check(path: Path, *, mode: SqliteIntegrityCheckMode = SqliteIntegrityCheckMode.FULL) -> IntegrityCheck:
+        assert path == db_path
+        seen.append(mode)
+        return IntegrityCheck(ok=True, details=None)
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            database_migrate_on_startup=False,
+        ),
+    )
+    monkeypatch.setattr(session_module, "check_sqlite_integrity", _check)
+    _stub_head_migration_state(monkeypatch)
+
+    await session_module.init_db()
+
+    assert seen == [SqliteIntegrityCheckMode.QUICK]
+    assert read_sqlite_runstate(db_path) is SqliteRunState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_init_db_records_running_state_even_when_check_is_disabled(monkeypatch, tmp_path) -> None:
+    """Re-enabling the check must not trust a state this process never wrote."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    write_sqlite_runstate(db_path, SqliteRunState.CLEAN)
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            database_migrate_on_startup=False,
+            database_sqlite_startup_check_mode="off",
+        ),
+    )
+    monkeypatch.setattr(
+        session_module,
+        "check_sqlite_integrity",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("check is disabled")),
+    )
+    _stub_head_migration_state(monkeypatch)
+
+    await session_module.init_db()
+
+    assert read_sqlite_runstate(db_path) is SqliteRunState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_init_db_leaves_state_unclean_when_the_startup_check_fails(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            database_migrate_on_startup=False,
+        ),
+    )
+    monkeypatch.setattr(
+        session_module,
+        "check_sqlite_integrity",
+        lambda *_args, **_kwargs: IntegrityCheck(ok=False, details="database disk image is malformed"),
+    )
+    _stub_head_migration_state(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="quick_check failed"):
+        await session_module.init_db()
+
+    assert read_sqlite_runstate(db_path) is None
+
+
+def test_mark_sqlite_shutdown_clean_records_a_clean_close(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    write_sqlite_runstate(db_path, SqliteRunState.RUNNING)
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(database_url=f"sqlite+aiosqlite:///{db_path}"),
+    )
+
+    session_module.mark_sqlite_shutdown_clean()
+
+    assert read_sqlite_runstate(db_path) is SqliteRunState.CLEAN
+
+
+def test_mark_sqlite_shutdown_clean_is_inert_for_non_sqlite_backends(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(database_url="postgresql+asyncpg://user@localhost/codexlb"),
+    )
+
+    session_module.mark_sqlite_shutdown_clean()
+
+    assert not list(tmp_path.iterdir())

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -1677,7 +1677,7 @@ async def test_close_db_drains_a_pending_reclaimed_rollback_and_its_bookkeeping_
                 release_wedge.set()
 
             releaser = asyncio.ensure_future(_release_soon())
-            await asyncio.wait_for(session_module.close_db(), timeout=5.0)
+            assert await asyncio.wait_for(session_module.close_db(), timeout=5.0) is True
             # RED pre-fix: close_db saw an empty registry and returned
             # immediately, before the wedge was even released.
             assert release_wedge.is_set(), "close_db must drain the pending reclaimed rollback"
@@ -1707,7 +1707,7 @@ async def test_close_db_bounds_the_wedged_teardown_drain(monkeypatch, caplog) ->
     session_module._wedged_teardown_cleanup_tasks.add(stuck)
     try:
         with caplog.at_level(logging.WARNING, logger=session_module.__name__):
-            await asyncio.wait_for(session_module.close_db(), timeout=2.0)
+            assert await asyncio.wait_for(session_module.close_db(), timeout=2.0) is False
         assert any("still-pending wedged-teardown" in record.getMessage() for record in caplog.records), (
             "the bounded drain must report what it abandoned"
         )

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -1827,6 +1827,34 @@ async def test_init_db_records_running_state_even_when_check_is_disabled(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_init_db_aborts_when_running_state_invalidation_cannot_be_confirmed(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            database_migrate_on_startup=False,
+        ),
+    )
+    monkeypatch.setattr(
+        session_module,
+        "check_sqlite_integrity",
+        lambda *_args, **_kwargs: IntegrityCheck(ok=True, details=None),
+    )
+
+    def _fail(*_args: object, **_kwargs: object) -> bool:
+        raise OSError("run-state cleanup could not be confirmed")
+
+    monkeypatch.setattr(session_module, "write_sqlite_runstate", _fail)
+
+    with pytest.raises(RuntimeError, match="refusing to start"):
+        await session_module.init_db()
+
+
+@pytest.mark.asyncio
 async def test_init_db_leaves_state_unclean_when_the_startup_check_fails(monkeypatch, tmp_path) -> None:
     db_path = tmp_path / "store.db"
     db_path.write_bytes(b"sqlite")

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import os
 import sqlite3
 from contextlib import closing
@@ -202,19 +203,25 @@ def test_runstate_write_syncs_the_payload_and_the_directory_entry(
     """A lost run-state transition would let the next startup skip the scan."""
     db_path = tmp_path / "store.db"
     db_path.write_bytes(b"sqlite")
-    synced: list[int] = []
+    payload_syncs: list[int] = []
+    directory_syncs: list[Path] = []
     real_fsync = os.fsync
 
-    def _record(fd: int) -> None:
-        synced.append(fd)
+    def _record_payload(fd: int) -> None:
+        payload_syncs.append(fd)
         real_fsync(fd)
 
-    monkeypatch.setattr(os, "fsync", _record)
+    def _record_directory(directory: Path) -> bool:
+        directory_syncs.append(directory)
+        return True
+
+    monkeypatch.setattr(os, "fsync", _record_payload)
+    monkeypatch.setattr(sqlite_utils_module, "_fsync_directory", _record_directory)
 
     assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN) is True
 
-    # One for the sidecar payload, one for the directory entry the rename created.
-    assert len(synced) == 2
+    assert len(payload_syncs) == 1
+    assert directory_syncs == [sqlite_utils_module.sqlite_runstate_path(db_path).parent]
 
 
 def test_runstate_write_fails_closed_when_the_directory_sync_fails(
@@ -235,24 +242,61 @@ def test_runstate_write_fails_closed_when_the_directory_sync_fails(
     assert not list(tmp_path.glob("*.tmp"))
 
 
-def test_fsync_directory_reports_success_when_the_platform_refuses_a_handle(
+def test_fsync_directory_reports_success_where_directory_handles_do_not_exist(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Windows cannot open a directory handle; that is not a storage failure."""
+    """Windows has no directory handle to sync, and that is not a failure."""
+    attempts: list[object] = []
 
-    def _refuse(*_args: object, **_kwargs: object) -> int:
-        raise PermissionError("directory handles are not supported here")
+    def _record(*args: object, **_kwargs: object) -> int:
+        attempts.append(args)
+        raise AssertionError("the open must not be attempted on such a platform")
 
-    monkeypatch.setattr(os, "open", _refuse)
+    monkeypatch.setattr(sqlite_utils_module, "_DIRECTORY_FSYNC_SUPPORTED", False)
+    monkeypatch.setattr(os, "open", _record)
 
     assert sqlite_utils_module._fsync_directory(tmp_path) is True
+    assert attempts == []
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        PermissionError(errno.EACCES, "permission denied"),
+        FileNotFoundError(errno.ENOENT, "no such directory"),
+        OSError(errno.EMFILE, "too many open files"),
+        OSError(errno.EIO, "input/output error"),
+    ],
+    ids=["eacces", "enoent", "emfile", "eio"],
+)
+def test_fsync_directory_reports_failure_when_the_directory_cannot_be_opened(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, error: OSError
+) -> None:
+    """A real open failure means the rename is unproven and must fail closed."""
+
+    def _fail(*_args: object, **_kwargs: object) -> int:
+        raise error
+
+    monkeypatch.setattr(sqlite_utils_module, "_DIRECTORY_FSYNC_SUPPORTED", True)
+    monkeypatch.setattr(os, "open", _fail)
+
+    assert sqlite_utils_module._fsync_directory(tmp_path) is False
 
 
 def test_fsync_directory_reports_failure_when_the_sync_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The sync path is exercised on every platform, not only where it runs."""
+    placeholder = tmp_path / "placeholder"
+    placeholder.write_bytes(b"")
+    real_open = os.open
+
+    def _open_placeholder(*_args: object, **_kwargs: object) -> int:
+        return real_open(placeholder, os.O_RDONLY)
 
     def _fail(_fd: int) -> None:
-        raise OSError("I/O error")
+        raise OSError(errno.EIO, "input/output error")
 
+    monkeypatch.setattr(sqlite_utils_module, "_DIRECTORY_FSYNC_SUPPORTED", True)
+    monkeypatch.setattr(os, "open", _open_placeholder)
     monkeypatch.setattr(os, "fsync", _fail)
 
     assert sqlite_utils_module._fsync_directory(tmp_path) is False

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -138,9 +138,17 @@ def test_runstate_write_failure_clears_a_stale_clean_marker(monkeypatch: pytest.
     def _explode(*_args: object, **_kwargs: object) -> None:
         raise OSError("read-only filesystem")
 
+    directory_syncs: list[Path] = []
+
+    def _record_directory(directory: Path) -> bool:
+        directory_syncs.append(directory)
+        return True
+
     monkeypatch.setattr(os, "replace", _explode)
+    monkeypatch.setattr(sqlite_utils_module, "_fsync_directory", _record_directory)
 
     assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is False
+    assert directory_syncs == [tmp_path]
 
     monkeypatch.undo()
     assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
@@ -234,12 +242,40 @@ def test_runstate_write_fails_closed_when_the_directory_sync_fails(
 
     monkeypatch.setattr(sqlite_utils_module, "_fsync_directory", lambda _directory: False)
 
-    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is False
+    with pytest.raises(OSError, match="persist removal"):
+        sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING)
 
     monkeypatch.undo()
     assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
     assert not sqlite_utils_module.sqlite_runstate_path(db_path).exists()
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_runstate_write_aborts_when_the_failed_marker_cannot_be_removed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A locked stale marker must stop startup instead of remaining trusted."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+    target = sqlite_utils_module.sqlite_runstate_path(db_path)
+    real_unlink = Path.unlink
+
+    def _fail_target_unlink(path: Path, *, missing_ok: bool = False) -> None:
+        if path == target:
+            raise OSError("sidecar is locked")
+        real_unlink(path, missing_ok=missing_ok)
+
+    def _fail_replace(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(os, "replace", _fail_replace)
+    monkeypatch.setattr(Path, "unlink", _fail_target_unlink)
+
+    with pytest.raises(OSError, match="remove failed SQLite run-state files"):
+        sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING)
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.CLEAN
 
 
 def test_fsync_directory_reports_success_where_directory_handles_do_not_exist(

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -215,3 +215,44 @@ def test_runstate_write_syncs_the_payload_and_the_directory_entry(
 
     # One for the sidecar payload, one for the directory entry the rename created.
     assert len(synced) == 2
+
+
+def test_runstate_write_fails_closed_when_the_directory_sync_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Storage that cannot confirm durability must not leave a trusted record."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+
+    monkeypatch.setattr(sqlite_utils_module, "_fsync_directory", lambda _directory: False)
+
+    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is False
+
+    monkeypatch.undo()
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+    assert not sqlite_utils_module.sqlite_runstate_path(db_path).exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_fsync_directory_reports_success_when_the_platform_refuses_a_handle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Windows cannot open a directory handle; that is not a storage failure."""
+
+    def _refuse(*_args: object, **_kwargs: object) -> int:
+        raise PermissionError("directory handles are not supported here")
+
+    monkeypatch.setattr(os, "open", _refuse)
+
+    assert sqlite_utils_module._fsync_directory(tmp_path) is True
+
+
+def test_fsync_directory_reports_failure_when_the_sync_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+
+    def _fail(_fd: int) -> None:
+        raise OSError("I/O error")
+
+    monkeypatch.setattr(os, "fsync", _fail)
+
+    assert sqlite_utils_module._fsync_directory(tmp_path) is False

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -104,3 +104,63 @@ def test_recover_cli_closes_connections_before_replacing_database(
             assert connection.execute("SELECT name FROM items").fetchall() == [("alpha",)]
     finally:
         _close_connections(connections)
+
+
+def test_runstate_round_trips(tmp_path: Path) -> None:
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+
+    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is True
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.RUNNING
+
+    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN) is True
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.CLEAN
+
+
+def test_runstate_reads_unrecognized_content_as_unknown(tmp_path: Path) -> None:
+    db_path = tmp_path / "store.db"
+    sqlite_utils_module.sqlite_runstate_path(db_path).write_text("half-written", encoding="utf-8")
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+
+
+def test_runstate_write_failure_clears_a_stale_clean_marker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A store left mid-write must never read back as cleanly closed."""
+    db_path = tmp_path / "store.db"
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "write_text", _explode)
+
+    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is False
+
+    monkeypatch.undo()
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+    assert not sqlite_utils_module.sqlite_runstate_path(db_path).exists()
+
+
+def test_runstate_clean_is_ignored_after_the_database_file_changes(tmp_path: Path) -> None:
+    """Restoring a backup must not inherit the previous file's clean record."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite-original")
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.CLEAN
+
+    db_path.write_bytes(b"sqlite-restored-from-a-backup")
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+
+
+def test_runstate_running_survives_database_writes(tmp_path: Path) -> None:
+    """Only the clean record is fenced; a running record stays readable."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING)
+
+    db_path.write_bytes(b"sqlite-after-a-few-writes")
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.RUNNING

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -129,18 +130,21 @@ def test_runstate_reads_unrecognized_content_as_unknown(tmp_path: Path) -> None:
 def test_runstate_write_failure_clears_a_stale_clean_marker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A store left mid-write must never read back as cleanly closed."""
     db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
     sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.CLEAN
 
     def _explode(*_args: object, **_kwargs: object) -> None:
         raise OSError("read-only filesystem")
 
-    monkeypatch.setattr(Path, "write_text", _explode)
+    monkeypatch.setattr(os, "replace", _explode)
 
     assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.RUNNING) is False
 
     monkeypatch.undo()
     assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
     assert not sqlite_utils_module.sqlite_runstate_path(db_path).exists()
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_runstate_clean_is_ignored_after_the_database_file_changes(tmp_path: Path) -> None:
@@ -164,3 +168,50 @@ def test_runstate_running_survives_database_writes(tmp_path: Path) -> None:
     db_path.write_bytes(b"sqlite-after-a-few-writes")
 
     assert sqlite_utils_module.read_sqlite_runstate(db_path) is sqlite_utils_module.SqliteRunState.RUNNING
+
+
+def test_runstate_reads_invalid_utf8_as_unknown(tmp_path: Path) -> None:
+    """A corrupt sidecar must not abort startup before the integrity check."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    sqlite_utils_module.sqlite_runstate_path(db_path).write_bytes(b'{"state": "clean", "\xff\xfe": 1}')
+
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+
+
+def test_runstate_clean_is_ignored_after_a_timestamp_preserving_restore(tmp_path: Path) -> None:
+    """`tar -x` and `cp -p` reproduce size and mtime; the inode still moves."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"A" * 4096)
+    sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN)
+    original = db_path.stat()
+
+    db_path.unlink()
+    db_path.write_bytes(b"B" * 4096)
+    os.utime(db_path, ns=(original.st_atime_ns, original.st_mtime_ns))
+
+    restored = db_path.stat()
+    assert restored.st_size == original.st_size
+    assert restored.st_mtime_ns == original.st_mtime_ns
+    assert sqlite_utils_module.read_sqlite_runstate(db_path) is None
+
+
+def test_runstate_write_syncs_the_payload_and_the_directory_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A lost run-state transition would let the next startup skip the scan."""
+    db_path = tmp_path / "store.db"
+    db_path.write_bytes(b"sqlite")
+    synced: list[int] = []
+    real_fsync = os.fsync
+
+    def _record(fd: int) -> None:
+        synced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _record)
+
+    assert sqlite_utils_module.write_sqlite_runstate(db_path, sqlite_utils_module.SqliteRunState.CLEAN) is True
+
+    # One for the sidecar payload, one for the directory entry the rename created.
+    assert len(synced) == 2

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -1098,3 +1098,52 @@ async def test_in_flight_middleware_allows_drain_stop_during_drain() -> None:
 
     assert app_called is True
     assert sent_messages[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_is_recorded_after_successful_disposal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    order: list[str] = []
+
+    async def _close_db() -> None:
+        order.append("close_db")
+
+    monkeypatch.setattr(app_main, "close_db", _close_db)
+    monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", lambda: order.append("mark_clean"))
+
+    await app_main._close_db_and_record_clean_shutdown()
+
+    assert order == ["close_db", "mark_clean"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        pytest.param(RuntimeError("dispose failed"), RuntimeError, id="dispose-raises"),
+        pytest.param(asyncio.CancelledError(), asyncio.CancelledError, id="dispose-cancelled"),
+    ],
+)
+async def test_clean_shutdown_is_not_recorded_when_disposal_does_not_complete(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    expected: type[BaseException],
+) -> None:
+    """An incomplete teardown is exactly what the next startup's scan is for."""
+    marked = False
+
+    async def _close_db() -> None:
+        raise failure
+
+    def _mark_clean() -> None:
+        nonlocal marked
+        marked = True
+
+    monkeypatch.setattr(app_main, "close_db", _close_db)
+    monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", _mark_clean)
+
+    with pytest.raises(expected):
+        await app_main._close_db_and_record_clean_shutdown()
+
+    assert marked is False

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -123,7 +123,7 @@ async def test_control_plane_drains_are_failure_isolated(
     monkeypatch.setattr(app_main.fleet_api, "drain_background_refresh_tasks", drain_fleet)
 
     with caplog.at_level(logging.WARNING, logger="app.main"):
-        await _drain_detached_control_plane_tasks(1)
+        assert await _drain_detached_control_plane_tasks(1) is False
 
     assert fleet_drained.is_set()
     assert "Failed to drain audit log tasks during shutdown" in caplog.text
@@ -178,7 +178,7 @@ async def test_control_plane_drain_requires_stable_clean_pass(
     monkeypatch.setattr(app_main, "drain_audit_log_tasks", drain_audit)
     monkeypatch.setattr(app_main.fleet_api, "drain_background_refresh_tasks", drain_fleet)
 
-    await _drain_detached_control_plane_tasks(1)
+    assert await _drain_detached_control_plane_tasks(1) is True
 
     assert audit_calls == 2
     assert fleet_calls == 2
@@ -1157,6 +1157,55 @@ async def test_clean_shutdown_is_not_recorded_when_leader_release_was_abandoned(
 
     await app_main._close_db_and_record_clean_shutdown(leader_lease_release_completed=False)
 
+    assert marked is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("drain_kind", ("persistence", "audit"))
+async def test_clean_shutdown_is_not_recorded_when_database_task_drain_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+    drain_kind: str,
+) -> None:
+    if drain_kind == "persistence":
+
+        class _ProxyService:
+            async def drain_persistence_tasks(self, **_kwargs: object) -> bool:
+                return False
+
+        database_tasks_drained = await _drain_proxy_persistence_tasks(
+            _ProxyService(),
+            0,
+            failure_message="unused",
+        )
+    else:
+
+        async def drain_audit(_: float) -> bool:
+            return False
+
+        async def drain_fleet(_: float) -> bool:
+            return True
+
+        monkeypatch.setattr(app_main, "drain_audit_log_tasks", drain_audit)
+        monkeypatch.setattr(app_main.fleet_api, "drain_background_refresh_tasks", drain_fleet)
+        database_tasks_drained = await _drain_detached_control_plane_tasks(0)
+
+    marked = False
+
+    async def _close_db() -> bool:
+        return True
+
+    def _mark_clean() -> None:
+        nonlocal marked
+        marked = True
+
+    monkeypatch.setattr(app_main, "close_db", _close_db)
+    monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", _mark_clean)
+
+    await app_main._close_db_and_record_clean_shutdown(
+        database_tasks_drained=database_tasks_drained,
+    )
+
+    assert database_tasks_drained is False
     assert marked is False
 
 

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -207,7 +207,7 @@ async def test_release_leader_lease_within_returns_when_release_wedged(
 
     loop = asyncio.get_running_loop()
     start = loop.time()
-    await _release_leader_lease_within(0.2)
+    assert await _release_leader_lease_within(0.2) is False
     elapsed = loop.time() - start
 
     assert 0.2 <= elapsed < 1.0
@@ -232,7 +232,7 @@ async def test_release_leader_lease_within_awaits_quick_release(
     election = _FastElection()
     monkeypatch.setattr(app_main, "get_leader_election", lambda: election)
 
-    await _release_leader_lease_within(5)
+    assert await _release_leader_lease_within(5) is True
 
     assert election.released is True
 
@@ -248,7 +248,7 @@ async def test_release_leader_lease_within_swallows_release_error(
     monkeypatch.setattr(app_main, "get_leader_election", lambda: _BrokenElection())
 
     # Must not raise: a failed release must never fail shutdown.
-    await _release_leader_lease_within(5)
+    assert await _release_leader_lease_within(5) is True
 
 
 @pytest.fixture(autouse=True)
@@ -1135,6 +1135,27 @@ async def test_clean_shutdown_is_not_recorded_when_wedged_teardown_was_abandoned
     monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", _mark_clean)
 
     await app_main._close_db_and_record_clean_shutdown()
+
+    assert marked is False
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_is_not_recorded_when_leader_release_was_abandoned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marked = False
+
+    async def _close_db() -> bool:
+        return True
+
+    def _mark_clean() -> None:
+        nonlocal marked
+        marked = True
+
+    monkeypatch.setattr(app_main, "close_db", _close_db)
+    monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", _mark_clean)
+
+    await app_main._close_db_and_record_clean_shutdown(leader_lease_release_completed=False)
 
     assert marked is False
 

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -1106,8 +1106,9 @@ async def test_clean_shutdown_is_recorded_after_successful_disposal(
 ) -> None:
     order: list[str] = []
 
-    async def _close_db() -> None:
+    async def _close_db() -> bool:
         order.append("close_db")
+        return True
 
     monkeypatch.setattr(app_main, "close_db", _close_db)
     monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", lambda: order.append("mark_clean"))
@@ -1115,6 +1116,27 @@ async def test_clean_shutdown_is_recorded_after_successful_disposal(
     await app_main._close_db_and_record_clean_shutdown()
 
     assert order == ["close_db", "mark_clean"]
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_is_not_recorded_when_wedged_teardown_was_abandoned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marked = False
+
+    async def _close_db() -> bool:
+        return False
+
+    def _mark_clean() -> None:
+        nonlocal marked
+        marked = True
+
+    monkeypatch.setattr(app_main, "close_db", _close_db)
+    monkeypatch.setattr(app_main, "mark_sqlite_shutdown_clean", _mark_clean)
+
+    await app_main._close_db_and_record_clean_shutdown()
+
+    assert marked is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`init_db()` runs `PRAGMA quick_check` over the whole SQLite file before anything else and the listener does not bind until it returns, so startup time grows with the store: 177 s of connection-refused on a 3.7 GB store, on every restart, with no log record to explain it. This records how each process left the store and runs the scan only when the previous shutdown was not recorded clean.

## Type of change

- [x] `fix:` bug fix (no behavior change beyond the bug)

Linked issue: Fixes #1865

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/skip-clean-shutdown-sqlite-startup-check/`

The delta lands on `database-backends`: when the startup integrity check runs, and the observability it emits. No codex-faithful path is touched.

## Changes

- Add `SqliteRunState` and `sqlite_runstate_path` / `read_sqlite_runstate` / `write_sqlite_runstate` to `app/db/sqlite_utils.py`. The sidecar is written atomically (temp file plus `os.replace`).
- Skip the startup scan in `init_db()` only when the sidecar records `clean`. Record `running` on every startup.
- Add `mark_sqlite_shutdown_clean()` and call it from the lifespan teardown after `close_db()`, nested so it cannot block `mark_lifespan_completed()`.
- Log the scan before it starts with path, mode, and file size, and log its elapsed duration on success. Log the skip too.
- Factor the duplicated `"quick_check" if ... else "integrity_check"` expression into `integrity_check_pragma_name()`.

### Why this is safe

Every state other than a recorded clean shutdown still scans:

| state | scans? |
|---|---|
| sidecar records `clean` and the file still matches | no |
| sidecar records `running` (crash, OOM kill, power loss, failed startup) | yes |
| no sidecar (first run, or upgrade from a build without one) | yes |
| unreadable or unrecognized sidecar content | yes |
| sidecar records `clean` but the database file changed (restored backup) | yes |
| startup check itself failed last time | yes, the clean record is never reached |

Failure modes resolve toward scanning. A failed sidecar write removes the file rather than leaving a stale `clean` behind, and a `clean` record carries the database file's size and mtime so it is discarded the moment the file is replaced.

The state is recorded even when the check mode is `off`, so re-enabling the check cannot trust a state the disabled build never maintained.

## Simplicity

This PR adds no setting, no README section, no dashboard nav item, and changes no default. `CODEX_LB_DATABASE_SQLITE_STARTUP_CHECK_MODE` keeps its `quick` default and its existing meaning; this only removes redundant runs of the mode already selected. The one new artifact is a small sidecar file next to the database, alongside the existing `.migrate-lock` and pre-migration backups.

## Test plan

```
$ make lint
uv run python scripts/check_proxy_architecture.py
proxy architecture checks passed
uv run ruff check .
All checks passed!
uv run ruff format --check .
954 files already formatted

$ uv run ty check
All checks passed!

$ uv run pytest tests/unit/test_db_session.py tests/unit/test_db_sqlite_maintenance.py \
    tests/unit/test_sqlite_url_windows.py tests/unit/test_db_migrate.py -q
153 passed

$ uv run pytest tests/unit/test_graceful_shutdown.py tests/unit/test_helm_shutdown_contract.py -q
53 passed
```

New coverage:

- `test_db_sqlite_maintenance.py`: sidecar round trip, unrecognized content reads as unknown, a failed write clears a stale `clean`, a `clean` record is ignored after the database file changes, a `running` record survives ordinary writes.
- `test_db_session.py`: `init_db()` skips the scan after a clean shutdown; still scans for a missing sidecar and for a `running` sidecar (parametrized); records `running` even when the check is disabled; leaves the state unclean when the check fails; `mark_sqlite_shutdown_clean()` records a clean close and is inert for non-SQLite backends.

I did not run the full `pre-commit run local-ci` (it builds the frontend, which this PR does not touch) or `openspec validate --specs` (the CLI is not in the Python dev environment). Happy to run either if you want them on the record.

## Screenshots / output

Before, on a 3.7 GB store. 177 s between "Waiting for application startup" and the listener, with nothing logged in between:

```
13:34:52  uvicorn.error Waiting for application startup.
13:37:49  alembic.runtime.plugins setup plugin alembic.autogenerate.schemas
13:37:49  app.db.migrate Database schema already at Alembic head
                         revision=20260816_000000_add_model_source_embeddings; skipping upgrade
13:37:50  uvicorn.error Application startup complete.
13:37:50  uvicorn.error Uvicorn running on http://<addr>:2455
```

After, captured against a 123 MB SQLite file on a local SSD so that all three
sidecar states fit in one paste. The production run is the section below this one:

```
# 1. no sidecar (first run / upgrade): scan runs
INFO  Running SQLite startup quick_check path=.../store.db size_bytes=123187200;
      the listener does not bind until it completes
INFO  SQLite startup quick_check passed in 0.1s path=.../store.db

# 2. process recorded a clean shutdown: scan skipped
INFO  Skipping SQLite startup quick_check after a recorded clean shutdown path=.../store.db

# 3. database restored from a backup under a stale clean record: scan runs
INFO  Running SQLite startup quick_check path=.../store.db size_bytes=123187200;
      the listener does not bind until it completes
INFO  SQLite startup quick_check passed in 0.1s path=.../store.db
```

### Production result

Since opening this PR I have run the patched build on the host from #1865. The
store had grown to 4.52 GB by then, so the baseline is worse than the 177 s in
the issue. Both halves of the change show up in the unit journal:

```
# patched build, first start. No sidecar exists yet, so the scan still runs.
# This is the "upgrade from a build without one" row of the table above.
02:17:53  systemd        Started codex-lb.service
02:17:57  app.db.session Running SQLite startup quick_check path=/root/.codex-lb/store.db
                         size_bytes=4520468480; the listener does not bind until it completes
02:23:33  app.db.session SQLite startup quick_check passed in 336.1s path=/root/.codex-lb/store.db
02:23:34  uvicorn.error  Uvicorn running on http://<addr>:2455

# next restart, previous shutdown recorded clean: scan skipped
02:39:40  systemd        Started codex-lb.service
02:39:43  app.db.session Skipping SQLite startup quick_check after a recorded clean shutdown
                         path=/root/.codex-lb/store.db
02:39:43  uvicorn.error  Uvicorn running on http://<addr>:2455
```

341 s of connection-refused becomes 3 s, same host, same store, one restart apart.

Two things worth recording beyond the headline number:

- The scan is getting more expensive faster than the store is growing. 3.73 GB
  took 177 s (21 MB/s effective), 4.52 GB took 336 s (13 MB/s). The host has
  7.1 GB of RAM, so my reading is that the store is outgrowing what stays
  resident in the page cache between runs, but I have not instrumented that and
  it is not load-bearing for this PR.
- The 336 s record is the new logging paying for itself. The identical stall
  before this PR produced no log line at all, and my first diagnosis of it was
  wrong: I blamed Alembic.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran `make lint`, `uv run ty check`, and the relevant `pytest` subset locally (see Test plan for what I did not run).
- [ ] `openspec validate --specs` not run: the CLI is not part of the Python dev environment.
- [x] Simplicity gates reviewed: no new setting, no new default, no new required setup step.
- [x] CHANGELOG not edited by hand.

## Note on scope

If you would rather keep the scan unconditional, the observability half stands on its own and I can strip the sidecar out. The logging alone turns a silent multi-minute stall into an attributable one, which was most of the diagnostic cost on my side.


## CI note

`Tests (pytest, integration-core-1)` failed once on 3429afaf with a `database is locked` error at setup of `test_dashboard_overview_maps_weekly_only_primary_to_secondary`, immediately after a 30s teardown of an unrelated streaming test. The same test failed the same way in the same shard on `fix/invalid-previous-response-id-recovery-soju` (run 32435578379), so it is a pre-existing flake in that shard rather than anything this branch introduces. It passed on the retrigger; the branch is green (24 pass, 6 path-filtered skips).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SQLite now records clean and unclean shutdown states.
  - Startup integrity checks are skipped after a verified clean shutdown when the database is unchanged.
  - Checks automatically run after crashes, file changes, invalid state records, or uncertain shutdowns.
  - Added clearer logging for integrity-check activity, including scan details and duration.

- **Bug Fixes**
  - Improved protection against stale or invalid shutdown information.
  - Incomplete database teardown now prevents shutdown from being recorded as clean.

- **Tests**
  - Added coverage for shutdown tracking, database changes, write failures, disabled checks, and non-SQLite backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

