### PR TITLE
fix(http-bridge): retire bridge anchors upstream has denied

### DIFF
--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -80,6 +80,11 @@ class _HTTPBridgeServiceProtocol(Protocol):
     ) -> tuple[list[_HTTPBridgeSession], list[asyncio.Future[_HTTPBridgeSession]]]: ...
     def _unregister_http_bridge_turn_states_locked(self, session: _HTTPBridgeSession) -> None: ...
     def _unregister_http_bridge_previous_response_ids_locked(self, session: _HTTPBridgeSession) -> None: ...
+    def _unregister_http_bridge_previous_response_id_locked(
+        self,
+        session: _HTTPBridgeSession,
+        response_id: str,
+    ) -> None: ...
     async def _register_http_bridge_turn_state_impl(
         self,
         session: _HTTPBridgeSession,
@@ -101,6 +106,11 @@ class _HTTPBridgeServiceProtocol(Protocol):
         input_full_fingerprint: str | None = None,
         pending_tool_calls: Mapping[str, str] | None = None,
     ) -> bool: ...
+    async def _unregister_http_bridge_previous_response_id(
+        self,
+        session: _HTTPBridgeSession,
+        response_id: str,
+    ) -> None: ...
     def _schedule_http_bridge_session_closes(
         self,
         sessions: list[_HTTPBridgeSession],

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1887,6 +1887,25 @@ class _HTTPBridgeRequestSubmitMixin:
                                     "The recovery checkpoint was consumed before dispatch; retry the request.",
                                 ),
                             )
+                    if (
+                        request_state.proxy_injected_previous_response_id
+                        and request_state.previous_response_id is not None
+                        and request_state.previous_response_id in session.denied_proxy_injected_anchor_ids
+                    ):
+                        _record_continuity_fail_closed(
+                            surface="http_bridge",
+                            reason="denied_proxy_anchor_before_dispatch",
+                            previous_response_id=request_state.previous_response_id,
+                            session_id=request_state.session_id,
+                            upstream_error_code="previous_response_not_found",
+                        )
+                        raise ProxyResponseError(
+                            502,
+                            openai_error(
+                                "stream_incomplete",
+                                "The previous response anchor was rejected upstream; retry the request.",
+                            ),
+                        )
                     async with session.pending_lock:
                         session.pending_requests.append(request_state)
                         session.admission_waiter_count = max(0, session.admission_waiter_count - 1)

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -428,6 +428,14 @@ class _HTTPBridgeSessionRegistryMixin:
         async with self._http_bridge_lock:
             self._unregister_http_bridge_previous_response_ids_locked(session)
 
+    async def _unregister_http_bridge_previous_response_id(
+        self: _HTTPBridgeServiceProtocol,
+        session: _HTTPBridgeSession,
+        response_id: str,
+    ) -> None:
+        async with self._http_bridge_lock:
+            self._unregister_http_bridge_previous_response_id_locked(session, response_id)
+
     def _detach_http_bridge_session_locked(
         self: _HTTPBridgeServiceProtocol,
         key: _HTTPBridgeSessionKey,
@@ -488,19 +496,31 @@ class _HTTPBridgeSessionRegistryMixin:
         self: _HTTPBridgeServiceProtocol,
         session: _HTTPBridgeSession,
     ) -> None:
-        current_session = self._http_bridge_sessions.get(session.key)
         for response_id in tuple(session.previous_response_ids):
