### PR TITLE
fix(proxy): preserve agent-control outputs during slimming

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -167,6 +167,7 @@ _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline im
 _SLIMMABLE_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
+_AGENT_CONTROL_TOOL_NAMESPACES = frozenset({"collaboration", "multi_agent_v1"})
 _UPSTREAM_TRACE_HEADER_ALLOWLIST = frozenset(
     {
         "accept",
@@ -2709,10 +2710,14 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
+    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
-        slimmed_item, item_tool_outputs_slimmed, item_images_slimmed = _slim_historical_response_input_item(item)
+        slimmed_item, item_tool_outputs_slimmed, item_images_slimmed = _slim_historical_response_input_item(
+            item,
+            protected_agent_control_call_ids=protected_agent_control_call_ids,
+        )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed
         slimmed_historical.append(slimmed_item)
@@ -2740,7 +2745,28 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
     return 0
 
 
-def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, int, int]:
+def _agent_control_function_call_ids(input_items: list[JsonValue]) -> set[str]:
+    call_ids: set[str] = set()
+    for item in input_items:
+        if not is_json_mapping(item) or item.get("type") != "function_call":
+            continue
+        namespace = item.get("namespace")
+        call_id = item.get("call_id")
+        if (
+            isinstance(namespace, str)
+            and namespace in _AGENT_CONTROL_TOOL_NAMESPACES
+            and isinstance(call_id, str)
+            and call_id
+        ):
+            call_ids.add(call_id)
+    return call_ids
+
+
+def _slim_historical_response_input_item(
+    item: JsonValue,
+    *,
+    protected_agent_control_call_ids: set[str],
+) -> tuple[JsonValue, int, int]:
     if not is_json_mapping(item):
         return item, 0, 0
 
@@ -2749,6 +2775,10 @@ def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, in
     images_slimmed = 0
 
     item_type = item_mapping.get("type")
+    if item_type == "function_call_output":
+        call_id = item_mapping.get("call_id")
+        if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
+            return item_mapping, tool_outputs_slimmed, images_slimmed
     if isinstance(item_type, str) and item_type in _SLIMMABLE_TOOL_CALL_OUTPUT_ITEM_TYPES:
         output = item_mapping.get("output")
         if isinstance(output, str):

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2392,6 +2392,7 @@ async def _close_unmanaged_websocket(websocket: Any | None) -> None:
 async def _stream_responses_via_websocket(
     *,
     payload_dict: JsonObject,
+    protected_agent_control_call_ids: set[str] | None = None,
     url: str,
     headers: Mapping[str, str],
     client_session: aiohttp.ClientSession,
@@ -2410,7 +2411,10 @@ async def _stream_responses_via_websocket(
     """Yield ``(sse_block, event_type)`` pairs from the upstream websocket."""
     websocket_url = _to_websocket_upstream_url(url)
     request_started_at = time.monotonic()
-    request_payload = _prepare_websocket_response_create_payload(payload_dict)
+    request_payload = _prepare_websocket_response_create_payload(
+        payload_dict,
+        protected_agent_control_call_ids=protected_agent_control_call_ids,
+    )
     websocket_cm: AsyncContextManager[aiohttp.ClientWebSocketResponse] | None = None
     websocket: aiohttp.ClientWebSocketResponse | None = None
     circuit_breaker = None
@@ -2632,7 +2636,11 @@ def _build_websocket_response_create_payload(payload_dict: JsonObject) -> JsonOb
     return request_payload
 
 
-def _prepare_websocket_response_create_payload(payload_dict: JsonObject) -> JsonObject:
+def _prepare_websocket_response_create_payload(
+    payload_dict: JsonObject,
+    *,
+    protected_agent_control_call_ids: set[str] | None = None,
+) -> JsonObject:
     request_payload = _build_websocket_response_create_payload(payload_dict)
     payload_text = json.dumps(request_payload, ensure_ascii=True, separators=(",", ":"))
     payload_size = len(payload_text.encode("utf-8"))
@@ -2640,6 +2648,7 @@ def _prepare_websocket_response_create_payload(payload_dict: JsonObject) -> Json
         slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
             request_payload,
             max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
+            protected_agent_control_call_ids=protected_agent_control_call_ids,
         )
         if slim_summary is not None:
             request_payload = slimmed_payload
@@ -2697,6 +2706,7 @@ def _slim_response_create_payload_for_upstream(
     payload: JsonObject,
     *,
     max_bytes: int,
+    protected_agent_control_call_ids: set[str] | None = None,
 ) -> tuple[JsonObject, dict[str, int] | None]:
     del max_bytes
     input_value = payload.get("input")
@@ -2710,7 +2720,8 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_call_ids is None:
+        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -2748,7 +2759,10 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
 def _agent_control_function_call_ids(input_items: list[JsonValue]) -> set[str]:
     call_ids: set[str] = set()
     for item in input_items:
-        if not is_json_mapping(item) or item.get("type") != "function_call":
+        if not is_json_mapping(item):
+            continue
+        item_type = item.get("type")
+        if not isinstance(item_type, str) or item_type not in {"function_call", "custom_tool_call"}:
             continue
         namespace = item.get("namespace")
         call_id = item.get("call_id")
@@ -2775,7 +2789,7 @@ def _slim_historical_response_input_item(
     images_slimmed = 0
 
     item_type = item_mapping.get("type")
-    if item_type == "function_call_output":
+    if isinstance(item_type, str) and item_type in {"function_call_output", "custom_tool_call_output"}:
         call_id = item_mapping.get("call_id")
         if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
             return item_mapping, tool_outputs_slimmed, images_slimmed
@@ -3231,6 +3245,11 @@ async def _stream_responses_with_session(
     failure_exception_type: str | None = None
     retryable_same_contract: bool | None = None
     client_session = session
+    protected_agent_control_call_ids = (
+        _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+        if isinstance(payload.input, list)
+        else set()
+    )
     payload_dict = dict(payload.to_payload())
     apply_codex_installation_metadata(payload_dict, codex_installation_id)
     if settings.image_inline_fetch_enabled:
@@ -3587,6 +3606,7 @@ async def _stream_responses_with_session(
             try:
                 async for event_block, event_type in _stream_responses_via_websocket(
                     payload_dict=payload_dict,
+                    protected_agent_control_call_ids=protected_agent_control_call_ids,
                     url=url,
                     headers=upstream_headers,
                     client_session=client_session,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -168,6 +168,10 @@ _SLIMMABLE_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
 _AGENT_CONTROL_TOOL_NAMESPACES = frozenset({"collaboration", "multi_agent_v1"})
+_AGENT_CONTROL_OUTPUT_TYPE_BY_CALL_TYPE = {
+    "function_call": "function_call_output",
+    "custom_tool_call": "custom_tool_call_output",
+}
 _UPSTREAM_TRACE_HEADER_ALLOWLIST = frozenset(
     {
         "accept",
@@ -2392,7 +2396,7 @@ async def _close_unmanaged_websocket(websocket: Any | None) -> None:
 async def _stream_responses_via_websocket(
     *,
     payload_dict: JsonObject,
-    protected_agent_control_call_ids: set[str] | None = None,
+    protected_agent_control_output_keys: set[tuple[str, str]] | None = None,
     url: str,
     headers: Mapping[str, str],
     client_session: aiohttp.ClientSession,
@@ -2413,7 +2417,7 @@ async def _stream_responses_via_websocket(
     request_started_at = time.monotonic()
     request_payload = _prepare_websocket_response_create_payload(
         payload_dict,
-        protected_agent_control_call_ids=protected_agent_control_call_ids,
+        protected_agent_control_output_keys=protected_agent_control_output_keys,
     )
     websocket_cm: AsyncContextManager[aiohttp.ClientWebSocketResponse] | None = None
     websocket: aiohttp.ClientWebSocketResponse | None = None
@@ -2639,7 +2643,7 @@ def _build_websocket_response_create_payload(payload_dict: JsonObject) -> JsonOb
 def _prepare_websocket_response_create_payload(
     payload_dict: JsonObject,
     *,
-    protected_agent_control_call_ids: set[str] | None = None,
+    protected_agent_control_output_keys: set[tuple[str, str]] | None = None,
 ) -> JsonObject:
     request_payload = _build_websocket_response_create_payload(payload_dict)
     payload_text = json.dumps(request_payload, ensure_ascii=True, separators=(",", ":"))
@@ -2648,7 +2652,7 @@ def _prepare_websocket_response_create_payload(
         slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
             request_payload,
             max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
-            protected_agent_control_call_ids=protected_agent_control_call_ids,
+            protected_agent_control_output_keys=protected_agent_control_output_keys,
         )
         if slim_summary is not None:
             request_payload = slimmed_payload
@@ -2706,7 +2710,7 @@ def _slim_response_create_payload_for_upstream(
     payload: JsonObject,
     *,
     max_bytes: int,
-    protected_agent_control_call_ids: set[str] | None = None,
+    protected_agent_control_output_keys: set[tuple[str, str]] | None = None,
 ) -> tuple[JsonObject, dict[str, int] | None]:
     del max_bytes
     input_value = payload.get("input")
@@ -2720,14 +2724,14 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    if protected_agent_control_call_ids is None:
-        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_output_keys is None:
+        protected_agent_control_output_keys = _agent_control_tool_output_keys(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
         slimmed_item, item_tool_outputs_slimmed, item_images_slimmed = _slim_historical_response_input_item(
             item,
-            protected_agent_control_call_ids=protected_agent_control_call_ids,
+            protected_agent_control_output_keys=protected_agent_control_output_keys,
         )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed
@@ -2756,13 +2760,16 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
     return 0
 
 
-def _agent_control_function_call_ids(input_items: list[JsonValue]) -> set[str]:
-    call_ids: set[str] = set()
+def _agent_control_tool_output_keys(input_items: list[JsonValue]) -> set[tuple[str, str]]:
+    output_keys: set[tuple[str, str]] = set()
     for item in input_items:
         if not is_json_mapping(item):
             continue
         item_type = item.get("type")
-        if not isinstance(item_type, str) or item_type not in {"function_call", "custom_tool_call"}:
+        if not isinstance(item_type, str):
+            continue
+        output_type = _AGENT_CONTROL_OUTPUT_TYPE_BY_CALL_TYPE.get(item_type)
+        if output_type is None:
             continue
         namespace = item.get("namespace")
         call_id = item.get("call_id")
@@ -2772,19 +2779,19 @@ def _agent_control_function_call_ids(input_items: list[JsonValue]) -> set[str]:
             and isinstance(call_id, str)
             and call_id
         ):
-            call_ids.add(call_id)
-    return call_ids
+            output_keys.add((output_type, call_id))
+    return output_keys
 
 
-def _historical_agent_control_call_ids(input_items: list[JsonValue]) -> set[str]:
+def _historical_agent_control_output_keys(input_items: list[JsonValue]) -> set[tuple[str, str]]:
     suffix_start = _response_create_recent_suffix_start(input_items)
-    return _agent_control_function_call_ids(input_items[:suffix_start])
+    return _agent_control_tool_output_keys(input_items[:suffix_start])
 
 
 def _slim_historical_response_input_item(
     item: JsonValue,
     *,
-    protected_agent_control_call_ids: set[str],
+    protected_agent_control_output_keys: set[tuple[str, str]],
 ) -> tuple[JsonValue, int, int]:
     if not is_json_mapping(item):
         return item, 0, 0
@@ -2796,7 +2803,7 @@ def _slim_historical_response_input_item(
     item_type = item_mapping.get("type")
     if isinstance(item_type, str) and item_type in {"function_call_output", "custom_tool_call_output"}:
         call_id = item_mapping.get("call_id")
-        if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
+        if isinstance(call_id, str) and (item_type, call_id) in protected_agent_control_output_keys:
             return item_mapping, tool_outputs_slimmed, images_slimmed
     if isinstance(item_type, str) and item_type in _SLIMMABLE_TOOL_CALL_OUTPUT_ITEM_TYPES:
         output = item_mapping.get("output")
@@ -3250,8 +3257,8 @@ async def _stream_responses_with_session(
     failure_exception_type: str | None = None
     retryable_same_contract: bool | None = None
     client_session = session
-    protected_agent_control_call_ids = (
-        _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
+    protected_agent_control_output_keys = (
+        _historical_agent_control_output_keys(cast(list[JsonValue], payload.input))
         if isinstance(payload.input, list)
         else set()
     )
@@ -3611,7 +3618,7 @@ async def _stream_responses_with_session(
             try:
                 async for event_block, event_type in _stream_responses_via_websocket(
                     payload_dict=payload_dict,
-                    protected_agent_control_call_ids=protected_agent_control_call_ids,
+                    protected_agent_control_output_keys=protected_agent_control_output_keys,
                     url=url,
                     headers=upstream_headers,
                     client_session=client_session,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2776,6 +2776,11 @@ def _agent_control_function_call_ids(input_items: list[JsonValue]) -> set[str]:
     return call_ids
 
 
+def _historical_agent_control_call_ids(input_items: list[JsonValue]) -> set[str]:
+    suffix_start = _response_create_recent_suffix_start(input_items)
+    return _agent_control_function_call_ids(input_items[:suffix_start])
+
+
 def _slim_historical_response_input_item(
     item: JsonValue,
     *,
@@ -3246,7 +3251,7 @@ async def _stream_responses_with_session(
     retryable_same_contract: bool | None = None
     client_session = session
     protected_agent_control_call_ids = (
-        _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+        _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
         if isinstance(payload.input, list)
         else set()
     )

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -23,7 +23,7 @@ from app.core.clients.proxy import (  # noqa: F401
     UpstreamProxyRouteTrace,
     _as_image_fetch_session,
     _finalize_responses_lite_reasoning_context,
-    _historical_agent_control_call_ids,
+    _historical_agent_control_output_keys,
     _inline_content_images,
     _inline_input_image_urls,
     _payload_has_responses_lite_websocket_marker,
@@ -633,8 +633,8 @@ class _HTTPBridgeRequestSubmitMixin:
                 deduped_replayed_input_count = len(replayed_input_items)
                 deduped_replayed_input_fingerprint = _fingerprint_input_items(replayed_input_items)
                 payload = payload.model_copy(update={"input": deduped_input_items})
-        protected_agent_control_call_ids = (
-            _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
+        protected_agent_control_output_keys = (
+            _historical_agent_control_output_keys(cast(list[JsonValue], payload.input))
             if isinstance(payload.input, list)
             else set()
         )
@@ -717,7 +717,7 @@ class _HTTPBridgeRequestSubmitMixin:
             slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
                 upstream_payload,
                 max_bytes=max_bytes,
-                protected_agent_control_call_ids=protected_agent_control_call_ids,
+                protected_agent_control_output_keys=protected_agent_control_output_keys,
             )
             if slim_summary is not None:
                 upstream_payload = slimmed_payload

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -21,6 +21,7 @@ from app.core.clients.proxy import (  # noqa: F401
     ImageFetchSession,
     ProxyResponseError,
     UpstreamProxyRouteTrace,
+    _agent_control_function_call_ids,
     _as_image_fetch_session,
     _finalize_responses_lite_reasoning_context,
     _inline_content_images,
@@ -632,6 +633,11 @@ class _HTTPBridgeRequestSubmitMixin:
                 deduped_replayed_input_count = len(replayed_input_items)
                 deduped_replayed_input_fingerprint = _fingerprint_input_items(replayed_input_items)
                 payload = payload.model_copy(update={"input": deduped_input_items})
+        protected_agent_control_call_ids = (
+            _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+            if isinstance(payload.input, list)
+            else set()
+        )
         upstream_payload = dict(payload.to_payload())
         upstream_payload.pop("stream", None)
         upstream_payload.pop("background", None)
@@ -711,6 +717,7 @@ class _HTTPBridgeRequestSubmitMixin:
             slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
                 upstream_payload,
                 max_bytes=max_bytes,
+                protected_agent_control_call_ids=protected_agent_control_call_ids,
             )
             if slim_summary is not None:
                 upstream_payload = slimmed_payload

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -21,9 +21,9 @@ from app.core.clients.proxy import (  # noqa: F401
     ImageFetchSession,
     ProxyResponseError,
     UpstreamProxyRouteTrace,
-    _agent_control_function_call_ids,
     _as_image_fetch_session,
     _finalize_responses_lite_reasoning_context,
+    _historical_agent_control_call_ids,
     _inline_content_images,
     _inline_input_image_urls,
     _payload_has_responses_lite_websocket_marker,
@@ -634,7 +634,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 deduped_replayed_input_fingerprint = _fingerprint_input_items(replayed_input_items)
                 payload = payload.model_copy(update={"input": deduped_input_items})
         protected_agent_control_call_ids = (
-            _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+            _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
             if isinstance(payload.input, list)
             else set()
         )

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -17,6 +17,7 @@ from app.core.clients.proxy import (
     CODEX_INSTALLATION_ID_HEADER,
     ImageFetchSession,
     ProxyResponseError,
+    _agent_control_function_call_ids,
     _finalize_responses_lite_reasoning_context,
     _inline_content_images,
     _normalize_responses_lite_websocket_client_metadata,
@@ -314,6 +315,7 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
+    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -321,7 +323,10 @@ def _slim_response_create_payload_for_upstream(
             slimmed_item,
             item_tool_outputs_slimmed,
             item_images_slimmed,
-        ) = _slim_historical_response_input_item(item)
+        ) = _slim_historical_response_input_item(
+            item,
+            protected_agent_control_call_ids=protected_agent_control_call_ids,
+        )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed
         slimmed_historical.append(slimmed_item)
@@ -449,7 +454,11 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
     return 0
 
 
-def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, int, int]:
+def _slim_historical_response_input_item(
+    item: JsonValue,
+    *,
+    protected_agent_control_call_ids: set[str],
+) -> tuple[JsonValue, int, int]:
     if not is_json_mapping(item):
         return item, 0, 0
 
@@ -458,6 +467,10 @@ def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, in
     images_slimmed = 0
 
     item_type = item_mapping.get("type")
+    if item_type == "function_call_output":
+        call_id = item_mapping.get("call_id")
+        if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
+            return item_mapping, tool_outputs_slimmed, images_slimmed
     if isinstance(item_type, str) and item_type in _PENDING_TOOL_CALL_OUTPUT_ITEM_TYPES:
         output = item_mapping.get("output")
         if isinstance(output, str):

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -213,6 +213,11 @@ def _response_create_text_with_size_guard(
     request_state: _WebSocketRequestState,
     transport: str,
 ) -> str | None:
+    protected_agent_control_call_ids = (
+        _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+        if isinstance(payload.input, list)
+        else set()
+    )
     upstream_payload = dict(payload.to_payload())
     upstream_payload.pop("stream", None)
     upstream_payload.pop("background", None)
@@ -239,6 +244,7 @@ def _response_create_text_with_size_guard(
         slimmed_payload, slim_summary = slim_payload_for_upstream(
             upstream_payload,
             max_bytes=max_bytes,
+            protected_agent_control_call_ids=protected_agent_control_call_ids,
         )
         if slim_summary is not None:
             upstream_payload = slimmed_payload
@@ -303,6 +309,7 @@ def _slim_response_create_payload_for_upstream(
     payload: dict[str, JsonValue],
     *,
     max_bytes: int,
+    protected_agent_control_call_ids: set[str] | None = None,
 ) -> tuple[dict[str, JsonValue], dict[str, int] | None]:
     input_value = payload.get("input")
     if not isinstance(input_value, list) or not input_value:
@@ -315,7 +322,8 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_call_ids is None:
+        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -467,7 +475,7 @@ def _slim_historical_response_input_item(
     images_slimmed = 0
 
     item_type = item_mapping.get("type")
-    if item_type == "function_call_output":
+    if isinstance(item_type, str) and item_type in {"function_call_output", "custom_tool_call_output"}:
         call_id = item_mapping.get("call_id")
         if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
             return item_mapping, tool_outputs_slimmed, images_slimmed

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -19,6 +19,7 @@ from app.core.clients.proxy import (
     ProxyResponseError,
     _agent_control_function_call_ids,
     _finalize_responses_lite_reasoning_context,
+    _historical_agent_control_call_ids,
     _inline_content_images,
     _normalize_responses_lite_websocket_client_metadata,
     _payload_has_responses_lite_websocket_marker,
@@ -214,7 +215,7 @@ def _response_create_text_with_size_guard(
     transport: str,
 ) -> str | None:
     protected_agent_control_call_ids = (
-        _agent_control_function_call_ids(cast(list[JsonValue], payload.input))
+        _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
         if isinstance(payload.input, list)
         else set()
     )

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -17,9 +17,9 @@ from app.core.clients.proxy import (
     CODEX_INSTALLATION_ID_HEADER,
     ImageFetchSession,
     ProxyResponseError,
-    _agent_control_function_call_ids,
+    _agent_control_tool_output_keys,
     _finalize_responses_lite_reasoning_context,
-    _historical_agent_control_call_ids,
+    _historical_agent_control_output_keys,
     _inline_content_images,
     _normalize_responses_lite_websocket_client_metadata,
     _payload_has_responses_lite_websocket_marker,
@@ -214,8 +214,8 @@ def _response_create_text_with_size_guard(
     request_state: _WebSocketRequestState,
     transport: str,
 ) -> str | None:
-    protected_agent_control_call_ids = (
-        _historical_agent_control_call_ids(cast(list[JsonValue], payload.input))
+    protected_agent_control_output_keys = (
+        _historical_agent_control_output_keys(cast(list[JsonValue], payload.input))
         if isinstance(payload.input, list)
         else set()
     )
@@ -245,7 +245,7 @@ def _response_create_text_with_size_guard(
         slimmed_payload, slim_summary = slim_payload_for_upstream(
             upstream_payload,
             max_bytes=max_bytes,
-            protected_agent_control_call_ids=protected_agent_control_call_ids,
+            protected_agent_control_output_keys=protected_agent_control_output_keys,
         )
         if slim_summary is not None:
             upstream_payload = slimmed_payload
@@ -310,7 +310,7 @@ def _slim_response_create_payload_for_upstream(
     payload: dict[str, JsonValue],
     *,
     max_bytes: int,
-    protected_agent_control_call_ids: set[str] | None = None,
+    protected_agent_control_output_keys: set[tuple[str, str]] | None = None,
 ) -> tuple[dict[str, JsonValue], dict[str, int] | None]:
     input_value = payload.get("input")
     if not isinstance(input_value, list) or not input_value:
@@ -323,8 +323,8 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    if protected_agent_control_call_ids is None:
-        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_output_keys is None:
+        protected_agent_control_output_keys = _agent_control_tool_output_keys(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -334,7 +334,7 @@ def _slim_response_create_payload_for_upstream(
             item_images_slimmed,
         ) = _slim_historical_response_input_item(
             item,
-            protected_agent_control_call_ids=protected_agent_control_call_ids,
+            protected_agent_control_output_keys=protected_agent_control_output_keys,
         )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed
@@ -466,7 +466,7 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
 def _slim_historical_response_input_item(
     item: JsonValue,
     *,
-    protected_agent_control_call_ids: set[str],
+    protected_agent_control_output_keys: set[tuple[str, str]],
 ) -> tuple[JsonValue, int, int]:
     if not is_json_mapping(item):
         return item, 0, 0
@@ -478,7 +478,7 @@ def _slim_historical_response_input_item(
     item_type = item_mapping.get("type")
     if isinstance(item_type, str) and item_type in {"function_call_output", "custom_tool_call_output"}:
         call_id = item_mapping.get("call_id")
-        if isinstance(call_id, str) and call_id in protected_agent_control_call_ids:
+        if isinstance(call_id, str) and (item_type, call_id) in protected_agent_control_output_keys:
             return item_mapping, tool_outputs_slimmed, images_slimmed
     if isinstance(item_type, str) and item_type in _PENDING_TOOL_CALL_OUTPUT_ITEM_TYPES:
         output = item_mapping.get("output")

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -731,6 +731,7 @@ def _slim_response_create_payload_for_upstream(
     payload: dict[str, JsonValue],
     *,
     max_bytes: int,
+    protected_agent_control_call_ids: set[str] | None = None,
 ) -> tuple[dict[str, JsonValue], dict[str, int] | None]:
     input_value = payload.get("input")
     if not isinstance(input_value, list) or not input_value:
@@ -743,7 +744,8 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_call_ids is None:
+        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -18,6 +18,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     ImageFetchSession,
     ProxyResponseError,
     UpstreamProxyRouteTrace,
+    _agent_control_function_call_ids,
     _as_image_fetch_session,
     _inline_content_images,
     _inline_input_image_urls,
@@ -742,6 +743,7 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
+    protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -749,7 +751,10 @@ def _slim_response_create_payload_for_upstream(
             slimmed_item,
             item_tool_outputs_slimmed,
             item_images_slimmed,
-        ) = _facade()._slim_historical_response_input_item(item)
+        ) = _facade()._slim_historical_response_input_item(
+            item,
+            protected_agent_control_call_ids=protected_agent_control_call_ids,
+        )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed
         slimmed_historical.append(slimmed_item)

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -18,7 +18,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     ImageFetchSession,
     ProxyResponseError,
     UpstreamProxyRouteTrace,
-    _agent_control_function_call_ids,
+    _agent_control_tool_output_keys,
     _as_image_fetch_session,
     _inline_content_images,
     _inline_input_image_urls,
@@ -731,7 +731,7 @@ def _slim_response_create_payload_for_upstream(
     payload: dict[str, JsonValue],
     *,
     max_bytes: int,
-    protected_agent_control_call_ids: set[str] | None = None,
+    protected_agent_control_output_keys: set[tuple[str, str]] | None = None,
 ) -> tuple[dict[str, JsonValue], dict[str, int] | None]:
     input_value = payload.get("input")
     if not isinstance(input_value, list) or not input_value:
@@ -744,8 +744,8 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    if protected_agent_control_call_ids is None:
-        protected_agent_control_call_ids = _agent_control_function_call_ids(historical)
+    if protected_agent_control_output_keys is None:
+        protected_agent_control_output_keys = _agent_control_tool_output_keys(historical)
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -755,7 +755,7 @@ def _slim_response_create_payload_for_upstream(
             item_images_slimmed,
         ) = _facade()._slim_historical_response_input_item(
             item,
-            protected_agent_control_call_ids=protected_agent_control_call_ids,
+            protected_agent_control_output_keys=protected_agent_control_output_keys,
         )
         tool_outputs_slimmed += item_tool_outputs_slimmed
         images_slimmed += item_images_slimmed

--- a/openspec/changes/preserve-agent-control-output-slimming/.openspec.yaml
+++ b/openspec/changes/preserve-agent-control-output-slimming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/preserve-agent-control-output-slimming/design.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/design.md
@@ -22,12 +22,16 @@ did not protect the direct core path and used a broad pending-call type set.
 
 ## Decisions
 
-- Derive protected call IDs from historical `function_call` items whose
-  namespace is exactly `collaboration` or `multi_agent_v1`; use call ID rather
-  than tool name, because names are user-controlled.
-- Skip slimming only for matching `function_call_output` items. Other output
-  types keep their current treatment because agent-control protocol evidence
-  identifies function calls and their function-call outputs.
+- Derive protected call IDs from historical `function_call` and
+  `custom_tool_call` items whose namespace is exactly `collaboration` or
+  `multi_agent_v1`; use call ID rather than tool name, because names are
+  user-controlled.
+- Derive those IDs from the original `ResponsesRequest.input` before the
+  outbound payload normalization removes replay namespaces, then carry only
+  the IDs into slimming.
+- Skip slimming only for matching `function_call_output` and
+  `custom_tool_call_output` items. Other output types keep their current
+  treatment.
 - Keep the detector in the reusable core proxy module and use it from the
   service façade, so the two live paths share the classification rule.
 

--- a/openspec/changes/preserve-agent-control-output-slimming/design.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The bridge/service and direct WebSocket paths each slim historical
+`response.create` input before upstream send. The previous façade-only repair
+did not protect the direct core path and used a broad pending-call type set.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve outputs needed to continue namespaced collaboration and
+  multi-agent control flows.
+- Make bridge and direct-WebSocket slimming equivalent.
+- Retain normal payload reduction for shell and unnamespaced user tools.
+
+**Non-Goals:**
+
+- Do not alter namespace serialization, retry/fallback behavior, or archived
+  OpenSpec history.
+- Do not protect a tool merely because its name is `wait_agent` or
+  `send_input`.
+
+## Decisions
+
+- Derive protected call IDs from historical `function_call` items whose
+  namespace is exactly `collaboration` or `multi_agent_v1`; use call ID rather
+  than tool name, because names are user-controlled.
+- Skip slimming only for matching `function_call_output` items. Other output
+  types keep their current treatment because agent-control protocol evidence
+  identifies function calls and their function-call outputs.
+- Keep the detector in the reusable core proxy module and use it from the
+  service façade, so the two live paths share the classification rule.
+
+## Risks / Trade-offs
+
+- [A protected result can leave an oversized request above budget] -> existing
+  fail-fast `payload_too_large` handling remains authoritative.
+- [Malformed or missing IDs cannot be correlated safely] -> they remain
+  slimmable under the current policy.

--- a/openspec/changes/preserve-agent-control-output-slimming/design.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/design.md
@@ -26,9 +26,10 @@ did not protect the direct core path and used a broad pending-call type set.
   `custom_tool_call` items whose namespace is exactly `collaboration` or
   `multi_agent_v1`; use call ID rather than tool name, because names are
   user-controlled.
-- Derive those IDs from the original `ResponsesRequest.input` before the
-  outbound payload normalization removes replay namespaces, then carry only
-  the IDs into slimming.
+- Derive those IDs only from the historical prefix of the original
+  `ResponsesRequest.input` before outbound payload normalization removes replay
+  namespaces, then carry only the IDs into slimming. Recent calls cannot
+  protect historical outputs that reuse the same call ID.
 - Skip slimming only for matching `function_call_output` and
   `custom_tool_call_output` items. Other output types keep their current
   treatment.

--- a/openspec/changes/preserve-agent-control-output-slimming/proposal.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/proposal.md
@@ -10,8 +10,8 @@ namespaced collaboration wait or other agent-control call.
   only when its matching pending call has the `collaboration` or
   `multi_agent_v1` namespace.
 - Apply the same call-ID-based rule to the bridge/service and direct WebSocket
-  response-create slim paths, classifying from the original request before
-  outbound normalization strips replay namespaces.
+  response-create slim paths, classifying only the original historical prefix
+  before outbound normalization strips replay namespaces.
 - Keep unrelated oversized outputs, including bare-name user tools, eligible
   for the existing omission policy.
 

--- a/openspec/changes/preserve-agent-control-output-slimming/proposal.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/proposal.md
@@ -6,10 +6,12 @@ namespaced collaboration wait or other agent-control call.
 
 ## What Changes
 
-- Preserve a historical `function_call_output` only when its matching pending
-  `function_call` has the `collaboration` or `multi_agent_v1` namespace.
+- Preserve a historical `function_call_output` or `custom_tool_call_output`
+  only when its matching pending call has the `collaboration` or
+  `multi_agent_v1` namespace.
 - Apply the same call-ID-based rule to the bridge/service and direct WebSocket
-  response-create slim paths.
+  response-create slim paths, classifying from the original request before
+  outbound normalization strips replay namespaces.
 - Keep unrelated oversized outputs, including bare-name user tools, eligible
   for the existing omission policy.
 

--- a/openspec/changes/preserve-agent-control-output-slimming/proposal.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Response-create slimming can replace a completed agent-control result with an
+omission notice. The next model turn then loses the state returned by a
+namespaced collaboration wait or other agent-control call.
+
+## What Changes
+
+- Preserve a historical `function_call_output` only when its matching pending
+  `function_call` has the `collaboration` or `multi_agent_v1` namespace.
+- Apply the same call-ID-based rule to the bridge/service and direct WebSocket
+  response-create slim paths.
+- Keep unrelated oversized outputs, including bare-name user tools, eligible
+  for the existing omission policy.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: response-create slimming preserves the completed
+  state of namespaced agent-control calls on every live upstream path.
+
+## Impact
+
+Touches the response-create slim helpers in the proxy service and core WebSocket
+client plus focused unit coverage. No protocol serialization, fallback, or
+archived specification changes are included.

--- a/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
@@ -7,9 +7,11 @@ Every live upstream path MUST preserve a historical `function_call_output` or
 unchanged before forwarding an oversized Responses `response.create` when
 its non-empty `call_id` matches a historical `function_call` or
 `custom_tool_call` whose namespace is exactly `collaboration` or
-`multi_agent_v1`. The service MUST determine this from the original request
-input before outbound payload normalization removes replay namespaces, and use
-namespace and call ID rather than the tool name alone. Historical outputs
+`multi_agent_v1`. The service MUST determine this from the historical prefix of
+the original request input before outbound payload normalization removes replay
+namespaces, and use namespace and call ID rather than the tool name alone. A
+recent namespaced call MUST NOT protect a historical output that reuses its
+call ID. Historical outputs
 without such a matching call, including an unnamespaced user tool named
 `wait_agent` or `send_input`, MUST remain eligible for the normal omission
 policy.
@@ -38,3 +40,9 @@ policy.
   namespaces
 - **AND** the unrelated custom output remains eligible for the historical
   tool-output omission policy
+
+#### Scenario: Recent calls do not protect reused historical IDs
+- **WHEN** a historical unrelated output reuses the call ID of an
+  agent-control call that appears only after the latest user item
+- **THEN** every live slimming path leaves the historical output eligible for
+  the normal omission policy

--- a/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Namespaced agent-control function-call outputs survive historical slimming
+
+Every live upstream path MUST preserve a historical `function_call_output`
+unchanged before forwarding an oversized Responses `response.create` when
+its non-empty `call_id` matches a historical `function_call` whose namespace is
+exactly `collaboration` or `multi_agent_v1`. The service MUST determine this
+from namespace and call ID, not from the tool name alone. Historical outputs
+without such a matching call, including an unnamespaced user tool named
+`wait_agent` or `send_input`, MUST remain eligible for the normal omission
+policy.
+
+#### Scenario: Agent wait output is retained while unrelated outputs are slimmed
+- **WHEN** a historical `multi_agent_v1` `function_call` for `wait_agent` has
+  a large matching `function_call_output` and the request also has a large
+  shell output before the latest user turn
+- **THEN** both the bridge/service and direct WebSocket paths preserve the
+  agent wait output unchanged
+- **AND** both paths replace the shell output with the historical tool-output
+  omission notice
+
+#### Scenario: A bare-name user tool is not exempt
+- **WHEN** a historical unnamespaced `function_call` is named `wait_agent` or
+  `send_input` and has a large matching `function_call_output`
+- **THEN** each live slimming path leaves that output eligible for the normal
+  historical tool-output omission policy

--- a/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/specs/responses-api-compat/spec.md
@@ -1,12 +1,15 @@
 ## ADDED Requirements
 
-### Requirement: Namespaced agent-control function-call outputs survive historical slimming
+### Requirement: Namespaced agent-control tool-call outputs survive historical slimming
 
-Every live upstream path MUST preserve a historical `function_call_output`
+Every live upstream path MUST preserve a historical `function_call_output` or
+`custom_tool_call_output`
 unchanged before forwarding an oversized Responses `response.create` when
-its non-empty `call_id` matches a historical `function_call` whose namespace is
-exactly `collaboration` or `multi_agent_v1`. The service MUST determine this
-from namespace and call ID, not from the tool name alone. Historical outputs
+its non-empty `call_id` matches a historical `function_call` or
+`custom_tool_call` whose namespace is exactly `collaboration` or
+`multi_agent_v1`. The service MUST determine this from the original request
+input before outbound payload normalization removes replay namespaces, and use
+namespace and call ID rather than the tool name alone. Historical outputs
 without such a matching call, including an unnamespaced user tool named
 `wait_agent` or `send_input`, MUST remain eligible for the normal omission
 policy.
@@ -25,3 +28,13 @@ policy.
   `send_input` and has a large matching `function_call_output`
 - **THEN** each live slimming path leaves that output eligible for the normal
   historical tool-output omission policy
+
+#### Scenario: Namespaced custom tool output is retained after wire normalization
+- **WHEN** a historical `collaboration` `custom_tool_call` has a large
+  matching `custom_tool_call_output`, and another custom call uses a namespace
+  outside the agent-control allowlist
+- **THEN** HTTP bridge and WebSocket bridge forwarding preserve the
+  agent-control custom output even though both outbound payloads omit replay
+  namespaces
+- **AND** the unrelated custom output remains eligible for the historical
+  tool-output omission policy

--- a/openspec/changes/preserve-agent-control-output-slimming/tasks.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Classify protected agent-control call IDs by exact namespace and
+      `function_call` type in the reusable proxy slimming logic.
+- [x] 1.2 Apply that classification in both the bridge/service and direct
+      WebSocket historical slimming loops.
+
+## 2. Regression coverage
+
+- [x] 2.1 Prove both live slim paths retain a namespaced agent wait output
+      while slimming an unrelated shell output and an unnamespaced bare-name
+      user tool.
+
+## 3. Validation
+
+- [x] 3.1 Run the focused unit test and OpenSpec validation.

--- a/openspec/changes/preserve-agent-control-output-slimming/tasks.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/tasks.md
@@ -7,6 +7,8 @@
       WebSocket historical slimming loops.
 - [x] 1.3 Classify IDs from the original request before outbound normalization
       strips replay namespaces, while keeping the normalized wire payload.
+- [x] 1.4 Restrict pre-normalization classification to the historical prefix so
+      recent calls cannot protect historical outputs with reused IDs.
 
 ## 2. Regression coverage
 
@@ -16,6 +18,8 @@
 - [x] 2.2 Prove HTTP and WebSocket bridge forwarding preserves both namespaced
       function and custom outputs after wire namespace stripping, while an
       unrelated namespaced custom output is still slimmed.
+- [x] 2.3 Prove a recent namespaced call does not protect a historical output
+      that reuses its call ID.
 
 ## 3. Validation
 

--- a/openspec/changes/preserve-agent-control-output-slimming/tasks.md
+++ b/openspec/changes/preserve-agent-control-output-slimming/tasks.md
@@ -1,15 +1,21 @@
 ## 1. Implementation
 
 - [x] 1.1 Classify protected agent-control call IDs by exact namespace and
-      `function_call` type in the reusable proxy slimming logic.
+      `function_call` or `custom_tool_call` type in the reusable proxy
+      slimming logic.
 - [x] 1.2 Apply that classification in both the bridge/service and direct
       WebSocket historical slimming loops.
+- [x] 1.3 Classify IDs from the original request before outbound normalization
+      strips replay namespaces, while keeping the normalized wire payload.
 
 ## 2. Regression coverage
 
 - [x] 2.1 Prove both live slim paths retain a namespaced agent wait output
       while slimming an unrelated shell output and an unnamespaced bare-name
       user tool.
+- [x] 2.2 Prove HTTP and WebSocket bridge forwarding preserves both namespaced
+      function and custom outputs after wire namespace stripping, while an
+      unrelated namespaced custom output is still slimmed.
 
 ## 3. Validation
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10406,6 +10406,91 @@ async def test_stream_responses_uses_websocket_upstream_when_forced(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_websocket_preserves_agent_outputs_before_wire_namespace_strip(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 75.0
+        upstream_stream_transport = "websocket"
+        upstream_websocket_mode = "force"
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 40 * 1024)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
+    unrelated_custom_output = "unrelated-custom-result:" + ("u" * (33 * 1024))
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "collaboration",
+                    "name": "wait_agent",
+                    "call_id": "call_agent_custom",
+                    "input": '{"timeout_ms":120000}',
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_agent_custom",
+                    "output": agent_custom_output,
+                },
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "unrelated_namespace",
+                    "name": "wait_agent",
+                    "call_id": "call_unrelated_custom",
+                    "input": "{}",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_unrelated_custom",
+                    "output": unrelated_custom_output,
+                },
+                {"role": "user", "content": "continue"},
+            ],
+        }
+    )
+    response = _WsResponse(
+        [
+            _WsMessage(
+                proxy_module.aiohttp.WSMsgType.TEXT,
+                json.dumps({"type": "response.completed", "response": {"id": "resp_ws"}}),
+            )
+        ]
+    )
+    session = _WsSession(response)
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={"originator": "Codex Desktop"},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert len(events) == 1
+    upstream_input = cast(list[JsonValue], response.sent_json[0]["input"])
+    assert all("namespace" not in item for item in upstream_input if isinstance(item, dict))
+    assert cast(dict[str, JsonValue], upstream_input[1])["output"] == agent_custom_output
+    assert cast(dict[str, JsonValue], upstream_input[3])["output"] == (
+        proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+            bytes=len(unrelated_custom_output.encode("utf-8"))
+        )
+    )
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_forced_websocket_does_not_fallback_on_handshake_rejection(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
@@ -24261,6 +24346,142 @@ def test_slim_response_create_preserves_only_namespaced_agent_control_outputs(sl
     )
     assert cast(dict[str, JsonValue], slimmed_input[5])["output"] == omission_notice.format(
         bytes=len(shell_output.encode("utf-8"))
+    )
+
+
+@pytest.mark.parametrize(
+    "slimmer",
+    [
+        pytest.param(streaming_helpers_module._slim_response_create_payload_for_upstream, id="service-bridge"),
+        pytest.param(proxy_module._slim_response_create_payload_for_upstream, id="core-websocket"),
+    ],
+)
+def test_slim_response_create_preserves_only_namespaced_agent_control_custom_outputs(slimmer):
+    agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
+    unrelated_custom_output = "unrelated-custom-result:" + ("u" * (33 * 1024))
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "namespace": "collaboration",
+                "name": "wait_agent",
+                "call_id": "call_agent_custom",
+                "input": '{"timeout_ms":120000}',
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_agent_custom",
+                "output": agent_custom_output,
+            },
+            {
+                "type": "custom_tool_call",
+                "namespace": "unrelated_namespace",
+                "name": "wait_agent",
+                "call_id": "call_unrelated_custom",
+                "input": "{}",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_unrelated_custom",
+                "output": unrelated_custom_output,
+            },
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    }
+
+    slimmed_payload, summary = slimmer(payload, max_bytes=256)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+
+    assert summary is not None
+    assert summary["historical_tool_outputs_slimmed"] == 1
+    assert cast(dict[str, JsonValue], slimmed_input[1])["output"] == agent_custom_output
+    assert cast(dict[str, JsonValue], slimmed_input[3])["output"] == (
+        proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+            bytes=len(unrelated_custom_output.encode("utf-8"))
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "transport",
+    [
+        pytest.param(proxy_service._REQUEST_TRANSPORT_HTTP, id="http-bridge"),
+        pytest.param(proxy_service._REQUEST_TRANSPORT_WEBSOCKET, id="websocket-bridge"),
+    ],
+)
+def test_prepare_response_bridge_preserves_namespaced_custom_outputs_before_wire_namespace_strip(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: str,
+):
+    agent_function_output = "agent-function-result:" + ("f" * (33 * 1024))
+    agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
+    unrelated_custom_output = "unrelated-custom-result:" + ("u" * (33 * 1024))
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "",
+            "input": [
+                {
+                    "type": "function_call",
+                    "namespace": "multi_agent_v1",
+                    "name": "wait_agent",
+                    "call_id": "call_agent_function",
+                    "arguments": '{"timeout_ms":120000}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_agent_function",
+                    "output": agent_function_output,
+                },
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "collaboration",
+                    "name": "wait_agent",
+                    "call_id": "call_agent_custom",
+                    "input": '{"timeout_ms":120000}',
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_agent_custom",
+                    "output": agent_custom_output,
+                },
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "unrelated_namespace",
+                    "name": "wait_agent",
+                    "call_id": "call_unrelated_custom",
+                    "input": "{}",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_unrelated_custom",
+                    "output": unrelated_custom_output,
+                },
+                {"role": "user", "content": "continue"},
+            ],
+        }
+    )
+    monkeypatch.setattr(proxy_http_bridge_request_submit, "_upstream_response_create_max_bytes", lambda: 256)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+
+    _, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=transport,
+        client_metadata=None,
+    )
+
+    upstream_input = json.loads(text_data)["input"]
+    assert all("namespace" not in item for item in upstream_input if isinstance(item, dict))
+    assert upstream_input[1]["output"] == agent_function_output
+    assert upstream_input[3]["output"] == agent_custom_output
+    assert upstream_input[5]["output"] == proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+        bytes=len(unrelated_custom_output.encode("utf-8"))
     )
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -24423,6 +24423,54 @@ def test_slim_response_create_preserves_only_namespaced_agent_control_custom_out
 
 
 @pytest.mark.parametrize(
+    "slimmer",
+    [
+        pytest.param(streaming_helpers_module._slim_response_create_payload_for_upstream, id="service-bridge"),
+        pytest.param(proxy_module._slim_response_create_payload_for_upstream, id="core-websocket"),
+    ],
+)
+def test_slim_response_create_keeps_agent_control_protocols_separate_for_reused_call_id(slimmer):
+    agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
+    unrelated_function_output = "unrelated-function-result:" + ("f" * (33 * 1024))
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "namespace": "collaboration",
+                "name": "wait_agent",
+                "call_id": "call_reused",
+                "input": '{"timeout_ms":120000}',
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_reused",
+                "output": agent_custom_output,
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_reused",
+                "output": unrelated_function_output,
+            },
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    }
+
+    slimmed_payload, summary = slimmer(payload, max_bytes=256)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+
+    assert summary is not None
+    assert summary["historical_tool_outputs_slimmed"] == 1
+    assert cast(dict[str, JsonValue], slimmed_input[1])["output"] == agent_custom_output
+    assert cast(dict[str, JsonValue], slimmed_input[2])["output"] == (
+        proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+            bytes=len(unrelated_function_output.encode("utf-8"))
+        )
+    )
+
+
+@pytest.mark.parametrize(
     "transport",
     [
         pytest.param(proxy_service._REQUEST_TRANSPORT_HTTP, id="http-bridge"),

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10425,6 +10425,7 @@ async def test_stream_responses_websocket_preserves_agent_outputs_before_wire_na
 
     agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
     unrelated_custom_output = "unrelated-custom-result:" + ("u" * (33 * 1024))
+    reused_historical_output = "reused-historical-result:" + ("r" * (33 * 1024))
     payload = ResponsesRequest.model_validate(
         {
             "model": "gpt-5.4",
@@ -10454,7 +10455,19 @@ async def test_stream_responses_websocket_preserves_agent_outputs_before_wire_na
                     "call_id": "call_unrelated_custom",
                     "output": unrelated_custom_output,
                 },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_reused",
+                    "output": reused_historical_output,
+                },
                 {"role": "user", "content": "continue"},
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "collaboration",
+                    "name": "wait_agent",
+                    "call_id": "call_reused",
+                    "input": "{}",
+                },
             ],
         }
     )
@@ -10486,6 +10499,11 @@ async def test_stream_responses_websocket_preserves_agent_outputs_before_wire_na
     assert cast(dict[str, JsonValue], upstream_input[3])["output"] == (
         proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
             bytes=len(unrelated_custom_output.encode("utf-8"))
+        )
+    )
+    assert cast(dict[str, JsonValue], upstream_input[4])["output"] == (
+        proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+            bytes=len(reused_historical_output.encode("utf-8"))
         )
     )
 
@@ -24418,6 +24436,7 @@ def test_prepare_response_bridge_preserves_namespaced_custom_outputs_before_wire
     agent_function_output = "agent-function-result:" + ("f" * (33 * 1024))
     agent_custom_output = "agent-custom-result:" + ("c" * (33 * 1024))
     unrelated_custom_output = "unrelated-custom-result:" + ("u" * (33 * 1024))
+    reused_historical_output = "reused-historical-result:" + ("r" * (33 * 1024))
     payload = ResponsesRequest.model_validate(
         {
             "model": "gpt-5.1",
@@ -24459,7 +24478,19 @@ def test_prepare_response_bridge_preserves_namespaced_custom_outputs_before_wire
                     "call_id": "call_unrelated_custom",
                     "output": unrelated_custom_output,
                 },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_reused",
+                    "output": reused_historical_output,
+                },
                 {"role": "user", "content": "continue"},
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "collaboration",
+                    "name": "wait_agent",
+                    "call_id": "call_reused",
+                    "input": "{}",
+                },
             ],
         }
     )
@@ -24482,6 +24513,9 @@ def test_prepare_response_bridge_preserves_namespaced_custom_outputs_before_wire
     assert upstream_input[3]["output"] == agent_custom_output
     assert upstream_input[5]["output"] == proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
         bytes=len(unrelated_custom_output.encode("utf-8"))
+    )
+    assert upstream_input[6]["output"] == proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+        bytes=len(reused_historical_output.encode("utf-8"))
     )
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -24208,6 +24208,62 @@ def test_slim_response_create_slims_oversized_custom_and_apply_patch_string_outp
     assert second_item["status"] == "completed"
 
 
