### PR TITLE
fix(proxy): own cancellable usage refresh sessions

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -222,6 +222,7 @@ async def _proxy_repo_context() -> AsyncIterator[ProxyRepositories]:
             additional_usage=AdditionalUsageRepository(session),
             quota_planner=QuotaPlannerRepository(session),
             capability_lineage=CapabilityLineageRepository(session),
+            session=session,
         )
 
 

--- a/app/modules/proxy/_service/rate_limit.py
+++ b/app/modules/proxy/_service/rate_limit.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Protocol, cast
 from app.core import usage as usage_core
 from app.core.usage.types import UsageWindowRow
 from app.db.models import Account, UsageHistory
+from app.db.session import detach_session_objects
+from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.proxy.helpers import (
     _credits_headers,
     _credits_snapshot,
@@ -26,6 +28,7 @@ from app.modules.proxy.types import (
     RateLimitWindowSnapshotData,
 )
 from app.modules.usage.additional_quota_keys import get_additional_display_label_for_quota_key
+from app.modules.usage.background_repository import BackgroundAdditionalUsageRepository, BackgroundUsageRepository
 from app.modules.usage.mappers import usage_history_to_window_row
 from app.modules.usage.updater import UsageUpdater
 
@@ -130,11 +133,19 @@ class _RateLimitMixin:
         proxy = cast(_RateLimitServiceProtocol, self)
         async with proxy._repo_factory() as repos:
             accounts = await repos.accounts.list_accounts()
-            await self._refresh_usage(repos, accounts)
+            latest_usage = await repos.usage.latest_by_account(window="primary")
+            if repos.session is not None:
+                detach_session_objects(repos.session)
+
+        # Do not hold the request session while an owned refresh checks out its
+        # background session; pool_size=1 must still make progress.
+        await self._refresh_usage(accounts, latest_usage)
+
+        async with proxy._repo_factory() as repos:
+            accounts = await repos.accounts.list_accounts()
             selected_accounts = _select_accounts_for_limits(accounts)
             if not selected_accounts:
                 return RateLimitStatusPayloadData(plan_type="guest")
-
             account_map = {account.id: account for account in selected_accounts}
             primary_rows_raw = await self._latest_usage_rows(repos, account_map, "primary")
             secondary_rows_raw = await self._latest_usage_rows(repos, account_map, "secondary")
@@ -176,10 +187,22 @@ class _RateLimitMixin:
                 additional_rate_limits=additional_rate_limits,
             )
 
-    async def _refresh_usage(self, repos: ProxyRepositories, accounts: list[Account]) -> None:
-        latest_usage = await repos.usage.latest_by_account(window="primary")
-        updater = UsageUpdater(repos.usage, repos.accounts, repos.additional_usage)
-        await updater.refresh_accounts(accounts, latest_usage)
+    async def _refresh_usage(
+        self,
+        accounts: list[Account],
+        latest_usage: Mapping[str, UsageHistory],
+    ) -> None:
+        updater = UsageUpdater(
+            BackgroundUsageRepository(),
+            BackgroundAccountsRepository(),
+            BackgroundAdditionalUsageRepository(),
+        )
+        await updater.refresh_accounts(
+            accounts,
+            latest_usage,
+            own_singleflight_sessions=True,
+            join_existing=True,
+        )
 
     async def _latest_usage_rows(
         self,

--- a/app/modules/proxy/repo_bundle.py
+++ b/app/modules/proxy/repo_bundle.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import AsyncContextManager
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy.capability_lineage_repository import CapabilityLineageRepository
@@ -23,6 +25,7 @@ class ProxyRepositories:
     additional_usage: AdditionalUsageRepository
     quota_planner: QuotaPlannerRepository | None = None
     capability_lineage: CapabilityLineageRepository | None = None
+    session: AsyncSession | None = None
 
 
 ProxyRepoFactory = Callable[[], AsyncContextManager[ProxyRepositories]]

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -31,7 +31,6 @@ from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
 from app.modules.accounts.background_repository import BackgroundAccountsRepository
-from app.modules.accounts.repository import AccountsRepository as SessionAccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
 from app.modules.usage.background_repository import BackgroundAdditionalUsageRepository, BackgroundUsageRepository
@@ -42,7 +41,6 @@ from app.modules.usage.plan_downgrade_observations import (
     get_plan_downgrade_observation_store,
 )
 from app.modules.usage.repository import AdditionalUsageRepository, UsageWindowWrite
-from app.modules.usage.repository import UsageRepository as SessionUsageRepository
 
 logger = logging.getLogger(__name__)
 
@@ -276,11 +274,23 @@ class UsageUpdater:
         latest_usage: Mapping[str, UsageHistory],
         *,
         own_singleflight_sessions: bool = False,
+        join_existing: bool | None = None,
     ) -> bool:
