### PR TITLE
fix(ui): constrain API key dialog to viewport

### DIFF
--- a/frontend/browser-smoke/dashboard.spec.ts
+++ b/frontend/browser-smoke/dashboard.spec.ts
@@ -172,3 +172,77 @@ test("mobile top-level navigation opens the destination heading at the top", asy
   await expect(page.getByRole("heading", { name: "Dashboard", exact: true })).toBeInViewport();
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
 });
+
+test("the API key create dialog stays inside supported viewports", async ({ page }) => {
+  const viewportCases = [
+    { size: { width: 320, height: 568 }, columns: 1 },
+    { size: { width: 390, height: 844 }, columns: 1 },
+    { size: { width: 1440, height: 900 }, columns: 2 },
+  ] as const;
+
+  await page.goto("/apis", { waitUntil: "networkidle" });
+
+  const consentDialog = page.getByRole("dialog", { name: "Anonymous telemetry" });
+  if (await consentDialog.isVisible()) {
+    await consentDialog.getByRole("button", { name: "Keep enabled" }).click();
+    await expect(consentDialog).toBeHidden();
+  }
+
+  await expect(page.getByRole("heading", { name: "APIs", exact: true })).toBeVisible();
+  const openDialogButton = page.getByRole("button", { name: "Create API Key" });
+  const dialog = page.getByRole("dialog", { name: "Create API key" });
+  const title = dialog.getByRole("heading", { name: "Create API key" });
+  const closeButton = dialog.getByRole("button", { name: "Close" });
+  const createButton = dialog.getByRole("button", { name: "Create" });
+
+  for (const viewportCase of viewportCases) {
+    await page.setViewportSize(viewportCase.size);
+    await openDialogButton.click();
+
+    for (const element of [dialog, title, closeButton, createButton]) {
+      const box = await element.boundingBox();
+      expect(box).not.toBeNull();
+      if (!box) {
+        throw new Error("Expected dialog element to have a bounding box");
+      }
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.y).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(viewportCase.size.width);
+      expect(box.y + box.height).toBeLessThanOrEqual(viewportCase.size.height);
+    }
+
+    const scrollRegion = dialog.getByTestId("api-key-create-scroll-region");
+    await expect(scrollRegion).toHaveCount(1);
+    const initialScrollState = await scrollRegion.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+    }));
+    expect(initialScrollState.overflowY).toBe("auto");
+    expect(initialScrollState.scrollHeight).toBeGreaterThan(initialScrollState.clientHeight);
+
+    const columnCount = await scrollRegion.locator(":scope > div").evaluate((element) =>
+      getComputedStyle(element).gridTemplateColumns.split(" ").filter(Boolean).length,
+    );
+    expect(columnCount).toBe(viewportCase.columns);
+
+    const finalField = dialog.getByRole("spinbutton", { name: "Weekly cost limit ($)" });
+    await finalField.scrollIntoViewIfNeeded();
+    await expect(finalField).toBeInViewport();
+    await expect(title).toBeInViewport();
+    await expect(closeButton).toBeInViewport();
+    await expect(createButton).toBeInViewport();
+    if (viewportCase.columns === 1) {
+      expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  }
+
+  await page.setViewportSize(viewportCases[0].size);
+  await openDialogButton.click();
+  await expect(dialog).toBeVisible();
+  await page.mouse.click(8, Math.floor(viewportCases[0].size.height / 2));
+  await expect(dialog).toBeHidden();
+});

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -335,7 +335,7 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {open ? (
-        <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
           <DialogHeader className="px-6 pt-6 pr-12 pb-2">
             <DialogTitle>{t("apiKeys.createDialog.title")}</DialogTitle>
             <DialogDescription>{t("apiKeys.createDialog.description")}</DialogDescription>

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -149,10 +149,14 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)}>
-        <div className="grid gap-x-6 sm:grid-cols-2">
-          <div className="max-h-[55vh] space-y-3 overflow-y-auto overscroll-contain pl-1 pr-2">
-            <h4 className="sticky top-0 bg-background pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t("apiKeys.form.general")}</h4>
+      <form className="flex min-h-0 flex-1 flex-col" onSubmit={form.handleSubmit(handleSubmit)}>
+        <div
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pb-4"
+          data-testid="api-key-create-scroll-region"
+        >
+          <div className="grid gap-x-6 sm:grid-cols-2">
+            <div className="space-y-3 pl-1 pr-2">
+              <h4 className="sticky top-0 bg-background pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t("apiKeys.form.general")}</h4>
 
             <FormField
               control={form.control}
