### PR TITLE
fix(db): add unique constraint on leader_id in scheduler_leader migration (closes #1682)

### DIFF
--- a/app/db/alembic/versions/20260328_140000_add_scheduler_leader_table.py
+++ b/app/db/alembic/versions/20260328_140000_add_scheduler_leader_table.py
@@ -20,6 +20,7 @@ def upgrade() -> None:
             sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
             sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
             sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("leader_id", name="uq_scheduler_leader_leader_id"),
         )
 
     index_names = {index["name"] for index in inspector.get_indexes("scheduler_leader")}


### PR DESCRIPTION
## What
Single-instance SQLite deployments suffer a self-sustaining 17-minute `database is locked` stall after losing the scheduler leader lease. The root cause is that the `scheduler_leader` table lacks a unique constraint on `leader_id`, allowing ambiguous rows and causing the leader election code to perform unsafe upserts that conflict with concurrent lease operations.

## Fix
Add a unique constraint on the `leader_id` column in the migration. This ensures only one leader row per leader ID exists, preventing row-ambiguity-related SQLite lock contention and allowing the election code to use a single-row atomic update pattern that avoids long write locks.

Closes #1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler leader data integrity by preventing duplicate leader identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->