+@pytest.mark.parametrize(
+    "slimmer",
+    [
+        pytest.param(streaming_helpers_module._slim_response_create_payload_for_upstream, id="service-bridge"),
+        pytest.param(proxy_module._slim_response_create_payload_for_upstream, id="core-websocket"),
+    ],
+)
+def test_slim_response_create_preserves_only_namespaced_agent_control_outputs(slimmer):
+    agent_wait_output = "agent-wait-result:" + ("a" * (33 * 1024))
+    bare_name_user_tool_output = "user-wait-result:" + ("b" * (33 * 1024))
+    shell_output = "shell-result:" + ("c" * (33 * 1024))
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {
+                "type": "function_call",
+                "namespace": "multi_agent_v1",
+                "name": "wait_agent",
+                "call_id": "call_agent_wait",
+                "arguments": '{"timeout_ms":120000}',
+            },
+            {"type": "function_call_output", "call_id": "call_agent_wait", "output": agent_wait_output},
+            {
+                "type": "function_call",
+                "name": "wait_agent",
+                "call_id": "call_user_wait",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_user_wait", "output": bare_name_user_tool_output},
+            {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call_shell",
+                "arguments": '{"cmd":"cat large-log"}',
+            },
+            {"type": "function_call_output", "call_id": "call_shell", "output": shell_output},
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    }
+
+    slimmed_payload, summary = slimmer(payload, max_bytes=256)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+
+    assert summary is not None
+    assert summary["historical_tool_outputs_slimmed"] == 2
+    assert cast(dict[str, JsonValue], slimmed_input[1])["output"] == agent_wait_output
+    omission_notice = proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE
+    assert cast(dict[str, JsonValue], slimmed_input[3])["output"] == omission_notice.format(
+        bytes=len(bare_name_user_tool_output.encode("utf-8"))
+    )
+    assert cast(dict[str, JsonValue], slimmed_input[5])["output"] == omission_notice.format(
+        bytes=len(shell_output.encode("utf-8"))
+    )
+
+
 def test_slim_response_create_ignores_malformed_unhashable_item_type():
     malformed_type: list[JsonValue] = []
     payload: dict[str, JsonValue] = {


### PR DESCRIPTION
## Summary

Historical `response.create` slimming could replace the result of a namespaced collaboration call with an omission notice. A later model turn would then lose the state returned by `wait_agent` or another hosted agent-control action.

This change preserves only `function_call_output` items whose `call_id` matches a historical `function_call` in the `collaboration` or `multi_agent_v1` namespace. The same rule now applies to the bridge/service and direct WebSocket paths.

This is the focused slimming follow-up requested during review of [Soju06/codex-lb#1730](https://github.com/Soju06/codex-lb/pull/1730#issuecomment-5306392565). It does not carry the quarantine, namespace-serialization, replay, or test-stabilization work from that PR.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/preserve-agent-control-output-slimming/`

## Changes

- Derive protected call IDs only from namespaced historical `function_call` items.
- Preserve matching agent-control results in both live slimming implementations.
- Keep large shell outputs and unnamespaced user tools named `wait_agent` or `send_input` eligible for normal slimming.
- Add one parameterized regression covering both paths and the two negative controls.

## Test plan

The new regression failed on the unmodified base in both paths because all three large outputs were slimmed:

```text
2 failed
```

With this change:

```text
$ uv run pytest tests/unit/test_proxy_utils.py -q -k 'slim_response_create'
11 passed, 1108 deselected

$ uv run ruff check app/core/clients/proxy.py app/modules/proxy/_service/response_create.py app/modules/proxy/_service/streaming/helpers.py tests/unit/test_proxy_utils.py
All checks passed!

$ uv run ruff format --check app/core/clients/proxy.py app/modules/proxy/_service/response_create.py app/modules/proxy/_service/streaming/helpers.py tests/unit/test_proxy_utils.py
4 files already formatted

$ openspec validate preserve-agent-control-output-slimming --strict
Change 'preserve-agent-control-output-slimming' is valid
```

## Output

The regression asserts that a 33 KiB namespaced `wait_agent` result remains byte-identical while equally large shell output and an unnamespaced same-name user-tool result become the existing omission notice.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related pull request and maintainer review are linked above.
- [x] Added tests covering the change and both negative controls.
- [x] Ran the relevant focused test and lint subset locally.
- [x] The OpenSpec change passes strict validation.
- [x] Simplicity gates reviewed; this adds no setting, setup step, README section, environment example, dashboard item, or default change.
- [x] CHANGELOG is not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved matching historical agent-control function and custom-tool results during response payload size reduction.
  - Prevented reused call IDs from incorrectly preserving unrelated earlier results.
  - Applied consistently across service, bridge, and WebSocket response paths.
  - Continued reducing unrelated or unmatched oversized outputs as before.

- **Tests**
  - Added coverage for preserving relevant results while slimming unrelated outputs.

- **Documentation**
  - Added specifications describing the updated response compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->