### PR TITLE
fix(api-keys): preserve usage on limit patches

### DIFF
--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -462,10 +462,17 @@ class ApiKeysRepository:
             await self._session.refresh(parent, attribute_names=["limits"])
         return await self.get_limits_by_key(key_id)
 
-    async def upsert_limits(self, key_id: str, limits: list[ApiKeyLimit], *, commit: bool = True) -> list[ApiKeyLimit]:
+    async def upsert_limits(
+        self,
+        key_id: str,
+        limits: list[ApiKeyLimit],
+        *,
+        commit: bool = True,
+        preserve_matched_usage: bool = False,
+    ) -> list[ApiKeyLimit]:
         existing = await self.get_limits_by_key(key_id)
         existing_by_key = {_limit_key(limit): limit for limit in existing}
-        incoming_keys = {_limit_key(limit) for limit in limits}
+        incoming_keys = {_limit_key(incoming) for incoming in limits}
 
         for incoming in limits:
             key = _limit_key(incoming)
@@ -475,8 +482,9 @@ class ApiKeysRepository:
                 self._session.add(incoming)
                 continue
             matched.max_value = incoming.max_value
-            matched.current_value = incoming.current_value
-            matched.reset_at = incoming.reset_at
+            if not preserve_matched_usage:
+                matched.current_value = incoming.current_value
+                matched.reset_at = incoming.reset_at
 
         for old_limit in existing:
             if _limit_key(old_limit) not in incoming_keys:

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -113,7 +113,12 @@ class ApiKeysRepositoryProtocol(Protocol):
     async def replace_limits(self, key_id: str, limits: list[ApiKeyLimit]) -> list[ApiKeyLimit]: ...
 
     async def upsert_limits(
-        self, key_id: str, limits: list[ApiKeyLimit], *, commit: bool = True
+        self,
+        key_id: str,
+        limits: list[ApiKeyLimit],
+        *,
+        commit: bool = True,
+        preserve_matched_usage: bool = False,
     ) -> list[ApiKeyLimit]: ...
     async def replace_account_assignments(
         self, key_id: str, account_ids: list[str], *, commit: bool = True
@@ -583,7 +588,13 @@ class ApiKeysService:
             for row in rows
         ]
 
-    async def update_key(self, key_id: str, payload: ApiKeyUpdateData) -> ApiKeyData:
+    async def update_key(
+        self,
+        key_id: str,
+        payload: ApiKeyUpdateData,
+        *,
+        _retry_attempt: int = 0,
+    ) -> ApiKeyData:
         expires_at = _normalize_expires_at(payload.expires_at) if payload.expires_at_set else None
         existing = await self._repository.get_by_id(key_id)
         if existing is None:
@@ -727,11 +738,20 @@ class ApiKeysService:
                 await self._repository.replace_source_assignments(key_id, assigned_source_ids, commit=False)
 
             if limit_rows is not None:
-                await self._repository.upsert_limits(key_id, limit_rows, commit=False)
+                await self._repository.upsert_limits(
+                    key_id,
+                    limit_rows,
+                    commit=False,
+                    preserve_matched_usage=not payload.reset_usage,
+                )
 
             await self._repository.commit()
         except Exception as exc:
             await self._repository.rollback()
+            if isinstance(exc, OperationalError) and _is_sqlite_database_locked(exc):
+                if _retry_attempt < _SQLITE_BUSY_RETRY_ATTEMPTS - 1:
+                    await asyncio.sleep(_SQLITE_BUSY_RETRY_BASE_SECONDS * (2**_retry_attempt))
+                    return await self.update_key(key_id, payload, _retry_attempt=_retry_attempt + 1)
             if isinstance(exc, IntegrityError) and _is_reasoning_policy_constraint_error(exc):
                 raise ApiKeyValidationError(
                     "enforced_reasoning_effort and allowed_reasoning_efforts cannot be configured together"
@@ -2005,6 +2025,8 @@ def _is_sqlite_database_locked(exc: OperationalError) -> bool:
         "database is locked" in message
         or "database table is locked" in message
         or "database schema is locked" in message
+        or "sqlite_busy_snapshot" in message
+        or "busy_snapshot" in message
     )
 
 