-        """Refresh usage for all accounts. Returns True if usage rows were written."""
+        """Refresh usage for all accounts. Returns True if usage rows were written.
+
+        ``own_singleflight_sessions`` makes each detached singleflight refresh
+        acquire and release its own DB session instead of using this updater's
+        caller-bound repositories. ``join_existing`` controls whether a caller
+        joins an in-flight refresh for the same key (deduplication) or waits
+        and forces a fresh one; it defaults to the historical coupling
+        ``not own_singleflight_sessions`` so existing callers keep their
+        semantics.
+        """
         settings = get_settings()
         if not settings.usage_refresh_enabled:
             return False
+        if join_existing is None:
+            join_existing = not own_singleflight_sessions
 
         refreshed = False
         now = utcnow()
@@ -349,9 +359,9 @@ class UsageUpdater:
                         own_singleflight_session=own_singleflight_sessions,
                     ),
                     refresh_factory,
-                    join_existing=not own_singleflight_sessions,
+                    join_existing=join_existing,
                 )
-                if not own_singleflight_sessions:
+                if join_existing:
                     await self._sync_account_from_repo(account)
                 refreshed = refreshed or result.usage_written
                 # Only cache when the upstream fetch actually succeeded.
@@ -518,28 +528,26 @@ class UsageUpdater:
     ) -> AccountRefreshResult:
         @contextlib.asynccontextmanager
         async def refresh_repo_factory():
-            async with get_background_session() as refresh_session:
-                yield SessionAccountsRepository(refresh_session)
+            yield BackgroundAccountsRepository()
 
