### PR TITLE
docs(clients): add experimental Claude Code gateway recipe

### DIFF
--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,6 +1,6 @@
 # Client Setup
 
-Point any OpenAI-compatible client at codex-lb. If [API key auth](api-keys.md) is enabled, pass a key from the dashboard as a Bearer token.
+Point OpenAI-compatible clients directly at codex-lb. If [API key auth](api-keys.md) is enabled, pass a key from the dashboard as a Bearer token. Claude Code is the exception below: it needs an external protocol-translating gateway.
 
 Model availability is discovered from the upstream Codex model catalog and can vary by account plan, workspace, rollout, and upstream deprecation state. Prefer the live `GET /v1/models` or `GET /backend-api/codex/models` response over a copied static table when configuring clients or API-key model allowlists.
 
@@ -12,6 +12,7 @@ The examples below use the current frontier lineup: **`gpt-5.6-sol`** (strongest
 | [OpenCode](#opencode) | `http://127.0.0.1:2455/v1` | `~/.config/opencode/opencode.json` |
 | [OpenClaw](#openclaw) | `http://127.0.0.1:2455/v1` | `~/.openclaw/openclaw.json` |
 | [Hermes Agent](#hermes-agent) | `http://127.0.0.1:2455/v1` | `~/.hermes/config.yaml` |
+| [Claude Code](#claude-code-experimental-external-gateway) | `http://127.0.0.1:4000/v1/messages` | Experimental external gateway |
 | [OpenAI Python SDK](#openai-python-sdk) | `http://127.0.0.1:2455/v1` | Code |
 
 ## Codex CLI / IDE Extension
@@ -368,6 +369,174 @@ Then select the model interactively with `hermes model`, or in a session:
 export CODEX_LB_API_KEY="sk-clb-..."   # key from dashboard
 hermes
 ```
+
+## Claude Code (experimental external gateway)
+
+!!! warning
+    Anthropic does not support routing Claude Code to non-Claude models through
+    a gateway. This is an experimental, community-owned composition; see
+    [Anthropic's gateway policy](https://docs.anthropic.com/en/docs/claude-code/llm-gateway)
+    and the [codex-lb maintainer decision](https://github.com/Soju06/codex-lb/issues/114#issuecomment-4988534309).
+
+codex-lb does not implement Anthropic's Messages API or manage Claude
+credentials. To use Claude Code's interface with a model served by codex-lb,
+run an Anthropic-to-OpenAI translator in front:
+
+```text
+Claude Code -> LiteLLM /v1/messages -> codex-lb /v1/responses
+```
+
+This adds neither Claude models nor Anthropic credentials to codex-lb.
+LiteLLM owns the Messages, streaming, tool, and error translation.
+
+### Configure the translator
+
+Create `litellm.yaml` outside the codex-lb repository:
+
+```yaml
+model_list:
+  - model_name: codex-lb-gpt-5.6-sol
+    litellm_params:
+      model: openai/gpt-5.6-sol
+      api_base: os.environ/CODEX_LB_BASE_URL
+      api_key: os.environ/CODEX_LB_API_KEY
+
+litellm_settings:
+  use_chat_completions_url_for_anthropic_messages: false
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+```
+
+The public `codex-lb-gpt-5.6-sol` alias maps to `gpt-5.6-sol` through
+codex-lb. The target must support Responses: choose a model from
+`GET /backend-api/codex/models`, or verify that an external source accepts
+`POST /v1/responses`. `GET /v1/models` can also list
+Chat-Completions-only sources, which do not work with this recipe.
+
+Keep the `openai/` provider prefix and the explicit LiteLLM setting. Marking
+the model as natively supporting `/v1/messages` would pass Anthropic
+payloads to codex-lb without translation.
+
+Set separate credentials for the two hops, then bind LiteLLM to loopback:
+
+```bash
+export CODEX_LB_BASE_URL="http://127.0.0.1:2455/v1"
+export CODEX_LB_API_KEY="sk-clb-..."        # dashboard key; see loopback note below
+export LITELLM_MASTER_KEY="sk-litellm-..." # choose a separate random secret
+
+env -u DEBUG uvx --from 'litellm[proxy]==1.97.0' \
+  --with 'fastapi==0.140.0' \
+  litellm \
+  --config ./litellm.yaml \
+  --host 127.0.0.1 \
+  --port 4000
+```
+
+The FastAPI pin avoids a startup incompatibility observed with FastAPI
+`0.141.1`. The scoped `env -u DEBUG` prevents an unrelated shell `DEBUG`
+value from being parsed as LiteLLM's Boolean CLI option. Transitive
+dependencies remain ranged, so repeat the smoke test when the environment is
+recreated.
+
+Do not reuse a Claude.ai OAuth token or Anthropic Console key for either
+value. `CODEX_LB_API_KEY` authenticates LiteLLM to codex-lb;
+`LITELLM_MASTER_KEY` authenticates Claude Code to LiteLLM. A non-empty
+placeholder works only when LiteLLM reaches an auth-disabled codex-lb over
+same-host loopback. Across containers, use their private network and enable
+codex-lb API-key auth with a registered dashboard key. Auth-disabled codex-lb
+rejects non-loopback proxy requests unless the raw peer is explicitly
+allowlisted with `CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS`. Do not expose
+an unencrypted LiteLLM listener or either key to an untrusted network.
+
+### Verify the translation path
+
+With LiteLLM running, send a streamed Anthropic-format request:
+
+```bash
+curl --fail-with-body --silent --show-error --no-buffer \
+  http://127.0.0.1:4000/v1/messages \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "codex-lb-gpt-5.6-sol",
+    "max_tokens": 32,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Reply with OK only."}]
+  }'
+```
+
+A successful stream contains Anthropic SSE events from `message_start`
+through `message_stop`. LiteLLM should log the public alias, and codex-lb
+should record a `POST /v1/responses` request for the serving account. This
+uses real quota.
+
+This recipe was prepared with Claude Code `2.1.220`, LiteLLM proxy
+`1.97.0`, and FastAPI `0.140.0`. Non-streaming, streaming, tool-use, and
+Claude one-shot translation were exercised against a local mock Responses
+endpoint; that does not replace the live-deployment smoke request above.
+Re-test when upgrading either proxy dependency or Claude Code.
+
+### Point Claude Code at LiteLLM
+
+Map the Opus, Sonnet, and Haiku aliases to the configured public alias so
+helper requests do not use an unconfigured Claude model name:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:4000"
+export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="codex-lb-gpt-5.6-sol"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="codex-lb-gpt-5.6-sol"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="codex-lb-gpt-5.6-sol"
+
+claude --model codex-lb-gpt-5.6-sol
+```
+
+`ANTHROPIC_DEFAULT_FABLE_MODEL` is intentionally unset. Claude Code also
+uses that variable to identify a target as Fable 5 for automatic fallback,
+which this non-Claude alias does not implement.
+
+`ANTHROPIC_AUTH_TOKEN` sends the LiteLLM key as a Bearer credential and
+takes precedence over a saved claude.ai login. Existing Claude Code settings
+can override shell variables; if they do, put the gateway values in an
+explicit settings `env` block. Run `/status` and confirm that a gateway
+credential is active. Follow Anthropic's
+[gateway setup](https://docs.anthropic.com/en/docs/claude-code/llm-gateway-connect)
+for persistent configuration, and unset these values to restore the previous
+login path.
+
+### Compatibility boundaries
+
+- Effective features and limits are the intersection of Claude Code,
+  LiteLLM's translation, codex-lb policy, and the mapped Responses model.
+- These family alias mappings can make Claude Code apply Claude-specific
+  context-window and compaction assumptions to the non-Claude target. If you set
+  `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, derive and test it against the effective
+  deployment limit; this recipe does not prescribe a value.
+- LiteLLM `1.97.0` does not preserve Responses reasoning identity or
+  signatures across Messages turns. Translated thinking can become summary or
+  ordinary text; do not assume encrypted reasoning or prompt-cache continuity.
+- LiteLLM serves `/v1/messages/count_tokens`, but codex-lb does not implement
+  `/v1/responses/input_tokens`. After that request returns `404`, this
+  LiteLLM version estimates locally and can omit separate system prompts or
+  tool definitions, materially undercounting the real input.
+- Anthropic error-envelope fidelity, beta fields, tool references, web search,
+  extended thinking, and prompt caching can degrade across the translation.
+- codex-lb API-key model allowlists, account assignment, and limits still
+  apply. Claude.ai identity features are unavailable with the gateway
+  credential, and optional Claude Code background traffic is not an
+  egress-isolation boundary.
+
+Common failures:
+
+| Symptom | Check |
+| --- | --- |
+| LiteLLM returns `401` | `ANTHROPIC_AUTH_TOKEN` must equal `LITELLM_MASTER_KEY`. |
+| codex-lb returns `401` | Use a valid dashboard `CODEX_LB_API_KEY`. An auth-disabled placeholder works only over loopback; across containers, enable key auth or explicitly allowlist the raw peer. |
+| LiteLLM reports an unknown model | Match `model_name`, the three configured `ANTHROPIC_DEFAULT_*_MODEL` values, and `claude --model`. |
+| LiteLLM cannot reach codex-lb | Keep `/v1` in `CODEX_LB_BASE_URL`; across containers, replace loopback with a private-network host. |
+| Claude Code still contacts Anthropic for model requests | Remove conflicting saved settings or use an explicit settings `env` block, then verify `/status`. |
 
 ## OpenAI Python SDK
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -451,9 +451,12 @@ an unencrypted LiteLLM listener or either key to an untrusted network.
 
 ### Verify the translation path
 
-With LiteLLM running, send a streamed Anthropic-format request:
+With LiteLLM running, open another shell, re-export the same master key, and
+send a streamed Anthropic-format request:
 
 ```bash
+export LITELLM_MASTER_KEY="sk-litellm-..." # same value used to start LiteLLM
+
 curl --fail-with-body --silent --show-error --no-buffer \
   http://127.0.0.1:4000/v1/messages \
   -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
@@ -482,9 +485,11 @@ Re-test when upgrading either proxy dependency or Claude Code.
 
 Map the Opus, Sonnet, and Haiku aliases to the configured public alias, and
 force subagents onto it so helper requests do not use an unconfigured Claude
-model name:
+model name. In the shell that will run Claude Code, re-export the same LiteLLM
+key:
 
 ```bash
+export LITELLM_MASTER_KEY="sk-litellm-..." # same value used to start LiteLLM
 export ANTHROPIC_BASE_URL="http://127.0.0.1:4000"
 export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="codex-lb-gpt-5.6-sol"

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -480,8 +480,9 @@ Re-test when upgrading either proxy dependency or Claude Code.
 
 ### Point Claude Code at LiteLLM
 
-Map the Opus, Sonnet, and Haiku aliases to the configured public alias so
-helper requests do not use an unconfigured Claude model name:
+Map the Opus, Sonnet, and Haiku aliases to the configured public alias, and
+force subagents onto it so helper requests do not use an unconfigured Claude
+model name:
 
 ```bash
 export ANTHROPIC_BASE_URL="http://127.0.0.1:4000"
@@ -489,10 +490,16 @@ export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="codex-lb-gpt-5.6-sol"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="codex-lb-gpt-5.6-sol"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="codex-lb-gpt-5.6-sol"
+export CLAUDE_CODE_SUBAGENT_MODEL="codex-lb-gpt-5.6-sol"
 
 claude --model codex-lb-gpt-5.6-sol
 ```
 
+`CLAUDE_CODE_SUBAGENT_MODEL` overrides per-agent model selection for this
+gateway session, including subagents that request the `fable` alias. This keeps
+agent teams and workflows on the one model LiteLLM exposes in this recipe. It
+does not redirect a main-session `/model fable` selection; keep the main session
+on the public alias shown above.
 `ANTHROPIC_DEFAULT_FABLE_MODEL` is intentionally unset. Claude Code also
 uses that variable to identify a target as Fable 5 for automatic fallback,
 which this non-Claude alias does not implement.
@@ -534,7 +541,7 @@ Common failures:
 | --- | --- |
 | LiteLLM returns `401` | `ANTHROPIC_AUTH_TOKEN` must equal `LITELLM_MASTER_KEY`. |
 | codex-lb returns `401` | Use a valid dashboard `CODEX_LB_API_KEY`. An auth-disabled placeholder works only over loopback; across containers, enable key auth or explicitly allowlist the raw peer. |
-| LiteLLM reports an unknown model | Match `model_name`, the three configured `ANTHROPIC_DEFAULT_*_MODEL` values, and `claude --model`. |
+| LiteLLM reports an unknown model | Match `model_name`, the three configured `ANTHROPIC_DEFAULT_*_MODEL` values, `CLAUDE_CODE_SUBAGENT_MODEL`, and `claude --model`. |
 | LiteLLM cannot reach codex-lb | Keep `/v1` in `CODEX_LB_BASE_URL`; across containers, replace loopback with a private-network host. |
 | Claude Code still contacts Anthropic for model requests | Remove conflicting saved settings or use an explicit settings `env` block, then verify `/status`. |
 

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -239,6 +239,10 @@ examples against the existing contract, not separate compatibility surfaces:
 - **Hermes Agent** (Nous Research) — named custom provider with
   `api_mode: codex_responses` against `/v1`; the responses transport carries
   reasoning state across turns like the OpenCode path.
+- **Claude Code** (experimental external composition) — a third-party
+  Anthropic-to-OpenAI translator can map Claude Code's Messages requests onto
+  `/v1/responses`. The translator, not codex-lb, owns the Messages contract;
+  codex-lb does not gain an Anthropic protocol surface or Claude credentials.
 
 New client guides added to `docs/client-setup.md` should stay configuration-only
 examples of this contract; anything needing new proxy behavior requires its own


### PR DESCRIPTION
## Summary

Documents an experimental external composition that translates Claude Code Messages requests through LiteLLM to codex-lb's existing `/v1/responses` endpoint. This follows the maintainer decision in #114 to keep Anthropic protocol translation outside codex-lb and prominently notes that Anthropic does not support routing Claude Code to non-Claude models this way.

This is documentation and non-normative OpenSpec context only. It adds no runtime behavior, Anthropic endpoint, Claude credentials, dependency, setting, or default.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [x] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #114

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: N/A — this only updates the existing non-normative `responses-api-compat` context; no requirement or behavior changes.

## Changes

- Add a Claude Code → LiteLLM → codex-lb recipe using the existing Responses API.
- Document separate credentials, loopback/private-network boundaries, streamed verification, model discovery, and troubleshooting.
- Route family aliases and all Claude Code subagents to the configured LiteLLM alias while deliberately leaving `ANTHROPIC_DEFAULT_FABLE_MODEL` unset so a non-Claude model is not misidentified as Fable 5.
- Record reasoning, token-counting, context, error-envelope, tool, web-search, thinking, and prompt-cache translation limitations.
- Register Claude Code as an experimental external composition in the existing Responses compatibility context without implying native Anthropic or Claude support.

## Test plan

Passed on the rebased current head:

```text
uv sync --group docs --frozen
uv run --no-sync mkdocs build --strict
npx --yes @fission-ai/openspec@latest validate --specs
# 57 passed, 0 failed

uvx codespell docs/client-setup.md openspec/specs/responses-api-compat/context.md
uvx ruff check .
uvx ruff format --check .
uv run ty check
git diff --check upstream/main...HEAD
```

The embedded LiteLLM YAML parses successfully and all newly added external links returned HTTP 200.

The translator path was exercised with Claude Code `2.1.220`, LiteLLM proxy `1.97.0`, and FastAPI `0.140.0` against a local mock OpenAI Responses endpoint. Non-streaming, streaming SSE, tool-use translation, token-count fallback, a Claude Code one-shot request, and Fable-selected subagent routing were checked. This was not a live codex-lb account test; the guide includes a separate live-deployment smoke request.

`uv run pytest` completed with 8,644 passed, 106 skipped, and four timing/state-sensitive failures in untouched process-shutdown, sticky-session, and load-balancer-concurrency tests. The exact four failed node IDs then passed together in isolation (`4 passed in 4.07s`), so a completely green aggregate pytest run is not claimed.

A full `local-ci` run was also attempted while preparing this docs-only change. Its sequential targets through `test-e2e` passed, including 145 frontend test files and 1,145 frontend tests. It then stopped during `test-postgres` collection because no PostgreSQL server was listening on `127.0.0.1:5432`. A full local-ci pass is therefore not claimed; PostgreSQL and the other required jobs remain covered by GitHub CI.

## Screenshots / output

No dashboard surface changed. Strict MkDocs rendering completed successfully on the rebased head.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Executable project tests are not applicable to this docs-only change; the documented external composition was smoke-tested as described above.
- [x] Ran the relevant current-head docs, static, and OpenSpec validation subset locally; broader-suite limitations are documented above.
- [x] `openspec validate --specs` passes; `/opsx:verify` is not applicable because there is no behavior change or OpenSpec change directory.
- [x] Simplicity gates reviewed: no setting, default, README section, `.env.example` entry, or dashboard navigation item changes.
- [x] CHANGELOG is **not** edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental Claude Code integration through an external Anthropic-to-OpenAI translator.
  * Added support for configuring Claude Code with the gateway’s Responses API endpoint and model aliases.
  * Added streamed verification guidance for validating the integration.

* **Documentation**
  * Expanded client setup instructions with configuration, credentials, startup steps, compatibility limitations, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->