### PR TITLE
fix(proxy): wait on usage-refresh singleflight without asyncio.shield

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -26,6 +26,7 @@ from app.core.plan_types import ACCOUNT_PLAN_TYPES, coerce_account_plan_type, no
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.usage.models import AdditionalRateLimitPayload, UsagePayload, UsageWindow
 from app.core.utils.request_id import get_request_id
+from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
@@ -199,14 +200,14 @@ class _UsageRefreshSingleflight:
             if wait_for_existing is None:
                 break
             try:
-                await asyncio.shield(wait_for_existing)
+                await wait_on_shared_future(wait_for_existing)
             except asyncio.CancelledError:
                 current_task = asyncio.current_task()
                 if current_task is not None and current_task.cancelling():
                     raise
             except Exception:
                 pass
-        return await asyncio.shield(task)
+        return await wait_on_shared_future(task)
 
     async def _run_factory(
         self,

--- a/openspec/changes/fix-usage-refresh-shared-future-waiters/.openspec.yaml
+++ b/openspec/changes/fix-usage-refresh-shared-future-waiters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/fix-usage-refresh-shared-future-waiters/design.md
+++ b/openspec/changes/fix-usage-refresh-shared-future-waiters/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`_UsageRefreshSingleflight` owns one task per account and may expose that task
+to many request and scheduler waiters. Its two shared waits still use
+`asyncio.shield`, unlike the bridge and token-refresh sites converted by
+[`harden-shared-future-admission-waits`](../harden-shared-future-admission-waits/).
+The existing helper already provides the required result, exception, and
+cancellation semantics; see the
+[`proxy-admission-control`](specs/proxy-admission-control/spec.md) delta and
+the existing
+[`proxy-runtime-observability`](../../specs/proxy-runtime-observability/)
+signals.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make both joining and non-joining usage-refresh waits constant-cost under
+  cancellation storms.
+- Preserve singleflight task ownership and successor ordering.
+- Prove the usage-refresh surface, not only the generic helper, maintains one
+  fan-out callback.
+
+**Non-Goals:**
+
+- Change refresh selection, persistence, exception swallowing, or shutdown.
+- Rewrite the helper or convert request-owned cleanup shields.
+- Integrate or rebase the unrelated session-ownership work in PR #1887.
+
+## Decisions
+
+### Reuse the established shared-future helper at both wait sites
+
+Both the `join_existing=True` return path and the `join_existing=False`
+predecessor wait can accumulate many waiters on one task, so both call
+`wait_on_shared_future`. Reusing the established helper preserves waiter
+cancellation isolation while keeping one fan-out callback. Keeping
+`asyncio.shield` at either site would retain the incident mechanism; a second
+usage-specific helper would duplicate the existing contract.
+
+### Preserve the current control flow
+
+The non-joining path continues swallowing predecessor failures and retries the
+loop, while caller cancellation continues propagating. The final wait
+continues propagating the selected task's result or exception. This limits the
+fix to waiter mechanics and avoids changing refresh policy.
+
+### Test callback structure through the usage singleflight
+
+The regression test attaches many `run` callers, inspects the in-flight task's
+callback count, cancels most callers, and verifies the count remains bounded
+while a survivor receives the factory result. This test fails with the old
+shield implementation because each waiter attaches callbacks to the shared
+task.
+
+## Risks / Trade-offs
+
+- **Risk:** The private callback-list assertion depends on CPython asyncio
+  internals. **Mitigation:** Match the existing helper and bridge regression
+  pattern, and guard only the structural property involved in the production
+  incident.
+- **Risk:** PR #1887 also edits the same singleflight. **Mitigation:** Keep this
+  patch focused on current `main` and call out the conflict so that PR must
+  carry this conversion forward.
+
+## Migration Plan
+
+Deploy through the normal image release process after merge. Rollback is a
+code rollback; there are no data, schema, or configuration migrations.

--- a/openspec/changes/fix-usage-refresh-shared-future-waiters/proposal.md
+++ b/openspec/changes/fix-usage-refresh-shared-future-waiters/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The usage-refresh singleflight was omitted when shared, many-waiter futures
+were hardened after the 2026-08-20 event-loop livelock. After roughly 91 hours
+of production uptime, cancelled usage-refresh waiters again drove the event
+loop into the same `asyncio.shield` callback-removal failure mode, so this
+remaining shared wait site must use the established fan-out helper.
+
+## What Changes
+
+- Route both usage-refresh singleflight wait paths through
+  `wait_on_shared_future`, preserving result, cancellation, exception, and
+  `join_existing=False` sequencing semantics.
+- Keep the shared refresh factory task running when an individual waiter is
+  cancelled or times out, with one bounded fan-out callback on that task.
+- Add usage-refresh surface regression coverage for concurrent joins,
+  cancellation isolation, callback fan-out, and successor sequencing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: extend the established shared-future admission
+  contract to usage-refresh singleflight waiters.
+
+## Impact
+
+- `app/modules/usage/updater.py` and `tests/unit/test_usage_updater.py`.
+- No API, schema, configuration, dependency, or deployment changes.
+- This is a focused follow-on to
+  [`harden-shared-future-admission-waits`](../harden-shared-future-admission-waits/)
+  and relies on the existing
+  [`proxy-admission-control`](../../specs/proxy-admission-control/) wait
+  mechanism and
+  [`proxy-runtime-observability`](../../specs/proxy-runtime-observability/)
+  event-loop lag signals.

--- a/openspec/changes/fix-usage-refresh-shared-future-waiters/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/fix-usage-refresh-shared-future-waiters/specs/proxy-admission-control/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Admission waits on shared futures scale O(1) per waiter
+
+When multiple requests wait on one shared future (an inflight bridge session creation, a capacity slot, a token-refresh singleflight, or a usage-refresh singleflight), the system MUST use the established shared-future fan-out wait mechanism so attaching a waiter, a waiter timing out, and a waiter being cancelled each perform O(1) work on the shared future. The shared future MUST carry a constant number of done callbacks regardless of waiter count, and the wait mechanism itself MUST NOT cancel or otherwise mutate the shared future or the work it represents when a waiter times out or is cancelled. Admission handlers MAY still settle the shared future explicitly after a waiter's timeout (the http-bridge timeout handler fails and unregisters the inflight future so piled-up waiters converge on one overload outcome); that settlement is an admission-contract decision, not a side effect of waiting. The shared future's result, exception, or cancellation MUST propagate to every waiter with the same semantics as `asyncio.wait_for(asyncio.shield(shared), timeout)`.
+
+#### Scenario: Waiter pile-up keeps the shared future's callback list constant
+
+- **WHEN** many requests wait on the same inflight bridge-session future
+- **THEN** the shared future carries a constant number of done callbacks
+- **AND** the callback count does not grow with the number of waiters
+
+#### Scenario: Mass timeout does not degrade the event loop
+
+- **GIVEN** waiters piled onto a shared future that has not resolved within
+  the admission wait timeout
+- **WHEN** the waiters time out together
+- **THEN** each timeout detaches in O(1) without scanning the shared future's
+  callback list
+- **AND** the surviving admission contract (local-overload `429` with the
+  capacity error code) is unchanged
+
+#### Scenario: Client-disconnect storm leaves the owner's creation running
+
+- **WHEN** every waiter on an inflight session future is cancelled by client
+  disconnects
+- **THEN** the shared future stays pending and the owner's session creation
+  continues
+- **AND** no per-waiter callbacks remain attached to the shared future
+
+#### Scenario: Cancelled usage-refresh waiters leave shared refresh running
+
+- **GIVEN** many callers are waiting on one in-flight usage refresh
+- **WHEN** all but one caller are cancelled
+- **THEN** the cancelled callers detach without adding or removing per-waiter
+  callbacks on the shared refresh task
+- **AND** the shared refresh continues to completion for the remaining caller
+
+#### Scenario: Non-joining usage refresh starts after its predecessor
+
+- **GIVEN** a usage refresh is already in flight for an account
+- **WHEN** another caller requests a non-joining refresh for that account
+- **THEN** it waits without cancelling or mutating the in-flight refresh
+- **AND** it starts a successor refresh only after the in-flight refresh has
+  finished

--- a/openspec/changes/fix-usage-refresh-shared-future-waiters/tasks.md
+++ b/openspec/changes/fix-usage-refresh-shared-future-waiters/tasks.md
@@ -1,0 +1,17 @@
+## 1. Shared-Future Wait Conversion
+
+- [x] 1.1 Audit remaining `asyncio.shield` calls in `app/` and confirm only usage-refresh singleflight matches the shared, many-waiter class.
+- [x] 1.2 Replace both `_UsageRefreshSingleflight.run` shared-task waits with `wait_on_shared_future` while preserving cancellation and exception semantics.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Test that concurrent usage-refresh waiters receive the same result and cancelling all but one does not cancel the factory task.
+- [x] 2.2 Test that cancelled usage-refresh waiters detach with one bounded fan-out callback on the in-flight task.
+- [x] 2.3 Test that `join_existing=False` waits for the predecessor before starting a successor through the shared-future helper.
+- [x] 2.4 Temporarily restore the shield implementation, run the callback fan-out regression test, and record the failing sabotage result.
+
+## 3. Verification
+
+- [x] 3.1 Run the targeted usage updater and shared-future waiter unit tests.
+- [x] 3.2 Run the repository lint source of truth and strict OpenSpec validation.
+- [x] 3.3 Record commands and exit codes in `/tmp/codex-lb-1896-verification.md`.

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -17,6 +17,7 @@ from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 from app.core.usage import refresh_scheduler as refresh_scheduler_module
 from app.core.usage.models import UsagePayload
 from app.core.usage.refresh_scheduler import _select_long_window_entries
+from app.core.utils.shared_future import _WAITERS_ATTR, wait_on_shared_future
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.usage import updater as usage_updater_module
@@ -75,6 +76,162 @@ async def test_usage_refresh_singleflight_cancel_all_cancels_inflight_task() -> 
         await task
     assert cancelled.is_set()
     assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_singleflight_concurrent_waiters_share_result() -> None:
+    singleflight = usage_updater_module._UsageRefreshSingleflight()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    result = usage_updater_module.AccountRefreshResult(usage_written=True)
+    factory_calls = 0
+
+    async def factory() -> usage_updater_module.AccountRefreshResult:
+        nonlocal factory_calls
+        factory_calls += 1
+        started.set()
+        await release.wait()
+        return result
+
+    waiters = [asyncio.create_task(singleflight.run("acc_shared_result", factory)) for _ in range(50)]
+    await asyncio.wait_for(started.wait(), timeout=1)
+    release.set()
+
+    results = await asyncio.gather(*waiters)
+
+    assert factory_calls == 1
+    assert all(item is result for item in results)
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_singleflight_waiter_cancellation_leaves_factory_running() -> None:
+    singleflight = usage_updater_module._UsageRefreshSingleflight()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    factory_cancelled = asyncio.Event()
+    result = usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    async def factory() -> usage_updater_module.AccountRefreshResult:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            factory_cancelled.set()
+            raise
+        return result
+
+    waiters = [asyncio.create_task(singleflight.run("acc_cancel_waiters", factory)) for _ in range(20)]
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    inflight = singleflight._inflight["acc_cancel_waiters"]
+
+    for waiter in waiters[:-1]:
+        waiter.cancel()
+    cancelled = await asyncio.gather(*waiters[:-1], return_exceptions=True)
+
+    assert all(isinstance(item, asyncio.CancelledError) for item in cancelled)
+    assert not inflight.done()
+    assert not factory_cancelled.is_set()
+
+    release.set()
+    assert await waiters[-1] is result
+    assert not factory_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_singleflight_cancelled_waiters_keep_callback_fanout_bounded() -> None:
+    singleflight = usage_updater_module._UsageRefreshSingleflight()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    result = usage_updater_module.AccountRefreshResult(usage_written=False)
+
+    async def factory() -> usage_updater_module.AccountRefreshResult:
+        started.set()
+        await release.wait()
+        return result
+
+    waiters = [asyncio.create_task(singleflight.run("acc_callback_fanout", factory)) for _ in range(100)]
+    await asyncio.wait_for(started.wait(), timeout=1)
+    inflight = singleflight._inflight["acc_callback_fanout"]
+    for _ in range(10):
+        if len(getattr(inflight, _WAITERS_ATTR, set())) == len(waiters):
+            break
+        await asyncio.sleep(0)
+
+    callbacks = getattr(inflight, "_callbacks", None)
+    assert callbacks is not None and len(callbacks) == 2, (
+        "usage-refresh waiters must share one fan-out callback in addition to "
+        f"singleflight cleanup; found {None if callbacks is None else len(callbacks)} callbacks"
+    )
+    assert len(getattr(inflight, _WAITERS_ATTR)) == len(waiters)
+
+    for waiter in waiters:
+        waiter.cancel()
+    cancelled = await asyncio.gather(*waiters, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert all(isinstance(item, asyncio.CancelledError) for item in cancelled)
+    assert not inflight.done()
+    callbacks = getattr(inflight, "_callbacks", None)
+    assert callbacks is not None and len(callbacks) == 2
+    assert getattr(inflight, _WAITERS_ATTR) == set()
+
+    release.set()
+    assert await inflight is result
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_singleflight_non_joiner_waits_then_starts_successor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = usage_updater_module._UsageRefreshSingleflight()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    successor_started = asyncio.Event()
+    release_successor = asyncio.Event()
+    first_result = usage_updater_module.AccountRefreshResult(usage_written=False)
+    successor_result = usage_updater_module.AccountRefreshResult(usage_written=True)
+    shared_waits: list[asyncio.Future[usage_updater_module.AccountRefreshResult]] = []
+
+    async def recording_wait(
+        shared: asyncio.Future[usage_updater_module.AccountRefreshResult],
+        *,
+        timeout: float | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        shared_waits.append(shared)
+        return await wait_on_shared_future(shared, timeout=timeout)
+
+    async def first_factory() -> usage_updater_module.AccountRefreshResult:
+        first_started.set()
+        await release_first.wait()
+        return first_result
+
+    async def successor_factory() -> usage_updater_module.AccountRefreshResult:
+        successor_started.set()
+        await release_successor.wait()
+        return successor_result
+
+    monkeypatch.setattr(usage_updater_module, "wait_on_shared_future", recording_wait)
+    first_waiter = asyncio.create_task(singleflight.run("acc_non_joiner", first_factory))
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    first_task = singleflight._inflight["acc_non_joiner"]
+    non_joiner = asyncio.create_task(
+        singleflight.run("acc_non_joiner", successor_factory, join_existing=False),
+    )
+    await asyncio.sleep(0)
+
+    assert not successor_started.is_set()
+    assert shared_waits.count(first_task) == 2
+
+    release_first.set()
+    assert await first_waiter is first_result
+    await asyncio.wait_for(successor_started.wait(), timeout=1)
+    successor_task = singleflight._inflight["acc_non_joiner"]
+    assert successor_task is not first_task
+
+    release_successor.set()
+    assert await non_joiner is successor_result
+    assert successor_task in shared_waits
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The shared usage-refresh singleflight remained on `asyncio.shield` after the
http-bridge and token-refresh shared waits were hardened. Under a large
cancelled-waiter backlog, shield attaches per-waiter callbacks to the long-lived
factory task and recreates the callback-removal storm that starves the event
loop.

## Approach

- Use `wait_on_shared_future` for both `_UsageRefreshSingleflight.run` wait
  paths: joining the current task and waiting for a predecessor when
  `join_existing=False`.
- Preserve the existing cancellation propagation, predecessor exception
  swallowing, result propagation, and successor ordering semantics.
- Add usage-refresh surface coverage for shared results, cancellation
  isolation, bounded callback fan-out, and non-joining successor sequencing.
- Add the strict-valid OpenSpec follow-on under
  `fix-usage-refresh-shared-future-waiters`, linked to the existing
  proxy-admission-control and proxy-runtime-observability contracts.

The sibling audit found no other remaining shared singleflight/inflight-map
shield sites in `app/`; request-owned cleanup, release, close, flush, and
settlement shields remain unchanged.

## Tests

- `uv run pytest tests/unit/test_usage_updater.py tests/unit/test_shared_future_waiters.py -q` — 127 passed
- `make lint` — passed
- `openspec validate fix-usage-refresh-shared-future-waiters --strict` — passed
- Sabotage proof: temporarily restoring `asyncio.shield` made the new fan-out
  regression fail with 201 callbacks for 100 waiters instead of the bounded
  count of 2; the helper implementation was then restored.

## Risk

The code change is limited to the two shared waits and reuses the established
helper without changing refresh ownership or policy. PR #1887 also edits
`app/modules/usage/updater.py`, still uses `asyncio.shield`, and adds an owned
task shield; it may conflict and must carry this conversion forward rather
than reintroducing the shared-wait pattern.

Fixes #1896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage refresh reliability when multiple requests refresh usage data concurrently.
  - Prevented cancelled or timed-out waiters from interrupting the shared refresh operation.
  - Preserved orderly handling of follow-up refreshes and existing error behavior.

- **Tests**
  - Added coverage for concurrent refreshes, cancellation isolation, bounded waiter handling, and successor refresh sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->