-        async with get_background_session() as session:
-            accounts_repo = SessionAccountsRepository(session)
-            usage_repo = SessionUsageRepository(session)
-            additional_usage_repo = AdditionalUsageRepository(session)
-            account = await accounts_repo.get_by_id(account_id)
-            if account is None:
-                return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
-            if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
-                return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
-            return await UsageUpdater(
-                usage_repo,
-                accounts_repo,
-                additional_usage_repo,
-                auth_manager=AuthManager(accounts_repo, refresh_repo_factory=refresh_repo_factory),
-            )._refresh_account_if_stale(
-                account,
-                usage_account_id=account.chatgpt_account_id,
-                interval_seconds=interval_seconds,
-            )
+        accounts_repo = BackgroundAccountsRepository()
+        usage_repo = BackgroundUsageRepository()
+        additional_usage_repo = BackgroundAdditionalUsageRepository()
+        account = await accounts_repo.get_by_id(account_id)
+        if account is None:
+            return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+        if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+            return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+        return await UsageUpdater(
+            usage_repo,
+            accounts_repo,
+            additional_usage_repo,
+            auth_manager=AuthManager(accounts_repo, refresh_repo_factory=refresh_repo_factory),
+        )._refresh_account_if_stale(
+            account,
+            usage_account_id=account.chatgpt_account_id,
+            interval_seconds=interval_seconds,
+        )
 
     async def _refresh_account(
         self,
@@ -911,7 +919,9 @@ class UsageUpdater:
     async def _sync_account_from_repo(self, account: Account) -> None:
         if not self._accounts_repo:
             return
-        stored = await self._accounts_repo.get_by_id(account.id)
+        # Joined owned-session refreshes run in a different session.  A plain
+        # get_by_id() can return the caller session's stale identity-map row.
+        stored = await self._accounts_repo.get_by_id_fresh(account.id)
         if stored is None:
             return
         account.chatgpt_account_id = stored.chatgpt_account_id

--- a/openspec/changes/fix-proxy-usage-refresh-owned-sessions/proposal.md
+++ b/openspec/changes/fix-proxy-usage-refresh-owned-sessions/proposal.md
@@ -1,0 +1,11 @@
+# Own proxy usage refresh sessions
+
+Proxy usage payload refreshes must remain safe when the request task is cancelled
+and must not retain a database session across upstream usage I/O.
+
+## Scope
+
+- Detach rows loaded for the pre-refresh decision before closing the request-adjacent repository scope.
+- Keep refresh reads and writes on caller-independent background sessions.
+- Reopen the repository scope only for post-refresh payload reads.
+- Add route-level regression coverage for cancellation and detached-row safety.

--- a/openspec/changes/fix-proxy-usage-refresh-owned-sessions/specs/database-backends/spec.md
+++ b/openspec/changes/fix-proxy-usage-refresh-owned-sessions/specs/database-backends/spec.md
@@ -1,0 +1,27 @@
+# database-backends Delta
+
+## ADDED Requirements
+
+### Requirement: Proxy usage refresh does not retain sessions across upstream I/O
+
+The public proxy usage payload path MUST detach rows loaded for its initial
+refresh decision before closing the request-adjacent repository scope. An owned
+usage refresh MUST use caller-independent short-lived repositories for freshness
+reads, upstream fetches, and required writes; it MUST NOT retain an
+`AsyncSession` while waiting for upstream usage I/O. The payload path MUST
+reopen a repository scope only after the refresh completes.
+
+#### Scenario: cancelled usage request closes its initial scope
+
+- **GIVEN** `/api/codex/usage` starts an owned usage refresh
+- **WHEN** the client request is cancelled while the refresh is in flight
+- **THEN** the initial repository scope is closed before the owned refresh runs
+- **AND** the owned refresh remains caller-independent and may finish safely
+- **AND** the payload-read repository scope is not reopened by the cancelled request
+
+#### Scenario: usage refresh releases its session during upstream fetch
+
+- **GIVEN** an owned usage refresh needs to fetch usage from an upstream service
+- **WHEN** the upstream request is in flight
+- **THEN** no database session remains checked out for that refresh's read/write work
+- **AND** the refresh reacquires short-lived sessions only for required database operations

--- a/openspec/changes/fix-proxy-usage-refresh-owned-sessions/tasks.md
+++ b/openspec/changes/fix-proxy-usage-refresh-owned-sessions/tasks.md
@@ -1,0 +1,17 @@
+## 1. Session Lifetime
+
+- [x] 1.1 Detach pre-refresh ORM rows before closing the request-adjacent repository scope.
+- [x] 1.2 Run owned usage refresh reads and writes through short-lived background repositories without retaining a session across upstream I/O.
+- [x] 1.3 Preserve caller-independent singleflight ownership when the public usage request is cancelled.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add payload-scope detachment coverage.
+- [x] 2.2 Add public `/api/codex/usage` cancellation coverage that verifies the initial scope closes and no payload-read scope reopens.
+- [x] 2.3 Preserve owned refresh completion after caller cancellation.
+
+## 3. Verification
+
+- [x] 3.1 Run focused usage updater, rate-limit, and Codex usage integration tests.
+- [x] 3.2 Run changed-file Ruff and type checks.
+- [x] 3.3 Validate the OpenSpec delta strictly.

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
 from datetime import timedelta, timezone
 
 import pytest
@@ -11,6 +13,7 @@ from app.core.usage.models import UsagePayload
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
 from app.db.session import SessionLocal
+from app.dependencies import get_proxy_service_for_app
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
@@ -907,3 +910,89 @@ async def test_codex_usage_reset_consume_rejects_empty_redeem_request_id(async_c
     )
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "invalid_request_error"
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_cancellation_closes_initial_scope_without_reopening(
+    async_client,
+    app_instance,
+    monkeypatch: pytest.MonkeyPatch,
+    db_setup,
+):
+    del db_setup
+    account_id = "acc_usage_cancel"
+    chatgpt_account_id = "workspace_usage_cancel"
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(
+            _make_account(
+                account_id,
+                "usage-cancel@example.com",
+                chatgpt_account_id=chatgpt_account_id,
+            )
+        )
+        await usage_repo.add_entry(
+            account_id,
+            10.0,
+            window="primary",
+            reset_at=int(utcnow().timestamp()) + 300,
+            window_minutes=300,
+        )
+
+    service = get_proxy_service_for_app(app_instance)
+    original_factory = service._repo_factory
+    scope_depth = 0
+    scope_depths_during_refresh: list[int] = []
+    refresh_started = asyncio.Event()
+    release_owned_refresh = asyncio.Event()
+    owned_tasks: list[asyncio.Task[None]] = []
+
+    @asynccontextmanager
+    async def tracking_factory():
+        nonlocal scope_depth
+        scope_depth += 1
+        try:
+            async with original_factory() as repos:
+                yield repos
+        finally:
+            scope_depth -= 1
+
+    async def fake_refresh_usage(accounts, latest_usage) -> None:
+        del accounts, latest_usage
+        scope_depths_during_refresh.append(scope_depth)
+        refresh_started.set()
+
+        async def owned_refresh() -> None:
+            await release_owned_refresh.wait()
+
+        owned_task = asyncio.create_task(owned_refresh())
+        owned_tasks.append(owned_task)
+        await asyncio.shield(owned_task)
+
+    monkeypatch.setattr(service, "_repo_factory", tracking_factory)
+    monkeypatch.setattr(service, "_refresh_usage", fake_refresh_usage)
+
+    request_task = asyncio.create_task(
+        async_client.get(
+            "/api/codex/usage",
+            headers={
+                "Authorization": "Bearer chatgpt-token",
+                "chatgpt-account-id": chatgpt_account_id,
+            },
+        )
+    )
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    try:
+        assert scope_depths_during_refresh == [0]
+        assert scope_depth == 0
+        assert len(owned_tasks) == 1
+        assert not owned_tasks[0].done()
+    finally:
+        release_owned_refresh.set()
+        for owned_task in owned_tasks:
+            await asyncio.wait_for(owned_task, timeout=1)

--- a/tests/unit/test_proxy_rate_limit.py
+++ b/tests/unit/test_proxy_rate_limit.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import TypeVar, cast
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts.repository import AccountsRepository
@@ -17,6 +18,7 @@ from app.modules.proxy.sticky_repository import StickySessionsRepository
 from app.modules.quota_planner.repository import QuotaPlannerRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+from app.modules.usage.updater import UsageUpdater
 
 pytestmark = pytest.mark.unit
 
@@ -42,6 +44,14 @@ class _SharedSessionGuard:
             return result
         finally:
             self.in_flight -= 1
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.expunge_all_calls = 0
+
+    def expunge_all(self) -> None:
+        self.expunge_all_calls += 1
 
 
 class _GuardedAccountsRepository:
@@ -81,9 +91,18 @@ class _TestRateLimitService(_RateLimitMixin):
         self._repo_factory = repo_factory
         self.refresh_calls = 0
 
-    async def _refresh_usage(self, repos: ProxyRepositories, accounts: list[Account]) -> None:
-        del repos, accounts
+    async def _refresh_usage(
+        self,
+        accounts: list[Account],
+        latest_usage: Mapping[str, UsageHistory],
+    ) -> None:
+        del accounts, latest_usage
         self.refresh_calls += 1
+
+
+class _RefreshRateLimitService(_RateLimitMixin):
+    def __init__(self, repo_factory: ProxyRepoFactory) -> None:
+        self._repo_factory = repo_factory
 
 
 def _account(account_id: str, *, plan_type: str) -> Account:
@@ -124,7 +143,7 @@ def _usage(
     )
 
 
-def _service_and_guard() -> tuple[_TestRateLimitService, _SharedSessionGuard]:
+def _service_and_guard(*, session: _FakeSession | None = None) -> tuple[_TestRateLimitService, _SharedSessionGuard]:
     guard = _SharedSessionGuard()
     plus_account = _account("plus", plan_type="plus")
     free_account = _account("free", plan_type="free")
@@ -176,6 +195,7 @@ def _service_and_guard() -> tuple[_TestRateLimitService, _SharedSessionGuard]:
                 _GuardedAdditionalUsageRepository(guard),
             ),
             quota_planner=cast(QuotaPlannerRepository, object()),