@@ -309,13 +313,14 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
             </div>
           </div>
 
-          <div className="max-h-[55vh] space-y-3 overflow-y-auto overscroll-contain pl-1 pr-2 max-sm:mt-3 max-sm:border-t max-sm:pt-3">
+            <div className="space-y-3 pl-1 pr-2 max-sm:mt-3 max-sm:border-t max-sm:pt-3">
             <h4 className="sticky top-0 bg-background pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t("apiKeys.form.limits")}</h4>
             <LimitRulesEditor rules={draft.limitRules} onChange={(limitRules) => updateDraft({ limitRules })} />
           </div>
         </div>
+        </div>
 
-        <DialogFooter className="mt-4">
+        <DialogFooter className="border-t px-6 py-4">
           <Button type="submit" disabled={busy || form.formState.isSubmitting}>
             {t("common.actions.create")}
           </Button>
@@ -330,8 +335,8 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {open ? (
-        <DialogContent className="sm:max-w-3xl">
-          <DialogHeader>
+        <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+          <DialogHeader className="px-6 pt-6 pr-12 pb-2">
             <DialogTitle>{t("apiKeys.createDialog.title")}</DialogTitle>
             <DialogDescription>{t("apiKeys.createDialog.description")}</DialogDescription>
           </DialogHeader>

--- a/openspec/changes/fix-compact-api-key-dialog/.openspec.yaml
+++ b/openspec/changes/fix-compact-api-key-dialog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/fix-compact-api-key-dialog/design.md
+++ b/openspec/changes/fix-compact-api-key-dialog/design.md
@@ -19,7 +19,7 @@ The existing `AutomationJobDialog` already demonstrates the project pattern for 
 
 ## Decisions
 
-1. **Use the established viewport-bounded dialog shell.** `DialogContent` will use a flex column with `max-h-[calc(100vh-2rem)]`, `overflow-hidden`, zero outer padding, and the existing desktop width. The header receives explicit internal padding so it remains outside form scrolling. This matches `AutomationJobDialog` rather than introducing a second tall-dialog convention.
+1. **Use the established viewport-bounded dialog shell.** `DialogContent` will use a flex column with `max-h-[calc(100dvh-2rem)]`, `overflow-hidden`, zero outer padding, and the existing desktop width. The header receives explicit internal padding so it remains outside form scrolling. This keeps the `AutomationJobDialog` shell structure while following the account list's dynamic-viewport convention.
 
    Alternative: change the shared Dialog primitive. Rejected because only the API key create dialog has this proven layout failure, and global sizing changes could affect unrelated dialogs.
 

--- a/openspec/changes/fix-compact-api-key-dialog/design.md
+++ b/openspec/changes/fix-compact-api-key-dialog/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`ApiKeyCreateDialog` currently renders a normal grid-style `DialogContent` around a form whose General and Limits columns each own `max-h-[55vh]` scrolling. Below the `sm` breakpoint those two columns stack, so both height budgets plus the header and footer produce a 713px dialog at 320x568. Because the shared Dialog centers its content, the title and Close control move above the viewport while Create moves below it.
+
+The existing `AutomationJobDialog` already demonstrates the project pattern for a tall dashboard form: a viewport-bounded flex-column dialog shell, fixed header and footer, and one `min-h-0` internal scroller.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep the create-dialog title, Close control, and Create action fully inside a 320x568 viewport.
+- Make every create field reachable through one internal vertical scroll region.
+- Preserve the existing stacked compact layout and two-column desktop layout, including correct rendering at 390x844.
+- Preserve form state, submission, overlay/Escape dismissal, and the shared Dialog primitive.
+
+**Non-Goals:**
+- Change API key fields, payloads, validation, translations, or API behavior.
+- Change `ApiKeyEditDialog` without separate evidence.
+- Introduce a new dialog abstraction or modify the shared Dialog primitive.
+
+## Decisions
+
+1. **Use the established viewport-bounded dialog shell.** `DialogContent` will use a flex column with `max-h-[calc(100vh-2rem)]`, `overflow-hidden`, zero outer padding, and the existing desktop width. The header receives explicit internal padding so it remains outside form scrolling. This matches `AutomationJobDialog` rather than introducing a second tall-dialog convention.
+
+   Alternative: change the shared Dialog primitive. Rejected because only the API key create dialog has this proven layout failure, and global sizing changes could affect unrelated dialogs.
+
+2. **Give the form one shrinking scroll owner.** The form will be a `flex min-h-0 flex-1 flex-col`; one body wrapper will use `min-h-0 flex-1 overflow-y-auto` and contain the existing responsive grid. The General and Limits columns will no longer set independent height or overflow constraints. This lets compact layouts scroll the stacked fields as one sequence while desktop retains two columns.
+
+   Alternative: reduce each column's `55vh` cap on compact screens. Rejected because two independent scroll regions remain confusing, consume separate height budgets, and do not guarantee a persistent footer.
+
+3. **Keep the action footer outside the scroller.** The existing Create action remains in `DialogFooter`, separated from the body with a top border and explicit padding. The shared absolute Close control remains anchored to the viewport-contained shell.
+
+   Alternative: place Create inside the scrollable body. Rejected because it would remain unreachable until the operator scrolls to the end and would not satisfy the persistent-action contract.
+
+## Risks / Trade-offs
+
+- [Long field content could shrink the body incorrectly] → Keep `min-h-0` on both the form and its single flexing body so overflow resolves on the intended element.
+- [Desktop columns could regress when their independent scroll caps are removed] → Preserve `sm:grid-cols-2` and verify the focused component plus a real desktop render.
+- [Nested menus could affect dismissal] → Leave `Dialog`, `DialogContent`, and all field components unchanged; verify Escape and overlay dismissal in the browser.

--- a/openspec/changes/fix-compact-api-key-dialog/proposal.md
+++ b/openspec/changes/fix-compact-api-key-dialog/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+At a 320x568 viewport, the API key creation dialog is taller than the viewport and remains vertically centered, placing its title and Close control above the visible area and its Create action below it. Operators need the complete form to remain usable on compact dashboard viewports without changing desktop behavior or dismissal semantics.
+
+## What Changes
+
+- Constrain the API key creation dialog shell to the viewport while keeping its header and footer visible.
+- Replace the two independently scrolling stacked columns with one internal form scroller on compact viewports while preserving the desktop two-column layout.
+- Add focused regression coverage for the viewport-bounded shell, single scroll region, and persistent actions.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Require the API key creation dialog to keep its title, Close control, and Create action inside compact viewports while making every field reachable through one internal scroll region.
+
+## Impact
+
+- Affected dashboard component: `frontend/src/features/api-keys/components/api-key-create-dialog.tsx`.
+- Affected tests: focused API key creation dialog component and browser-smoke tests.
+- No API, schema, persistence, dependency, configuration, or API key edit-dialog changes.

--- a/openspec/changes/fix-compact-api-key-dialog/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-compact-api-key-dialog/specs/frontend-architecture/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: API key create dialog remains usable in compact viewports
+
+The dashboard API key create dialog MUST constrain its outer shell to the visible viewport. Its title, Close control, and Create action MUST remain fully visible at a 320x568 viewport, and every form field MUST remain reachable through exactly one internal vertical scroll region. The header and footer MUST remain outside that scroll region. The dialog SHALL retain its stacked compact layout, two-column desktop layout, shared Dialog primitive, field behavior, and overlay and Escape dismissal behavior.
+
+#### Scenario: Compact viewport keeps primary controls visible
+
+- **WHEN** an operator opens Create API Key from `/apis` at a 320x568 viewport
+- **THEN** the dialog title, Close control, and Create action are fully inside the viewport
+- **AND** the dialog shell does not extend above or below the viewport
+
+#### Scenario: Compact form fields use one internal scroller
+
+- **WHEN** the create form fields exceed the height available between the dialog header and footer
+- **THEN** all General and Limits fields are reachable through one internal vertical scroll region
+- **AND** the dialog header and footer remain outside the scroll region
+
+#### Scenario: Larger compact and desktop layouts remain responsive
+
+- **WHEN** an operator opens Create API Key at 390x844 or a desktop viewport
+- **THEN** the dialog remains inside the viewport with its primary controls visible
+- **AND** the form is stacked below the desktop breakpoint and uses two columns at the desktop breakpoint
+
+#### Scenario: Existing dismissal behavior is preserved
+
+- **WHEN** an operator presses Escape or activates the dialog overlay while no nested menu surface is active
+- **THEN** the create dialog closes through the shared Dialog primitive

--- a/openspec/changes/fix-compact-api-key-dialog/tasks.md
+++ b/openspec/changes/fix-compact-api-key-dialog/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add a focused browser regression that proves the viewport-bounded dialog shell, one shrinking internal scroll region, persistent controls, field reachability, and dismissal behavior.
+- [x] 1.2 Run the focused regression against the baseline layout and record that it fails before the implementation change.
+
+## 2. Dialog layout
+
+- [x] 2.1 Convert the API key create dialog to the established viewport-bounded flex-column shell with persistent header and footer.
+- [x] 2.2 Move the existing responsive form grid into one `min-h-0` internal scroller and remove the two independent column scroll constraints without changing fields or submission behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused component tests and affected frontend format, lint, and typecheck subsets.
+- [x] 3.2 Validate the scoped OpenSpec change and verify implementation completeness, correctness, and coherence.
+- [x] 3.3 Exercise the real `/apis` create dialog at 320x568, 390x844, and desktop, including internal scrolling plus overlay and Escape dismissal, and capture honest before/after browser evidence.


### PR DESCRIPTION
## Summary

Keep the Create API Key dialog usable on compact dashboard viewports by constraining its shell to the viewport and scrolling the form body instead of the whole dialog. This keeps the title, Close control, and Create action visible while preserving the existing desktop columns and dismissal behavior.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None found. Related work: #1198 is closed/superseded and concerns nested portal-menu dismissal rather than viewport layout; it is not a prerequisite.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/fix-compact-api-key-dialog/`

## Changes

- Reuse the established viewport-bounded flex dialog shell with a persistent header and footer.
- Put the existing responsive form grid in one `min-h-0` internal scroller, removing the two independent `55vh` column scrollers.
- Add a focused built-dashboard browser regression for viewport bounds, the single scroll owner, field reachability, persistent controls, Escape dismissal, and overlay dismissal.

## Test plan

```text
bun run test -- src/features/api-keys/components/api-key-create-dialog.test.tsx src/__integration__/apis-page-flow.test.tsx
# 2 files, 17 tests passed

bunx eslint src/features/api-keys/components/api-key-create-dialog.tsx src/features/api-keys/components/api-key-create-dialog.test.tsx browser-smoke/dashboard.spec.ts
bun run typecheck
openspec validate fix-compact-api-key-dialog --type change --strict
PYTHONPATH="$PWD" .venv/bin/python scripts/run_dashboard_browser_smoke.py
# 2 browser-smoke tests passed against the built dashboard and real local API
```

The final browser regression was also run against an immutable `d4b00fd0` source snapshot: it failed on the compact dialog bound (`top=-55.51`, expected `>= 0`) before the fix and passes at this head.

Real Chromium checks with deterministic mocked API data:

| Viewport | Observable result |
| --- | --- |
| 320x568 | Dialog moved from `top=-72.70, bottom=640.70` to `top=16, bottom=552`; title, 16x16 Close, and Create are fully inside the viewport. Exactly one body scroller has a 786px range; at maximum scroll the final Weekly cost field ends at y=466 while Create remains at y=499–535. |
| 390x844 | Dialog is y=16–828 with title, Close, and Create visible; one scroller; form grid remains stacked (`308px`). |
| 1440x900 | Dialog is y=16–884 with title, Close, and Create visible; one scroller; form grid remains two columns (`347px 347px`). |

Escape and a real pointer click on the visible side overlay both dismissed the dialog.

Not run locally: full local CI. GitHub required CI is the integration gate. The unchanged main `frontend-architecture` spec has two pre-existing strict-validation errors for requirements without SHALL/MUST; the scoped change above validates strictly.

## Screenshots / output

| Before — 320x568 | After — 320x568 |
| --- | --- |
| ![Before: compact dialog extends beyond the 320x568 viewport](https://github.com/user-attachments/assets/df92c4c3-1736-41e2-966d-7c2140c24865) | ![After: compact dialog controls remain inside the 320x568 viewport](https://github.com/user-attachments/assets/5369af88-d287-43f5-b8a6-a0256f66622a) |

After scrolling the single form body to the final fields, with the header and Create footer still visible:

![After scrolling: final fields are reachable while the header and Create footer remain visible](https://github.com/user-attachments/assets/d2c0170a-b62d-4a26-87c6-b227044438a8)

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Related-work evidence is documented above; no matching issue exists.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused local subsets instead of full local CI.
- [x] Scoped strict OpenSpec validation passes and implementation verification is clean.
- [x] Simplicity gates reviewed: no setting, setup step, README section, `.env.example` entry, dashboard nav item, or default changed.
- [x] `CHANGELOG.md` is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the API key creation dialog on compact screens.
  - Keeps the title, form controls, and Create action accessible within the viewport.
  - Added a consistent internal scroll area while preserving responsive layouts.
  - Maintains Escape-key and outside-click dismissal behavior.
  - Preserved the desktop two-column layout and existing field interactions.

- **Tests**
  - Added responsive browser coverage for mobile and desktop viewports, scrolling, layout boundaries, and dialog dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->