### PR TITLE
fix(proxy): release cancelled embeddings reservations

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4495,7 +4495,7 @@ async def _source_embeddings_response(
                 release_exc = exc
         if release_exc is not None:
             logger.warning(
-                "Failed to release source embeddings reservation after client disconnect source_id=%s model=%s",
+                "Failed to release source embeddings reservation after request cancellation source_id=%s model=%s",
                 source.id,
                 model,
                 exc_info=release_exc,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4486,6 +4486,21 @@ async def _source_embeddings_response(
     outbound["model"] = model
     try:
         result = await forward_source_embeddings(source, outbound)
+    except asyncio.CancelledError:
+        release_exc: BaseException | None = None
+        if reservation is not None:
+            try:
+                await _release_reservation_deferring_cancellation(reservation)
+            except BaseException as exc:
+                release_exc = exc
+        if release_exc is not None:
+            logger.warning(
+                "Failed to release source embeddings reservation after client disconnect source_id=%s model=%s",
+                source.id,
+                model,
+                exc_info=release_exc,
+            )
+        raise
     except ModelSourceForwardingError as exc:
         await _release_reservation(reservation)
         await _log_source_chat_completion(

--- a/openspec/changes/fix-embeddings-cancel-reservation/.openspec.yaml
+++ b/openspec/changes/fix-embeddings-cancel-reservation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/fix-embeddings-cancel-reservation/design.md
+++ b/openspec/changes/fix-embeddings-cancel-reservation/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`_source_embeddings_response` owns the API-key reservation it creates immediately before forwarding to the selected OpenAI-compatible model source. It releases on `ModelSourceForwardingError` and settles normal responses, but task cancellation is a `BaseException` that bypasses both paths. `v1_embeddings` only awaits the helper, so no outer layer owns fallback release. The stale-reservation sweeper is an age-based orphan backstop, not request-lifecycle settlement.
+
+The adjacent source-chat implementation already provides `_release_reservation_deferring_cancellation`, which shields and drains the owned release operation despite repeated cancellation delivery. Source audio transcription has the same current exception shape, but this candidate is deliberately limited to embeddings.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Release the embeddings reservation exactly once when cancellation interrupts upstream forwarding.
+- Complete release despite cancellation already being active, then re-raise the original `CancelledError`.
+- Leave existing forwarding-error, success, missing-usage, and settlement behavior unchanged.
+
+**Non-Goals:**
+
+- Changing source audio transcription or any other proxy flow.
+- Changing reservation persistence, idempotency, stale-reclamation timing, or request logging.
+- Adding a new cleanup abstraction when the established helper already encodes the required semantics.
+
+## Decisions
+
+1. **Catch cancellation beside the forwarding await.** Reservation ownership begins before `forward_source_embeddings`; handling cancellation at that exact seam avoids duplicating ownership in the route and cannot affect pre-reservation failures.
+2. **Use the established cancellation-deferring release helper.** A raw `await _release_reservation` can itself be interrupted by the already-cancelled task. The existing helper shields an owned cleanup task and waits through repeated cancellation, while reservation transition idempotency keeps release exactly once.
+3. **Use a route-level deterministic regression.** The test starts a real source-routed `/v1/embeddings` request, waits on an upstream-entry event, cancels the request task, and inspects the exact persisted reservation. This distinguishes direct cancellation from setup failures and does not rely on sleeps or stale reclamation.
+
+## Risks / Trade-offs
+
+- **Release persistence can delay cancellation propagation.** → This is required ownership cleanup and uses the existing bounded database/session behavior; the original cancellation is re-raised immediately after release completes.
+- **Audio transcription remains exposed to the same shape.** → Record it as an adjacent follow-up risk; do not broaden this candidate beyond the confirmed embeddings scope.
+- **Cancellation after forwarding returns enters later settlement work.** → This fix targets cancellation while upstream forwarding is in flight, matching the confirmed candidate and regression; existing settlement semantics remain unchanged.

--- a/openspec/changes/fix-embeddings-cancel-reservation/proposal.md
+++ b/openspec/changes/fix-embeddings-cancel-reservation/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+A cancelled limited-key `/v1/embeddings` request can leave its committed usage reservation in `reserved` state until stale reclamation, consuming quota after request ownership has ended. Cancellation must release that reservation immediately through the same cancellation-safe cleanup mechanism used by adjacent source-chat paths.
+
+## What Changes
+
+- Release the owned source-embeddings usage reservation when upstream forwarding is cancelled.
+- Preserve the original cancellation exception after cleanup and keep existing success, forwarding-error, and usage settlement behavior unchanged.
+- Add deterministic route-level regression coverage that cancels only after upstream forwarding begins and verifies the exact reservation reaches `released` state.
+- Record source audio transcription as an adjacent same-shape risk without changing that route in this scoped fix.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Require immediate, exactly-once release of an owned source-embeddings reservation when request cancellation interrupts upstream forwarding.
+
+## Impact
+
+The change is limited to the source-routed `/v1/embeddings` helper in `app/modules/proxy/api.py`, its focused integration coverage, and the API-key reservation contract. It adds no public API, setting, dependency, migration, or dashboard change.

--- a/openspec/changes/fix-embeddings-cancel-reservation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-embeddings-cancel-reservation/specs/api-keys/spec.md
@@ -35,3 +35,9 @@ only a backstop and MUST NOT substitute for request-owned cancellation cleanup.
 
 - **GIVEN** a limited API key has created an owned reservation for a
   source-routed `/v1/embeddings` request
+- **WHEN** cancellation interrupts the request while upstream embeddings
+  forwarding is in flight
+- **THEN** the request owner finishes releasing the reservation exactly once
+  despite active cancellation
+- **AND** the original cancellation propagates after cleanup completes
+- **AND** stale-reservation reclamation is not required for that request

--- a/openspec/changes/fix-embeddings-cancel-reservation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-embeddings-cancel-reservation/specs/api-keys/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Source-routed usage uses API-key reservations
+
+The system MUST reserve API-key usage before forwarding an OpenAI-compatible
+source-routed request authenticated by an API key, and MUST finalize the
+reservation from the upstream OpenAI-compatible `usage` payload when the
+request completes.
+The finalized input, output, cached-input, and cost values MUST update the same
+API-key limit and usage-reporting paths used by subscription-backed requests.
+When cancellation interrupts source-routed `/v1/embeddings` upstream
+forwarding after reservation creation, the request owner MUST finish releasing
+that reservation exactly once despite active cancellation, and MUST then
+propagate the original cancellation. Stale-reservation reclamation MUST remain
+only a backstop and MUST NOT substitute for request-owned cancellation cleanup.
+
+#### Scenario: Source-routed response finalizes token usage
+
+- **WHEN** an API key calls a source-routed model and the upstream response
+  includes `usage.prompt_tokens=100` and `usage.completion_tokens=20`
+- **THEN** the API-key reservation is finalized with 100 input tokens and 20
+  output tokens
+- **AND** `/v1/usage` for that key reflects the completed usage
+
+#### Scenario: Missing usage fails closed for limited keys
+
+- **GIVEN** an API key has a token or cost limit
+- **WHEN** a source-routed response succeeds but lacks usable OpenAI `usage`
+  fields
+- **THEN** the system does not silently finalize zero usage
+- **AND** the request fails or is marked failed according to the source-routing
+  error contract
+
+#### Scenario: Cancelled source embeddings forwarding releases its reservation
+
+- **GIVEN** a limited API key has created an owned reservation for a
+  source-routed `/v1/embeddings` request

--- a/openspec/changes/fix-embeddings-cancel-reservation/tasks.md
+++ b/openspec/changes/fix-embeddings-cancel-reservation/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression
+
+- [x] 1.1 Add a deterministic route-level cancellation test that waits for source embeddings forwarding to begin before cancelling.
+- [x] 1.2 Confirm the focused test fails on baseline because the exact created reservation remains `reserved`.
+
+## 2. Implementation
+
+- [x] 2.1 Release the owned embeddings reservation through the established cancellation-deferring cleanup helper.
+- [x] 2.2 Preserve the original cancellation and existing success, forwarding-error, missing-usage, and settlement behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused cancellation regression and existing embeddings success/error/usage integration tests.
+- [x] 3.2 Run Ruff format-check/check and ty on changed Python files.
+- [x] 3.3 Run strict OpenSpec validation and build the package outside the worktree.
+- [x] 3.4 Run a temporary helper-level cancellation driver that prints exactly `RELEASE_CALLS=1`, then remove all QA artifacts.
+- [x] 3.5 Inspect the final diff and worktree status for scope and unrelated changes.

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -3402,6 +3402,72 @@ async def test_source_embeddings_routes_payload_and_settles_usage(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_source_embeddings_cancellation_releases_reservation(async_client, source_upstream) -> None:
+    await _enable_api_key_auth(async_client)
+    forward_started = asyncio.Event()
+    allow_upstream_finish = asyncio.Event()
+
+    async def embed(_request: web.Request) -> web.Response:
+        forward_started.set()
+        await allow_upstream_finish.wait()
+        return web.json_response(
+            {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                "model": "cancelled-embedder",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        )
+
+    base_url = await source_upstream(embed)
+    model = "cancelled-embedder"
+    source_id = await _create_model_source(
+        async_client,
+        name="cancelled-embedder-source",
+        model=model,
+        base_url=base_url,
+        supports_embeddings=True,
+    )
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "cancelled-embeddings-key",
+            "assignedSourceIds": [source_id],
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 1_000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key = created.json()["key"]
+    key_id = created.json()["id"]
+    request_task = asyncio.create_task(
+        async_client.post(
+            "/v1/embeddings",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"model": model, "input": "hello"},
+        )
+    )
+    await asyncio.wait_for(forward_started.wait(), timeout=1)
+
+    request_task.cancel()
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+    finally:
+        allow_upstream_finish.set()
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(ApiKeyUsageReservation).where(
+                ApiKeyUsageReservation.api_key_id == key_id,
+                ApiKeyUsageReservation.model == model,
+            )
+        )
+        assert result.scalar_one().status == "released"
+
+
+@pytest.mark.asyncio
 async def test_source_embeddings_unknown_model_returns_model_not_found(async_client) -> None:
     await _enable_api_key_auth(async_client)
     created = await async_client.post("/api/api-keys/", json={"name": "embeddings-404-key"})


### PR DESCRIPTION
## Summary

Release an owned API-key usage reservation when cancellation interrupts a
source-routed `/v1/embeddings` request during upstream forwarding, rather than
leaving quota reserved until stale reclamation.

Linked issue: discovery `CLB-20260821-01`

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only

Change directory:
`openspec/changes/fix-embeddings-cancel-reservation/`

## Changes

- Catch cancellation at the source-embeddings forwarding ownership seam.
- Finish reservation release through the existing cancellation-deferring
  cleanup helper, then re-raise the original cancellation.
- Preserve success, forwarding-error, missing-usage, and normal settlement
  behavior.
- Add an event-gated route-level regression that inspects the exact persisted
  reservation state.

## Simplicity

- No new setting, environment variable, database migration, dependency,
  endpoint, or setup step.
- The fix reuses the established cancellation-safe reservation helper.

## Test plan

```text
.venv/bin/python -m pytest -q \
  tests/integration/test_model_source_routing.py \
  -k source_embeddings
# 6 passed, 85 deselected

.venv/bin/ruff format --check \
  app/modules/proxy/api.py \
  tests/integration/test_model_source_routing.py
# 2 files already formatted

.venv/bin/ruff check \
  app/modules/proxy/api.py \
  tests/integration/test_model_source_routing.py
# All checks passed

.venv/bin/ty check \
  app/modules/proxy/api.py \
  tests/integration/test_model_source_routing.py
# All checks passed

openspec validate fix-embeddings-cancel-reservation --strict
# Change 'fix-embeddings-cancel-reservation' is valid

uv build --offline
# sdist and wheel built successfully
```

`openspec validate --specs` retains the same 49-pass / 8-fail baseline result
as `upstream/main`; this change's strict validation is green.

## Screenshots / output

Before the fix, the route-level cancellation regression observed:

```text
AssertionError: assert 'reserved' == 'released'
```

After the fix:

```text
6 passed, 85 deselected
RELEASE_CALLS=1
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related discovery above.
- [x] Added tests covering the change.
- [x] Ran the relevant local test, format, lint, type, and build subset.
- [x] The change-specific OpenSpec validation passes.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cancelled source-routed embeddings requests now reliably release API-key usage reservations.
  - Original cancellation behavior is preserved while preventing reservations from remaining active.
  - Existing success, error, usage reporting, and settlement behavior remains unchanged.

- **Tests**
  - Added integration coverage to verify reservation cleanup when an in-flight embeddings request is cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->