### PR TITLE
docs(community): list macOS companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ Full docs live at **<https://soju06.github.io/codex-lb/>**:
 - [Deployment](https://soju06.github.io/codex-lb/deployment/docker/) — [Docker](https://soju06.github.io/codex-lb/deployment/docker/), [Kubernetes](https://soju06.github.io/codex-lb/deployment/kubernetes/), [remote access](https://soju06.github.io/codex-lb/deployment/remote/)
 - [Troubleshooting](https://soju06.github.io/codex-lb/troubleshooting/)
 
+### Community companions
+
+Independent projects that consume the dashboard API, maintained outside codex-lb
+(see [the docs listing](https://soju06.github.io/codex-lb/#community-companions)
+for access guidance):
+
+- [Codex LB Status Bar](https://github.com/sm1ee/codex-lb-statusbar) — native macOS app: account status, quota details, account controls
+- [codex-lb SwiftBar](https://github.com/joschi655/codex-lb-swiftbar) — read-only SwiftBar/Bun monitor for pool status and quota headroom
+
 ## Development
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,20 @@ Load balancer for ChatGPT accounts. Pool multiple accounts, track usage, manage 
 - [Deployment](deployment/docker.md) — Docker, [Kubernetes](deployment/kubernetes.md), [remote access](deployment/remote.md)
 - [Troubleshooting](troubleshooting.md)
 
+## Community companions
+
+These independent projects consume the existing dashboard API and are
+maintained outside codex-lb:
+
+- [Codex LB Status Bar](https://github.com/sm1ee/codex-lb-statusbar) — a native
+  macOS app with account status, quota details, and authenticated account
+  controls.
+- [codex-lb SwiftBar](https://github.com/joschi655/codex-lb-swiftbar) — a
+  read-only SwiftBar/Bun monitor for account-pool status and quota headroom.
+
+Review each project's repository and release notes before giving it access to
+an authenticated dashboard.
+
 ## Screenshots
 
 | Settings | Login |

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,16 @@ Load balancer for ChatGPT accounts. Pool multiple accounts, track usage, manage 
 - [Deployment](deployment/docker.md) — Docker, [Kubernetes](deployment/kubernetes.md), [remote access](deployment/remote.md)
 - [Troubleshooting](troubleshooting.md)
 
+## Screenshots
+
+| Settings | Login |
+|:---:|:---:|
+| ![settings](screenshots/settings.jpg) | ![login](screenshots/login.jpg) |
+
+| Dashboard (dark) | Accounts (dark) | Settings (dark) |
+|:---:|:---:|:---:|
+| ![dashboard-dark](screenshots/dashboard-dark.jpg) | ![accounts-dark](screenshots/accounts-dark.jpg) | ![settings-dark](screenshots/settings-dark.jpg) |
+
 ## Community companions
 
 These independent projects consume the existing dashboard API and are
@@ -48,16 +58,6 @@ repository and release notes before connecting it.
 OpenSpec: the [user-documentation capability](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation)
 governs this listing, while [admin-auth](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/admin-auth)
 defines the guest and admin access contracts.
-
-## Screenshots
-
-| Settings | Login |
-|:---:|:---:|
-| ![settings](screenshots/settings.jpg) | ![login](screenshots/login.jpg) |
-
-| Dashboard (dark) | Accounts (dark) | Settings (dark) |
-|:---:|:---:|:---:|
-| ![dashboard-dark](screenshots/dashboard-dark.jpg) | ![accounts-dark](screenshots/accounts-dark.jpg) | ![settings-dark](screenshots/settings-dark.jpg) |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,11 @@ maintained outside codex-lb:
 - [codex-lb SwiftBar](https://github.com/joschi655/codex-lb-swiftbar) — a
   read-only SwiftBar/Bun monitor for account-pool status and quota headroom.
 
-Review each project's repository and release notes before giving it access to
-an authenticated dashboard.
+Prefer a guest dashboard session for monitoring-only access when the companion
+supports it, and grant admin access only for Status Bar account controls.
+codex-lb SwiftBar is read-only; consult its compatibility table for the
+authentication modes supported by the current release. Review each project's
+repository and release notes before connecting it.
 
 ## Screenshots
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,10 @@ codex-lb SwiftBar is read-only; consult its compatibility table for the
 authentication modes supported by the current release. Review each project's
 repository and release notes before connecting it.
 
+OpenSpec: the [user-documentation capability](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation)
+governs this listing, while [admin-auth](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/admin-auth)
+defines the guest and admin access contracts.
+
 ## Screenshots
 
 | Settings | Login |

--- a/openspec/specs/user-documentation/context.md
+++ b/openspec/specs/user-documentation/context.md
@@ -50,6 +50,9 @@ README and sample env stay slim without losing content.
   [codex-lb SwiftBar](https://github.com/joschi655/codex-lb-swiftbar),
   following the maintainer direction in
   [PR #1233](https://github.com/Soju06/codex-lb/pull/1233#issuecomment-4988227303).
+  Listings also carry least-privilege guidance: guest access for monitoring
+  where the companion supports it, and admin access only for control features;
+  each companion remains responsible for documenting its current auth modes.
 - **zh-CN README gets a canonical-English banner** rather than a parallel diet;
   full i18n (mkdocs-static-i18n) is a deferred follow-up.
 

--- a/openspec/specs/user-documentation/context.md
+++ b/openspec/specs/user-documentation/context.md
@@ -53,6 +53,12 @@ README and sample env stay slim without losing content.
   Listings also carry least-privilege guidance: guest access for monitoring
   where the companion supports it, and admin access only for control features;
   each companion remains responsible for documenting its current auth modes.
+  Placement: the listing renders as an appendix-level section at the end of
+  `docs/index.md` (below core usage and screenshots) and is kept
+  self-contained so it can move to a dedicated page once the list grows; a
+  short mirror lives in the README under the Documentation section (a
+  sub-heading, not a new top-level README section, per the simplicity
+  budgets).
 - **zh-CN README gets a canonical-English banner** rather than a parallel diet;
   full i18n (mkdocs-static-i18n) is a deferred follow-up.
 

--- a/openspec/specs/user-documentation/context.md
+++ b/openspec/specs/user-documentation/context.md
@@ -40,6 +40,16 @@ README and sample env stay slim without losing content.
   by `tests/unit/test_helm_replica_artifacts.py`.
 - **OpenSpec stays normative.** Docs pages carry footer links to their
   governing capability; they render behavior, they do not define it.
+- **Community companions stay separate.** Small operator tools that consume an
+  existing API can be maintained in independent repositories and linked from
+  the docs once they are public and tested. A listing keeps the tool
+  discoverable without adding its runtime, CI, release process, or support
+  surface to codex-lb. The first listings cover the independently published
+  [Codex LB Status Bar](https://github.com/sm1ee/codex-lb-statusbar) and the
+  read-only
+  [codex-lb SwiftBar](https://github.com/joschi655/codex-lb-swiftbar),
+  following the maintainer direction in
+  [PR #1233](https://github.com/Soju06/codex-lb/pull/1233#issuecomment-4988227303).
 - **zh-CN README gets a canonical-English banner** rather than a parallel diet;
   full i18n (mkdocs-static-i18n) is a deferred follow-up.
 


### PR DESCRIPTION
## Summary

List the two independently maintained macOS companions in the published docs:
the native Codex LB Status Bar app and the read-only codex-lb SwiftBar monitor.
This makes the tools discoverable without adding their runtime, release, or
support surface to codex-lb, following the maintainer invitation in #1233.

## Type of change

- [x] `docs:` — documentation only

Linked issue: Refs #1233

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Change directory: N/A. The non-normative context for the existing
`user-documentation` capability is updated alongside the docs page.

## Changes

- Add a Community companions section to the docs landing page.
- Describe the ownership and capabilities of both public macOS projects.
- Warn operators to review an independent project before granting authenticated dashboard access.

## Test plan

```text
git diff --check upstream/main...HEAD
uv run --no-sync mkdocs build --strict
openspec validate --specs --strict  # 57 specs passed
```

An additional isolated adversarial review verified both linked repositories,
their public releases, and their use of the current dashboard API; it found no
actionable defect.

## Screenshots / output

The rendered docs landing page gains the text-only Community companions section.
No dashboard UI changes are included.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] No code path or testable behavior changed.
- [x] Ran the relevant docs and OpenSpec validation subset locally.
- [x] If touching specs: strict validation passes; only non-normative context changed.
- [x] Simplicity gates reviewed: no setting, setup step, README section, or dashboard navigation item is added.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Community companions listings for Codex LB Status Bar and codex-lb SwiftBar.
  * Clarified that companion tools are independently maintained and consume the dashboard API.
  * Added least-privilege access guidance, recommending guest access for monitoring and administrator access only for control features.
  * Directed readers to companion projects for authentication details.
  * Moved the Screenshots section above Community companions for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->