--- a/openspec/changes/fix-api-key-limit-patch-preserve-usage/proposal.md
+++ b/openspec/changes/fix-api-key-limit-patch-preserve-usage/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Updating an existing API-key limit can race with a reservation or lazy reset that commits newer `current_value` and `reset_at` state. The PATCH must change the submitted maximum without clearing that newer usage state, and SQLite snapshot conflicts must not turn the valid PATCH into a 500 response.
+
+## What Changes
+
+- Preserve matched limit usage and reset timestamps when a PATCH changes only the limit maximum.
+- Retry the complete API-key update transaction after a transient SQLite lock or snapshot conflict so the retry rereads current limit state.
+- Add route and service regression coverage for committed usage preservation and transient SQLite conflicts.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Define usage-preserving matched-limit PATCH behavior and transient SQLite retry semantics.
+
+## Impact
+
+The change is limited to API-key service/repository update behavior, focused API-key tests, and the API-key specification. It adds no API fields, settings, dependencies, or migrations.

--- a/openspec/changes/fix-api-key-limit-patch-preserve-usage/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-limit-patch-preserve-usage/specs/api-keys/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: API Key update
+
+The system SHALL allow updating key properties via `PATCH /api/api-keys/{id}`. Updatable fields: `name`, `allowedModels`, `weeklyTokenLimit`, `expiresAt`, `isActive`, `usageSections`, `transportPolicyOverride`; `resetUsage` is a supported non-persisted control option for submitted limits. The key hash and prefix MUST NOT be modifiable. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt` and normalize them to UTC naive before persistence. The `transportPolicyOverride` field MUST accept `null` (follow the global policy) or one of `"smart"`, `"always_http"`, `"always_websocket"`; any other value MUST be rejected with HTTP 400. When `resetUsage` is true, submitted limits MUST be initialized with `current_value: 0`.
+
+When a submitted API key limit rule matches an existing rule by `limit_type`, `limit_window`, and `model_filter`, updating the rule's maximum MUST preserve the latest committed `current_value` and `reset_at` unless `resetUsage` is true. A transient SQLite lock or snapshot conflict during the update MUST roll back and retry the complete read/build/write transaction, including rereading existing limits, before returning an error.
+
+When a submitted API key limit rule does not match an existing rule by `limit_type`, `limit_window`, and `model_filter`, the system MUST initialize the new rule's `current_value` from the API key's successful existing request-log usage in that rule's current window. If `resetUsage` is true, the system MUST initialize submitted limits with `current_value: 0`.
+
+#### Scenario: Preserve matched limit usage during PATCH
+
+- **GIVEN** an API key has a matched limit with committed `current_value` and `reset_at`
+- **WHEN** admin submits a PATCH that changes the matched limit's maximum without `resetUsage`
+- **THEN** the limit maximum is updated
+- **AND** the latest committed `current_value` and `reset_at` remain unchanged
+
+#### Scenario: Retry API-key PATCH after a transient SQLite snapshot conflict
+
+- **GIVEN** a concurrent reservation or lazy reset commits after the PATCH's initial read
+- **WHEN** the PATCH write encounters a transient SQLite lock or snapshot conflict
+- **THEN** the transaction is rolled back
+- **AND** the PATCH rereads current state and retries the complete update
+- **AND** the PATCH succeeds without clearing the concurrent usage state

--- a/openspec/changes/fix-api-key-limit-patch-preserve-usage/tasks.md
+++ b/openspec/changes/fix-api-key-limit-patch-preserve-usage/tasks.md
@@ -1,0 +1,14 @@
+## 1. Regression
+
+- [x] 1.1 Cover matched-limit PATCH preservation through the API route with committed usage and reset state.
+- [x] 1.2 Add deterministic service coverage for retrying a transient SQLite lock after rollback.
+
+## 2. Implementation
+
+- [x] 2.1 Preserve `current_value` and `reset_at` for matched limits unless `resetUsage` is requested.
+- [x] 2.2 Retry the complete API-key update read/build/write transaction after transient SQLite lock or snapshot-conflict errors.
+
+## 3. Verification
+
+- [x] 3.1 Run focused API-key unit and integration tests.
+- [x] 3.2 Run changed-file Ruff, format, type, and strict OpenSpec checks.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -24,7 +24,15 @@ from app.core.clients.proxy import ProxyResponseError
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
 from app.core.openai.models import OpenAIResponsePayload
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, ApiKeyUsageReservation, LimitWindow, RequestLog, UsageHistory
+from app.db.models import (
+    Account,
+    AccountStatus,
+    ApiKeyLimit,
+    ApiKeyUsageReservation,
+    LimitWindow,
+    RequestLog,
+    UsageHistory,
+)
 from app.db.session import SessionLocal
 from app.modules.api_keys.last_used_coalescer import get_api_key_last_used_coalescer
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -3550,6 +3558,62 @@ async def test_update_key_same_policy_and_max_change_preserve_usage_state(async_
         assert len(limits) == 1
         assert limits[0].current_value == 222
         assert limits[0].reset_at == original_reset_at
+        assert limits[0].max_value == 2000
+
+
+@pytest.mark.asyncio
+async def test_update_limits_preserves_usage_committed_between_read_and_patch(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "preserve-interleaved-usage",
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 1000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+    concurrent_value = 777
+    concurrent_reset_at = utcnow() + timedelta(hours=6)
+
+    original_get_limits = ApiKeysRepository.get_limits_by_key
+    read_count = 0
+
+    async def interleave_after_initial_read(self, key_id: str):
+        nonlocal read_count
+        limits = await original_get_limits(self, key_id)
+        read_count += 1
+        if read_count == 1:
+            async with SessionLocal() as concurrent_session:
+                await concurrent_session.execute(
+                    update(ApiKeyLimit)
+                    .where(ApiKeyLimit.api_key_id == key_id)
+                    .values(current_value=concurrent_value, reset_at=concurrent_reset_at)
+                )
+                await concurrent_session.commit()
+        return limits
+
+    monkeypatch.setattr(ApiKeysRepository, "get_limits_by_key", interleave_after_initial_read)
+
+    updated = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 2000},
+            ],
+        },
+    )
+    assert updated.status_code == 200
+
+    async with SessionLocal() as session:
+        limits = await ApiKeysRepository(session).get_limits_by_key(key_id)
+        assert len(limits) == 1
+        assert limits[0].current_value == concurrent_value
+        assert limits[0].reset_at == concurrent_reset_at
         assert limits[0].max_value == 2000
 
 

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 
-from app.db.models import LimitType, LimitWindow
+from app.db.models import ApiKeyLimit, LimitType, LimitWindow
 from app.modules.api_keys.repository import ApiKeyAccountCost, ApiKeysRepository
 
 pytestmark = pytest.mark.unit
@@ -47,6 +47,41 @@ async def test_reset_expired_limits_counts_successful_updates_without_rowcount()
     assert "RETURNING api_key_limits.id" in executed_sql[1]
     assert "RETURNING api_key_limits.id" in executed_sql[2]
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_limits_preserves_matched_usage_when_requested() -> None:
+    session = AsyncMock()
+    existing_reset_at = datetime(2026, 8, 22, 12, 0, 0)
+    existing = ApiKeyLimit(
+        id=101,
+        api_key_id="key_1",
+        limit_type=LimitType.TOTAL_TOKENS,
+        limit_window=LimitWindow.WEEKLY,
+        max_value=1_000,
+        current_value=725,
+        model_filter=None,
+        reset_at=existing_reset_at,
+    )
+    incoming = ApiKeyLimit(
+        api_key_id="key_1",
+        limit_type=LimitType.TOTAL_TOKENS,
+        limit_window=LimitWindow.WEEKLY,
+        max_value=2_000,
+        current_value=275,
+        model_filter=None,
+        reset_at=datetime(2026, 8, 29, 12, 0, 0),
+    )
+    session.execute.return_value = SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [existing]))
+    session.get.return_value = None
+    repo = ApiKeysRepository(session)
+
+    result = await repo.upsert_limits("key_1", [incoming], commit=False, preserve_matched_usage=True)
+
+    assert result == [existing]
+    assert existing.max_value == 2_000
+    assert existing.current_value == 725
+    assert existing.reset_at == existing_reset_at
 
 
 class TestUsage7dByAccount:

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -55,6 +55,7 @@ pytestmark = pytest.mark.unit
         "database is locked",
         "database table is locked",
         "database schema is locked",
+        "SQLITE_BUSY_SNAPSHOT",
     ],
 )
 def test_is_sqlite_database_locked_matches_transient_lock_messages(message: str) -> None:
@@ -222,7 +223,14 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
             row.limits = self._limits[key_id]
         return self._limits[key_id]
 
-    async def upsert_limits(self, key_id: str, limits: list[ApiKeyLimit], *, commit: bool = True) -> list[ApiKeyLimit]:
+    async def upsert_limits(
+        self,
+        key_id: str,
+        limits: list[ApiKeyLimit],
+        *,
+        commit: bool = True,
+        preserve_matched_usage: bool = False,
+    ) -> list[ApiKeyLimit]:
         del commit
         existing = self._limits.get(key_id, [])
         existing_by_key = {(limit.limit_type, limit.limit_window, limit.model_filter): limit for limit in existing}
@@ -233,8 +241,9 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
             matched = existing_by_key.get(key)
             if matched is not None:
                 matched.max_value = incoming.max_value
-                matched.current_value = incoming.current_value
-                matched.reset_at = incoming.reset_at
+                if not preserve_matched_usage:
+                    matched.current_value = incoming.current_value
+                    matched.reset_at = incoming.reset_at
                 updated.append(matched)
                 continue
             self._limit_id_seq += 1
@@ -1851,12 +1860,124 @@ async def test_update_key_normalizes_timezone_aware_expiry_to_utc_naive() -> Non
             expires_at_set=True,
         ),
     )
-
     assert updated.expires_at == datetime(2026, 4, 1, 12, 30, 0)
 
     stored = await repo.get_by_id(created.id)
     assert stored is not None
     assert stored.expires_at == datetime(2026, 4, 1, 12, 30, 0)
+
+
+@pytest.mark.asyncio
+async def test_update_key_limit_patch_preserves_matched_usage() -> None:
+    class _ConcurrentUsageRepo(_FakeApiKeysRepository):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inject_after_read = False
+            self.concurrent_reset_at = datetime(2026, 8, 22, 12, 0, 0)
+
+        async def upsert_limits(
+            self,
+            key_id: str,
+            limits: list[ApiKeyLimit],
+            *,
+            commit: bool = True,
+            preserve_matched_usage: bool = False,
+        ) -> list[ApiKeyLimit]:
+            if self.inject_after_read:
+                existing = self._limits[key_id][0]
+                existing.current_value = 725
+                existing.reset_at = self.concurrent_reset_at
+            return await super().upsert_limits(
+                key_id,
+                limits,
+                commit=commit,
+                preserve_matched_usage=preserve_matched_usage,
+            )
+
+    repo = _ConcurrentUsageRepo()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="limit-preservation-key",
+            allowed_models=None,
+            expires_at=None,
+            limits=[LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=1_000)],
+        )
+    )
+    limits = await repo.get_limits_by_key(created.id)
+    limits[0].current_value = 275
+    original_reset_at = limits[0].reset_at
+    repo.inject_after_read = True
+
+    await service.update_key(
+        created.id,
+        ApiKeyUpdateData(
+            limits=[LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=2_000)],
+            limits_set=True,
+        ),
+    )
+
+    stored = await repo.get_limits_by_key(created.id)
+    assert stored[0].max_value == 2_000
+    assert stored[0].current_value == 725
+    assert stored[0].reset_at == repo.concurrent_reset_at
+    assert stored[0].reset_at != original_reset_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lock_message", ["database is locked", "SQLITE_BUSY_SNAPSHOT"])
+async def test_update_key_retries_after_sqlite_snapshot_conflict(lock_message: str) -> None:
+    class _BusyPatchRepo(_FakeApiKeysRepository):
+        fail_next_commit = False
+
+        async def commit(self) -> None:
+            if self.fail_next_commit:
+                self.fail_next_commit = False
+                raise OperationalError("UPDATE api_keys", {}, Exception(lock_message))
+            await super().commit()
+
+    repo = _BusyPatchRepo()
+    service = ApiKeysService(repo)
+    created = await service.create_key(ApiKeyCreateData(name="busy-key", allowed_models=None))
+    repo.fail_next_commit = True
+
+    updated = await service.update_key(
+        created.id,
+        ApiKeyUpdateData(name="retried-key", name_set=True),
+    )
+
+    assert updated.name == "retried-key"
+    assert repo.commit_calls == 2
+    assert repo.rollback_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_update_key_limit_reset_still_clears_matched_usage() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="limit-reset-key",
+            allowed_models=None,
+            expires_at=None,
+            limits=[LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=1_000)],
+        )
+    )
+    limits = await repo.get_limits_by_key(created.id)
+    limits[0].current_value = 275
+
+    await service.update_key(
+        created.id,
+        ApiKeyUpdateData(
+            limits=[LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=2_000)],
+            limits_set=True,
+            reset_usage=True,
+        ),
+    )
+
+    stored = await repo.get_limits_by_key(created.id)
+    assert stored[0].max_value == 2_000
+    assert stored[0].current_value == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Updating an existing API-key limit can overwrite newer usage and reset state read by a concurrent reservation or lazy reset.

## Solution
- Preserve matched `current_value` and `reset_at` when changing a limit maximum unless `resetUsage` is requested.
- Retry the complete API-key update transaction after transient SQLite lock or snapshot conflicts.
- Cover route-level committed interleaving, service retry variants, repository semantics, explicit resets, and the normative OpenSpec delta.

## Verification
- `191 passed`: focused API-key unit and integration tests
- Ruff, `uv run ty check`, and strict OpenSpec validation passed
- Current-head CI Required, unit, PostgreSQL, integration shards, bridge, e2e, package, migration, Docker, and type checks pass

OpenSpec: `openspec/changes/fix-api-key-limit-patch-preserve-usage`