### PR TITLE
docs(observability): sync reasoning-aware TPS spec

### DIFF
--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -56,7 +56,13 @@ _TTFT_EVENT_TYPES = frozenset(
         "response.reasoning_text.delta",
     }
 )
-_TTFT_TOOL_DELTA_EVENT_TYPES = frozenset({"response.function_call_arguments.delta", "response.output_tool_call.delta"})
+_TTFT_TOOL_DELTA_EVENT_TYPES = frozenset(
+    {
+        "response.function_call_arguments.delta",
+        "response.output_tool_call.delta",
+        "response.custom_tool_call_input.delta",
+    }
+)
 _TTFT_REASONING_EVENT_TYPES = frozenset(
     {"response.reasoning_summary_text.delta", "response.reasoning_summary_text.done"}
 )
@@ -232,10 +238,16 @@ def _ttft_event_visible_at(
     if event_type in _TTFT_EVENT_TYPES:
         delta = payload.get("delta") if payload is not None else None
         return now if isinstance(delta, str) and bool(delta) else None
-    if event_type != "response.output_item.added" or not isinstance(payload, dict):
+    if event_type not in {"response.output_item.added", "response.output_item.done"} or not isinstance(payload, dict):
         return None
     item = payload.get("item")
-    return now if isinstance(item, dict) and item.get("type") in _TTFT_OUTPUT_ITEM_TYPES else None
+    if not isinstance(item, dict) or item.get("type") not in _TTFT_OUTPUT_ITEM_TYPES:
+        return None
+    if item.get("type") == "custom_tool_call":
+        meaningful = any(isinstance(item.get(key), str) and bool(item[key]) for key in ("input", "arguments"))
+    else:
+        meaningful = any(item.get(key) not in (None, "", {}) for key in ("operation", "patch", "input"))
+    return now if meaningful else None
 
 
 def _is_ttft_event(

--- a/openspec/changes/expand-ttft-output-events/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/expand-ttft-output-events/specs/proxy-runtime-observability/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Websocket responses capture request-log latency timings
 
-The websocket responses proxy path MUST record first-upstream-event, response-created, and first-token latency into the same request-log latency fields the HTTP bridge populates, so websocket request logs expose TTFT and generation speed. First-token latency MUST use the first token-bearing output delta, including text, refusal, reasoning-summary, function-call argument, and tool-call output deltas, or a custom/apply-patch tool-call `response.output_item.added` event when the tool protocol does not stream argument deltas. Recording MUST NOT change routing, failover, or the bytes returned to the client.
+The websocket responses proxy path MUST record first-upstream-event, response-created, and first-token latency into the same request-log latency fields the HTTP bridge populates, so websocket request logs expose TTFT and generation speed. First-token latency MUST use the first token-bearing output delta, including text, refusal, reasoning-summary, function-call argument, custom-tool input, and tool-call output deltas, or a custom/apply-patch tool-call `response.output_item.added` or `response.output_item.done` event only when the item contains meaningful tool-call payload content and the tool protocol does not stream argument deltas. Recording MUST NOT change routing, failover, or the bytes returned to the client.
 
 #### Scenario: Websocket text response records latency timings
 
@@ -13,7 +13,7 @@ The websocket responses proxy path MUST record first-upstream-event, response-cr
 
 #### Scenario: Websocket tool call records first-token latency
 
-- **GIVEN** a websocket responses request whose first token-bearing output is a function-call argument delta, tool-call output delta, or custom/apply-patch tool-call `response.output_item.added` event
+- **GIVEN** a websocket responses request whose first token-bearing output is a function-call argument delta, custom-tool input delta, tool-call output delta, or a custom/apply-patch tool-call `response.output_item.added` or `response.output_item.done` event with meaningful tool-call payload content when the tool protocol does not stream argument deltas
 - **WHEN** the proxy persists the request log
 - **THEN** the log has a non-null first-token latency value
 - **AND** the proxy forwards the upstream event unchanged
@@ -22,14 +22,14 @@ The websocket responses proxy path MUST record first-upstream-event, response-cr
 
 - **GIVEN** a responses request whose upstream has emitted only control events such as `response.created`
 - **WHEN** the proxy inspects the request timing
-- **THEN** first-token latency remains null until a token-bearing output delta arrives
+- **THEN** first-token latency remains null until a token-bearing output delta arrives, unless a meaningful custom/apply-patch completion event anchors TTFT for a completion-only tool protocol
 - **AND** a message, reasoning, or function-call `response.output_item.added` lifecycle event does not record first-token latency
 - **AND** reasoning-summary placeholder deltas that are stripped before delivery do not record first-token latency
-- **AND** metadata-only or empty tool-call delta events do not record first-token latency
+- **AND** metadata-only or empty tool-call delta and completion events do not record first-token latency
 
 ### Requirement: Dashboard TPS excludes reasoning tokens
 
-The dashboard request-log table and Reports median TPS MUST divide non-reasoning output tokens by elapsed generation time after TTFT. The displayed metric MUST remain named `TPS`.
+The dashboard request-log table and Reports median TPS MUST divide non-reasoning output tokens by elapsed generation time after TTFT. When reasoning-token usage is unknown, it MUST be treated as zero for this metric. Rows with missing or invalid timing inputs, or with non-positive non-reasoning output tokens, MUST remain blank in request-log TPS and be excluded from Reports medians. The displayed metric MUST remain named `TPS`.
 
 #### Scenario: Reasoning tokens are excluded from TPS
 
@@ -37,3 +37,15 @@ The dashboard request-log table and Reports median TPS MUST divide non-reasoning
 - **WHEN** the dashboard calculates TPS
 - **THEN** it displays `(200 - 40) / 0.8 = 200.0` TPS
 - **AND** Reports uses the same per-request numerator for daily median TPS
+
+#### Scenario: Unknown reasoning usage is treated as zero
+
+- **GIVEN** a request has output tokens, valid total latency and TTFT, but no reasoning-token usage
+- **WHEN** the dashboard calculates TPS
+- **THEN** it uses the full output-token count as non-reasoning output
+
+#### Scenario: Invalid speed samples are excluded
+
+- **GIVEN** a request is missing required timing fields, has total latency less than or equal to TTFT, or has zero or negative non-reasoning output tokens
+- **WHEN** the dashboard renders request logs or Reports calculates a daily median
+- **THEN** request-log TPS remains blank and the invalid row is excluded from the median

--- a/openspec/specs/proxy-runtime-observability/spec.md
+++ b/openspec/specs/proxy-runtime-observability/spec.md
@@ -509,14 +509,14 @@ select the PostgreSQL datasource in Grafana.
 
 ### Requirement: Dashboard request logs show generation speed
 
-The dashboard request-log table MUST show time to first token and output-token generation speed when the required latency and output-token fields are available. Generation speed MUST use output tokens divided by elapsed generation time after time to first token, not total input plus output tokens and not total request latency including TTFT.
+The dashboard request-log table MUST show time to first token and output-token generation speed when the required latency and output-token fields are available. Generation speed MUST use non-reasoning output tokens divided by elapsed generation time after time to first token, not total input plus output tokens and not total request latency including TTFT. When reasoning-token usage is unknown, it MUST be treated as zero for this metric. The displayed metric MUST remain named `TPS`.
 
-#### Scenario: TPS excludes TTFT and input tokens
+#### Scenario: TPS excludes TTFT, input tokens, and reasoning tokens
 
-- **GIVEN** a successful request log has 1,000 input tokens, 200 output tokens, 1,000 ms total latency, and 200 ms TTFT
+- **GIVEN** a successful request log has 1,000 input tokens, 200 output tokens, including 40 reasoning tokens, 1,000 ms total latency, and 200 ms TTFT
 - **WHEN** the dashboard renders request logs
 - **THEN** it shows TTFT as 200ms
-- **AND** it shows TPS as 250.0
+- **AND** it shows TPS as `(200 - 40) / 0.8 = 200.0`
 
 #### Scenario: missing speed inputs stay blank
 
@@ -524,9 +524,16 @@ The dashboard request-log table MUST show time to first token and output-token g
 - **WHEN** the dashboard renders request logs
 - **THEN** it does not show a misleading calculated TPS value
 
+#### Scenario: invalid speed inputs stay blank
+
+- **GIVEN** a request log has output tokens and latency fields
+- **AND** either total latency is less than or equal to TTFT or non-reasoning output tokens are zero or negative
+- **WHEN** the dashboard renders request logs
+- **THEN** it does not show a calculated TPS value
+
 ### Requirement: Reports show daily median generation speed trends
 
-The Reports dashboard MUST expose daily median TTFT, daily median TPS, and daily median queue-wait trends when request-log latency fields are available. Empty days and rows with no valid timing/speed inputs MUST render as zero in those trend charts. Daily TPS MUST median per-request output-token TPS after TTFT rather than use input tokens or include TTFT wait time. Daily queue wait MUST median per-request `latency_queue_ms` over rows where it is non-null.
+The Reports dashboard MUST expose daily median TTFT, daily median TPS, and daily median queue-wait trends when request-log latency fields are available. Empty days and rows with no valid timing/speed inputs MUST render as zero in those trend charts. Daily TPS MUST median per-request non-reasoning output-token TPS after TTFT rather than use input tokens or include TTFT wait time. Unknown reasoning-token usage MUST be treated as zero when deriving non-reasoning output tokens. Daily queue wait MUST median per-request `latency_queue_ms` over rows where it is non-null.
 
 #### Scenario: Daily speed charts use median valid request values
 
@@ -534,6 +541,12 @@ The Reports dashboard MUST expose daily median TTFT, daily median TPS, and daily
 - **WHEN** the dashboard renders Reports
 - **THEN** it shows a Time to First Token chart using median TTFT for the day
 - **AND** it shows a Tokens per Second chart using median per-request TPS for the day
+
+#### Scenario: Invalid daily speed samples are excluded
+
+- **GIVEN** a report day contains rows where total latency is less than or equal to TTFT or non-reasoning output tokens are zero or negative
+- **WHEN** the daily TPS median is calculated
+- **THEN** those rows are excluded from the median
 
 #### Scenario: Missing daily speed data is zero-filled
 
@@ -550,14 +563,29 @@ The Reports dashboard MUST expose daily median TTFT, daily median TPS, and daily
 
 ### Requirement: Websocket responses capture request-log latency timings
 
-The websocket responses proxy path MUST record first-upstream-event, response-created, and first-token latency into the same request-log latency fields the HTTP bridge populates, so websocket request logs expose TTFT and generation speed. Recording MUST NOT change routing, failover, or the bytes returned to the client.
+The websocket responses proxy path MUST record first-upstream-event, response-created, and first-token latency into the same request-log latency fields the HTTP bridge populates, so websocket request logs expose TTFT and generation speed. First-token latency MUST use the first token-bearing output delta, including text, refusal, reasoning-summary, function-call argument, custom-tool input, and tool-call output deltas, or a custom/apply-patch tool-call `response.output_item.added` or `response.output_item.done` event only when the item contains meaningful tool-call payload content and the tool protocol does not stream argument deltas. Recording MUST NOT change routing, failover, or the bytes returned to the client.
 
-#### Scenario: Websocket request log records latency timings
+#### Scenario: Websocket text response records latency timings
 
 - **GIVEN** a websocket responses request whose upstream emits a `response.created` event, then a text delta, then completion
 - **WHEN** the proxy persists the request log
 - **THEN** the log has non-null first-upstream-event, response-created, and first-token latency values
 - **AND** first-upstream-event latency is less than or equal to response-created latency, which is less than or equal to first-token latency
+
+#### Scenario: Websocket tool call records first-token latency
+
+- **GIVEN** a websocket responses request whose first token-bearing output is a function-call argument delta, custom-tool input delta, tool-call output delta, or a custom/apply-patch tool-call `response.output_item.added` or `response.output_item.done` event with meaningful tool-call payload content when the tool protocol does not stream argument deltas
+- **WHEN** the proxy persists the request log
+- **THEN** the log has a non-null first-token latency value
+- **AND** the proxy forwards the upstream event unchanged
+
+#### Scenario: Control events do not record first-token latency
+
+- **GIVEN** a responses request whose upstream has emitted only control events such as `response.created`
+- **WHEN** the proxy inspects the request timing
+- **THEN** first-token latency remains null until a token-bearing output delta arrives, unless a meaningful custom/apply-patch completion event anchors TTFT for a completion-only tool protocol
+- **AND** reasoning-summary placeholder deltas that are stripped before delivery do not record first-token latency
+- **AND** metadata-only or empty tool-call delta and completion events do not record first-token latency
 
 ### Requirement: Startup probe timeouts do not emit shielded-future diagnostics
 
@@ -626,12 +654,8 @@ For a single request-log row, `latency_ms` and `latency_first_token_ms` MUST be
 measured from the same anchor: the start of the attempt that produced the row.
 Time spent before that attempt — account selection, admission waits, and failed
 failover attempts — MUST NOT inflate `latency_first_token_ms`; the HTTP
-streaming path MUST record it instead in a nullable `latency_queue_ms`
-request-log column. First-token detection MUST treat the first output delta of
-any kind — visible text, refusal, or reasoning deltas — as the first token, so
-TTFT means time to first model output and the generation window
-(`latency_ms - latency_first_token_ms`) covers reasoning generation, matching
-the reasoning-inclusive `output_tokens` numerator used for TPS.
+streaming path MUST record it instead in a nullable `latency_queue_ms`.
+First-token detection MUST treat the first token-bearing output event — visible text, refusal, reasoning deltas, function-call argument, custom-tool input, tool-call output, or a custom/apply-patch tool-call `response.output_item.added` or `response.output_item.done` event with meaningful tool-call payload content when the tool protocol does not stream argument deltas — as the first token. Lifecycle/control events, reasoning-summary placeholder deltas stripped before delivery, and metadata-only or empty tool-call deltas or completion events MUST NOT record first-token latency. TTFT means time to first model output and the generation window (`latency_ms - latency_first_token_ms`) covers reasoning generation, while TPS uses the non-reasoning output-token numerator.
 
 #### Scenario: Failover no longer inflates TTFT
 
@@ -643,13 +667,11 @@ the reasoning-inclusive `output_tokens` numerator used for TPS.
   failed attempt)
 - **AND** `latency_ms` is greater than or equal to `latency_first_token_ms`
 
-#### Scenario: Reasoning delta counts as the first token
+#### Scenario: Non-placeholder reasoning delta counts as the first token
 
-- **GIVEN** an upstream stream emits a reasoning summary delta before the first
-  visible text delta
+- **GIVEN** an upstream stream emits a non-placeholder, token-bearing reasoning summary delta before the first visible text delta
 - **WHEN** first-token latency is captured
-- **THEN** `latency_first_token_ms` anchors to the reasoning delta rather than
-  waiting for visible text
+- **THEN** `latency_first_token_ms` anchors to the reasoning delta rather than waiting for visible text
 
 #### Scenario: Single-anchor rows on websocket and bridge paths
 
@@ -710,9 +732,10 @@ MUST also be rejected rather than failing or interrupting the proxied request.
 #### Scenario: Dashboard retains generation-only throughput semantics
 
 - **GIVEN** a source response reports `time_to_first_token_ms: 108.83`,
-  `generation_time_ms: 162.98`, and `9` output tokens
-- **WHEN** the existing dashboard computes tokens per second as output tokens
-  divided by `latency_ms - latency_first_token_ms`
+  `generation_time_ms: 162.98`, and `9` output tokens, including zero reasoning
+  tokens
+- **WHEN** the existing dashboard computes tokens per second as non-reasoning
+  output tokens divided by `latency_ms - latency_first_token_ms`
 - **THEN** it reports approximately `55.2` generation tokens per second
 - **AND** it does not substitute an upstream `tokens_per_second` value that may
   include TTFT

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5214,6 +5214,7 @@ async def test_forwarded_recovery_uses_durable_owner_and_strips_stale_affinity(
 @pytest.mark.asyncio
 async def test_v1_responses_http_bridge_injects_interrupted_custom_tool_output_on_followup(
     async_client,
+    app_instance,
     monkeypatch,
 ):
     _install_bridge_settings(monkeypatch, enabled=True)
@@ -5223,7 +5224,7 @@ async def test_v1_responses_http_bridge_injects_interrupted_custom_tool_output_o
         "http-bridge-custom-interrupt@example.com",
     )
     account = await _get_account(account_id)
-    fake_upstream = _InterruptedCustomToolUpstreamWebSocket()
+    fake_upstream = _InterruptedCustomToolUpstreamWebSocket(emit_added=True)
 
     async def fake_select_account_with_budget(
         self,
@@ -5303,6 +5304,18 @@ async def test_v1_responses_http_bridge_injects_interrupted_custom_tool_output_o
     assert first.status_code == 200
     first_body = first.json()
     assert first_body["id"] == "resp_bridge_custom_1"
+
+    service = get_proxy_service_for_app(app_instance)
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    async with SessionLocal() as session:
+        request_logs = list(
+            (
+                await session.execute(
+                    select(RequestLog).where(RequestLog.account_id == account_id).order_by(RequestLog.requested_at)
+                )
+            ).scalars()
+        )
+    assert any(log.latency_first_token_ms is not None for log in request_logs)
 
     second = await async_client.post(
         "/v1/responses",

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2271,10 +2271,22 @@ def test_backend_responses_websocket_pinned_transient_refresh_claim_emits_retrya
 
 
 @pytest.mark.parametrize(
-    ("output_event_type", "output_event_fields"),
+    ("output_event_type", "output_event_fields", "followup_events"),
     [
-        ("response.output_text.delta", {"delta": "hello"}),
-        ("response.function_call_arguments.delta", {"delta": "hello"}),
+        ("response.output_text.delta", {"delta": "hello"}, []),
+        ("response.function_call_arguments.delta", {"delta": "hello"}, []),
+        (
+            "response.output_item.added",
+            {
+                "item": {
+                    "type": "custom_tool_call",
+                    "call_id": "call_shell_1",
+                    "name": "shell",
+                    "input": "pwd",
+                }
+            },
+            [],
+        ),
         (
             "response.output_item.added",
             {
@@ -2285,11 +2297,28 @@ def test_backend_responses_websocket_pinned_transient_refresh_claim_emits_retrya
                     "input": "",
                 }
             },
+            [
+                (
+                    "response.output_item.done",
+                    {
+                        "item": {
+                            "type": "custom_tool_call",
+                            "call_id": "call_shell_1",
+                            "name": "shell",
+                            "input": "pwd",
+                        }
+                    },
+                )
+            ],
         ),
     ],
 )
 def test_backend_responses_websocket_proxies_and_persists_conversation_id(
-    app_instance, monkeypatch, output_event_type: str, output_event_fields: dict[str, object]
+    app_instance,
+    monkeypatch,
+    output_event_type: str,
+    output_event_fields: dict[str, object],
+    followup_events: list[tuple[str, dict[str, object]]],
 ):
     upstream_messages = [
         _FakeUpstreamMessage(
@@ -2313,6 +2342,22 @@ def test_backend_responses_websocket_proxies_and_persists_conversation_id(
                 separators=(",", ":"),
             ),
         ),
+    ]
+    for followup_event_type, followup_event_fields in followup_events:
+        upstream_messages.append(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": followup_event_type,
+                        "response_id": "resp_ws_1",
+                        **followup_event_fields,
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        )
+    upstream_messages.append(
         _FakeUpstreamMessage(
             "text",
             text=json.dumps(
@@ -2328,8 +2373,8 @@ def test_backend_responses_websocket_proxies_and_persists_conversation_id(
                 },
                 separators=(",", ":"),
             ),
-        ),
-    ]
+        )
+    )
     fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
     seen: dict[str, object] = {}
     log_calls: list[dict[str, object]] = []