-            alias_key = _http_bridge_previous_response_alias_key(response_id, session.key.api_key_id)
-            if (
+            self._unregister_http_bridge_previous_response_id_locked(session, response_id)
+        session.previous_response_ids.clear()
+        session.previous_response_alias_registration_generations.clear()
+
+    def _unregister_http_bridge_previous_response_id_locked(
+        self: _HTTPBridgeServiceProtocol,
+        session: _HTTPBridgeSession,
+        response_id: str,
+    ) -> None:
+        if response_id not in session.previous_response_ids:
+            return
+        alias_key = _http_bridge_previous_response_alias_key(response_id, session.key.api_key_id)
+        current_session = self._http_bridge_sessions.get(session.key)
+        if (
+            not (
                 current_session is not None
                 and current_session is not session
                 and response_id in current_session.previous_response_ids
-            ):
-                continue
-            if self._http_bridge_previous_response_index.get(alias_key) == session.key:
-                self._http_bridge_previous_response_index.pop(alias_key, None)
-        session.previous_response_ids.clear()
-        session.previous_response_alias_registration_generations.clear()
+            )
+            and self._http_bridge_previous_response_index.get(alias_key) == session.key
+        ):
+            self._http_bridge_previous_response_index.pop(alias_key, None)
+        session.previous_response_ids.discard(response_id)
+        session.previous_response_alias_registration_generations.pop(response_id, None)
 
     def _promote_http_bridge_session_to_codex_affinity(
         self: _HTTPBridgeServiceProtocol,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3459,6 +3459,14 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_state.proxy_injected_previous_response_id = (
                     request_state.proxy_injected_previous_response_id and retry_previous_response_id is not None
                 )
+                # Carried with the flag above, not separately: the anchor's
+                # retirability depends on whether the payload it was injected
+                # onto was full-resend shaped, and a retry that replays the
+                # anchor replays that shape too.
+                retry_request_state.proxy_injected_anchor_had_full_resend_payload = (
+                    request_state.proxy_injected_anchor_had_full_resend_payload
+                    and retry_request_state.proxy_injected_previous_response_id
+                )
                 if recovery_path == "local_previous_response_error":
                     # The prior response.failed/error made the operation
                     # terminal. Re-enter record_operation so its owner fence

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3447,6 +3447,18 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_state.operation_attempt_generation = request_state.operation_attempt_generation
                 retry_request_state.operation_persisted_response_id = request_state.operation_persisted_response_id
                 retry_request_state.operation_rebind_required = request_state.operation_rebind_required
+                # An anchored recovery replays the proxy's own anchor, so the
+                # retry inherits its provenance. Without this the retry looks
+                # client-anchored: diagnostics report
+                # ``previous_response_source=client_supplied`` for an id no
+                # client sent, ``_http_bridge_request_state_wedged_reattach``
+                # cannot recognise the reattach, and an upstream denial of the
+                # anchor is not attributable to this proxy. The anchor-free
+                # recovery paths carry no anchor at all, so the flag stays
+                # false there and cannot describe an id the retry never sends.
+                retry_request_state.proxy_injected_previous_response_id = (
+                    request_state.proxy_injected_previous_response_id and retry_previous_response_id is not None
+                )
                 if recovery_path == "local_previous_response_error":
                     # The prior response.failed/error made the operation
                     # terminal. Re-enter record_operation so its owner fence

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1011,6 +1011,48 @@ async def _abandon_durable_http_bridge_continuity(
     return True
 
 
+async def _invalidate_denied_http_bridge_anchor(
+    service: Any,
+    session: "_HTTPBridgeSession",
+    *,
+    denied_response_id: str | None,
+) -> bool:
+    """Retire an anchor upstream has explicitly denied.
+
+    ``previous_response_not_found`` against an anchor the proxy injected is a
+    verdict, not a symptom: the id came from this proxy's own durable record,
+    no client asked for it, and upstream says it does not exist. The poison
+    counter cannot act on that verdict because it only scores reader failures
+    (see ``_HTTP_BRIDGE_ANCHOR_POISON_DETAILS``), so the dead id survives at
+    any threshold and is re-injected into the following turn, where the
+    store-context trim strips the resent history against it and upstream never
+    emits ``response.created``.
+
+    Clearing costs nothing that is not already lost. The next turn simply
+    dispatches unanchored with the history the client sends, which is the
+    client's own replay rather than a server-side one, so no forked child
+    response can be created against a parent this proxy cannot see.
+    """
+    if denied_response_id is None:
+        return False
+    # Another request may have completed and advanced the anchor between the
+    # denied dispatch and this frame. Only retire the id that was refused.
+    if session.last_completed_response_id != denied_response_id:
+        return False
+    cleared = await _abandon_durable_http_bridge_continuity(
+        service,
+        session,
+        detail="upstream_denied_proxy_injected_anchor",
+    )
+    await service._unregister_http_bridge_previous_response_ids(session)
+    session.last_completed_response_id = None
+    session.last_completed_response_account_id = None
+    session.last_completed_input_count = 0
+    session.last_completed_input_prefix_fingerprint = None
+    session.last_pending_tool_calls.clear()
+    return cleared
+
+
 class _HTTPBridgeUpstreamEventsMixin:
     async def _fail_http_bridge_reader_and_maybe_retire(
         self: Any,
@@ -2289,6 +2331,12 @@ class _HTTPBridgeUpstreamEventsMixin:
                 original_text=text,
             )
             event_block = f"data: {rewritten_text}\n\n"
+            if status_request_state.proxy_injected_previous_response_id:
+                await _invalidate_denied_http_bridge_anchor(
+                    self,
+                    session,
+                    denied_response_id=status_request_state.previous_response_id,
+                )
 
         retry_error_code = _websocket_precreated_retry_error_code(
             status_request_state,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import replace
 from typing import Any, TypeVar, cast
 
@@ -1032,6 +1032,12 @@ async def _invalidate_denied_http_bridge_anchor(
     dispatches unanchored with the history the client sends, which is the
     client's own replay rather than a server-side one, so no forked child
     response can be created against a parent this proxy cannot see.
+
+    The in-memory clear is unconditional even when the durable write is fenced,
+    because it strictly removes one way for the denied id to come back. A
+    durable row that survives re-injects the id on a later turn, which is denied
+    in turn and re-enters this path, so the clear is re-attempted rather than
+    lost.
     """
     if denied_response_id is None:
         return False
@@ -1051,6 +1057,51 @@ async def _invalidate_denied_http_bridge_anchor(
     session.last_completed_input_prefix_fingerprint = None
     session.last_pending_tool_calls.clear()
     return cleared
+
+
+def _denied_proxy_injected_anchor_id(
+    request_states: Iterable["_WebSocketRequestState"],
+) -> str | None:
+    """Choose the anchor a denial may retire, if any.
+
+    Only an anchor codex-lb injected onto a full-resend-shaped payload can be
+    retired. A delta-only request has no other way to convey prior context once
+    its anchor is gone, which is the same rule the expired-anchor path applies
+    before clearing durable continuity.
+    """
+    for request_state in request_states:
+        if (
+            request_state.proxy_injected_previous_response_id
+            and request_state.proxy_injected_anchor_had_full_resend_payload
+            and request_state.previous_response_id is not None
+        ):
+            return request_state.previous_response_id
+    return None
+
+
+async def _retire_denied_http_bridge_anchor(
+    service: Any,
+    session: "_HTTPBridgeSession",
+    *,
+    request_states: Iterable["_WebSocketRequestState"],
+) -> None:
+    """Best-effort retirement of an anchor upstream denied.
+
+    Retirement is bookkeeping. It must never change how the denial itself is
+    delivered downstream, so a failure here is logged and swallowed rather than
+    escaping into terminal-event handling.
+    """
+    denied_response_id = _denied_proxy_injected_anchor_id(request_states)
+    if denied_response_id is None:
+        return
+    try:
+        await _invalidate_denied_http_bridge_anchor(
+            service,
+            session,
+            denied_response_id=denied_response_id,
+        )
+    except Exception:
+        logger.warning("Failed to retire a denied proxy-injected HTTP bridge anchor", exc_info=True)
 
 
 class _HTTPBridgeUpstreamEventsMixin:
@@ -2056,6 +2107,15 @@ class _HTTPBridgeUpstreamEventsMixin:
 
         if len(grouped_previous_response_request_states) > 1:
             session.upstream_control.reconnect_requested = True
+            if is_previous_response_not_found_event:
+                # This branch settles every request that shared the denied
+                # anchor and then returns, so the single-request retirement
+                # below is never reached for a fan-out denial.
+                await _retire_denied_http_bridge_anchor(
+                    self,
+                    session,
+                    request_states=grouped_previous_response_request_states,
+                )
             grouped_error_reason = (
                 "previous_response_not_found"
                 if is_previous_response_not_found_event
@@ -2331,12 +2391,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                 original_text=text,
             )
             event_block = f"data: {rewritten_text}\n\n"
-            if status_request_state.proxy_injected_previous_response_id:
-                await _invalidate_denied_http_bridge_anchor(
-                    self,
-                    session,
-                    denied_response_id=status_request_state.previous_response_id,
-                )
+            await _retire_denied_http_bridge_anchor(
+                self,
+                session,
+                request_states=(status_request_state,),
+            )
 
         retry_error_code = _websocket_precreated_retry_error_code(
             status_request_state,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1033,7 +1033,9 @@ async def _invalidate_denied_http_bridge_anchor(
     client's own replay rather than a server-side one, so no forked child
     response can be created against a parent this proxy cannot see.
 
-    The in-memory clear is unconditional even when the durable write is fenced,
+    The durable clear is conditional on the denied id still being the durable
+    latest response, and removes only that response alias. The in-memory clear
+    is unconditional for the same id even when the durable write is fenced,
     because it strictly removes one way for the denied id to come back. A
     durable row that survives re-injects the id on a later turn, which is denied
     in turn and re-enters this path, so the clear is re-attempted rather than
@@ -1045,17 +1047,35 @@ async def _invalidate_denied_http_bridge_anchor(
     # denied dispatch and this frame. Only retire the id that was refused.
     if session.last_completed_response_id != denied_response_id:
         return False
-    cleared = await _abandon_durable_http_bridge_continuity(
-        service,
-        session,
-        detail="upstream_denied_proxy_injected_anchor",
-    )
-    await service._unregister_http_bridge_previous_response_ids(session)
-    session.last_completed_response_id = None
-    session.last_completed_response_account_id = None
-    session.last_completed_input_count = 0
-    session.last_completed_input_prefix_fingerprint = None
-    session.last_pending_tool_calls.clear()
+    # Publish the denial before the first await. A request that prepared the
+    # same injected anchor concurrently must revalidate before dispatch rather
+    # than race the durable write and send the denied id again.
+    session.denied_proxy_injected_anchor_ids.add(denied_response_id)
+    cleared = False
+    try:
+        if session.durable_session_id is not None and session.durable_owner_epoch is not None:
+            lookup = await service._durable_bridge.clear_live_session_response_anchor_if_matches(
+                session_id=session.durable_session_id,
+                api_key_id=session.key.api_key_id,
+                instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
+                owner_epoch=session.durable_owner_epoch,
+                response_id=denied_response_id,
+            )
+            cleared = lookup is not None
+    except Exception:
+        logger.warning("Failed to clear denied HTTP bridge response anchor", exc_info=True)
+    finally:
+        try:
+            await service._unregister_http_bridge_previous_response_id(session, denied_response_id)
+        finally:
+            # Do not erase a newer response that completed while the fenced
+            # durable write was in flight.
+            if session.last_completed_response_id == denied_response_id:
+                session.last_completed_response_id = None
+                session.last_completed_response_account_id = None
+                session.last_completed_input_count = 0
+                session.last_completed_input_prefix_fingerprint = None
+                session.last_pending_tool_calls.clear()
     return cleared
 
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1202,6 +1202,7 @@ class _HTTPBridgeSession:
     downstream_turn_state: str | None = None
     downstream_turn_state_aliases: set[str] = field(default_factory=set)
     previous_response_ids: set[str] = field(default_factory=set)
+    denied_proxy_injected_anchor_ids: set[str] = field(default_factory=set)
     alias_registration_generation: int = 0
     turn_state_alias_registration_generations: dict[str, int] = field(default_factory=dict)
     previous_response_alias_registration_generations: dict[str, int] = field(default_factory=dict)

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -416,6 +416,27 @@ class DurableBridgeSessionCoordinator:
             return None
         return _to_lookup(snapshot)
 
+    async def clear_live_session_response_anchor_if_matches(
+        self,
+        *,
+        session_id: str,
+        api_key_id: str | None,
+        instance_id: str,
+        owner_epoch: int,
+        response_id: str,
+    ) -> DurableBridgeLookup | None:
+        async with self._session() as session:
+            snapshot = await DurableBridgeRepository(session).clear_latest_response_anchor_if_matches(
+                session_id=session_id,
+                api_key_scope=durable_bridge_api_key_scope(api_key_id),
+                instance_id=instance_id,
+                owner_epoch=owner_epoch,
+                response_id=response_id,
+            )
+        if snapshot is None:
+            return None
+        return _to_lookup(snapshot)
+
     async def record_recovery_attempt(
         self,
         *,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -937,6 +937,57 @@ class DurableBridgeRepository:
             values=values,
         )
 
+    async def clear_latest_response_anchor_if_matches(
+        self,
+        *,
+        session_id: str,
+        api_key_scope: str,
+        instance_id: str,
+        owner_epoch: int,
+        response_id: str,
+    ) -> DurableBridgeSessionSnapshot | None:
+        """Clear one response anchor and its matching alias under the owner fence.
+
+        The response-id predicate makes a concurrent newer completion win over
+        a stale denial. Only the denied response alias is removed; turn-state
+        and other response aliases remain routable.
+        """
+
+        values: dict[str, object] = {
+            "latest_response_id": None,
+            "latest_input_item_count": None,
+            "latest_input_full_fingerprint": None,
+            "latest_pending_tool_calls_json": None,
+        }
+        async with sqlite_writer_section():
+            cleared = await self._session.execute(
+                update(HttpBridgeSessionRecord)
+                .where(
+                    HttpBridgeSessionRecord.id == session_id,
+                    HttpBridgeSessionRecord.api_key_scope == api_key_scope,
+                    HttpBridgeSessionRecord.owner_instance_id == instance_id,
+                    HttpBridgeSessionRecord.owner_epoch == owner_epoch,
+                    HttpBridgeSessionRecord.latest_response_id == response_id,
+                )
+                .values(**values)
+                .returning(HttpBridgeSessionRecord.id)
+            )
+            if cleared.scalar_one_or_none() is None:
+                await self._session.rollback()
+                return None
+            await self._session.execute(
+                delete(HttpBridgeSessionAlias).where(
+                    HttpBridgeSessionAlias.session_id == session_id,
+                    HttpBridgeSessionAlias.alias_kind == "previous_response_id",
+                    HttpBridgeSessionAlias.alias_hash == durable_bridge_hash(response_id),
+                    HttpBridgeSessionAlias.alias_value == response_id,
+                    HttpBridgeSessionAlias.api_key_scope == api_key_scope,
+                )
+            )
+            row = await self._session.get(HttpBridgeSessionRecord, session_id)
+            await self._session.commit()
+        return _to_snapshot(row)
+
     async def record_recovery_attempt(
         self,
         *,

--- a/openspec/changes/invalidate-denied-bridge-anchor/.openspec.yaml
+++ b/openspec/changes/invalidate-denied-bridge-anchor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/invalidate-denied-bridge-anchor/proposal.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/proposal.md
@@ -1,0 +1,41 @@
+# Invalidate Bridge Anchors Upstream Has Denied
+
+## Why
+
+The HTTP responses session bridge keeps re-injecting a `previous_response_id` that upstream has already said does not exist (issue #1852).
+
+When upstream answers an anchored bridge request with `previous_response_not_found`, that is a verdict about the anchor. If the proxy injected the anchor itself, no client asked for the id, it came from the proxy's own durable record, and upstream has now refused it. Nothing in the bridge acts on that verdict:
+
+1. Anchor poisoning cannot see it. `_http_bridge_anchor_poison_detail` only scores reader failures whose detail is `stream_incomplete` or `stream_idle_timeout`. A denial arrives as a terminal upstream event, not a reader failure, so it contributes nothing at any value of `http_responses_session_bridge_anchor_poison_failure_threshold`. Lowering the threshold does not help.
+2. The dead id therefore survives in both carriers, the durable `latest_response_id` row and the in-memory `session.last_completed_response_id`, and the fresh-reattach path injects it into the next turn.
+3. On that next turn the store-context trim matches the stored prefix and strips it, because the trim consults the stored fingerprint and never whether the anchor is still alive. Upstream then receives a few items instead of the conversation, never emits `response.created`, and the attempt presents as an eventless failure rather than as a stale anchor.
+
+Two of those eventless failures open the retry circuit, so the client sees `503 ... cooling down`. Measured over 12.7 h on one host: 163 `continuity_fail_closed` rejections, 29 circuit opens, and a worst-case trim of `original_items=602 trimmed_to=3`.
+
+The second half of this change is why the first half currently could not fire even if it existed. The anchored recovery replays the proxy's own anchor but never copies `proxy_injected_previous_response_id` onto the retry state, so a denial of the replayed anchor is not attributable to the proxy. The same gap misreports `previous_response_source=client_supplied` for ids no client sent and keeps `_http_bridge_request_state_wedged_reattach` from recognising the reattach shape it exists to catch.
+
+## What Changes
+
+- Retire a `previous_response_id` on the first explicit upstream denial when the proxy injected it, clearing the durable continuity row and the in-memory anchor together, instead of waiting for a counter that this failure class never increments. The retirement is skipped when a concurrent request has already advanced the anchor past the denied id.
+- Carry `proxy_injected_previous_response_id` onto the anchored recovery retry state, so a denial of the replayed anchor is attributable, diagnostics report the real provenance, and the wedge classifier sees the reattach. Anchor-free recovery paths keep the flag false because they send no anchor.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: An explicit upstream previous-response denial retires a proxy-injected anchor immediately, and anchored recovery retries retain the provenance of the anchor they replay.
+
+## Impact
+
+- HTTP bridge terminal-event handling (`app/modules/proxy/_service/http_bridge/upstream_events.py`) and anchored recovery retry state (`app/modules/proxy/_service/http_bridge/streaming.py`).
+- No API, schema, migration, dependency, configuration, or dashboard changes. The poison threshold setting and its default of seven are untouched, and the downstream error contract is unchanged: the denial is still masked to `stream_incomplete` and still surfaces as 502, so clients keep their anchor and do not resend full history (the invariant from #397).
+
+## Non-Goals
+
+- Adding another upstream dispatch. This change never resends the turn. The next turn is the client's own, with the history the client sends, so no forked child response can be created against a parent the proxy cannot observe. Retrying the turn server-side without the anchor is what #1857 and #1863 propose and is deliberately out of scope here.
+- Changing the poison threshold arithmetic that issue #1852 is titled after.
+- Exposing the stale-anchor classifier downstream on the bridge path.

--- a/openspec/changes/invalidate-denied-bridge-anchor/proposal.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/proposal.md
@@ -16,7 +16,8 @@ The second half of this change is why the first half currently could not fire ev
 
 ## What Changes
 
-- Retire a `previous_response_id` on the first explicit upstream denial when the proxy injected it, clearing the durable continuity row and the in-memory anchor together, instead of waiting for a counter that this failure class never increments. The retirement is skipped when a concurrent request has already advanced the anchor past the denied id.
+- Retire only the denied `previous_response_id` on the first explicit upstream denial when the proxy injected it, instead of waiting for a counter that this failure class never increments. The fenced durable write clears the four anchor-bound columns only while that id is still the durable latest response, deletes only that response alias, and preserves turn-state plus other response aliases. The in-memory carrier is cleared in a `finally` path even when alias unregistering fails. The retirement is skipped when a concurrent request has already advanced the anchor past the denied id.
+- Mark the denied id before the durable await and revalidate prepared requests immediately before dispatch. A request that already captured the denied proxy-injected id is failed closed without another upstream send, closing the retirement/dispatch race.
 - Carry `proxy_injected_previous_response_id` onto the anchored recovery retry state, so a denial of the replayed anchor is attributable, diagnostics report the real provenance, and the wedge classifier sees the reattach. Anchor-free recovery paths keep the flag false because they send no anchor.
 
 ## Capabilities
@@ -33,6 +34,7 @@ None.
 
 - HTTP bridge terminal-event handling (`app/modules/proxy/_service/http_bridge/upstream_events.py`) and anchored recovery retry state (`app/modules/proxy/_service/http_bridge/streaming.py`).
 - No API, schema, migration, dependency, configuration, or dashboard changes. The poison threshold setting and its default of seven are untouched, and the downstream error contract is unchanged: the denial is still masked to `stream_incomplete` and still surfaces as 502, so clients keep their anchor and do not resend full history (the invariant from #397).
+- The session's turn-state and unrelated response-id aliases remain routable after retirement; only the denied response-id alias is removed.
 
 ## Non-Goals
 

--- a/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
@@ -1,0 +1,54 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Explicit upstream previous-response denials retire proxy-injected anchors
+
+When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy rather than supplied by the client, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST clear the durable continuity record under the session's owner epoch and the in-memory session anchor together, so no later turn can re-inject the denied id from either carrier. The proxy MUST NOT retire the anchor when the session's current anchor is no longer the denied id, because a concurrent request may have completed and advanced it. A client-supplied `previous_response_id` MUST NOT be retired by this path.
+
+The downstream error contract is unchanged: the denial is still reported to the client as `stream_incomplete`, so the client retains its own anchor and is not driven into a full-history resend.
+
+#### Scenario: A denied proxy-injected anchor is retired immediately
+
+- **GIVEN** an HTTP bridge session whose stored anchor was injected by the proxy
+- **WHEN** upstream answers the anchored request with `previous_response_not_found`
+- **THEN** the proxy clears the durable continuity record under the session's owner epoch
+- **AND** clears the in-memory session anchor and its stored input count and prefix fingerprint
+- **AND** the next turn on that session dispatches without a `previous_response_id`
+
+#### Scenario: The following turn is not trimmed against a denied anchor
+
+- **GIVEN** a proxy-injected anchor was denied by upstream on the previous turn
+- **WHEN** the client sends a full resend of the conversation on the next turn
+- **THEN** the request MUST NOT be trimmed against the denied anchor's stored prefix
+- **AND** upstream receives the resent conversation rather than a suffix of it
+
+#### Scenario: A concurrent completion protects the current anchor
+
+- **GIVEN** a proxy-injected anchor is denied by upstream
+- **AND** another request on the same session completed first and advanced the session anchor to a different response id
+- **WHEN** the denial is handled
+- **THEN** the proxy MUST NOT clear the session anchor
+
+#### Scenario: Client-supplied anchors are left alone
+
+- **GIVEN** an HTTP bridge request carries a `previous_response_id` the client supplied
+- **WHEN** upstream answers it with `previous_response_not_found`
+- **THEN** the proxy MUST NOT retire the anchor on the client's behalf
+
+### Requirement: Anchored recovery retries retain the provenance of the anchor they replay
+
+When the HTTP bridge dispatches an anchored recovery retry that replays a `previous_response_id` the proxy injected, the retry request state MUST record that the anchor is proxy-injected. A recovery path that dispatches without an anchor MUST leave that provenance false, because there is no anchor for it to describe.
+
+#### Scenario: An anchored recovery retry is attributable to the proxy
+
+- **GIVEN** a request whose `previous_response_id` was injected by the proxy fails and enters anchored recovery
+- **WHEN** the recovery retry replays the same anchor
+- **THEN** the retry request state records the anchor as proxy-injected
+- **AND** continuity diagnostics for the retry report `previous_response_source=proxy_injected` rather than `client_supplied`
+
+#### Scenario: Anchor-free recovery retries claim no provenance
+
+- **GIVEN** a recovery path dispatches without a `previous_response_id`
+- **WHEN** the retry request state is prepared
+- **THEN** it MUST NOT record a proxy-injected anchor

--- a/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
@@ -4,7 +4,19 @@
 
 ### Requirement: Explicit upstream previous-response denials retire proxy-injected anchors
 
-When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy rather than supplied by the client, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST clear the durable continuity record under the session's owner epoch and the in-memory session anchor together, so no later turn can re-inject the denied id from either carrier. The proxy MUST NOT retire the anchor when the session's current anchor is no longer the denied id, because a concurrent request may have completed and advanced it. A client-supplied `previous_response_id` MUST NOT be retired by this path.
+When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy onto a full-resend-shaped payload, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST attempt to clear the durable continuity record under the session's owner epoch, and MUST clear the in-memory session anchor.
+
+The proxy MUST NOT retire the anchor when:
+
+- the anchor was supplied by the client, because removing it changes the meaning of the client's own request;
+- the anchor was injected onto a payload that is not full-resend shaped, because a delta-only request has no other way to convey prior context once its anchor is gone;
+- the session's current anchor is no longer the denied id, because a concurrent request may have completed and advanced it.
+
+When the durable clear cannot be confirmed, the proxy MUST NOT report the anchor as retired, and MUST still clear the in-memory anchor, which strictly removes one carrier that could re-inject the denied id. A durable record that survives re-injects the id on a later turn, which is denied in turn and re-enters this path, so the clear is re-attempted rather than lost.
+
+Retirement is bookkeeping and MUST NOT change how the denial is delivered downstream. A failure while retiring MUST NOT propagate into terminal-event handling.
+
+A denial that settles several requests sharing one anchor MUST retire that anchor once, on the same terms.
 
 The downstream error contract is unchanged: the denial is still reported to the client as `stream_incomplete`, so the client retains its own anchor and is not driven into a full-history resend.
 
@@ -35,6 +47,32 @@ The downstream error contract is unchanged: the denial is still reported to the 
 - **GIVEN** an HTTP bridge request carries a `previous_response_id` the client supplied
 - **WHEN** upstream answers it with `previous_response_not_found`
 - **THEN** the proxy MUST NOT retire the anchor on the client's behalf
+
+#### Scenario: A delta-only payload keeps its injected anchor
+
+- **GIVEN** the proxy injected an anchor onto a payload that is not full-resend shaped
+- **WHEN** upstream answers that request with `previous_response_not_found`
+- **THEN** the proxy MUST NOT clear the anchor
+- **AND** the request keeps the only reference it has to its prior context
+
+#### Scenario: A fan-out denial retires the shared anchor once
+
+- **GIVEN** several pending requests on one session share a proxy-injected anchor
+- **WHEN** upstream answers with a single `previous_response_not_found` that settles all of them together
+- **THEN** the proxy retires that anchor before the grouped settlement completes
+
+#### Scenario: An unconfirmed durable clear still drops the in-memory anchor
+
+- **GIVEN** a denied proxy-injected anchor whose durable clear is fenced or fails
+- **WHEN** the denial is handled
+- **THEN** the proxy MUST clear the in-memory session anchor
+- **AND** MUST NOT report the anchor as retired
+
+#### Scenario: A retirement failure cannot change the denial delivered downstream
+
+- **GIVEN** the bookkeeping performed while retiring a denied anchor raises
+- **WHEN** the denial is handled
+- **THEN** the error MUST NOT propagate into terminal-event handling
 
 ### Requirement: Anchored recovery retries retain the provenance of the anchor they replay
 

--- a/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/specs/responses-api-compat/spec.md
@@ -4,7 +4,9 @@
 
 ### Requirement: Explicit upstream previous-response denials retire proxy-injected anchors
 
-When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy onto a full-resend-shaped payload, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST attempt to clear the durable continuity record under the session's owner epoch, and MUST clear the in-memory session anchor.
+When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy onto a full-resend-shaped payload, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST clear the durable anchor only when the denied id is still the durable latest response and the session owner fence still matches; the write MUST clear the four anchor-bound fields and delete only the matching response-id alias, preserving turn-state and sibling response aliases. The proxy MUST clear the in-memory session carrier even if durable cleanup or alias unregistering fails.
+
+Before awaiting durable cleanup, the proxy MUST publish the denied id to the live session. Immediately before dispatch, any already-prepared request carrying that id as a proxy-injected anchor MUST fail closed without sending another upstream frame. This revalidation MUST close the retirement/dispatch race; it MUST NOT reject a client-supplied anchor merely because the same id is tombstoned for proxy injection.
 
 The proxy MUST NOT retire the anchor when:
 
@@ -61,12 +63,29 @@ The downstream error contract is unchanged: the denial is still reported to the 
 - **WHEN** upstream answers with a single `previous_response_not_found` that settles all of them together
 - **THEN** the proxy retires that anchor before the grouped settlement completes
 
+#### Scenario: A prepared denied anchor is rejected before dispatch
+
+- **GIVEN** a request was prepared with a proxy-injected anchor
+- **AND** another request receives `previous_response_not_found` for that anchor before the prepared request reaches the upstream send
+- **WHEN** the prepared request reaches its final dispatch check
+- **THEN** the proxy fails it closed as `stream_incomplete`
+- **AND** the proxy MUST NOT send that denied anchor upstream again
+
+#### Scenario: Sibling response aliases survive retirement
+
+- **GIVEN** a session has a denied response alias and another valid response alias
+- **WHEN** the denied anchor is retired
+- **THEN** only the denied response alias is removed
+- **AND** the valid response alias and turn-state aliases remain routable
+
 #### Scenario: An unconfirmed durable clear still drops the in-memory anchor
 
 - **GIVEN** a denied proxy-injected anchor whose durable clear is fenced or fails
 - **WHEN** the denial is handled
 - **THEN** the proxy MUST clear the in-memory session anchor
 - **AND** MUST NOT report the anchor as retired
+
+If alias unregistering raises after the durable clear, the same in-memory cleanup MUST still occur.
 
 #### Scenario: A retirement failure cannot change the denial delivered downstream
 

--- a/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## 1. Regression Coverage
+
+- [x] 1.1 Add a bridge integration regression driving a completed turn, an anchored turn denied with `previous_response_not_found`, then a following client full resend, asserting the third dispatch carries no `previous_response_id` and is not trimmed against the denied anchor.
+- [x] 1.2 Add unit coverage that a denial retires both anchor carriers on the first occurrence, and that it is skipped when a concurrent completion has already advanced the anchor.
+- [x] 1.3 Assert at the product path that no continuity diagnostic reports a proxy-injected anchor as `client_supplied`, which fails before the provenance fix.
+
+## 2. Anchor Retirement
+
+- [x] 2.1 Add `_invalidate_denied_http_bridge_anchor`, clearing durable continuity through the existing fenced `_abandon_durable_http_bridge_continuity` write and the in-memory anchor fields together.
+- [x] 2.2 Call it from the terminal `previous_response_not_found` branch when the denied anchor was proxy-injected.
+
+## 3. Recovery Provenance
+
+- [x] 3.1 Copy `proxy_injected_previous_response_id` onto the anchored recovery retry state, gated on the retry actually carrying an anchor.
+
+## 4. Verification
+
+- [x] 4.1 Run the touched bridge unit and integration suites, ruff, and type checks.
+- [x] 4.2 Run strict OpenSpec validation for this change and review the final diff for unrelated changes.

--- a/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
@@ -4,16 +4,20 @@
 
 - [x] 1.1 Add a bridge integration regression driving a completed turn, an anchored turn denied with `previous_response_not_found`, then a following client full resend, asserting the third dispatch carries no `previous_response_id` and is not trimmed against the denied anchor.
 - [x] 1.2 Add unit coverage that a denial retires both anchor carriers on the first occurrence, and that it is skipped when a concurrent completion has already advanced the anchor.
+- [x] 1.4 Add unit coverage for the retirement decision: delta-only payloads and client-supplied anchors are left alone, a shared anchor is selected once from a fan-out, and a bookkeeping failure is swallowed.
 - [x] 1.3 Assert at the product path that no continuity diagnostic reports a proxy-injected anchor as `client_supplied`, which fails before the provenance fix.
 
 ## 2. Anchor Retirement
 
 - [x] 2.1 Add `_invalidate_denied_http_bridge_anchor`, clearing durable continuity through the existing fenced `_abandon_durable_http_bridge_continuity` write and the in-memory anchor fields together.
-- [x] 2.2 Call it from the terminal `previous_response_not_found` branch when the denied anchor was proxy-injected.
+- [x] 2.2 Call it from the terminal `previous_response_not_found` branch when the denied anchor was proxy-injected onto a full-resend-shaped payload.
+- [x] 2.3 Call it from the grouped fan-out branch as well, which settles every request sharing the anchor and returns before the single-request branch.
+- [x] 2.4 Keep retirement best-effort so a bookkeeping failure cannot change how the denial is delivered downstream.
 
 ## 3. Recovery Provenance
 
 - [x] 3.1 Copy `proxy_injected_previous_response_id` onto the anchored recovery retry state, gated on the retry actually carrying an anchor.
+- [x] 3.2 Copy `proxy_injected_anchor_had_full_resend_payload` with it, so a replayed anchor keeps the shape that decides whether it may be retired.
 
 ## 4. Verification
 

--- a/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
+++ b/openspec/changes/invalidate-denied-bridge-anchor/tasks.md
@@ -6,13 +6,15 @@
 - [x] 1.2 Add unit coverage that a denial retires both anchor carriers on the first occurrence, and that it is skipped when a concurrent completion has already advanced the anchor.
 - [x] 1.4 Add unit coverage for the retirement decision: delta-only payloads and client-supplied anchors are left alone, a shared anchor is selected once from a fan-out, and a bookkeeping failure is swallowed.
 - [x] 1.3 Assert at the product path that no continuity diagnostic reports a proxy-injected anchor as `client_supplied`, which fails before the provenance fix.
+- [x] 1.5 Add a pre-dispatch regression proving a request that already captured a denied proxy-injected anchor is failed closed without sending another upstream frame.
 
 ## 2. Anchor Retirement
 
-- [x] 2.1 Add `_invalidate_denied_http_bridge_anchor`, clearing durable continuity through the existing fenced `_abandon_durable_http_bridge_continuity` write and the in-memory anchor fields together.
+- [x] 2.1 Add `_invalidate_denied_http_bridge_anchor`, clearing only the matching durable response anchor and alias under the current owner fence while preserving turn-state and sibling response aliases; clear the in-memory carrier even when alias unregistering fails.
 - [x] 2.2 Call it from the terminal `previous_response_not_found` branch when the denied anchor was proxy-injected onto a full-resend-shaped payload.
 - [x] 2.3 Call it from the grouped fan-out branch as well, which settles every request sharing the anchor and returns before the single-request branch.
 - [x] 2.4 Keep retirement best-effort so a bookkeeping failure cannot change how the denial is delivered downstream.
+- [x] 2.5 Publish a session-local denied-anchor tombstone before the first await and reject any prepared proxy-injected request carrying that id immediately before dispatch.
 
 ## 3. Recovery Provenance
 

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import logging
 import socket
 import time
 from collections import deque
@@ -15556,3 +15557,155 @@ async def test_v1_responses_http_bridge_successor_claim_fences_the_retiring_rele
     # on the same key keeps working instead of failing with 409.
     third = await asyncio.wait_for(async_client.post("/v1/responses", json=payload), timeout=_TEST_SYNC_TIMEOUT_SECONDS)
     assert third.status_code == 200, third.text
+
+
+class _DeniesAnchoredTurnUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    """Completes unanchored turns and denies any turn that arrives with an anchor."""
+
+    async def send_text(self, text: str) -> None:
+        payload = json.loads(text)
+        previous_response_id = payload.get("previous_response_id")
+        if previous_response_id is None:
+            await super().send_text(text)
+            return
+        self.sent_text.append(text)
+        await self._messages.put(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "error",
+                        "status": 400,
+                        "error": {
+                            "type": "invalid_request_error",
+                            "code": "previous_response_not_found",
+                            "message": f"Previous response with id '{previous_response_id}' not found.",
+                            "param": "previous_response_id",
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_stops_reinjecting_an_anchor_upstream_denied(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """A denied proxy-injected anchor must not be re-injected into the next turn.
+
+    Regression for the amplification in issue #1852: the denial leaves the dead
+    anchor in the session, the next full resend is trimmed against its stored
+    prefix, and upstream then receives a suffix of the conversation behind an id
+    it has already refused.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_denied_anchor",
+        "http-bridge-denied-anchor@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _DeniesAnchoredTurnUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del self, deadline, request_id, kind, request_stage, sticky_key, sticky_kind
+        del reallocate_sticky, sticky_max_age_seconds, prefer_earlier_reset_accounts
+        del routing_strategy, model, exclude_account_ids, additional_limit_name
+        del api_key, preferred_account_id
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    headers = {"session_id": "http-bridge-denied-anchor-session"}
+
+    def _user_item(text: str) -> dict[str, Any]:
+        return {"role": "user", "content": [{"type": "input_text", "text": text}]}
+
+    turn_one_input = [_user_item("turn one")]
+    turn_two_input = [*turn_one_input, _user_item("turn two")]
+    turn_three_input = [*turn_two_input, _user_item("turn three")]
+
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+
+    first = await async_client.post(
+        "/backend-api/codex/responses",
+        json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_one_input},
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = await async_client.post(
+        "/backend-api/codex/responses",
+        json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_two_input},
+        headers=headers,
+    )
+    assert second.status_code in {200, 502}
+
+    third = await async_client.post(
+        "/backend-api/codex/responses",
+        json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_three_input},
+        headers=headers,
+    )
+    assert third.status_code == 200
+
+    dispatched = [json.loads(text) for text in upstream.sent_text]
+    anchored = [frame for frame in dispatched if frame.get("previous_response_id") is not None]
+    assert anchored, "expected the proxy to inject an anchor on the second turn"
+
+    final = dispatched[-1]
+    assert final.get("previous_response_id") is None, (
+        f"the denied anchor was re-injected into a later turn: {final.get('previous_response_id')}"
+    )
+    assert len(final["input"]) == len(turn_three_input), (
+        "the later turn was trimmed against the denied anchor's stored prefix"
+    )
+
+    # No client supplied an anchor in this test, so every anchor the diagnostics
+    # describe must be attributed to the proxy that injected it.
+    continuity_diagnostics = [
+        record.getMessage() for record in caplog.records if "continuity_fail_closed" in record.getMessage()
+    ]
+    assert continuity_diagnostics, "expected the denial to be recorded"
+    assert not [line for line in continuity_diagnostics if "previous_response_source=client_supplied" in line], (
+        "an anchored recovery retry reported a proxy-injected anchor as client-supplied"
+    )

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -31626,3 +31626,86 @@ async def test_invalidate_denied_bridge_anchor_drops_memory_even_when_the_durabl
     assert cleared is False
     assert session.last_completed_response_id is None
     assert session.last_completed_input_prefix_fingerprint is None
+
+
+def _denied_anchor_request_state(
+    *,
+    previous_response_id: str | None = "resp_denied",
+    proxy_injected: bool = True,
+    full_resend_shaped: bool = True,
+) -> proxy_service._WebSocketRequestState:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-denied-anchor",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    request_state.previous_response_id = previous_response_id
+    request_state.proxy_injected_previous_response_id = proxy_injected
+    request_state.proxy_injected_anchor_had_full_resend_payload = full_resend_shaped
+    return request_state
+
+
+def test_denied_anchor_id_requires_a_full_resend_shaped_payload():
+    """A delta-only request cannot convey prior context once its anchor is gone.
+
+    This mirrors the rule the expired-anchor path already applies before it
+    clears durable continuity.
+    """
+    assert (
+        http_bridge_upstream_events_module._denied_proxy_injected_anchor_id(
+            [_denied_anchor_request_state(full_resend_shaped=False)]
+        )
+        is None
+    )
+
+
+def test_denied_anchor_id_ignores_a_client_supplied_anchor():
+    assert (
+        http_bridge_upstream_events_module._denied_proxy_injected_anchor_id(
+            [_denied_anchor_request_state(proxy_injected=False)]
+        )
+        is None
+    )
+
+
+def test_denied_anchor_id_picks_the_shared_anchor_from_a_fan_out():
+    """A grouped denial settles several requests that shared one anchor."""
+    request_states = [
+        _denied_anchor_request_state(proxy_injected=False),
+        _denied_anchor_request_state(previous_response_id="resp_shared"),
+        _denied_anchor_request_state(previous_response_id="resp_shared"),
+    ]
+
+    assert http_bridge_upstream_events_module._denied_proxy_injected_anchor_id(request_states) == "resp_shared"
+
+
+@pytest.mark.asyncio
+async def test_retire_denied_bridge_anchor_swallows_bookkeeping_failures():
+    """Retirement is cleanup and must never change how the denial is delivered."""
+    session = _denied_anchor_session()
+    service = _denied_anchor_service()
+    service._unregister_http_bridge_previous_response_ids = AsyncMock(side_effect=RuntimeError("registry down"))
+
+    await http_bridge_upstream_events_module._retire_denied_http_bridge_anchor(
+        service,
+        session,
+        request_states=[_denied_anchor_request_state()],
+    )
+
+
+@pytest.mark.asyncio
+async def test_retire_denied_bridge_anchor_leaves_a_delta_only_anchor_alone():
+    session = _denied_anchor_session()
+    service = _denied_anchor_service()
+
+    await http_bridge_upstream_events_module._retire_denied_http_bridge_anchor(
+        service,
+        session,
+        request_states=[_denied_anchor_request_state(full_resend_shaped=False)],
+    )
+
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    assert session.last_completed_response_id == "resp_denied"

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -31522,3 +31522,107 @@ async def test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_
     remaining = await asyncio.gather(*waiters[25:], return_exceptions=True)
     assert all(isinstance(result, ProxyResponseError) and result.status_code == 429 for result in remaining)
     assert key not in service._http_bridge_inflight_sessions
+
+
+def _denied_anchor_session(
+    *,
+    anchor: str | None = "resp_denied",
+) -> proxy_service._HTTPBridgeSession:
+    session = _make_bridge_session(key_value="denied-anchor")
+    session.durable_session_id = "durable-denied-anchor"
+    session.durable_owner_epoch = 4
+    session.last_completed_response_id = anchor
+    session.last_completed_response_account_id = "acc-bridge"
+    session.last_completed_input_count = 12
+    session.last_completed_input_prefix_fingerprint = "fingerprint-denied"
+    session.last_pending_tool_calls["call-1"] = "tool-1"
+    return session
+
+
+def _denied_anchor_service(*, cleared: bool = True) -> Any:
+    return SimpleNamespace(
+        _durable_bridge=SimpleNamespace(rebind_session_account=AsyncMock(return_value=cleared)),
+        _unregister_http_bridge_previous_response_ids=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalidate_denied_bridge_anchor_clears_both_carriers():
+    """An upstream denial of a proxy-injected anchor retires it on the first occurrence.
+
+    The poison counter cannot reach this failure class at any threshold, so the
+    dead id would otherwise survive in the durable row and in memory and be
+    re-injected into the next turn.
+    """
+    session = _denied_anchor_session()
+    service = _denied_anchor_service()
+
+    cleared = await http_bridge_upstream_events_module._invalidate_denied_http_bridge_anchor(
+        service,
+        session,
+        denied_response_id="resp_denied",
+    )
+
+    assert cleared is True
+    rebind_kwargs = service._durable_bridge.rebind_session_account.await_args.kwargs
+    assert rebind_kwargs["clear_continuity"] is True
+    assert rebind_kwargs["session_id"] == "durable-denied-anchor"
+    assert rebind_kwargs["owner_epoch"] == 4
+    service._unregister_http_bridge_previous_response_ids.assert_awaited_once_with(session)
+    assert session.last_completed_response_id is None
+    assert session.last_completed_response_account_id is None
+    assert session.last_completed_input_count == 0
+    assert session.last_completed_input_prefix_fingerprint is None
+    assert session.last_pending_tool_calls == {}
+
+
+@pytest.mark.asyncio
+async def test_invalidate_denied_bridge_anchor_keeps_an_anchor_a_sibling_already_advanced():
+    """A concurrent completion may advance the anchor before the denial is handled."""
+    session = _denied_anchor_session(anchor="resp_completed_meanwhile")
+    service = _denied_anchor_service()
+
+    cleared = await http_bridge_upstream_events_module._invalidate_denied_http_bridge_anchor(
+        service,
+        session,
+        denied_response_id="resp_denied",
+    )
+
+    assert cleared is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._unregister_http_bridge_previous_response_ids.assert_not_awaited()
+    assert session.last_completed_response_id == "resp_completed_meanwhile"
+    assert session.last_completed_input_count == 12
+
+
+@pytest.mark.asyncio
+async def test_invalidate_denied_bridge_anchor_ignores_a_missing_anchor():
+    session = _denied_anchor_session()
+    service = _denied_anchor_service()
+
+    cleared = await http_bridge_upstream_events_module._invalidate_denied_http_bridge_anchor(
+        service,
+        session,
+        denied_response_id=None,
+    )
+
+    assert cleared is False
+    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    assert session.last_completed_response_id == "resp_denied"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_denied_bridge_anchor_drops_memory_even_when_the_durable_clear_is_fenced():
+    """A fenced durable clear must not leave the dead id addressable in memory."""
+    session = _denied_anchor_session()
+    service = _denied_anchor_service(cleared=False)
+
+    cleared = await http_bridge_upstream_events_module._invalidate_denied_http_bridge_anchor(
+        service,
+        session,
+        denied_response_id="resp_denied",
+    )
+
+    assert cleared is False
+    assert session.last_completed_response_id is None
+    assert session.last_completed_input_prefix_fingerprint is None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -440,6 +440,51 @@ async def test_submit_hard_turn_walks_race_path_chain_before_recording(
     assert request_state.proxy_injected_previous_response_id is True
 
 
+@pytest.mark.asyncio
+async def test_submit_rejects_a_denied_proxy_anchor_before_upstream_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A queued request must revalidate an anchor retired by a sibling turn."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="denied-anchor-dispatch-race")
+    session.denied_proxy_injected_anchor_ids.add("resp-denied")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-denied-anchor-dispatch-race",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp-denied",
+        proxy_injected_previous_response_id=True,
+        request_text='{"type":"response.create","input":"next"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    send_text = AsyncMock()
+    session.upstream = cast(
+        UpstreamWebSocket,
+        SimpleNamespace(send_text=send_text, close=AsyncMock()),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", AsyncMock(return_value=True))
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request_with_handoff(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+            request_scope_id="scope-denied-anchor-dispatch-race",
+            owned_unanchored_handoff=False,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "stream_incomplete"
+    send_text.assert_not_awaited()
+    assert not session.pending_requests
+
+
 def test_ambiguous_continuation_recovery_is_opt_in_and_requires_unobserved_anchor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -31536,13 +31581,24 @@ def _denied_anchor_session(
     session.last_completed_input_count = 12
     session.last_completed_input_prefix_fingerprint = "fingerprint-denied"
     session.last_pending_tool_calls["call-1"] = "tool-1"
+    session.previous_response_ids.update({"resp_old", "resp_denied"})
     return session
 
 
 def _denied_anchor_service(*, cleared: bool = True) -> Any:
+    async def unregister_previous_response_id(
+        session: proxy_service._HTTPBridgeSession,
+        response_id: str,
+    ) -> None:
+        session.previous_response_ids.discard(response_id)
+
     return SimpleNamespace(
-        _durable_bridge=SimpleNamespace(rebind_session_account=AsyncMock(return_value=cleared)),
-        _unregister_http_bridge_previous_response_ids=AsyncMock(),
+        _durable_bridge=SimpleNamespace(
+            clear_live_session_response_anchor_if_matches=AsyncMock(
+                return_value=SimpleNamespace() if cleared else None,
+            )
+        ),
+        _unregister_http_bridge_previous_response_id=AsyncMock(side_effect=unregister_previous_response_id),
     )
 
 
@@ -31564,11 +31620,12 @@ async def test_invalidate_denied_bridge_anchor_clears_both_carriers():
     )
 
     assert cleared is True
-    rebind_kwargs = service._durable_bridge.rebind_session_account.await_args.kwargs
-    assert rebind_kwargs["clear_continuity"] is True
-    assert rebind_kwargs["session_id"] == "durable-denied-anchor"
-    assert rebind_kwargs["owner_epoch"] == 4
-    service._unregister_http_bridge_previous_response_ids.assert_awaited_once_with(session)
+    clear_kwargs = service._durable_bridge.clear_live_session_response_anchor_if_matches.await_args.kwargs
+    assert clear_kwargs["session_id"] == "durable-denied-anchor"
+    assert clear_kwargs["owner_epoch"] == 4
+    assert clear_kwargs["response_id"] == "resp_denied"
+    service._unregister_http_bridge_previous_response_id.assert_awaited_once_with(session, "resp_denied")
+    assert session.previous_response_ids == {"resp_old"}
     assert session.last_completed_response_id is None
     assert session.last_completed_response_account_id is None
     assert session.last_completed_input_count == 0
@@ -31589,8 +31646,8 @@ async def test_invalidate_denied_bridge_anchor_keeps_an_anchor_a_sibling_already
     )
 
     assert cleared is False
-    service._durable_bridge.rebind_session_account.assert_not_awaited()
-    service._unregister_http_bridge_previous_response_ids.assert_not_awaited()
+    service._durable_bridge.clear_live_session_response_anchor_if_matches.assert_not_awaited()
+    service._unregister_http_bridge_previous_response_id.assert_not_awaited()
     assert session.last_completed_response_id == "resp_completed_meanwhile"
     assert session.last_completed_input_count == 12
 
@@ -31607,7 +31664,7 @@ async def test_invalidate_denied_bridge_anchor_ignores_a_missing_anchor():
     )
 
     assert cleared is False
-    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.clear_live_session_response_anchor_if_matches.assert_not_awaited()
     assert session.last_completed_response_id == "resp_denied"
 
 
@@ -31687,13 +31744,15 @@ async def test_retire_denied_bridge_anchor_swallows_bookkeeping_failures():
     """Retirement is cleanup and must never change how the denial is delivered."""
     session = _denied_anchor_session()
     service = _denied_anchor_service()
-    service._unregister_http_bridge_previous_response_ids = AsyncMock(side_effect=RuntimeError("registry down"))
+    service._unregister_http_bridge_previous_response_id = AsyncMock(side_effect=RuntimeError("registry down"))
 
     await http_bridge_upstream_events_module._retire_denied_http_bridge_anchor(
         service,
         session,
         request_states=[_denied_anchor_request_state()],
     )
+    assert session.last_completed_response_id is None
+    assert session.last_completed_input_prefix_fingerprint is None
 
 
 @pytest.mark.asyncio
@@ -31707,5 +31766,5 @@ async def test_retire_denied_bridge_anchor_leaves_a_delta_only_anchor_alone():
         request_states=[_denied_anchor_request_state(full_resend_shaped=False)],
     )
 
-    service._durable_bridge.rebind_session_account.assert_not_awaited()
+    service._durable_bridge.clear_live_session_response_anchor_if_matches.assert_not_awaited()
     assert session.last_completed_response_id == "resp_denied"


### PR DESCRIPTION
## Summary

An upstream `previous_response_not_found` against a `previous_response_id` **the proxy injected itself** is a verdict about that anchor, and nothing in the bridge acts on it. The dead id survives in both carriers, gets re-injected into the next turn, and the store-context trim then strips the resent history against it. Upstream receives a suffix of a conversation behind an id it has already refused, never emits `response.created`, and the attempt presents as an eventless failure. Two of those open the retry circuit and the client gets `503 ... cooling down`.

This retires the anchor on the first denial instead. It adds no new upstream dispatch.

## Type of change

- [x] `fix:` bug fix (no behavior change beyond the bug)

Linked issue: Refs #1852. This is a partial fix. It does not address the poison-threshold arithmetic that #1852 is titled after, and deliberately leaves that alone.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/invalidate-denied-bridge-anchor/`

The delta lands on `responses-api-compat`. The downstream contract is unchanged: the denial is still masked to `stream_incomplete` and still surfaces as 502, so clients keep their own anchor and are not pushed into a full-history resend (the invariant from #397, whose comment block at `request_submit.py` is untouched).

## Changes

- Add `_invalidate_denied_http_bridge_anchor`. On a terminal `previous_response_not_found` whose anchor was proxy-injected onto a full-resend payload, clear only the matching durable response anchor and alias under the owner fence, preserve turn-state and sibling response aliases, and clear the in-memory carrier even if alias unregistering fails. Skip it when a sibling request has already advanced the session anchor past the denied id. Client-supplied and delta-only anchors are never retired.
- Carry `proxy_injected_previous_response_id` and the full-resend shape flag onto anchored recovery retry state, gated on the retry actually carrying an anchor. Publish a denied-anchor tombstone before cleanup and reject any already-prepared request carrying that proxy-injected id immediately before dispatch.

### Why the second change is not a separate concern

Without it the first change cannot fire on the path that needs it. The anchored recovery replays the proxy's own anchor (`retry_previous_response_id = request_state.previous_response_id`) but `retry_request_state` copies seven `operation_*` fields and not the provenance flag, so a denial of the replayed anchor is not attributable to the proxy. Compare the other recovery path, which does set it.

That gap has two other visible effects: continuity diagnostics report `previous_response_source=client_supplied` for ids no client ever sent, and `_http_bridge_request_state_wedged_reattach` (`quarantine.py`) cannot recognise the reattach shape it exists to catch.

### Why poisoning does not already cover this

`_http_bridge_anchor_poison_detail` maps only `stream_incomplete` and `stream_idle_timeout`, and only scores reader failures with `observed_response_events == 0`. A denial arrives as a terminal upstream event, not a reader failure, so it contributes nothing at any value of `http_responses_session_bridge_anchor_poison_failure_threshold`. I confirmed this in production: dropping the threshold from 7 to 2 moved `durable_anchor_poisoned` from 0 to 29 occurrences but left the circuit-open rate per bridge reuse unchanged (0.43 to 0.41 per 100 reuses).

### On the duplicate-child-response objection

You rejected same-anchor replay on #1735 / #1736 on the grounds that a local zero-event view cannot prove upstream never dispatched an anchored turn. That reasoning was right and it still applies, so this PR does not resend anything. Nothing is dispatched here. The turn that follows is the client's own, carrying the history the client sends, so there is no server-originated turn that could fork against a parent the proxy cannot observe.

## Test plan

```
$ uv run ruff check .
All checks passed!
$ uv run ruff format --check .
954 files already formatted
$ uv run ty check
All checks passed!
$ uv run python scripts/check_proxy_architecture.py
proxy architecture checks passed

$ uv run pytest tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py -q
260 passed

$ uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_http_bridge_cancel_drain.py tests/unit/test_bridge_ring_lifecycle.py -q
1 failed, 705 passed
```

New coverage:

- `tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_stops_reinjecting_an_anchor_upstream_denied`, at the product path per AGENTS.md: turn 1 completes and registers the anchor, turn 2 is a full resend that the proxy anchors and upstream denies, turn 3 is another full resend. Asserts turn 3 carries no `previous_response_id`, is not trimmed against the denied anchor's stored prefix, and that no continuity diagnostic attributes a proxy-injected anchor to the client.
- Four unit tests on the new helper: both carriers cleared, the sibling-advanced anchor is preserved, a missing anchor is ignored, and a fenced durable clear still drops the in-memory id.

### The one failing test is pre-existing on `main`

`test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` fails identically on a pristine checkout of `d4b00fd0` with no changes applied, so it is not from this branch. Happy to open it separately if it is not already known.

## Follow-up commit and validation (73882792)

- Fixed the four review findings: alias-specific durable clear, finally-protected in-memory cleanup, pre-dispatch denied-anchor fencing, and strict OpenSpec proof.
- Added a regression proving a prepared denied proxy-injected anchor is not sent upstream.
- `6356 passed, 71 skipped` in `tests/unit tests/test_request_logs_options_api.py`.
- Focused denied-anchor/race unit tests: `3 passed`; durable anchor repository tests: `2 passed`.
- Product-path denied-anchor integration regression: `1 passed`.
- Ruff check, Ruff format check, `ty check`, proxy architecture checks, strict change validation, and all 57 OpenSpec specs pass.

## Screenshots / output

The new integration test, run against `main` without the fix. Turn 3 is denied because the anchor upstream already refused was re-injected into it:

```
continuity_fail_closed surface=websocket_stream reason=previous_response_not_found
    diagnostics=previous_response_source=proxy_injected ...
http_bridge_event event=terminal_error detail=stream_incomplete ...
continuity_fail_closed surface=websocket_stream reason=previous_response_not_found
    diagnostics=previous_response_source=client_supplied ...      <- the replayed anchor, misattributed
proxy_error_response path=/backend-api/codex/responses status=502
    code="bridge_previous_response_not_found"                     <- turn 2

continuity_fail_closed ... previous_response_source=proxy_injected ...
continuity_fail_closed ... previous_response_source=client_supplied ...
proxy_error_response path=/backend-api/codex/responses status=502
    code="bridge_previous_response_not_found"                     <- turn 3, same dead anchor

E   assert 502 == 200
```

With the fix, turn 3 returns 200, dispatches unanchored with all three input items, and the only diagnostics emitted are two `previous_response_source=proxy_injected` lines.

Production context, one host, 12.7 h on `1.24.0-beta.3` with the threshold already lowered to 2 (numbers and method in https://github.com/Soju06/codex-lb/issues/1852#issuecomment-5374372122, with a correction to my own earlier mechanism in the comment after it):

```
bridge create / reuse             204 / 7073
previous_response_not_found       163   (86 proxy_injected, 77 client_supplied)
store_context_input_trimmed      6936   worst case original_items=602 trimmed_to=3
retry circuit opened               29
```

## Why this is a separate PR

Three open PRs touch this surface and I do not want to collide with them.

- **#1857** invalidates the rejected anchor in both carriers as well, so that half genuinely overlaps. It also adds a `retry-http-bridge-rejected-anchor` change that retries the turn without the anchor, and it is +6487/-451 across 69 files with `Lint (ruff)` and `Type check (ty)` currently red. This PR is 60 source lines and one concern. If you would rather take #1857 whole, close this.
- **#1863** and its **#1867** stack recover stale anchors by stripping the anchor and re-dispatching under a full-resend proof. That is the retry half, which this PR deliberately does not do. The two are compatible: retiring a denied anchor does not prevent a proven-safe replacement from being dispatched.
- **#1633** is adjacent rather than overlapping (the pre-`response.created` silence watchdog).

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change, including a product-path regression that fails without it.
- [x] Ran `make lint`, `uv run ty check`, and the relevant `pytest` subset locally.
- [x] `npx -y @fission-ai/openspec@latest validate invalidate-denied-bridge-anchor --strict` passes.
- [x] `npx -y @fission-ai/openspec@latest validate --specs` passes: 57/57 specs.
- [x] Simplicity gates reviewed: no new setting, no new default, no new required setup step, no schema or migration change.
- [x] CHANGELOG not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when upstream rejects a stored continuation.
  * Prevented reuse of invalid proxy-managed continuation state.
  * Ensured subsequent full-resend requests include complete input without the rejected continuation.
  * Added pre-dispatch rejection with a retryable `502 stream_incomplete` response.
  * Preserved accurate continuity diagnostics and isolated cleanup failures.

* **Tests**
  * Added integration and unit coverage for rejected continuations, concurrent updates, fan-out requests, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->