+            session=cast(AsyncSession, session),
         )
 
     return _TestRateLimitService(repo_factory), guard
@@ -223,6 +243,8 @@ async def test_rate_limit_payload_serializes_usage_reads(monkeypatch: pytest.Mon
     assert guard.calls == [
         "accounts",
         "usage:primary",
+        "accounts",
+        "usage:primary",
         "usage:secondary",
         "usage:monthly",
         "additional:list_limit_names",
@@ -247,3 +269,42 @@ async def test_rate_limit_payload_serializes_usage_reads(monkeypatch: pytest.Mon
     assert payload.credits.unlimited is False
     assert payload.credits.balance == "8.75"
     assert payload.additional_rate_limits == []
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_payload_detaches_pre_refresh_rows() -> None:
+    session = _FakeSession()
+    service, _ = _service_and_guard(session=session)
+
+    await service.get_rate_limit_payload()
+
+    assert session.expunge_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_usage_refresh_owns_and_joins_singleflight_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_service, _ = _service_and_guard()
+    service = _RefreshRateLimitService(base_service._repo_factory)
+    account = _account("plus", plan_type="plus")
+    captured: dict[str, object] = {}
+
+    async def capture_refresh(
+        self,
+        accounts: list[Account],
+        latest_usage: dict[str, UsageHistory],
+        **kwargs: object,
+    ) -> bool:
+        del self
+        captured["accounts"] = accounts
+        captured["latest_usage"] = latest_usage
+        captured.update(kwargs)
+        return False
+
+    monkeypatch.setattr(UsageUpdater, "refresh_accounts", capture_refresh)
+
+    await service._refresh_usage([account], {})
+
+    assert captured["own_singleflight_sessions"] is True
+    assert captured["join_existing"] is True

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -6,7 +6,7 @@ from collections.abc import Collection
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -82,6 +82,8 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     account = _make_account("acc_owned_session", "workspace_owned")
+    stored_account = _make_account("acc_owned_session", "workspace_owned")
+    stored_account.status = AccountStatus.PAUSED
     refresh_started = asyncio.Event()
     allow_refresh_finish = asyncio.Event()
     non_owned_started = asyncio.Event()
@@ -126,26 +128,25 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
             return []
 
     class InnerUsageRepository(OuterUsageRepository):
-        def __init__(self, session) -> None:
-            self.session = session
+        pass
 
     class InnerAdditionalUsageRepository:
-        def __init__(self, session) -> None:
-            self.session = session
-
-    class InnerAccountsRepository:
-        def __init__(self, session) -> None:
-            self.session = session
-
-        async def get_by_id(self, account_id: str):
-            return account if account_id == account.id else None
+        pass
 
     @asynccontextmanager
-    async def recording_background_session():
+    async def owned_session_scope():
         try:
-            yield object()
+            yield
         finally:
             inner_session_closed.set()
+
+    class InnerAccountsRepository:
+        async def get_by_id(self, account_id: str):
+            async with owned_session_scope():
+                return account if account_id == account.id else None
+
+        async def get_by_id_fresh(self, account_id: str):
+            return stored_account if account_id == account.id else None
 
     async def fake_refresh_account_if_stale(
         self,
@@ -159,10 +160,9 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
         session_was_open_during_refresh.append(not inner_session_closed.is_set())
         return usage_updater_module.AccountRefreshResult(usage_written=True)
 
-    monkeypatch.setattr(usage_updater_module, "get_background_session", recording_background_session)
-    monkeypatch.setattr(usage_updater_module, "SessionAccountsRepository", InnerAccountsRepository)
-    monkeypatch.setattr(usage_updater_module, "SessionUsageRepository", InnerUsageRepository)
-    monkeypatch.setattr(usage_updater_module, "AdditionalUsageRepository", InnerAdditionalUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAccountsRepository", InnerAccountsRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundUsageRepository", InnerUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAdditionalUsageRepository", InnerAdditionalUsageRepository)
     monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fake_refresh_account_if_stale)
     monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
 
@@ -191,6 +191,7 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
             [account],
             {},
             own_singleflight_sessions=True,
+            join_existing=True,
         )
     )
     await asyncio.wait_for(refresh_started.wait(), timeout=1)
@@ -200,13 +201,92 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
         await task
     await asyncio.sleep(0)
 
-    assert not inner_session_closed.is_set()
+    assert inner_session_closed.is_set()
     allow_refresh_finish.set()
-    await asyncio.wait_for(inner_session_closed.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert session_was_open_during_refresh == [False]
     allow_non_owned_finish.set()
     await non_owned_task
     await prefixed_non_owned_task
-    assert session_was_open_during_refresh == [True]
+    assert session_was_open_during_refresh == [False]
+
+
+@pytest.mark.parametrize(
+    ("join_existing", "expected_calls"),
+    [(True, 1), (False, 2)],
+)
+@pytest.mark.asyncio
+async def test_refresh_accounts_owned_session_join_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    join_existing: bool,
+    expected_calls: int,
+) -> None:
+    account = _make_account("acc_owned_join_policy", "workspace_owned_join_policy")
+    stored_account = _make_account("acc_owned_join_policy", "workspace_owned_join_policy")
+    stored_account.status = AccountStatus.PAUSED
+    started = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+
+    @dataclass(frozen=True, slots=True)
+    class Settings:
+        usage_refresh_enabled: bool = True
+        usage_refresh_interval_seconds: int = 0
+        usage_refresh_auth_failure_cooldown_seconds: int = 0
+
+    class AccountsRepo:
+        async def get_by_id(self, account_id: str):
+            return account if account_id == account.id else None
+
+        async def get_by_id_fresh(self, account_id: str):
+            return stored_account if account_id == account.id else None
+
+    async def fake_owned_refresh(
+        self: UsageUpdater,
+        account_id: str,
+        *,
+        interval_seconds: int,
+    ) -> usage_updater_module.AccountRefreshResult:
+        nonlocal refresh_calls
+        assert self is not None
+        assert account_id == account.id
+        assert interval_seconds == 0
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=False)
+
+    monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
+    monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale_with_owned_session", fake_owned_refresh)
+
+    updater = UsageUpdater(
+        StubUsageRepository(),
+        cast(usage_updater_module.AccountsRepositoryPort, AccountsRepo()),
+    )
+    first = asyncio.create_task(
+        updater.refresh_accounts(
+            [account],
+            {},
+            own_singleflight_sessions=True,
+            join_existing=join_existing,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    second = asyncio.create_task(
+        updater.refresh_accounts(
+            [account],
+            {},
+            own_singleflight_sessions=True,
+            join_existing=join_existing,
+        )
+    )
+
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert refresh_calls == expected_calls
+    if join_existing:
+        assert account.status == AccountStatus.PAUSED
 
 
 @pytest.mark.asyncio
@@ -253,23 +333,17 @@ async def test_owned_singleflight_reload_skips_account_that_became_ineligible(
             return []
 
     class InnerUsageRepository(OuterUsageRepository):
-        def __init__(self, session) -> None:
-            self.session = session
+        pass
 
     class InnerAdditionalUsageRepository:
-        def __init__(self, session) -> None:
-            self.session = session
+        pass
 
     class InnerAccountsRepository:
-        def __init__(self, session) -> None:
-            self.session = session
-
         async def get_by_id(self, account_id: str):
             return account if account_id == account.id else None
 
-    @asynccontextmanager
-    async def background_session():
-        yield object()
+        async def get_by_id_fresh(self, account_id: str):
+            return account if account_id == account.id else None
 
     async def fail_if_refreshed(
         self,
@@ -282,10 +356,9 @@ async def test_owned_singleflight_reload_skips_account_that_became_ineligible(
         refresh_called = True
         return usage_updater_module.AccountRefreshResult(usage_written=True)
 
-    monkeypatch.setattr(usage_updater_module, "get_background_session", background_session)
-    monkeypatch.setattr(usage_updater_module, "SessionAccountsRepository", InnerAccountsRepository)
-    monkeypatch.setattr(usage_updater_module, "SessionUsageRepository", InnerUsageRepository)
-    monkeypatch.setattr(usage_updater_module, "AdditionalUsageRepository", InnerAdditionalUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAccountsRepository", InnerAccountsRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundUsageRepository", InnerUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAdditionalUsageRepository", InnerAdditionalUsageRepository)
     monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fail_if_refreshed)
     monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
 


### PR DESCRIPTION
## Problem
Client-cancellable rate-limit refreshes used caller-bound repositories while running singleflight work, and joined owned refreshes could leave account state stale.

## Solution
- Run rate-limit refreshes with caller-independent owned repositories and joined owned-session singleflight.
- Release the request repository scope before the owned refresh, then reopen it only for payload reads.
- Detach pre-refresh ORM rows and synchronize account state after joined refreshes.
- Add public-route cancellation, session-lifetime, join-policy, account-sync, and rate-limit regressions.

## Verification
- Focused updater, rate-limit, and Codex usage integration tests pass
- Ruff and `uv run ty check` pass
- `openspec validate fix-proxy-usage-refresh-owned-sessions --strict` passes
- Current-head CI Required, unit, PostgreSQL, integration shards, bridge, e2e, package, migration, Docker, and type checks pass

OpenSpec: `openspec/changes/fix-proxy-usage-refresh-owned-sessions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy usage refresh reliability during cancellations and concurrent requests.
  * Prevented stale account and usage data during refreshes.
  * Ensured database sessions are safely released during upstream usage checks and reopened only when needed.
  * Improved coordination of overlapping refreshes to avoid duplicate work.

* **Tests**
  * Added coverage for cancellation, concurrent refreshes, session handling, and Codex usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->