### PR TITLE
fix(ui): restore settings dialog focus

### DIFF
--- a/frontend/src/features/settings/components/password-settings.test.tsx
+++ b/frontend/src/features/settings/components/password-settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -58,6 +58,33 @@ describe("PasswordSettings", () => {
     await user.click(screen.getAllByRole("button", { name: "Set password" }).find((btn) => btn.getAttribute("type") === "submit")!);
     expect(setupPassword).toHaveBeenCalledWith({ password: "new-password-1" });
   });
+
+  it.each(["Escape", "Cancel"] as const)(
+    "returns focus to the exact setup invoker after %s dismissal",
+    async (dismissal) => {
+      const user = userEvent.setup();
+      render(<PasswordSettings />);
+
+      const setupButton = screen.getByRole("button", { name: "Set password" });
+      const scrollPosition = window.scrollY;
+      await user.click(setupButton);
+
+      const dialog = screen.getByRole("dialog", { name: "Set password" });
+      if (dismissal === "Escape") {
+        await user.keyboard("{Escape}");
+      } else {
+        await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+      }
+
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog", { name: "Set password" })).not.toBeInTheDocument(),
+      );
+      expect(setupPassword).not.toHaveBeenCalled();
+      expect(setupButton).toHaveFocus();
+      expect(document.body).not.toHaveFocus();
+      expect(window.scrollY).toBe(scrollPosition);
+    },
+  );
 
   it("requires bootstrap token in remote setup flow", async () => {
     const user = userEvent.setup();

--- a/frontend/src/features/settings/components/password-settings.test.tsx
+++ b/frontend/src/features/settings/components/password-settings.test.tsx
@@ -66,7 +66,6 @@ describe("PasswordSettings", () => {
       render(<PasswordSettings />);
 
       const setupButton = screen.getByRole("button", { name: "Set password" });
-      const scrollPosition = window.scrollY;
       await user.click(setupButton);
 
       const dialog = screen.getByRole("dialog", { name: "Set password" });
@@ -82,7 +81,6 @@ describe("PasswordSettings", () => {
       expect(setupPassword).not.toHaveBeenCalled();
       expect(setupButton).toHaveFocus();
       expect(document.body).not.toHaveFocus();
-      expect(window.scrollY).toBe(scrollPosition);
     },
   );
 

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -1,5 +1,5 @@
 import { KeyRound } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -24,6 +24,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const authenticated = useAuthStore((s) => s.authenticated);
 
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
+  const setupInvokerRef = useRef<HTMLButtonElement>(null);
 
   const lock = disabled || !passwordManagementEnabled;
   const closeIfMatches = (dialog: PasswordDialog) => (open: boolean) => {
@@ -93,6 +94,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
               </Button>
             ) : !passwordRequired ? (
               <Button
+                ref={setupInvokerRef}
                 type="button"
                 size="sm"
                 className="h-8 text-xs"
@@ -110,6 +112,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
         open={activeDialog === "setup"}
         onOpenChange={closeIfMatches("setup")}
         disabled={disabled}
+        returnFocusRef={setupInvokerRef}
       />
       <PasswordChangeDialog
         open={activeDialog === "change"}

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -1,5 +1,5 @@
 import { KeyRound } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -24,11 +24,18 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const authenticated = useAuthStore((s) => s.authenticated);
 
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
-  const setupInvokerRef = useRef<HTMLButtonElement>(null);
 
   const lock = disabled || !passwordManagementEnabled;
   const closeIfMatches = (dialog: PasswordDialog) => (open: boolean) => {
     if (!open && activeDialog === dialog) {
+      setActiveDialog(null);
+    }
+  };
+
+  const handleSetupOpenChange = (open: boolean) => {
+    if (open) {
+      setActiveDialog("setup");
+    } else if (activeDialog === "setup") {
       setActiveDialog(null);
     }
   };
@@ -93,27 +100,20 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
                 {t("settings.password.actions.loginToManage")}
               </Button>
             ) : !passwordRequired ? (
-              <Button
-                ref={setupInvokerRef}
-                type="button"
-                size="sm"
-                className="h-8 text-xs"
-                disabled={lock}
-                onClick={() => setActiveDialog("setup")}
+              <PasswordSetupDialog
+                open={activeDialog === "setup"}
+                onOpenChange={handleSetupOpenChange}
+                disabled={disabled}
               >
-                {t("settings.password.actions.set")}
-              </Button>
+                <Button type="button" size="sm" className="h-8 text-xs" disabled={lock}>
+                  {t("settings.password.actions.set")}
+                </Button>
+              </PasswordSetupDialog>
             ) : null}
           </div>
         </div>
       </div>
 
-      <PasswordSetupDialog
-        open={activeDialog === "setup"}
-        onOpenChange={closeIfMatches("setup")}
-        disabled={disabled}
-        returnFocusRef={setupInvokerRef}
-      />
       <PasswordChangeDialog
         open={activeDialog === "change"}
         onOpenChange={closeIfMatches("change")}

--- a/frontend/src/features/settings/components/password-setup-dialog.tsx
+++ b/frontend/src/features/settings/components/password-setup-dialog.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { type RefObject, useEffect } from "react";
+import { type ReactElement, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -25,14 +26,14 @@ export type PasswordSetupDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   disabled?: boolean;
-  returnFocusRef: RefObject<HTMLButtonElement | null>;
+  children: ReactElement;
 };
 
 export function PasswordSetupDialog({
   open,
   onOpenChange,
   disabled = false,
-  returnFocusRef,
+  children,
 }: PasswordSetupDialogProps) {
   const { t } = useTranslation();
   const bootstrapRequired = useAuthStore((s) => s.bootstrapRequired);
@@ -81,17 +82,8 @@ export function PasswordSetupDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="sm:max-w-md"
-        onCloseAutoFocus={(event) => {
-          const returnFocus = returnFocusRef.current;
-          if (!returnFocus?.isConnected) {
-            return;
-          }
-          event.preventDefault();
-          returnFocus.focus({ preventScroll: true });
-        }}
-      >
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("settings.password.setupDialog.title")}</DialogTitle>
           <DialogDescription>{t("settings.password.setupDialog.description")}</DialogDescription>

--- a/frontend/src/features/settings/components/password-setup-dialog.tsx
+++ b/frontend/src/features/settings/components/password-setup-dialog.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -25,9 +25,15 @@ export type PasswordSetupDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   disabled?: boolean;
+  returnFocusRef: RefObject<HTMLButtonElement | null>;
 };
 
-export function PasswordSetupDialog({ open, onOpenChange, disabled = false }: PasswordSetupDialogProps) {
+export function PasswordSetupDialog({
+  open,
+  onOpenChange,
+  disabled = false,
+  returnFocusRef,
+}: PasswordSetupDialogProps) {
   const { t } = useTranslation();
   const bootstrapRequired = useAuthStore((s) => s.bootstrapRequired);
   const bootstrapTokenConfigured = useAuthStore((s) => s.bootstrapTokenConfigured);
@@ -75,7 +81,17 @@ export function PasswordSetupDialog({ open, onOpenChange, disabled = false }: Pa
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        onCloseAutoFocus={(event) => {
+          const returnFocus = returnFocusRef.current;
+          if (!returnFocus?.isConnected) {
+            return;
+          }
+          event.preventDefault();
+          returnFocus.focus({ preventScroll: true });
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{t("settings.password.setupDialog.title")}</DialogTitle>
           <DialogDescription>{t("settings.password.setupDialog.description")}</DialogDescription>

--- a/frontend/src/features/settings/components/telemetry-settings.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.test.tsx
@@ -103,7 +103,6 @@ describe("TelemetrySettings", () => {
 
       const viewButton = await screen.findByRole("button", { name: "View collected data" });
       await waitFor(() => expect(viewButton).toBeEnabled());
-      const scrollPosition = window.scrollY;
 
       await user.click(viewButton);
       const dialog = await screen.findByRole("dialog", { name: "Collected telemetry data" });
@@ -123,7 +122,6 @@ describe("TelemetrySettings", () => {
       );
       expect(viewButton).toHaveFocus();
       expect(document.body).not.toHaveFocus();
-      expect(window.scrollY).toBe(scrollPosition);
     },
   );
 });

--- a/frontend/src/features/settings/components/telemetry-settings.test.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.test.tsx
@@ -94,4 +94,36 @@ describe("TelemetrySettings", () => {
       telemetryRequests.filter((url) => url.searchParams.get("include_preview") === "true"),
     ).toHaveLength(1);
   });
+
+  it.each(["Escape", "Close"] as const)(
+    "returns focus to the exact preview invoker after %s dismissal",
+    async (dismissal) => {
+      const user = userEvent.setup();
+      renderWithProviders(<TelemetrySettings disabled={false} />);
+
+      const viewButton = await screen.findByRole("button", { name: "View collected data" });
+      await waitFor(() => expect(viewButton).toBeEnabled());
+      const scrollPosition = window.scrollY;
+
+      await user.click(viewButton);
+      const dialog = await screen.findByRole("dialog", { name: "Collected telemetry data" });
+
+      if (dismissal === "Escape") {
+        await user.keyboard("{Escape}");
+      } else {
+        const closeButton = within(dialog)
+          .getAllByRole("button", { name: "Close" })
+          .find((button) => button.textContent === "Close");
+        expect(closeButton).toBeDefined();
+        await user.click(closeButton!);
+      }
+
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog", { name: "Collected telemetry data" })).not.toBeInTheDocument(),
+      );
+      expect(viewButton).toHaveFocus();
+      expect(document.body).not.toHaveFocus();
+      expect(window.scrollY).toBe(scrollPosition);
+    },
+  );
 });

--- a/frontend/src/features/settings/components/telemetry-settings.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.tsx
@@ -1,5 +1,5 @@
 import { Activity } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { AlertMessage } from "@/components/alert-message";
@@ -24,6 +24,7 @@ export type TelemetrySettingsProps = {
 export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
   const { t } = useTranslation();
   const [previewOpen, setPreviewOpen] = useState(false);
+  const previewInvokerRef = useRef<HTMLButtonElement>(null);
   const { telemetryConsentQuery, updateTelemetryConsentMutation } = useTelemetryConsent();
   // Building the snapshot is expensive, so the preview is fetched only once
   // the operator opens the dialog.
@@ -71,6 +72,7 @@ export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
             </p>
           </div>
           <Button
+            ref={previewInvokerRef}
             type="button"
             size="sm"
             variant="outline"
@@ -85,7 +87,17 @@ export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
 
       <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
         {previewOpen ? (
-          <DialogContent className="sm:max-w-2xl">
+          <DialogContent
+            className="sm:max-w-2xl"
+            onCloseAutoFocus={(event) => {
+              const invoker = previewInvokerRef.current;
+              if (!invoker?.isConnected) {
+                return;
+              }
+              event.preventDefault();
+              invoker.focus({ preventScroll: true });
+            }}
+          >
             <DialogHeader>
               <DialogTitle>{t("settings.telemetry.previewDialog.title")}</DialogTitle>
               <DialogDescription>

--- a/frontend/src/features/settings/components/telemetry-settings.tsx
+++ b/frontend/src/features/settings/components/telemetry-settings.tsx
@@ -1,5 +1,5 @@
 import { Activity } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { AlertMessage } from "@/components/alert-message";
@@ -11,6 +11,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
@@ -24,7 +25,6 @@ export type TelemetrySettingsProps = {
 export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
   const { t } = useTranslation();
   const [previewOpen, setPreviewOpen] = useState(false);
-  const previewInvokerRef = useRef<HTMLButtonElement>(null);
   const { telemetryConsentQuery, updateTelemetryConsentMutation } = useTelemetryConsent();
   // Building the snapshot is expensive, so the preview is fetched only once
   // the operator opens the dialog.
@@ -71,50 +71,39 @@ export function TelemetrySettings({ disabled }: TelemetrySettingsProps) {
               {t("settings.telemetry.collectedData.description")}
             </p>
           </div>
-          <Button
-            ref={previewInvokerRef}
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-8 text-xs"
-            disabled={!consent}
-            onClick={() => setPreviewOpen(true)}
-          >
-            {t("settings.telemetry.collectedData.view")}
-          </Button>
+          <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 text-xs"
+                disabled={!consent}
+              >
+                {t("settings.telemetry.collectedData.view")}
+              </Button>
+            </DialogTrigger>
+            {previewOpen ? (
+              <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>{t("settings.telemetry.previewDialog.title")}</DialogTitle>
+                  <DialogDescription>
+                    {t("settings.telemetry.previewDialog.description")}
+                  </DialogDescription>
+                </DialogHeader>
+                {previewEnvelope ? (
+                  <TelemetryPayloadPreview preview={previewEnvelope} />
+                ) : telemetryPreviewQuery.error ? (
+                  <AlertMessage variant="error">{telemetryPreviewQuery.error.message}</AlertMessage>
+                ) : (
+                  <Skeleton className="h-64 w-full rounded-lg" />
+                )}
+                <DialogFooter showCloseButton />
+              </DialogContent>
+            ) : null}
+          </Dialog>
         </div>
       </div>
-
-      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-        {previewOpen ? (
-          <DialogContent
-            className="sm:max-w-2xl"
-            onCloseAutoFocus={(event) => {
-              const invoker = previewInvokerRef.current;
-              if (!invoker?.isConnected) {
-                return;
-              }
-              event.preventDefault();
-              invoker.focus({ preventScroll: true });
-            }}
-          >
-            <DialogHeader>
-              <DialogTitle>{t("settings.telemetry.previewDialog.title")}</DialogTitle>
-              <DialogDescription>
-                {t("settings.telemetry.previewDialog.description")}
-              </DialogDescription>
-            </DialogHeader>
-            {previewEnvelope ? (
-              <TelemetryPayloadPreview preview={previewEnvelope} />
-            ) : telemetryPreviewQuery.error ? (
-              <AlertMessage variant="error">{telemetryPreviewQuery.error.message}</AlertMessage>
-            ) : (
-              <Skeleton className="h-64 w-full rounded-lg" />
-            )}
-            <DialogFooter showCloseButton />
-          </DialogContent>
-        ) : null}
-      </Dialog>
     </section>
   );
 }

--- a/openspec/changes/restore-settings-dialog-focus/.openspec.yaml
+++ b/openspec/changes/restore-settings-dialog-focus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/restore-settings-dialog-focus/design.md
+++ b/openspec/changes/restore-settings-dialog-focus/design.md
@@ -23,16 +23,15 @@ The change is limited to those two Settings paths. Telemetry preview fetching re
 
 ## Decisions
 
-1. **Retain each invoker with a local button ref.** `TelemetrySettings` owns the telemetry button ref. `PasswordSettings` owns the setup button ref and passes it only to `PasswordSetupDialog`, because the parent owns the conditional action button. This records the exact element rather than looking it up later by label or selector.
+1. **Use each dialog's real invoker as a Radix `DialogTrigger`.** Both buttons render through `DialogTrigger asChild`, so the dialog root registers the exact DOM element that opened it and Radix restores that element through its established close-auto-focus lifecycle. This matches the working trigger-backed Language menu instead of adding a second focus mechanism.
 
-2. **Restore during Radix's close-auto-focus lifecycle.** Each affected `DialogContent` uses `onCloseAutoFocus`. When the retained element is still connected, the handler prevents the fallback and calls `focus({ preventScroll: true })`. Restoring in this lifecycle avoids a timer or effect racing the focus scope teardown, and `preventScroll` preserves the operator's Settings position.
+2. **Keep controlled state and conditional content.** The telemetry trigger and conditionally rendered content share the existing `previewOpen` root, so the expensive preview query still starts only after opening. `PasswordSetupDialog` accepts its button as the trigger child at the existing action position; `activeDialog` remains the single controlled state, and dialog content/form cleanup still follows the existing open/close lifecycle.
 
-3. **Fall back when the invoker no longer exists.** The handler only prevents Radix's default when the retained element is connected. If successful password setup changes auth state and unmounts the setup action, the existing close behavior remains instead of focusing a detached node. Mutation, refresh, toast, and close ordering stay unchanged.
+3. **Do not duplicate focus handlers or broaden the shared primitive.** Native trigger registration removes the need for repeated `onCloseAutoFocus` callbacks, timers, DOM queries, or changes to `dialog.tsx` and `useFloatingLayerDismissGuard`. Other controlled dialogs retain their existing behavior.
 
-4. **Keep the fix local instead of changing the shared primitive.** Many dialogs already use real triggers or have different lifecycle needs. A shared default would broaden behavior beyond the two reproduced failures; duplicating the small close handler at these two ownership points is the narrower change.
+4. **Split proof by environment.** Focus identity and dismissal behavior are permanent component regressions. Scroll preservation is exercised in real Chromium on a nonzero Settings scroll position because jsdom has no layout-driven focus scrolling.
 
 ## Risks / Trade-offs
 
-- A future refactor that replaces either invoker must keep the ref attached; focused component tests guard the public focus behavior.
-- The no-scroll guarantee depends on browser support for `HTMLElement.focus({ preventScroll: true })`, which is supported by the dashboard's modern-browser target.
-- Successful password setup may remove the invoking button as auth state refreshes; in that case there is no connected exact target, so the guarded handler deliberately leaves the existing fallback behavior unchanged.
+- The trigger must remain mounted through Escape or explicit dismissal; both affected buttons do. Successful password setup can replace the setup action after session refresh, but that disappearing-trigger path is not one of the proven dismissal flows and keeps its existing auth lifecycle.
+- Radix focuses the registered trigger after teardown. Real-browser proof covers both dismissal methods at nonzero scroll positions so a future layout or focus change cannot be mistaken for jsdom behavior.

--- a/openspec/changes/restore-settings-dialog-focus/design.md
+++ b/openspec/changes/restore-settings-dialog-focus/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The telemetry preview and password setup flows use controlled Radix dialogs without a `DialogTrigger`. When either dialog unmounts after Escape or its explicit dismissal action, the dialog cannot identify the invoker and focus falls back to `document.body`. The `View collected data` and `Set password` buttons remain the correct return targets for the proven dismissal flows.
+
+The change is limited to those two Settings paths. Telemetry preview fetching remains conditional on `previewOpen`; password setup keeps its existing mutation, session refresh, toast, form reset, and conditional action rendering.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Return focus to the exact `View collected data` or `Set password` button that opened the dialog.
+- Cover both Escape and the explicit Close/Cancel action.
+- Keep `document.body` from becoming the active element after those closes.
+- Restore focus without changing the Settings page scroll position.
+- Preserve telemetry and password product side effects and dialog mounting behavior.
+
+**Non-Goals:**
+
+- Shared `dialog.tsx` or `useFloatingLayerDismissGuard` changes.
+- Password change, remove, verify, or TOTP dialog behavior.
+- New focus-management abstractions or visual changes.
+- API, authentication, telemetry payload, or persistence changes.
+
+## Decisions
+
+1. **Retain each invoker with a local button ref.** `TelemetrySettings` owns the telemetry button ref. `PasswordSettings` owns the setup button ref and passes it only to `PasswordSetupDialog`, because the parent owns the conditional action button. This records the exact element rather than looking it up later by label or selector.
+
+2. **Restore during Radix's close-auto-focus lifecycle.** Each affected `DialogContent` uses `onCloseAutoFocus`. When the retained element is still connected, the handler prevents the fallback and calls `focus({ preventScroll: true })`. Restoring in this lifecycle avoids a timer or effect racing the focus scope teardown, and `preventScroll` preserves the operator's Settings position.
+
+3. **Fall back when the invoker no longer exists.** The handler only prevents Radix's default when the retained element is connected. If successful password setup changes auth state and unmounts the setup action, the existing close behavior remains instead of focusing a detached node. Mutation, refresh, toast, and close ordering stay unchanged.
+
+4. **Keep the fix local instead of changing the shared primitive.** Many dialogs already use real triggers or have different lifecycle needs. A shared default would broaden behavior beyond the two reproduced failures; duplicating the small close handler at these two ownership points is the narrower change.
+
+## Risks / Trade-offs
+
+- A future refactor that replaces either invoker must keep the ref attached; focused component tests guard the public focus behavior.
+- The no-scroll guarantee depends on browser support for `HTMLElement.focus({ preventScroll: true })`, which is supported by the dashboard's modern-browser target.
+- Successful password setup may remove the invoking button as auth state refreshes; in that case there is no connected exact target, so the guarded handler deliberately leaves the existing fallback behavior unchanged.

--- a/openspec/changes/restore-settings-dialog-focus/proposal.md
+++ b/openspec/changes/restore-settings-dialog-focus/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Settings `View collected data` and `Set password` dialogs leave focus on the document body after they close, so keyboard users lose their place. Both controlled dialog flows need to restore focus to the exact button that opened them without changing their existing data or authentication behavior.
+
+## What Changes
+
+- Retain the `View collected data` and `Set password` invoker elements while their controlled dialogs are open.
+- Restore focus to the exact invoker when either dialog closes through Escape or its explicit Close/Cancel action.
+- Add focused regressions for both dismissal paths while preserving Settings scroll position, conditional mounting, telemetry requests, and password side effects.
+- Keep shared dialog primitives and the change/remove/verify/TOTP dialog flows unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Settings dialog dismissal restores keyboard focus to the exact invoking control for the two affected flows.
+
+## Impact
+
+Dashboard SPA only: `telemetry-settings.tsx`, `password-settings.tsx`, `password-setup-dialog.tsx` only as required, their focused component tests, and the `frontend-architecture` delta spec. No API, database, shared dialog primitive, navigation, dependency, or product-side-effect changes.

--- a/openspec/changes/restore-settings-dialog-focus/specs/frontend-architecture/spec.md
+++ b/openspec/changes/restore-settings-dialog-focus/specs/frontend-architecture/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Affected Settings dialogs restore invoker focus
 
-The Settings `View collected data` telemetry preview and `Set password` setup dialogs SHALL retain the exact button that invoked them. When either dialog is dismissed with Escape or its explicit Close/Cancel action, the dialog SHALL restore focus to that connected invoking button with scroll prevention. After restoration, `document.body` MUST NOT be the active element and the Settings page scroll position MUST remain unchanged.
+The Settings `View collected data` telemetry preview and `Set password` setup dialogs SHALL retain the exact button that invoked them. When either dialog is dismissed with Escape or its explicit Close/Cancel action, the dialog SHALL restore focus to that connected invoking button without changing the Settings page scroll position. After restoration, `document.body` MUST NOT be the active element.
 
 Focus restoration MUST preserve the telemetry preview's on-demand fetch and conditional mounting behavior and the password setup flow's authentication request, session refresh, toast, form reset, and conditional mounting behavior. Password change, remove, verify, and TOTP dialogs are outside this requirement.
 

--- a/openspec/changes/restore-settings-dialog-focus/specs/frontend-architecture/spec.md
+++ b/openspec/changes/restore-settings-dialog-focus/specs/frontend-architecture/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Affected Settings dialogs restore invoker focus
+
+The Settings `View collected data` telemetry preview and `Set password` setup dialogs SHALL retain the exact button that invoked them. When either dialog is dismissed with Escape or its explicit Close/Cancel action, the dialog SHALL restore focus to that connected invoking button with scroll prevention. After restoration, `document.body` MUST NOT be the active element and the Settings page scroll position MUST remain unchanged.
+
+Focus restoration MUST preserve the telemetry preview's on-demand fetch and conditional mounting behavior and the password setup flow's authentication request, session refresh, toast, form reset, and conditional mounting behavior. Password change, remove, verify, and TOTP dialogs are outside this requirement.
+
+#### Scenario: Telemetry preview closes with Escape
+
+- **GIVEN** an operator opened `View collected data` from its Settings button
+- **WHEN** the operator presses Escape
+- **THEN** the preview dialog closes
+- **AND** focus returns to that exact `View collected data` button without scrolling Settings
+- **AND** `document.body` is not active
+
+#### Scenario: Telemetry preview closes explicitly
+
+- **GIVEN** an operator opened `View collected data` from its Settings button
+- **WHEN** the operator activates the dialog's Close action
+- **THEN** the preview dialog closes
+- **AND** focus returns to that exact `View collected data` button without scrolling Settings
+- **AND** `document.body` is not active
+
+#### Scenario: Password setup closes with Escape
+
+- **GIVEN** an operator opened password setup from the `Set password` button
+- **WHEN** the operator presses Escape
+- **THEN** the setup dialog closes without submitting password setup
+- **AND** focus returns to that exact `Set password` button without scrolling Settings
+- **AND** `document.body` is not active
+
+#### Scenario: Password setup closes explicitly
+
+- **GIVEN** an operator opened password setup from the `Set password` button
+- **WHEN** the operator activates Cancel
+- **THEN** the setup dialog closes without submitting password setup
+- **AND** focus returns to that exact `Set password` button without scrolling Settings
+- **AND** `document.body` is not active

--- a/openspec/changes/restore-settings-dialog-focus/tasks.md
+++ b/openspec/changes/restore-settings-dialog-focus/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Focus regressions
 
-- [x] 1.1 Add focused telemetry-preview coverage for Escape and explicit Close returning focus to the exact invoker without activating `document.body` or changing scroll position.
-- [x] 1.2 Add focused password-setup coverage for Escape and Cancel returning focus to the exact invoker without submitting setup, activating `document.body`, or changing scroll position.
+- [x] 1.1 Add focused telemetry-preview coverage for Escape and explicit Close returning focus to the exact invoker without activating `document.body`.
+- [x] 1.2 Add focused password-setup coverage for Escape and Cancel returning focus to the exact invoker without submitting setup or activating `document.body`.
 - [x] 1.3 Prove the new focus regressions fail on the dispatched baseline before implementing the fix.
 
 ## 2. Local focus restoration
 
-- [x] 2.1 Retain the `View collected data` invoker and restore it from the telemetry dialog close-auto-focus lifecycle with scroll prevention.
-- [x] 2.2 Retain the `Set password` invoker in `PasswordSettings` and restore it from `PasswordSetupDialog` only while that exact element remains connected.
+- [x] 2.1 Register `View collected data` as the telemetry dialog's native trigger while preserving on-demand preview mounting.
+- [x] 2.2 Register `Set password` through `PasswordSetupDialog` while retaining `activeDialog` as the controlled password-dialog state.
 - [x] 2.3 Preserve telemetry fetching/mutation behavior, password auth/refresh/toast behavior, and both dialogs' conditional mounting semantics.
 
 ## 3. Verification

--- a/openspec/changes/restore-settings-dialog-focus/tasks.md
+++ b/openspec/changes/restore-settings-dialog-focus/tasks.md
@@ -1,0 +1,17 @@
+## 1. Focus regressions
+
+- [x] 1.1 Add focused telemetry-preview coverage for Escape and explicit Close returning focus to the exact invoker without activating `document.body` or changing scroll position.
+- [x] 1.2 Add focused password-setup coverage for Escape and Cancel returning focus to the exact invoker without submitting setup, activating `document.body`, or changing scroll position.
+- [x] 1.3 Prove the new focus regressions fail on the dispatched baseline before implementing the fix.
+
+## 2. Local focus restoration
+
+- [x] 2.1 Retain the `View collected data` invoker and restore it from the telemetry dialog close-auto-focus lifecycle with scroll prevention.
+- [x] 2.2 Retain the `Set password` invoker in `PasswordSettings` and restore it from `PasswordSetupDialog` only while that exact element remains connected.
+- [x] 2.3 Preserve telemetry fetching/mutation behavior, password auth/refresh/toast behavior, and both dialogs' conditional mounting semantics.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused affected Vitest files and confirm all focus and existing side-effect regressions pass.
+- [x] 3.2 Run affected frontend formatting/lint/typecheck subsets and scoped strict OpenSpec validation.
+- [x] 3.3 Browser-verify both Settings flows for Escape and explicit dismissal, including exact active element and unchanged scroll position, and record honest before/after evidence for the PR.


### PR DESCRIPTION
## Summary

Restore keyboard focus to the exact Settings button that opened the **View collected data** or **Set password** dialog. Both controlled dialogs now register their real invoker through Radix `DialogTrigger`, matching the existing trigger-backed focus behavior instead of leaving `document.activeElement` on `body`.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — independently reproduced; the bounded issue and PR overlap checks found no relevant work or prerequisite.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/restore-settings-dialog-focus/`

## Changes

- Register **View collected data** as the telemetry preview dialog trigger while keeping the preview fetch conditional on the dialog being open.
- Render **Set password** through the password setup dialog trigger while retaining `activeDialog` as the controlled password-dialog state.
- Cover Escape and explicit Close/Cancel for both flows, including exact invoker focus and `document.body` exclusion.
- Leave shared dialog primitives plus password change/remove/verify and TOTP flows unchanged.

## Simplicity

No new setting, default, setup step, dependency, README section, dashboard navigation item, or shared focus abstraction. The fix reuses the existing Radix trigger mechanism.

## Test plan

- `bun run test -- src/features/settings/components/telemetry-settings.test.tsx src/features/settings/components/password-settings.test.tsx` — 2 files, 21 tests passed. The four new cases failed on the dispatched baseline with `body` focused, then passed after the fix.
- `bun node_modules/eslint/bin/eslint.js src/features/settings/components/telemetry-settings.tsx src/features/settings/components/telemetry-settings.test.tsx src/features/settings/components/password-settings.tsx src/features/settings/components/password-settings.test.tsx src/features/settings/components/password-setup-dialog.tsx` — passed.
- `bun run typecheck` — passed.
- `openspec validate restore-settings-dialog-focus --type change --strict` — passed.
- OpenSpec verification — 9/9 tasks complete; the requirement and all four scenarios map to implementation plus focused Vitest/browser evidence; no critical, warning, or coherence findings.
- `git diff --check` — passed.

Known baseline-only validation debt: `openspec validate frontend-architecture --type spec --strict` still reports the two unchanged existing conversation requirements whose first paragraph lacks a normative keyword. This branch does not edit `openspec/specs/frontend-architecture/spec.md`; the scoped change validates strictly.

Not run locally: full local CI, full frontend suite, or coverage. The focused Standard-risk checks above cover this seam; required GitHub CI remains the integration gate.

## Screenshots / output

This focus-only fix has no static visual delta, so equivalent observable Chromium evidence is more accurate than screenshots. Against an isolated empty local backend, each flow was exercised before and after at a nonzero Settings scroll position:

| Flow | Dismissal | Baseline `document.activeElement` | Fixed `document.activeElement` | Scroll before → after |
|---|---|---|---|---|
| View collected data | Escape | `BODY` | `BUTTON` — View collected data | `1735 → 1735` |
| View collected data | Close | `BODY` | `BUTTON` — View collected data | `1735 → 1735` |
| Set password | Escape | `BODY` | `BUTTON` — Set password | `982 → 982` |
| Set password | Cancel | `BODY` | `BUTTON` — Set password | `982 → 982` |

The telemetry preview still loaded its real envelope, and password Cancel/Escape submitted no setup request.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related issue/PR overlap checked; no relevant public work exists to link.
- [x] Added tests covering the changed behavior.
- [x] Ran the relevant focused lint, test, typecheck, and browser subsets locally.
- [x] Scoped strict OpenSpec validation passes and OpenSpec verification is clean.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored keyboard focus to the exact button that opened the Settings dialogs after dismissal.
  * Improved focus behavior when closing the telemetry preview or password setup dialogs with Escape, Close, or Cancel.
  * Prevented focus from incorrectly moving to the document body.
  * Ensured dismissing the password setup dialog does not trigger a password submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->