### PR TITLE
fix(tooling): reject dashboard smoke runs without rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ frontend-playwright-chromium: frontend-install
 
 test-dashboard-browser-smoke: frontend-build frontend-playwright-chromium
 	uv sync --dev --frozen
-	uv run python scripts/run_dashboard_browser_smoke.py
+	uv run python scripts/run_dashboard_browser_smoke.py --frontend-built
 
 .PHONY: lint typecheck architecture-check
 lint: architecture-check

--- a/scripts/run_dashboard_browser_smoke.py
+++ b/scripts/run_dashboard_browser_smoke.py
@@ -140,8 +140,19 @@ def run() -> int:
             _stop_server(server)
 
 
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if len(arguments) == 2 and arguments[0] == "--backend-fd":
+        _run_backend(int(arguments[1]))
+        return 0
+    if arguments != ["--frontend-built"]:
+        print(
+            "Run `make test-dashboard-browser-smoke` so app/static is rebuilt before the browser smoke test.",
+            file=sys.stderr,
+        )
+        return 2
+    return run()
+
+
 if __name__ == "__main__":
-    if len(sys.argv) == 3 and sys.argv[1] == "--backend-fd":
-        _run_backend(int(sys.argv[2]))
-        raise SystemExit(0)
-    raise SystemExit(run())
+    raise SystemExit(main())

--- a/scripts/run_dashboard_browser_smoke.py
+++ b/scripts/run_dashboard_browser_smoke.py
@@ -143,7 +143,15 @@ def run() -> int:
 def main(argv: list[str] | None = None) -> int:
     arguments = sys.argv[1:] if argv is None else argv
     if len(arguments) == 2 and arguments[0] == "--backend-fd":
-        _run_backend(int(arguments[1]))
+        try:
+            listener_fd = int(arguments[1])
+        except ValueError:
+            print("Invalid --backend-fd value.", file=sys.stderr)
+            return 2
+        if listener_fd < 0:
+            print("Invalid --backend-fd value.", file=sys.stderr)
+            return 2
+        _run_backend(listener_fd)
         return 0
     if arguments != ["--frontend-built"]:
         print(

--- a/tests/unit/test_dashboard_browser_smoke.py
+++ b/tests/unit/test_dashboard_browser_smoke.py
@@ -85,3 +85,20 @@ def test_smoke_main_dispatches_backend_without_frontend_build_acknowledgement(
 
     assert smoke_harness.main(["--backend-fd", "123"]) == 0
     assert captured == [123]
+
+
+@pytest.mark.parametrize("listener_fd", ["not-an-integer", "-1"])
+def test_smoke_main_rejects_invalid_backend_fd(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    listener_fd: str,
+) -> None:
+    smoke_harness = _load_smoke_harness()
+
+    def fail_if_run(_listener_fd: int) -> None:
+        pytest.fail("backend started with an invalid listener descriptor")
+
+    monkeypatch.setattr(smoke_harness, "_run_backend", fail_if_run)
+
+    assert smoke_harness.main(["--backend-fd", listener_fd]) == 2
+    assert capsys.readouterr().err == "Invalid --backend-fd value.\n"

--- a/tests/unit/test_dashboard_browser_smoke.py
+++ b/tests/unit/test_dashboard_browser_smoke.py
@@ -50,3 +50,38 @@ def test_smoke_backend_disables_dotenv_sources_before_importing_the_app(
     assert "CODEX_LB_DATABASE_URL" not in settings_module._effective_environ()
     assert "CODEX_LB_DASHBOARD_AUTH_MODE" not in settings_module._effective_environ()
     assert captured == {"app": "app.main:app", "fd": 123, "log_level": "warning"}
+
+
+def test_smoke_main_requires_frontend_build_before_allocating_resources(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    smoke_harness = _load_smoke_harness()
+
+    def fail_if_run() -> int:
+        pytest.fail("smoke resources were allocated before the frontend-build preflight")
+
+    monkeypatch.setattr(smoke_harness, "run", fail_if_run)
+
+    assert smoke_harness.main([]) == 2
+    assert (
+        capsys.readouterr().err
+        == "Run `make test-dashboard-browser-smoke` so app/static is rebuilt before the browser smoke test.\n"
+    )
+
+
+def test_smoke_main_runs_after_frontend_build_acknowledgement(monkeypatch: pytest.MonkeyPatch) -> None:
+    smoke_harness = _load_smoke_harness()
+    monkeypatch.setattr(smoke_harness, "run", lambda: 17)
+
+    assert smoke_harness.main(["--frontend-built"]) == 17
+
+
+def test_smoke_main_dispatches_backend_without_frontend_build_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    smoke_harness = _load_smoke_harness()
+    captured: list[int] = []
+    monkeypatch.setattr(smoke_harness, "_run_backend", captured.append)
+
+    assert smoke_harness.main(["--backend-fd", "123"]) == 0
+    assert captured == [123]


### PR DESCRIPTION
## Summary

Prevent direct dashboard browser-smoke runs from exercising stale `app/static` assets and reporting misleading product failures. The supported Make target remains the single local entrypoint and now explicitly acknowledges its preceding frontend build.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None; proactive tooling reliability fix.

Related work: #1449 introduced the smoke harness and documents `make test-dashboard-browser-smoke` as the one-command local entrypoint. No overlapping issue or follow-up PR was found.

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — development tooling only
- [ ] This PR touches a codex-faithful path

Change directory: Not applicable.

## Changes

- fail fast with a clear Make-target instruction when the Python harness is run without a frontend-build acknowledgement
- preserve the internal `--backend-fd` subprocess mode used by the isolated backend
- pass the acknowledgement only from the Make target that rebuilds frontend assets first
- cover rejection ordering, acknowledged execution, and backend dispatch with focused unit tests

## Simplicity

- Adds no setting, README section, `.env.example` entry, dashboard navigation item, runtime default, or user setup step.

## Test plan

```text
.venv/bin/python -m pytest tests/unit/test_dashboard_browser_smoke.py -q
4 passed in 0.10s

.venv/bin/python scripts/run_dashboard_browser_smoke.py
Run `make test-dashboard-browser-smoke` so app/static is rebuilt before the browser smoke test.
exit 2

make test-dashboard-browser-smoke
1 passed (1.5s)

.venv/bin/ruff check scripts/run_dashboard_browser_smoke.py tests/unit/test_dashboard_browser_smoke.py
All checks passed!

.venv/bin/ruff format --check scripts/run_dashboard_browser_smoke.py tests/unit/test_dashboard_browser_smoke.py
2 files already formatted
```

Full local CI was intentionally not run; the focused unit and real browser/backend seams cover this tooling change, and required GitHub CI remains authoritative.

## Screenshots / output

Not applicable: no dashboard-rendering change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No issue is closed by this proactive fix.
- [x] Added tests covering the changed behavior.
- [x] Ran the relevant Make target and focused checks locally.
- [x] OpenSpec is not applicable to this development-tooling fix.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard browser smoke tests now verify that the frontend build is complete before running.
  * Added clearer validation and error handling for invalid smoke-test arguments.
  * Backend smoke-test execution now supports dedicated invocation options and rejects invalid connection settings.

* **Tests**
  * Added coverage for frontend-build validation, successful execution, backend dispatch, and invalid argument handling.
  * Smoke tests now fail early with actionable error messages when required setup is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->