@@ -2433,13 +2478,16 @@ def test_backend_responses_websocket_proxies_and_persists_conversation_id(
             },
         ) as websocket:
             websocket.send_text(json.dumps(request_payload))
-            first = json.loads(websocket.receive_text())
-            second = json.loads(websocket.receive_text())
-            third = json.loads(websocket.receive_text())
+            events = [json.loads(websocket.receive_text()) for _ in range(3 + len(followup_events))]
 
-    assert first["type"] == "response.created"
-    assert second["type"] == output_event_type
-    assert third["type"] == "response.completed"
+    assert events[0]["type"] == "response.created"
+    expected_output_events = [(output_event_type, output_event_fields), *followup_events]
+    for event, (expected_type, expected_fields) in zip(events[1:-1], expected_output_events, strict=True):
+        assert event["type"] == expected_type
+        assert event["response_id"] == "resp_ws_1"
+        for field, expected_value in expected_fields.items():
+            assert event[field] == expected_value
+    assert events[-1]["type"] == "response.completed"
     seen_headers = cast(dict[str, str], seen["headers"])
     assert seen_headers["session_id"] == "thread-ws-1"
     assert seen_headers["openai-beta"] == "responses_websockets=2026-02-06"

--- a/tests/unit/test_ttft_optimization.py
+++ b/tests/unit/test_ttft_optimization.py
@@ -160,9 +160,14 @@ def test_normalize_sse_event_block_skips_json_parsing_without_type(monkeypatch) 
         '{"type":"response.output_tool_call.delta","delta":"hi"}',
         '{"type":"response.reasoning_summary_text.delta","delta":"hi"}',
         '{"type":"response.reasoning_text.delta","delta":"hi"}',
+        '{"type":"response.custom_tool_call_input.delta","delta":"pwd"}',
         (
             '{"type":"response.output_item.added","item":'
-            '{"type":"custom_tool_call","call_id":"call_1","name":"shell","input":""}}'
+            '{"type":"custom_tool_call","call_id":"call_1","name":"shell","input":"pwd"}}'
+        ),
+        (
+            '{"type":"response.output_item.done","item":'
+            '{"type":"custom_tool_call","call_id":"call_1","name":"shell","input":"pwd"}}'
         ),
     ],
 )
@@ -201,6 +206,65 @@ async def test_stream_responses_tracks_latency_first_token_ms(monkeypatch, event
 
     assert len(chunks) == 2
     assert latency_first_token_ms > 0
+
+
+def test_ttft_ignores_metadata_only_and_empty_tool_items() -> None:
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.added",
+            {"item": {"type": "custom_tool_call", "call_id": "call-empty", "input": ""}},
+        )
+        is None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.added",
+            {"item": {"type": "apply_patch_call", "call_id": "call-meta"}},
+        )
+        is None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.added",
+            {"item": {"type": "custom_tool_call", "input": "pwd"}},
+        )
+        is not None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.custom_tool_call_input.delta",
+            {"delta": ""},
+        )
+        is None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.custom_tool_call_input.delta",
+            {"delta": "pwd"},
+        )
+        is not None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.done",
+            {"item": {"type": "custom_tool_call", "input": "pwd"}},
+        )
+        is not None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.done",
+            {"item": {"type": "custom_tool_call", "input": ""}},
+        )
+        is None
+    )
+    assert (
+        proxy_service._ttft_event_visible_at(
+            "response.output_item.done",
+            {"item": {"type": "apply_patch_call", "call_id": "call-meta"}},
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change
Sync the active `expand-ttft-output-events` delta into the main proxy-runtime-observability spec.

## Details
- Define TPS using non-reasoning output tokens and explicitly exclude invalid samples.
- Recognize token-bearing text, refusal, reasoning, function-call, custom-tool, and tool-call events.
- Require meaningful payloads for custom/apply-patch output items, including completed items; exclude lifecycle, placeholder, metadata-only, and empty events.
- Keep the active delta synchronized with the main specification.

## Verification
- `23 passed`: TTFT unit and WebSocket integration regression tests, including added-empty/done-populated tool events
- Ruff and `uv run ty check` passed
- `openspec validate proxy-runtime-observability --type spec --strict` passed
- `openspec validate expand-ttft-output-events --strict` passed
- Current-head CI Required, all backend shards, bridge, e2e, PostgreSQL, package, Docker, migration, lint, and type checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token-per-second reporting to exclude reasoning tokens.
  * Defined handling of invalid inputs in dashboard metrics and daily reports.
  * Expanded first-token detection to include valid tool, refusal, custom tool, and patch responses.
  * Excluded control, metadata-only, empty, and unsupported events from measurements.
  * Clarified generation timing and updated dashboard TPS examples.

* **Bug Fixes**
  * Improved first-token measurements across streaming events, including tool-call input deltas and completed output items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->