### PR TITLE
fix(db): clean stale SQLite sidecars during recovery

### DIFF
--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -62,12 +62,11 @@ def _remove_sqlite_sidecars(db_path: Path) -> None:
 
 @contextmanager
 def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
-    """Hold SQLite's exclusive lock across the replacement boundary.
+    """Fence recovery preparation with SQLite's exclusive lock.
 
-    Recovery renames the source file, so a writer that gets through after the
-    rename would keep writing the old inode instead of the installed database.
-    An immediate exclusive transaction makes that boundary fail closed for
-    active connections rather than letting them write into the renamed backup.
+    The lock blocks active writers while the recovered file and its sidecars
+    are prepared. The connection is closed when this context exits, before any
+    filesystem rename, because Windows rejects renames with an open handle.
     """
     connection = sqlite3.connect(str(db_path), timeout=0, isolation_level=None)
     acquired = False
@@ -75,7 +74,7 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
         try:
             connection.execute("BEGIN EXCLUSIVE")
             acquired = True
-        except sqlite3.OperationalError as exc:
+        except sqlite3.Error as exc:
             raise RuntimeError(f"could not acquire exclusive SQLite recovery lock for {db_path}: {exc}") from exc
         yield
     finally:
@@ -123,9 +122,9 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
             _write_dump(options.output, dump)
             _remove_sqlite_sidecars(options.output)
             _remove_sqlite_sidecars(options.source)
-            backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
-            options.source.replace(backup)
-            options.output.replace(options.source)
+        backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
+        options.source.replace(backup)
+        options.output.replace(options.source)
         return RecoveryOutcome(
             source=backup,
             output=options.source,

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import logging
 import sqlite3
 from dataclasses import dataclass
@@ -12,6 +13,8 @@ from app.core.config.settings import get_settings
 from app.db.sqlite_utils import IntegrityCheck, check_sqlite_integrity, sqlite_connection, sqlite_db_path_from_url
 
 logger = logging.getLogger(__name__)
+
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 
 
 @dataclass(slots=True)
@@ -36,6 +39,24 @@ def _timestamp() -> str:
 def _default_output_path(source: Path) -> Path:
     suffix = source.suffix or ".db"
     return source.with_name(f"{source.stem}.recover-{_timestamp()}{suffix}")
+
+
+def _sqlite_sidecar_paths(db_path: Path) -> tuple[Path, ...]:
+    fixed = tuple(db_path.with_name(f"{db_path.name}{suffix}") for suffix in _SQLITE_SIDECAR_SUFFIXES)
+    master = tuple(sorted(db_path.parent.glob(f"{db_path.name}-mj*")))
+    return (*fixed, *master)
+
+
+def _remove_sqlite_sidecars(db_path: Path) -> None:
+    failures: list[tuple[Path, OSError]] = []
+    for sidecar in _sqlite_sidecar_paths(db_path):
+        try:
+            sidecar.unlink(missing_ok=True)
+        except OSError as exc:
+            failures.append((sidecar, exc))
+    if failures:
+        details = "; ".join(f"{path}: {error}" for path, error in failures)
+        raise RuntimeError(f"failed to remove SQLite sidecars: {details}")
 
 
 def _load_dump(source: Path) -> str:
@@ -71,9 +92,12 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
         logger.info("SQLite integrity check OK. Proceeding with export/import.")
 
     dump = _load_dump(options.source)
+    _remove_sqlite_sidecars(options.output)
     _write_dump(options.output, dump)
+    _remove_sqlite_sidecars(options.output)
 
     if options.replace:
+        _remove_sqlite_sidecars(options.source)
         backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
         options.source.replace(backup)
         options.output.replace(options.source)

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -62,8 +62,18 @@ def _is_sqlite_sidecar_path(database: Path, candidate: Path) -> bool:
 
 
 def _validate_recovery_paths(source: Path, output: Path) -> None:
-    normalized_source = source.expanduser().resolve(strict=False)
-    normalized_output = output.expanduser().resolve(strict=False)
+    # Check lexical names before resolving symlinks. A sidecar path can itself
+    # be a symlink to a real database; resolving it first would hide the
+    # source/output overlap and let cleanup unlink the caller's symlink.
+    lexical_source = Path(os.path.abspath(source.expanduser()))
+    lexical_output = Path(os.path.abspath(output.expanduser()))
+    if _is_sqlite_sidecar_path(lexical_source, lexical_output):
+        raise ValueError(f"output path overlaps a SQLite sidecar of source: {source} -> {output}")
+    if _is_sqlite_sidecar_path(lexical_output, lexical_source):
+        raise ValueError(f"source path overlaps a SQLite sidecar of output: {source} -> {output}")
+
+    normalized_source = lexical_source.resolve(strict=False)
+    normalized_output = lexical_output.resolve(strict=False)
     if normalized_source == normalized_output:
         raise ValueError(f"source and output paths must differ: {source}")
     if _is_sqlite_sidecar_path(normalized_source, normalized_output):

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -67,6 +67,8 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
     The lock blocks active writers while the recovered file and its sidecars
     are prepared. The connection is closed when this context exits, before any
     filesystem rename, because Windows rejects renames with an open handle.
+    This leaves only the bounded post-probe window before the operator CLI's
+    renames; the exclusive transaction still fences all preparation work.
     """
     connection = sqlite3.connect(str(db_path), timeout=0, isolation_level=None)
     acquired = False
@@ -81,6 +83,21 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
         if acquired:
             connection.rollback()
         connection.close()
+
+
+def _replace_recovered_database(source: Path, output: Path, backup: Path) -> None:
+    source.replace(backup)
+    try:
+        output.replace(source)
+    except OSError as exc:
+        try:
+            backup.replace(source)
+        except OSError as restore_exc:
+            raise RuntimeError(
+                f"failed to install recovered SQLite database at {source}: {exc}; "
+                f"failed to restore the original database from {backup}: {restore_exc}"
+            ) from exc
+        raise RuntimeError(f"failed to install recovered SQLite database at {source}: {exc}") from exc
 
 
 def _load_dump(source: Path) -> str:
@@ -123,8 +140,7 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
             _remove_sqlite_sidecars(options.output)
             _remove_sqlite_sidecars(options.source)
         backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
-        options.source.replace(backup)
-        options.output.replace(options.source)
+        _replace_recovered_database(options.source, options.output, backup)
         return RecoveryOutcome(
             source=backup,
             output=options.source,

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -4,10 +4,11 @@ import argparse
 import glob
 import logging
 import sqlite3
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Iterator, Sequence
 
 from app.core.config.settings import get_settings
 from app.db.sqlite_utils import IntegrityCheck, check_sqlite_integrity, sqlite_connection, sqlite_db_path_from_url
@@ -59,6 +60,30 @@ def _remove_sqlite_sidecars(db_path: Path) -> None:
         raise RuntimeError(f"failed to remove SQLite sidecars: {details}")
 
 
+@contextmanager
+def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
+    """Hold SQLite's exclusive lock across the replacement boundary.
+
+    Recovery renames the source file, so a writer that gets through after the
+    rename would keep writing the old inode instead of the installed database.
+    An immediate exclusive transaction makes that boundary fail closed for
+    active connections rather than letting them write into the renamed backup.
+    """
+    connection = sqlite3.connect(str(db_path), timeout=0, isolation_level=None)
+    acquired = False
+    try:
+        try:
+            connection.execute("BEGIN EXCLUSIVE")
+            acquired = True
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError(f"could not acquire exclusive SQLite recovery lock for {db_path}: {exc}") from exc
+        yield
+    finally:
+        if acquired:
+            connection.rollback()
+        connection.close()
+
+
 def _load_dump(source: Path) -> str:
     try:
         with sqlite_connection(source) as conn:
@@ -92,21 +117,25 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
         logger.info("SQLite integrity check OK. Proceeding with export/import.")
 
     dump = _load_dump(options.source)
-    _remove_sqlite_sidecars(options.output)
-    _write_dump(options.output, dump)
-    _remove_sqlite_sidecars(options.output)
-
     if options.replace:
-        _remove_sqlite_sidecars(options.source)
-        backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
-        options.source.replace(backup)
-        options.output.replace(options.source)
+        with _sqlite_recovery_lock(options.source):
+            _remove_sqlite_sidecars(options.output)
+            _write_dump(options.output, dump)
+            _remove_sqlite_sidecars(options.output)
+            _remove_sqlite_sidecars(options.source)
+            backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
+            options.source.replace(backup)
+            options.output.replace(options.source)
         return RecoveryOutcome(
             source=backup,
             output=options.source,
             replaced=True,
             integrity=integrity,
         )
+
+    _remove_sqlite_sidecars(options.output)
+    _write_dump(options.output, dump)
+    _remove_sqlite_sidecars(options.output)
 
     return RecoveryOutcome(
         source=options.source,

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -80,9 +80,13 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
             raise RuntimeError(f"could not acquire exclusive SQLite recovery lock for {db_path}: {exc}") from exc
         yield
     finally:
-        if acquired:
-            connection.rollback()
-        connection.close()
+        try:
+            if acquired:
+                connection.rollback()
+        finally:
+            # Do not let a rollback failure strand the recovery handle. The
+            # rollback exception is preserved while close remains guaranteed.
+            connection.close()
 
 
 def _replace_recovered_database(source: Path, output: Path, backup: Path) -> None:

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -64,11 +64,11 @@ def _remove_sqlite_sidecars(db_path: Path) -> None:
 def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
     """Fence recovery preparation with SQLite's exclusive lock.
 
-    The lock blocks active writers while the recovered file and its sidecars
-    are prepared. The connection is closed when this context exits, before any
-    filesystem rename, because Windows rejects renames with an open handle.
-    This leaves only the bounded post-probe window before the operator CLI's
-    renames; the exclusive transaction still fences all preparation work.
+    The lock blocks active writers while the recovered file is imported. The
+    connection is closed when this context exits, before sidecars are removed
+    or any filesystem rename, because Windows rejects file mutations with an
+    open handle. Sidecar cleanup and the renames therefore require the caller
+    to keep external writers quiescent during the bounded post-probe window.
     """
     connection = sqlite3.connect(str(db_path), timeout=0, isolation_level=None)
     acquired = False
@@ -88,8 +88,12 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
 def _replace_recovered_database(source: Path, output: Path, backup: Path) -> None:
     source.replace(backup)
     try:
+        # A writer can recreate source sidecars after the probe closes and just
+        # before the source rename. Remove those orphaned entries while the
+        # source path is empty, before installing the recovered database.
+        _remove_sqlite_sidecars(source)
         output.replace(source)
-    except OSError as exc:
+    except (OSError, RuntimeError) as exc:
         try:
             backup.replace(source)
         except OSError as restore_exc:
@@ -134,11 +138,12 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
 
     dump = _load_dump(options.source)
     if options.replace:
+        _remove_sqlite_sidecars(options.output)
         with _sqlite_recovery_lock(options.source):
-            _remove_sqlite_sidecars(options.output)
             _write_dump(options.output, dump)
-            _remove_sqlite_sidecars(options.output)
-            _remove_sqlite_sidecars(options.source)
+        # Recovery-owned SQLite handles are closed before any sidecar unlink.
+        _remove_sqlite_sidecars(options.output)
+        _remove_sqlite_sidecars(options.source)
         backup = options.source.with_name(f"{options.source.name}.corrupt-{_timestamp()}")
         _replace_recovered_database(options.source, options.output, backup)
         return RecoveryOutcome(

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -43,7 +43,7 @@ def _default_output_path(source: Path) -> Path:
 
 def _sqlite_sidecar_paths(db_path: Path) -> tuple[Path, ...]:
     fixed = tuple(db_path.with_name(f"{db_path.name}{suffix}") for suffix in _SQLITE_SIDECAR_SUFFIXES)
-    master = tuple(sorted(db_path.parent.glob(f"{db_path.name}-mj*")))
+    master = tuple(sorted(db_path.parent.glob(f"{glob.escape(db_path.name)}-mj*")))
     return (*fixed, *master)
 
 

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import glob
 import logging
+import os
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -46,6 +47,29 @@ def _sqlite_sidecar_paths(db_path: Path) -> tuple[Path, ...]:
     fixed = tuple(db_path.with_name(f"{db_path.name}{suffix}") for suffix in _SQLITE_SIDECAR_SUFFIXES)
     master = tuple(sorted(db_path.parent.glob(f"{glob.escape(db_path.name)}-mj*")))
     return (*fixed, *master)
+
+
+def _is_sqlite_sidecar_path(database: Path, candidate: Path) -> bool:
+    database_parent = os.path.normcase(str(database.parent))
+    candidate_parent = os.path.normcase(str(candidate.parent))
+    if database_parent != candidate_parent:
+        return False
+
+    database_name = os.path.normcase(database.name)
+    candidate_name = os.path.normcase(candidate.name)
+    fixed_names = {f"{database_name}{suffix}" for suffix in _SQLITE_SIDECAR_SUFFIXES}
+    return candidate_name in fixed_names or candidate_name.startswith(f"{database_name}-mj")
+
+
+def _validate_recovery_paths(source: Path, output: Path) -> None:
+    normalized_source = source.expanduser().resolve(strict=False)
+    normalized_output = output.expanduser().resolve(strict=False)
+    if normalized_source == normalized_output:
+        raise ValueError(f"source and output paths must differ: {source}")
+    if _is_sqlite_sidecar_path(normalized_source, normalized_output):
+        raise ValueError(f"output path overlaps a SQLite sidecar of source: {source} -> {output}")
+    if _is_sqlite_sidecar_path(normalized_output, normalized_source):
+        raise ValueError(f"source path overlaps a SQLite sidecar of output: {source} -> {output}")
 
 
 def _remove_sqlite_sidecars(db_path: Path) -> None:
@@ -129,6 +153,7 @@ def _write_dump(output: Path, dump: str) -> None:
 
 
 def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
+    _validate_recovery_paths(options.source, options.output)
     if not options.source.exists():
         raise FileNotFoundError(f"sqlite database not found: {options.source}")
     if options.output.exists():

--- a/app/db/recover.py
+++ b/app/db/recover.py
@@ -85,14 +85,15 @@ def _remove_sqlite_sidecars(db_path: Path) -> None:
 
 
 @contextmanager
-def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
-    """Fence recovery preparation with SQLite's exclusive lock.
+def _sqlite_recovery_lock(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """Fence source export and output import with an exclusive SQLite lock.
 
-    The lock blocks active writers while the recovered file is imported. The
-    connection is closed when this context exits, before sidecars are removed
-    or any filesystem rename, because Windows rejects file mutations with an
-    open handle. Sidecar cleanup and the renames therefore require the caller
-    to keep external writers quiescent during the bounded post-probe window.
+    The lock blocks active writers while the source dump is generated and the
+    recovered file is imported. The connection is closed when this context
+    exits, before sidecars are removed or any filesystem rename, because
+    Windows rejects file mutations with an open handle. Sidecar cleanup and
+    the renames therefore require the caller to keep external writers
+    quiescent during the bounded post-probe window.
     """
     connection = sqlite3.connect(str(db_path), timeout=0, isolation_level=None)
     acquired = False
@@ -102,7 +103,7 @@ def _sqlite_recovery_lock(db_path: Path) -> Iterator[None]:
             acquired = True
         except sqlite3.Error as exc:
             raise RuntimeError(f"could not acquire exclusive SQLite recovery lock for {db_path}: {exc}") from exc
-        yield
+        yield connection
     finally:
         try:
             if acquired:
@@ -132,10 +133,9 @@ def _replace_recovered_database(source: Path, output: Path, backup: Path) -> Non
         raise RuntimeError(f"failed to install recovered SQLite database at {source}: {exc}") from exc
 
 
-def _load_dump(source: Path) -> str:
+def _load_dump(connection: sqlite3.Connection) -> str:
     try:
-        with sqlite_connection(source) as conn:
-            return "\n".join(conn.iterdump())
+        return "\n".join(connection.iterdump())
     except sqlite3.DatabaseError as exc:
         message = f"failed to read sqlite dump: {exc}"
         raise RuntimeError(message) from exc
@@ -165,11 +165,12 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
     else:
         logger.info("SQLite integrity check OK. Proceeding with export/import.")
 
-    dump = _load_dump(options.source)
+    _remove_sqlite_sidecars(options.output)
+    with _sqlite_recovery_lock(options.source) as source_connection:
+        dump = _load_dump(source_connection)
+        _write_dump(options.output, dump)
+
     if options.replace:
-        _remove_sqlite_sidecars(options.output)
-        with _sqlite_recovery_lock(options.source):
-            _write_dump(options.output, dump)
         # Recovery-owned SQLite handles are closed before any sidecar unlink.
         _remove_sqlite_sidecars(options.output)
         _remove_sqlite_sidecars(options.source)
@@ -182,8 +183,6 @@ def recover_sqlite_db(options: RecoveryOptions) -> RecoveryOutcome:
             integrity=integrity,
         )
 
-    _remove_sqlite_sidecars(options.output)
-    _write_dump(options.output, dump)
     _remove_sqlite_sidecars(options.output)
 
     return RecoveryOutcome(

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -36,5 +36,7 @@ untouched.
 
 ## Dependencies
 
-None. The implementation and proof stand on the beta.4 base without the
-startup run-state candidate.
+The implementation and proof stand on the beta.4 base without the startup
+run-state candidate. The hosted Contributors attribution check is a merge
+dependency on #1902, the sole carrier of contributor metadata; this change
+must not duplicate `.all-contributorsrc` or README edits.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -8,9 +8,12 @@ not part of the dump, so they must be removed at each replacement boundary.
 
 - Remove `-wal`, `-shm`, and `-journal` by exact path.
 - Remove `-mj*` master journals by globbing an escaped database basename.
-- Hold `BEGIN EXCLUSIVE` on the source across final output import, sidecar
-  cleanup, and source replacement. A lock failure aborts before any rename,
-  so an active connection cannot write the old inode after installation.
+- Hold `BEGIN EXCLUSIVE` on the source across final output import and sidecar
+  cleanup. Release and close that connection before any sidecar or database
+  rename because Windows rejects file mutations with an open SQLite handle.
+  The exclusive transaction remains the pre-replacement race/ownership fence:
+  active writers fail closed while the replacement is prepared, and a lock
+  failure aborts before any rename.
 - Fail recovery rather than install an ambiguous replacement when sidecar
   removal reports an error.
 
@@ -19,8 +22,10 @@ not part of the dump, so they must be removed at each replacement boundary.
 Recovery tests hold a source WAL open across dump creation, seed output
 sidecars, and verify the installed database and both sidecar sets. A boundary
 test attempts a write while the exclusive lock is held and verifies that a
-fresh connection writes to the installed database. A wildcard filename test
-proves unrelated master journals remain untouched.
+fresh connection writes to the installed database. A rename seam asserts that
+every tracked recovery connection is closed before each file mutation. Partial
+cleanup and busy-source failures prove no replacement is installed, and a
+wildcard filename test proves unrelated master journals remain untouched.
 
 ## Dependencies
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -13,16 +13,18 @@ not part of the dump, so they must be removed at each replacement boundary.
   output creation.
 - Remove pre-existing output sidecars before opening the recovery lock so stale
   WAL/journal state cannot attach during import. Hold `BEGIN EXCLUSIVE` on the
-  source across final output import. Release and close that connection before
-  final output/source sidecar cleanup or either database rename because Windows
-  rejects filesystem mutation with an open SQLite handle. Repeat source cleanup
-  after moving the source to its backup so sidecars recreated around that move
-  are removed before the recovered output is installed. The exclusive
-  transaction remains the pre-replacement race/ownership fence: active writers
-  fail closed while the replacement is prepared, and a lock failure aborts
-  before any rename. Closing the probe necessarily leaves a bounded post-probe
-  window before the cleanup and renames; the operator must keep external
-  writers quiescent throughout that window.
+  source before exporting it, generate the dump from that lock-holding
+  connection, and retain the transaction across final output import. Release
+  and close that connection before final output/source sidecar cleanup or
+  either database rename because Windows rejects filesystem mutation with an
+  open SQLite handle. Repeat source cleanup after moving the source to its
+  backup so sidecars recreated around that move are removed before the
+  recovered output is installed. The exclusive transaction remains the
+  pre-replacement race/ownership fence: active writers fail closed while the
+  snapshot is exported and the replacement is prepared, and a lock failure
+  aborts before any rename. Closing the probe necessarily leaves a bounded
+  post-probe window before the cleanup and renames; the operator must keep
+  external writers quiescent throughout that window.
 - Fail recovery rather than install an ambiguous replacement when pre-move
   sidecar removal reports an error. If the repeat source cleanup after the
   source move fails, restore the backup to the source path before reporting
@@ -37,10 +39,11 @@ not part of the dump, so they must be removed at each replacement boundary.
 ## Proof seam
 
 Recovery tests hold a source WAL open across dump creation, seed output
-sidecars, and verify the installed database and both sidecar sets. A boundary
-test attempts a write while the exclusive lock is held, closes that external
-writer before lock release, and verifies that a fresh connection writes to the
-installed database. A filesystem seam tracks
+sidecars, and verify the installed database and both sidecar sets. A snapshot
+boundary test attempts a write while the lock-holding connection exports the
+source, closes that external writer before lock release, and verifies that a
+fresh connection writes to the installed database in both output-only and
+replacement flows. A filesystem seam tracks
 every sidecar unlink and database rename, asserting that every tracked recovery
 connection is closed first; it also recreates a source sidecar around the
 source move to prove the repeat cleanup. Partial cleanup, busy-source, and

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -8,14 +8,19 @@ not part of the dump, so they must be removed at each replacement boundary.
 
 - Remove `-wal`, `-shm`, and `-journal` by exact path.
 - Remove `-mj*` master journals by globbing an escaped database basename.
+- Hold `BEGIN EXCLUSIVE` on the source across final output import, sidecar
+  cleanup, and source replacement. A lock failure aborts before any rename,
+  so an active connection cannot write the old inode after installation.
 - Fail recovery rather than install an ambiguous replacement when sidecar
   removal reports an error.
 
 ## Proof seam
 
 Recovery tests hold a source WAL open across dump creation, seed output
-sidecars, and verify the installed database and both sidecar sets. A wildcard
-filename test proves unrelated master journals remain untouched.
+sidecars, and verify the installed database and both sidecar sets. A boundary
+test attempts a write while the exclusive lock is held and verifies that a
+fresh connection writes to the installed database. A wildcard filename test
+proves unrelated master journals remain untouched.
 
 ## Dependencies
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -8,6 +8,9 @@ not part of the dump, so they must be removed at each replacement boundary.
 
 - Remove `-wal`, `-shm`, and `-journal` by exact path.
 - Remove `-mj*` master journals by globbing an escaped database basename.
+- Reject identical source/output paths and any source/output pair where either
+  path is the other's fixed sidecar or `-mj*` master journal before cleanup or
+  output creation.
 - Remove pre-existing output sidecars before opening the recovery lock so stale
   WAL/journal state cannot attach during import. Hold `BEGIN EXCLUSIVE` on the
   source across final output import. Release and close that connection before

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -20,8 +20,12 @@ not part of the dump, so they must be removed at each replacement boundary.
   before any rename. Closing the probe necessarily leaves a bounded post-probe
   window before the cleanup and renames; the operator must keep external
   writers quiescent throughout that window.
-- Fail recovery rather than install an ambiguous replacement when sidecar
-  removal reports an error.
+- Fail recovery rather than install an ambiguous replacement when pre-move
+  sidecar removal reports an error. If the repeat source cleanup after the
+  source move fails, restore the backup to the source path before reporting
+  the cleanup error; leave the recovered output and any partial cleanup in
+  place as operator-recovery artifacts rather than installing it as the live
+  source.
 - Treat the two filesystem renames as a small transaction: if installing the
   output fails after the source moved to its backup, restore the backup to the
   source path and report the original failure. If restoration also fails,
@@ -31,13 +35,16 @@ not part of the dump, so they must be removed at each replacement boundary.
 
 Recovery tests hold a source WAL open across dump creation, seed output
 sidecars, and verify the installed database and both sidecar sets. A boundary
-test attempts a write while the exclusive lock is held and verifies that a
-fresh connection writes to the installed database. A filesystem seam tracks
+test attempts a write while the exclusive lock is held, closes that external
+writer before lock release, and verifies that a fresh connection writes to the
+installed database. A filesystem seam tracks
 every sidecar unlink and database rename, asserting that every tracked recovery
 connection is closed first; it also recreates a source sidecar around the
 source move to prove the repeat cleanup. Partial cleanup, busy-source, and
 second-rename failures prove the replacement fails closed, and a wildcard
-filename test proves unrelated master journals remain untouched.
+filename test proves unrelated master journals remain untouched. A rollback
+seam injects a repeat-cleanup failure and verifies source restoration; the lock
+seam also verifies the handle closes when rollback itself raises.
 
 ## Dependencies
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -13,9 +13,15 @@ not part of the dump, so they must be removed at each replacement boundary.
   rename because Windows rejects file mutations with an open SQLite handle.
   The exclusive transaction remains the pre-replacement race/ownership fence:
   active writers fail closed while the replacement is prepared, and a lock
-  failure aborts before any rename.
+  failure aborts before any rename. Closing the probe necessarily leaves a
+  bounded post-probe window before the operator CLI's renames; this is the
+  accepted Windows trade-off, while all preparation work remains fenced.
 - Fail recovery rather than install an ambiguous replacement when sidecar
   removal reports an error.
+- Treat the two filesystem renames as a small transaction: if installing the
+  output fails after the source moved to its backup, restore the backup to the
+  source path and report the original failure. If restoration also fails,
+  include both errors so the operator can recover the preserved backup.
 
 ## Proof seam
 
@@ -24,8 +30,9 @@ sidecars, and verify the installed database and both sidecar sets. A boundary
 test attempts a write while the exclusive lock is held and verifies that a
 fresh connection writes to the installed database. A rename seam asserts that
 every tracked recovery connection is closed before each file mutation. Partial
-cleanup and busy-source failures prove no replacement is installed, and a
-wildcard filename test proves unrelated master journals remain untouched.
+cleanup, busy-source, and second-rename failures prove the replacement fails
+closed, and a wildcard filename test proves unrelated master journals remain
+untouched.
 
 ## Dependencies
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -8,14 +8,18 @@ not part of the dump, so they must be removed at each replacement boundary.
 
 - Remove `-wal`, `-shm`, and `-journal` by exact path.
 - Remove `-mj*` master journals by globbing an escaped database basename.
-- Hold `BEGIN EXCLUSIVE` on the source across final output import and sidecar
-  cleanup. Release and close that connection before any sidecar or database
-  rename because Windows rejects file mutations with an open SQLite handle.
-  The exclusive transaction remains the pre-replacement race/ownership fence:
-  active writers fail closed while the replacement is prepared, and a lock
-  failure aborts before any rename. Closing the probe necessarily leaves a
-  bounded post-probe window before the operator CLI's renames; this is the
-  accepted Windows trade-off, while all preparation work remains fenced.
+- Remove pre-existing output sidecars before opening the recovery lock so stale
+  WAL/journal state cannot attach during import. Hold `BEGIN EXCLUSIVE` on the
+  source across final output import. Release and close that connection before
+  final output/source sidecar cleanup or either database rename because Windows
+  rejects filesystem mutation with an open SQLite handle. Repeat source cleanup
+  after moving the source to its backup so sidecars recreated around that move
+  are removed before the recovered output is installed. The exclusive
+  transaction remains the pre-replacement race/ownership fence: active writers
+  fail closed while the replacement is prepared, and a lock failure aborts
+  before any rename. Closing the probe necessarily leaves a bounded post-probe
+  window before the cleanup and renames; the operator must keep external
+  writers quiescent throughout that window.
 - Fail recovery rather than install an ambiguous replacement when sidecar
   removal reports an error.
 - Treat the two filesystem renames as a small transaction: if installing the
@@ -28,11 +32,12 @@ not part of the dump, so they must be removed at each replacement boundary.
 Recovery tests hold a source WAL open across dump creation, seed output
 sidecars, and verify the installed database and both sidecar sets. A boundary
 test attempts a write while the exclusive lock is held and verifies that a
-fresh connection writes to the installed database. A rename seam asserts that
-every tracked recovery connection is closed before each file mutation. Partial
-cleanup, busy-source, and second-rename failures prove the replacement fails
-closed, and a wildcard filename test proves unrelated master journals remain
-untouched.
+fresh connection writes to the installed database. A filesystem seam tracks
+every sidecar unlink and database rename, asserting that every tracked recovery
+connection is closed first; it also recreates a source sidecar around the
+source move to prove the repeat cleanup. Partial cleanup, busy-source, and
+second-rename failures prove the replacement fails closed, and a wildcard
+filename test proves unrelated master journals remain untouched.
 
 ## Dependencies
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/design.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/design.md
@@ -1,0 +1,23 @@
+## Context
+
+Recovery exports the source and imports a dump into a new output before an
+optional replacement. SQLite sidecars are separate filesystem entries and are
+not part of the dump, so they must be removed at each replacement boundary.
+
+## Decisions
+
+- Remove `-wal`, `-shm`, and `-journal` by exact path.
+- Remove `-mj*` master journals by globbing an escaped database basename.
+- Fail recovery rather than install an ambiguous replacement when sidecar
+  removal reports an error.
+
+## Proof seam
+
+Recovery tests hold a source WAL open across dump creation, seed output
+sidecars, and verify the installed database and both sidecar sets. A wildcard
+filename test proves unrelated master journals remain untouched.
+
+## Dependencies
+
+None. The implementation and proof stand on the beta.4 base without the
+startup run-state candidate.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -9,6 +9,8 @@ with those sidecars present can attach stale state to the replacement.
 - Remove fixed SQLite sidecars around output dump import and source replacement.
 - Match master journals literally so glob metacharacters in a database name
   cannot remove another database's journal.
+- Hold an exclusive SQLite recovery lock across the final import and source
+  replacement boundary, failing closed if an active writer prevents the lock.
 
 The recovery output and backup naming remain unchanged.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -9,8 +9,10 @@ with those sidecars present can attach stale state to the replacement.
 - Remove fixed SQLite sidecars around output dump import and source replacement.
 - Match master journals literally so glob metacharacters in a database name
   cannot remove another database's journal.
-- Hold an exclusive SQLite recovery lock across the final import and source
-  replacement boundary, failing closed if an active writer prevents the lock.
+- Fence final output import and sidecar cleanup with an exclusive SQLite
+  transaction, then close every recovery connection before sidecar or database
+  renames so Windows can perform the file mutations. Fail closed if the lock or
+  any sidecar cleanup cannot complete.
 
 The recovery output and backup naming remain unchanged.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -26,5 +26,8 @@ or runtime startup behavior.
 
 ## Dependencies
 
-None. This focused change is based directly on beta.4 and does not require the
-SQLite startup run-state changes from the other local candidate.
+The implementation is self-contained and does not require the SQLite startup
+run-state changes from the other local candidate. The hosted Contributors
+attribution check is intentionally carried by #1902, which is the sole PR
+allowed to change contributor metadata; merge #1902 first (or otherwise satisfy
+that check) before merging this PR.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -14,7 +14,10 @@ with those sidecars present can attach stale state to the replacement.
   before final sidecar cleanup or either database rename so Windows can perform
   the file mutations; repeat source cleanup after the source move to catch
   sidecars recreated around that move. Fail closed if the lock or any sidecar
-  cleanup cannot complete. If the second replacement rename fails, restore the
+  cleanup cannot complete before the source move. If repeat source cleanup
+  fails after the source move, restore the original source path before
+  reporting the error and leave the recovered output as an uninstalled
+  recovery artifact. If the second replacement rename fails, restore the
   original source path before reporting the error. Closing the transaction
   leaves a bounded post-probe window before cleanup and renames, so the
   operator must keep external writers quiescent throughout it.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -12,7 +12,10 @@ with those sidecars present can attach stale state to the replacement.
 - Fence final output import and sidecar cleanup with an exclusive SQLite
   transaction, then close every recovery connection before sidecar or database
   renames so Windows can perform the file mutations. Fail closed if the lock or
-  any sidecar cleanup cannot complete.
+  any sidecar cleanup cannot complete. If the second replacement rename fails,
+  restore the original source path before reporting the error. Closing the
+  transaction leaves a bounded post-probe window before the operator CLI's
+  renames; all preparation work remains fenced.
 
 The recovery output and backup naming remain unchanged.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -11,18 +11,19 @@ with those sidecars present can attach stale state to the replacement.
   cannot remove another database's journal.
 - Reject identical source/output paths and source/output overlap with either
   path's fixed sidecars or master-journal namespace before any cleanup or write.
-- Remove pre-existing output sidecars before import, then fence final output
-  import with an exclusive SQLite transaction. Close every recovery connection
-  before final sidecar cleanup or either database rename so Windows can perform
-  the file mutations; repeat source cleanup after the source move to catch
-  sidecars recreated around that move. Fail closed if the lock or any sidecar
-  cleanup cannot complete before the source move. If repeat source cleanup
-  fails after the source move, restore the original source path before
-  reporting the error and leave the recovered output as an uninstalled
-  recovery artifact. If the second replacement rename fails, restore the
-  original source path before reporting the error. Closing the transaction
-  leaves a bounded post-probe window before cleanup and renames, so the
-  operator must keep external writers quiescent throughout it.
+- Remove pre-existing output sidecars before opening an exclusive SQLite
+  recovery transaction. Acquire that lock before exporting the source, generate
+  the dump from the lock-holding connection, and keep the transaction through
+  output import. Close every recovery connection before final sidecar cleanup
+  or either database rename so Windows can perform the file mutations; repeat
+  source cleanup after the source move to catch sidecars recreated around that
+  move. Fail closed if the lock or any sidecar cleanup cannot complete before
+  the source move. If repeat source cleanup fails after the source move, restore
+  the original source path before reporting the error and leave the recovered
+  output as an uninstalled recovery artifact. If the second replacement rename
+  fails, restore the original source path before reporting the error. Closing
+  the transaction leaves a bounded post-probe window before cleanup and
+  renames, so the operator must keep external writers quiescent throughout it.
 
 The recovery output and backup naming remain unchanged.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -9,6 +9,8 @@ with those sidecars present can attach stale state to the replacement.
 - Remove fixed SQLite sidecars around output dump import and source replacement.
 - Match master journals literally so glob metacharacters in a database name
   cannot remove another database's journal.
+- Reject identical source/output paths and source/output overlap with either
+  path's fixed sidecars or master-journal namespace before any cleanup or write.
 - Remove pre-existing output sidecars before import, then fence final output
   import with an exclusive SQLite transaction. Close every recovery connection
   before final sidecar cleanup or either database rename so Windows can perform

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+SQLite recovery can leave WAL, shared-memory, rollback-journal, or
+master-journal files beside the source or output. Installing a recovered file
+with those sidecars present can attach stale state to the replacement.
+
+## What Changes
+
+- Remove fixed SQLite sidecars around output dump import and source replacement.
+- Match master journals literally so glob metacharacters in a database name
+  cannot remove another database's journal.
+
+The recovery output and backup naming remain unchanged.
+
+## Impact
+
+This is isolated to file-backed SQLite recovery. It adds no migration, setting,
+or runtime startup behavior.
+
+## Dependencies
+
+None. This focused change is based directly on beta.4 and does not require the
+SQLite startup run-state changes from the other local candidate.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/proposal.md
@@ -9,13 +9,15 @@ with those sidecars present can attach stale state to the replacement.
 - Remove fixed SQLite sidecars around output dump import and source replacement.
 - Match master journals literally so glob metacharacters in a database name
   cannot remove another database's journal.
-- Fence final output import and sidecar cleanup with an exclusive SQLite
-  transaction, then close every recovery connection before sidecar or database
-  renames so Windows can perform the file mutations. Fail closed if the lock or
-  any sidecar cleanup cannot complete. If the second replacement rename fails,
-  restore the original source path before reporting the error. Closing the
-  transaction leaves a bounded post-probe window before the operator CLI's
-  renames; all preparation work remains fenced.
+- Remove pre-existing output sidecars before import, then fence final output
+  import with an exclusive SQLite transaction. Close every recovery connection
+  before final sidecar cleanup or either database rename so Windows can perform
+  the file mutations; repeat source cleanup after the source move to catch
+  sidecars recreated around that move. Fail closed if the lock or any sidecar
+  cleanup cannot complete. If the second replacement rename fails, restore the
+  original source path before reporting the error. Closing the transaction
+  leaves a bounded post-probe window before cleanup and renames, so the
+  operator must keep external writers quiescent throughout it.
 
 The recovery output and backup naming remain unchanged.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -10,41 +10,45 @@ master-journal namespace.
 
 When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
-before and after dump import. For `--replace`, pre-existing output sidecars
-MUST be removed before opening the recovery lock; recovery MUST then acquire an
-exclusive SQLite transaction on the source before final output import. Once
-that transaction closes, recovery MUST perform final output/source sidecar
-cleanup before either database rename. It MUST remove source sidecars before
-moving the source to its corrupt backup and repeat source cleanup after that
-move, before installing the output. Master-journal matching MUST treat the
-database basename literally. Recovery MUST close every recovery-opened SQLite
-connection before each sidecar unlink or database rename. The operator MUST
-keep external writers quiescent from lock release through completion of both
-renames; this is the bounded post-probe window required by platforms that
-reject filesystem mutation with open SQLite handles. If an active connection
-prevents the lock, or any pre-move sidecar cleanup fails, recovery MUST fail
-without moving the source or installing the output. If the repeat source
-cleanup after the source move fails, recovery MUST restore the source from its
-corrupt backup before reporting the cleanup failure; the recovered output MUST
-NOT be installed as the live source, though the output and any partially
-cleaned sidecars MAY remain for operator recovery.
+before and after dump import. For both output-only and `--replace` flows,
+pre-existing output sidecars MUST be removed before opening the recovery lock;
+recovery MUST then acquire an exclusive SQLite transaction on the source before
+exporting the source dump, generate that dump from the lock-holding connection,
+and retain the transaction through final output import. Once that transaction
+closes, recovery MUST perform final output/source sidecar cleanup before either
+database rename. It MUST remove source sidecars before moving the source to its
+corrupt backup and repeat source cleanup after that move, before installing the
+output. Master-journal matching MUST treat the database basename literally.
+Recovery MUST close every recovery-opened SQLite connection before each sidecar
+unlink or database rename. The operator MUST keep external writers quiescent
+from lock release through completion of both renames; this is the bounded
+post-probe window required by platforms that reject filesystem mutation with
+open SQLite handles. If an active connection prevents the lock, or any
+pre-move sidecar cleanup fails, recovery MUST fail without moving the source or
+installing the output. If the repeat source cleanup after the source move
+fails, recovery MUST restore the source from its corrupt backup before
+reporting the cleanup failure; the recovered output MUST NOT be installed as
+the live source, though the output and any partially cleaned sidecars MAY
+remain for operator recovery.
 
 #### Scenario: A stale source WAL cannot attach to the replacement
 
 - **GIVEN** recovery is replacing a file-backed SQLite database
-- **AND** a source WAL is created after the dump is read
+- **AND** source WAL/shared-memory sidecars contain rows that are absent from
+  the exported dump
 - **AND** external writers remain quiescent after the recovery lock closes
   until both replacement renames complete
 - **WHEN** recovery moves the source aside and installs the output
 - **THEN** source and output SQLite sidecars MUST be absent
 - **AND** reopening the installed database MUST not apply stale WAL rows
 
-#### Scenario: An active writer cannot cross the fenced preparation boundary
+#### Scenario: An active writer cannot cross the fenced snapshot boundary
 
 - **GIVEN** a source connection is open while recovery is replacing the database
 - **AND** the external writer closes its connection before recovery releases
   the lock and starts replacement renames
-- **WHEN** that connection attempts a write during final import and cleanup
+- **WHEN** that connection attempts a write while recovery exports the source
+  from the lock-holding transaction
 - **THEN** the write MUST fail with the source's exclusive recovery lock held
 - **AND** a fresh connection MUST be able to write to the installed database
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -1,0 +1,27 @@
+# database-migrations Delta
+
+## ADDED Requirements
+
+### Requirement: SQLite recovery MUST fence replacement sidecars
+
+When recovery writes or installs a file-backed SQLite replacement, it MUST
+remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
+before and after dump import. With `--replace`, it MUST remove source sidecars
+before moving the source to its corrupt backup. Master-journal matching MUST
+treat the database basename literally.
+
+#### Scenario: A stale source WAL cannot attach to the replacement
+
+- **GIVEN** recovery is replacing a file-backed SQLite database
+- **AND** a source WAL is created after the dump is read
+- **WHEN** recovery moves the source aside and installs the output
+- **THEN** source and output SQLite sidecars MUST be absent
+- **AND** reopening the installed database MUST not apply stale WAL rows
+
+#### Scenario: Wildcard names do not broaden cleanup
+
+- **GIVEN** the database basename contains a glob metacharacter
+- **AND** an unrelated database has a matching-looking master journal
+- **WHEN** recovery cleans the target sidecars
+- **THEN** the target journal MUST be removed
+- **AND** the unrelated journal MUST remain

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -7,11 +7,16 @@
 When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
 before and after dump import. With `--replace`, it MUST remove source sidecars
-before moving the source to its corrupt backup. Master-journal matching MUST
-treat the database basename literally. Before final output import and sidecar
-cleanup, recovery MUST acquire an exclusive SQLite transaction on the source
-and MUST close every recovery-opened SQLite connection before any sidecar or
-database rename.
+before moving the source to its corrupt backup and repeat source cleanup after
+that move, before installing the output. Master-journal matching MUST treat the
+database basename literally. Before final output import, recovery MUST acquire
+an exclusive SQLite transaction on the source. After that transaction closes,
+recovery MUST perform final sidecar cleanup before either database rename, and
+MUST close every recovery-opened SQLite connection before each sidecar unlink or
+database rename. The operator MUST keep external writers quiescent from lock
+release through completion of both renames; this is the bounded post-probe
+window required by platforms that reject filesystem mutation with open SQLite
+handles.
 If an active connection prevents the lock, or sidecar cleanup fails, recovery
 MUST fail without moving the source or installing the output.
 
@@ -19,6 +24,8 @@ MUST fail without moving the source or installing the output.
 
 - **GIVEN** recovery is replacing a file-backed SQLite database
 - **AND** a source WAL is created after the dump is read
+- **AND** external writers remain quiescent after the recovery lock closes
+  until both replacement renames complete
 - **WHEN** recovery moves the source aside and installs the output
 - **THEN** source and output SQLite sidecars MUST be absent
 - **AND** reopening the installed database MUST not apply stale WAL rows

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -6,17 +6,18 @@
 
 When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
-before and after dump import. With `--replace`, it MUST remove source sidecars
-before moving the source to its corrupt backup and repeat source cleanup after
-that move, before installing the output. Master-journal matching MUST treat the
-database basename literally. Before final output import, recovery MUST acquire
-an exclusive SQLite transaction on the source. After that transaction closes,
-recovery MUST perform final sidecar cleanup before either database rename, and
-MUST close every recovery-opened SQLite connection before each sidecar unlink or
-database rename. The operator MUST keep external writers quiescent from lock
-release through completion of both renames; this is the bounded post-probe
-window required by platforms that reject filesystem mutation with open SQLite
-handles.
+before and after dump import. For `--replace`, pre-existing output sidecars
+MUST be removed before opening the recovery lock; recovery MUST then acquire an
+exclusive SQLite transaction on the source before final output import. Once
+that transaction closes, recovery MUST perform final output/source sidecar
+cleanup before either database rename. It MUST remove source sidecars before
+moving the source to its corrupt backup and repeat source cleanup after that
+move, before installing the output. Master-journal matching MUST treat the
+database basename literally. Recovery MUST close every recovery-opened SQLite
+connection before each sidecar unlink or database rename. The operator MUST
+keep external writers quiescent from lock release through completion of both
+renames; this is the bounded post-probe window required by platforms that
+reject filesystem mutation with open SQLite handles.
 If an active connection prevents the lock, or sidecar cleanup fails, recovery
 MUST fail without moving the source or installing the output.
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -4,6 +4,10 @@
 
 ### Requirement: SQLite recovery MUST fence replacement sidecars
 
+Before any sidecar cleanup or output write, recovery MUST reject source/output
+paths that are identical or overlap either path's fixed SQLite sidecars or
+master-journal namespace.
+
 When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
 before and after dump import. For `--replace`, pre-existing output sidecars
@@ -90,3 +94,11 @@ cleaned sidecars MAY remain for operator recovery.
 - **WHEN** recovery cleans the target sidecars
 - **THEN** the target journal MUST be removed
 - **AND** the unrelated journal MUST remain
+
+#### Scenario: Source and output sidecar namespaces cannot overlap
+
+- **GIVEN** the source or output path is a fixed SQLite sidecar or master
+  journal of the other path
+- **WHEN** recovery is invoked in either replace or non-replace mode
+- **THEN** recovery MUST fail before deleting sidecars, writing output, or
+  moving the source

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -8,7 +8,10 @@ When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
 before and after dump import. With `--replace`, it MUST remove source sidecars
 before moving the source to its corrupt backup. Master-journal matching MUST
-treat the database basename literally.
+treat the database basename literally. Before that final import and replacement
+boundary, recovery MUST hold an exclusive SQLite transaction on the source;
+if an active connection prevents the lock, recovery MUST fail without moving
+the source or installing the output.
 
 #### Scenario: A stale source WAL cannot attach to the replacement
 
@@ -17,6 +20,21 @@ treat the database basename literally.
 - **WHEN** recovery moves the source aside and installs the output
 - **THEN** source and output SQLite sidecars MUST be absent
 - **AND** reopening the installed database MUST not apply stale WAL rows
+
+#### Scenario: An active writer cannot cross the replacement boundary
+
+- **GIVEN** a source connection is open while recovery is replacing the database
+- **WHEN** that connection attempts a write during the final import and rename
+- **THEN** the write MUST fail with the source's exclusive recovery lock held
+- **AND** a fresh connection MUST be able to write to the installed database
+
+#### Scenario: A busy source fails closed before replacement
+
+- **GIVEN** another process already holds a conflicting SQLite write lock
+- **WHEN** recovery cannot acquire its exclusive source lock
+- **THEN** recovery MUST fail
+- **AND** the source MUST remain at its original path
+- **AND** no replacement MUST be installed
 
 #### Scenario: Wildcard names do not broaden cleanup
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -17,9 +17,13 @@ database basename literally. Recovery MUST close every recovery-opened SQLite
 connection before each sidecar unlink or database rename. The operator MUST
 keep external writers quiescent from lock release through completion of both
 renames; this is the bounded post-probe window required by platforms that
-reject filesystem mutation with open SQLite handles.
-If an active connection prevents the lock, or sidecar cleanup fails, recovery
-MUST fail without moving the source or installing the output.
+reject filesystem mutation with open SQLite handles. If an active connection
+prevents the lock, or any pre-move sidecar cleanup fails, recovery MUST fail
+without moving the source or installing the output. If the repeat source
+cleanup after the source move fails, recovery MUST restore the source from its
+corrupt backup before reporting the cleanup failure; the recovered output MUST
+NOT be installed as the live source, though the output and any partially
+cleaned sidecars MAY remain for operator recovery.
 
 #### Scenario: A stale source WAL cannot attach to the replacement
 
@@ -34,6 +38,8 @@ MUST fail without moving the source or installing the output.
 #### Scenario: An active writer cannot cross the fenced preparation boundary
 
 - **GIVEN** a source connection is open while recovery is replacing the database
+- **AND** the external writer closes its connection before recovery releases
+  the lock and starts replacement renames
 - **WHEN** that connection attempts a write during final import and cleanup
 - **THEN** the write MUST fail with the source's exclusive recovery lock held
 - **AND** a fresh connection MUST be able to write to the installed database
@@ -59,6 +65,15 @@ MUST fail without moving the source or installing the output.
 - **WHEN** recovery prepares a replacement
 - **THEN** recovery MUST fail before moving the source or installing the output
 - **AND** the source MUST remain at its original path
+
+#### Scenario: Post-move sidecar cleanup restores the source
+
+- **GIVEN** recovery has moved the source to its corrupt backup
+- **AND** the repeat source sidecar cleanup fails
+- **WHEN** recovery handles the cleanup error
+- **THEN** the corrupt backup MUST be restored to the original source path
+- **AND** the recovered output MUST remain uninstalled as the live source
+- **AND** recovery MUST report the cleanup failure
 
 #### Scenario: Output installation failure restores the source
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -52,6 +52,14 @@ MUST fail without moving the source or installing the output.
 - **THEN** recovery MUST fail before moving the source or installing the output
 - **AND** the source MUST remain at its original path
 
+#### Scenario: Output installation failure restores the source
+
+- **GIVEN** the source has moved to its corrupt backup
+- **AND** moving the recovered output into the source path fails
+- **WHEN** recovery handles the replacement error
+- **THEN** recovery MUST restore the corrupt backup to the original source path
+- **AND** recovery MUST report the installation failure
+
 #### Scenario: Wildcard names do not broaden cleanup
 
 - **GIVEN** the database basename contains a glob metacharacter

--- a/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/specs/database-migrations/spec.md
@@ -8,10 +8,12 @@ When recovery writes or installs a file-backed SQLite replacement, it MUST
 remove the target's `-wal`, `-shm`, `-journal`, and master-journal sidecars
 before and after dump import. With `--replace`, it MUST remove source sidecars
 before moving the source to its corrupt backup. Master-journal matching MUST
-treat the database basename literally. Before that final import and replacement
-boundary, recovery MUST hold an exclusive SQLite transaction on the source;
-if an active connection prevents the lock, recovery MUST fail without moving
-the source or installing the output.
+treat the database basename literally. Before final output import and sidecar
+cleanup, recovery MUST acquire an exclusive SQLite transaction on the source
+and MUST close every recovery-opened SQLite connection before any sidecar or
+database rename.
+If an active connection prevents the lock, or sidecar cleanup fails, recovery
+MUST fail without moving the source or installing the output.
 
 #### Scenario: A stale source WAL cannot attach to the replacement
 
@@ -21,12 +23,19 @@ the source or installing the output.
 - **THEN** source and output SQLite sidecars MUST be absent
 - **AND** reopening the installed database MUST not apply stale WAL rows
 
-#### Scenario: An active writer cannot cross the replacement boundary
+#### Scenario: An active writer cannot cross the fenced preparation boundary
 
 - **GIVEN** a source connection is open while recovery is replacing the database
-- **WHEN** that connection attempts a write during the final import and rename
+- **WHEN** that connection attempts a write during final import and cleanup
 - **THEN** the write MUST fail with the source's exclusive recovery lock held
 - **AND** a fresh connection MUST be able to write to the installed database
+
+#### Scenario: Recovery closes handles before Windows renames
+
+- **GIVEN** recovery has prepared an output replacement
+- **WHEN** it moves the source to its corrupt backup and the output into place
+- **THEN** every recovery-opened SQLite connection MUST already be closed before each rename
+- **AND** both file mutations MUST succeed on a platform with exclusive rename handles
 
 #### Scenario: A busy source fails closed before replacement
 
@@ -35,6 +44,13 @@ the source or installing the output.
 - **THEN** recovery MUST fail
 - **AND** the source MUST remain at its original path
 - **AND** no replacement MUST be installed
+
+#### Scenario: Partial sidecar cleanup fails closed
+
+- **GIVEN** one target sidecar cannot be removed while other sidecars can be removed
+- **WHEN** recovery prepares a replacement
+- **THEN** recovery MUST fail before moving the source or installing the output
+- **AND** the source MUST remain at its original path
 
 #### Scenario: Wildcard names do not broaden cleanup
 

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -3,11 +3,14 @@
 - [x] 1.1 Remove fixed source/output SQLite sidecars around replacement.
 - [x] 1.2 Fail closed when sidecar removal cannot complete.
 - [x] 1.3 Escape database basenames before matching master journals.
-- [x] 1.4 Hold an exclusive SQLite recovery lock across final replacement.
+- [x] 1.4 Fence final import and cleanup with an exclusive SQLite lock, then
+  close the lock before filesystem renames.
 
 ## 2. Verification
 
 - [x] 2.1 Cover stale source/output WAL and journal cleanup.
 - [x] 2.2 Cover literal wildcard filename matching.
-- [x] 2.3 Cover a write attempt during the replacement boundary.
-- [x] 2.4 Run focused recovery tests, Ruff, formatting, and `ty`.
+- [x] 2.3 Cover a write attempt during the fenced preparation boundary.
+- [x] 2.4 Cover Windows-style rename behavior with a tracked-handle seam.
+- [x] 2.5 Cover partial cleanup and busy-source failures.
+- [x] 2.6 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -5,15 +5,17 @@
 - [x] 1.3 Escape database basenames before matching master journals.
 - [x] 1.4 Reject source/output path and sidecar namespace overlap before any
   cleanup or output write.
-- [x] 1.5 Fence final import with an exclusive SQLite lock; close the lock
-  before final sidecar cleanup and filesystem renames, then repeat source
-  cleanup after the source move.
+- [x] 1.5 Acquire an exclusive SQLite lock before source dump export, generate
+  the dump from the lock-holding connection, and retain the lock through final
+  import; close it before final sidecar cleanup and filesystem renames, then
+  repeat source cleanup after the source move.
 
 ## 2. Verification
 
 - [x] 2.1 Cover stale source/output WAL and journal cleanup.
 - [x] 2.2 Cover literal wildcard filename matching.
-- [x] 2.3 Cover a write attempt during the fenced preparation boundary.
+- [x] 2.3 Cover a deterministic write attempt during lock-held source export
+  and final import in both output-only and replacement flows.
 - [x] 2.4 Cover Windows-style sidecar unlink and rename behavior with a
   tracked-handle seam, including a sidecar recreated around source move.
 - [x] 2.5 Cover pre-move partial cleanup and busy-source failures.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -1,0 +1,11 @@
+## 1. Recovery cleanup
+
+- [x] 1.1 Remove fixed source/output SQLite sidecars around replacement.
+- [x] 1.2 Fail closed when sidecar removal cannot complete.
+- [x] 1.3 Escape database basenames before matching master journals.
+
+## 2. Verification
+
+- [x] 2.1 Cover stale source/output WAL and journal cleanup.
+- [x] 2.2 Cover literal wildcard filename matching.
+- [x] 2.3 Run focused recovery tests, Ruff, formatting, and `ty`.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -3,15 +3,17 @@
 - [x] 1.1 Remove fixed source/output SQLite sidecars around replacement.
 - [x] 1.2 Fail closed when sidecar removal cannot complete.
 - [x] 1.3 Escape database basenames before matching master journals.
-- [x] 1.4 Fence final import and cleanup with an exclusive SQLite lock, then
-  close the lock before filesystem renames.
+- [x] 1.4 Fence final import with an exclusive SQLite lock; close the lock
+  before final sidecar cleanup and filesystem renames, then repeat source
+  cleanup after the source move.
 
 ## 2. Verification
 
 - [x] 2.1 Cover stale source/output WAL and journal cleanup.
 - [x] 2.2 Cover literal wildcard filename matching.
 - [x] 2.3 Cover a write attempt during the fenced preparation boundary.
-- [x] 2.4 Cover Windows-style rename behavior with a tracked-handle seam.
+- [x] 2.4 Cover Windows-style sidecar unlink and rename behavior with a
+  tracked-handle seam, including a sidecar recreated around source move.
 - [x] 2.5 Cover partial cleanup and busy-source failures.
 - [x] 2.6 Cover second-rename failure and source restoration.
 - [x] 2.7 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -13,4 +13,5 @@
 - [x] 2.3 Cover a write attempt during the fenced preparation boundary.
 - [x] 2.4 Cover Windows-style rename behavior with a tracked-handle seam.
 - [x] 2.5 Cover partial cleanup and busy-source failures.
-- [x] 2.6 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.
+- [x] 2.6 Cover second-rename failure and source restoration.
+- [x] 2.7 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -14,6 +14,8 @@
 - [x] 2.3 Cover a write attempt during the fenced preparation boundary.
 - [x] 2.4 Cover Windows-style sidecar unlink and rename behavior with a
   tracked-handle seam, including a sidecar recreated around source move.
-- [x] 2.5 Cover partial cleanup and busy-source failures.
-- [x] 2.6 Cover second-rename failure and source restoration.
-- [x] 2.7 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.
+- [x] 2.5 Cover pre-move partial cleanup and busy-source failures.
+- [x] 2.6 Cover post-move cleanup/second-rename failures and source
+  restoration.
+- [x] 2.7 Cover recovery-handle closure when rollback itself raises.
+- [x] 2.8 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -3,7 +3,9 @@
 - [x] 1.1 Remove fixed source/output SQLite sidecars around replacement.
 - [x] 1.2 Fail closed when sidecar removal cannot complete.
 - [x] 1.3 Escape database basenames before matching master journals.
-- [x] 1.4 Fence final import with an exclusive SQLite lock; close the lock
+- [x] 1.4 Reject source/output path and sidecar namespace overlap before any
+  cleanup or output write.
+- [x] 1.5 Fence final import with an exclusive SQLite lock; close the lock
   before final sidecar cleanup and filesystem renames, then repeat source
   cleanup after the source move.
 
@@ -18,4 +20,5 @@
 - [x] 2.6 Cover post-move cleanup/second-rename failures and source
   restoration.
 - [x] 2.7 Cover recovery-handle closure when rollback itself raises.
-- [x] 2.8 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.
+- [x] 2.8 Cover source/output overlap rejection in replace and non-replace mode.
+- [x] 2.9 Run focused recovery tests, Ruff, formatting, `ty`, and strict OpenSpec.

--- a/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
+++ b/openspec/changes/clean-recovery-sqlite-sidecars/tasks.md
@@ -3,9 +3,11 @@
 - [x] 1.1 Remove fixed source/output SQLite sidecars around replacement.
 - [x] 1.2 Fail closed when sidecar removal cannot complete.
 - [x] 1.3 Escape database basenames before matching master journals.
+- [x] 1.4 Hold an exclusive SQLite recovery lock across final replacement.
 
 ## 2. Verification
 
 - [x] 2.1 Cover stale source/output WAL and journal cleanup.
 - [x] 2.2 Cover literal wildcard filename matching.
-- [x] 2.3 Run focused recovery tests, Ruff, formatting, and `ty`.
+- [x] 2.3 Cover a write attempt during the replacement boundary.
+- [x] 2.4 Run focused recovery tests, Ruff, formatting, and `ty`.

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -27,7 +27,7 @@ class _TrackedConnection(sqlite3.Connection):
 def _track_connections(monkeypatch: pytest.MonkeyPatch) -> list[_TrackedConnection]:
     connections: list[_TrackedConnection] = []
 
-    def connect(database: str | Path) -> sqlite3.Connection:
+    def connect(database: str | Path, *_args: object, **_kwargs: object) -> sqlite3.Connection:
         connection = _TrackedConnection(str(database))
         connections.append(connection)
         return connection
@@ -150,6 +150,50 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
     finally:
         for connection in held_source_connections:
             connection.close()
+
+
+def test_recover_replace_blocks_writes_across_the_install_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An active source connection cannot write while recovery replaces it."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    writer = sqlite3.connect(db_path, timeout=0, isolation_level=None)
+    write_attempts: list[str] = []
+    real_write_dump = recover_module._write_dump
+
+    def _write_dump_then_attempt_source_write(output: Path, dump: str) -> None:
+        try:
+            writer.execute("BEGIN IMMEDIATE")
+            writer.execute("INSERT INTO items (name) VALUES ('raced')")
+            writer.commit()
+            write_attempts.append("wrote")
+        except sqlite3.OperationalError as exc:
+            writer.rollback()
+            write_attempts.append(str(exc).lower())
+        real_write_dump(output, dump)
+
+    monkeypatch.setattr(recover_module, "_write_dump", _write_dump_then_attempt_source_write)
+
+    try:
+        recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        )
+    finally:
+        writer.close()
+
+    assert write_attempts == ["database is locked"]
+    with closing(sqlite3.connect(db_path)) as connection:
+        connection.execute("INSERT INTO items (name) VALUES ('after')")
+        assert connection.execute("SELECT name FROM items ORDER BY rowid").fetchall() == [
+            ("base",),
+            ("after",),
+        ]
 
 
 def test_recover_sidecar_cleanup_treats_wildcard_database_names_literally(tmp_path: Path) -> None:

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -150,3 +150,17 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
     finally:
         for connection in held_source_connections:
             connection.close()
+
+
+def test_recover_sidecar_cleanup_treats_wildcard_database_names_literally(tmp_path: Path) -> None:
+    """A wildcard in the database name must not broaden master-journal cleanup."""
+    db_path = tmp_path / "store*.db"
+    target_master_journal = tmp_path / "store*.db-mj12345678"
+    unrelated_master_journal = tmp_path / "storeOTHER.db-mj12345678"
+    target_master_journal.write_bytes(b"target")
+    unrelated_master_journal.write_bytes(b"unrelated")
+
+    recover_module._remove_sqlite_sidecars(db_path)
+
+    assert not target_master_journal.exists()
+    assert unrelated_master_journal.read_bytes() == b"unrelated"

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -81,14 +81,27 @@ def test_recover_cli_closes_connections_before_replacing_database(
 
     connections = _track_connections(monkeypatch)
     rename_checks: list[bool] = []
+    unlink_checks: list[bool] = []
     path_type = type(db_path)
     real_replace = path_type.replace
+    real_unlink = path_type.unlink
 
     def replace_without_open_sqlite_handles(path: Path, target: str | Path) -> Path:
         rename_checks.append(all(connection.closed for connection in connections))
         return real_replace(path, target)
 
+    tracked_sidecars = {
+        *(db_path.with_name(f"{db_path.name}{suffix}") for suffix in ("-wal", "-shm", "-journal")),
+        *(output_path.with_name(f"{output_path.name}{suffix}") for suffix in ("-wal", "-shm", "-journal")),
+    }
+
+    def unlink_without_open_sqlite_handles(path: Path, *, missing_ok: bool = False) -> None:
+        if path in tracked_sidecars:
+            unlink_checks.append(all(connection.closed for connection in connections))
+        real_unlink(path, missing_ok=missing_ok)
+
     monkeypatch.setattr(path_type, "replace", replace_without_open_sqlite_handles)
+    monkeypatch.setattr(path_type, "unlink", unlink_without_open_sqlite_handles)
 
     try:
         exit_code = recover_module.main(
@@ -109,6 +122,8 @@ def test_recover_cli_closes_connections_before_replacing_database(
         assert connections
         assert all(connection.closed for connection in connections)
         assert rename_checks == [True, True]
+        assert unlink_checks
+        assert all(unlink_checks)
 
         with closing(sqlite3.connect(db_path)) as connection:
             assert connection.execute("SELECT name FROM items").fetchall() == [("alpha",)]
@@ -146,6 +161,20 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
         return dump
 
     monkeypatch.setattr(recover_module, "_load_dump", _load_dump_then_leave_source_wal)
+
+    path_type = type(db_path)
+    real_replace = path_type.replace
+
+    def replace_and_recreate_source_sidecar(path: Path, target: str | Path) -> Path:
+        result = real_replace(path, target)
+        if path == db_path and Path(target).name.startswith(f"{db_path.name}.corrupt-"):
+            # Model a writer recreating a sidecar after source.replace() while
+            # the source path is temporarily empty. The post-rename cleanup
+            # must remove it before the recovered output is installed.
+            Path(f"{path}-wal").write_bytes(b"recreated around source rename")
+        return result
+
+    monkeypatch.setattr(path_type, "replace", replace_and_recreate_source_sidecar)
 
     recover_module.recover_sqlite_db(recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True))
 

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -130,7 +130,6 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
     for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
         (tmp_path / f"{output_path.name}{suffix}").write_bytes(b"stale output sidecar")
 
-    held_source_connections: list[sqlite3.Connection] = []
     real_load_dump = recover_module._load_dump
 
     def _load_dump_then_leave_source_wal(path: Path) -> str:
@@ -140,26 +139,22 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
         connection.execute("PRAGMA wal_autocheckpoint=0")
         connection.execute("INSERT INTO items (name) VALUES ('stale-after-dump')")
         connection.commit()
-        held_source_connections.append(connection)
+        source_sidecars = {suffix: Path(f"{path}{suffix}").read_bytes() for suffix in ("-wal", "-shm")}
+        connection.close()
+        for suffix, contents in source_sidecars.items():
+            Path(f"{path}{suffix}").write_bytes(contents)
         return dump
 
     monkeypatch.setattr(recover_module, "_load_dump", _load_dump_then_leave_source_wal)
 
-    try:
-        recover_module.recover_sqlite_db(
-            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
-        )
-        held_source_connections[0].close()
+    recover_module.recover_sqlite_db(recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True))
 
-        with closing(sqlite3.connect(db_path)) as connection:
-            assert connection.execute("SELECT name FROM items").fetchall() == [("base",)]
+    with closing(sqlite3.connect(db_path)) as connection:
+        assert connection.execute("SELECT name FROM items").fetchall() == [("base",)]
 
-        for path in (db_path, output_path):
-            for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
-                assert not Path(f"{path}{suffix}").exists()
-    finally:
-        for connection in held_source_connections:
-            connection.close()
+    for path in (db_path, output_path):
+        for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
+            assert not Path(f"{path}{suffix}").exists()
 
 
 def test_recover_replace_blocks_writes_across_the_install_boundary(
@@ -267,6 +262,39 @@ def test_recover_replace_fails_closed_when_source_is_busy(tmp_path: Path) -> Non
     assert db_path.exists()
     assert not output_path.exists()
     assert not list(tmp_path.glob("store.db.corrupt-*"))
+
+
+def test_recover_replace_restores_source_when_install_rename_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed output rename must restore the original source path."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    path_type = type(db_path)
+    real_replace = path_type.replace
+
+    def fail_output_install(path: Path, target: str | Path) -> Path:
+        if path == output_path and target == db_path:
+            raise PermissionError("simulated output rename failure")
+        return real_replace(path, target)
+
+    monkeypatch.setattr(path_type, "replace", fail_output_install)
+
+    with pytest.raises(RuntimeError, match="failed to install recovered SQLite database"):
+        recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        )
+
+    assert db_path.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))
+    assert output_path.exists()
+    with closing(sqlite3.connect(db_path)) as connection:
+        assert connection.execute("SELECT name FROM items").fetchall() == [("base",)]
 
 
 def test_recover_sidecar_cleanup_treats_wildcard_database_names_literally(tmp_path: Path) -> None:

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -452,3 +452,23 @@ def test_recover_rejects_source_output_sidecar_overlap(
     assert source.exists()
     assert not output.exists()
     assert not list(tmp_path.glob("store.db.corrupt-*"))
+
+
+@pytest.mark.parametrize("replace", [False, True])
+def test_recover_rejects_symlink_sidecar_before_cleanup(tmp_path: Path, replace: bool) -> None:
+    """A sidecar symlink must not be unlinked as part of recovery cleanup."""
+    real_source = tmp_path / "real.db"
+    source = tmp_path / "store.db-wal"
+    output = tmp_path / "store.db"
+    with closing(sqlite3.connect(real_source)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+    source.symlink_to(real_source)
+
+    with pytest.raises(ValueError, match="overlaps a SQLite sidecar"):
+        recover_module.recover_sqlite_db(recover_module.RecoveryOptions(source=source, output=output, replace=replace))
+
+    assert source.is_symlink()
+    assert source.resolve() == real_source
+    assert not output.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -24,6 +24,11 @@ class _TrackedConnection(sqlite3.Connection):
         super().close()
 
 
+class _RollbackFailingConnection(_TrackedConnection):
+    def rollback(self) -> None:
+        raise sqlite3.OperationalError("simulated rollback failure")
+
+
 def _track_connections(monkeypatch: pytest.MonkeyPatch) -> list[_TrackedConnection]:
     connections: list[_TrackedConnection] = []
 
@@ -131,6 +136,28 @@ def test_recover_cli_closes_connections_before_replacing_database(
         _close_connections(connections)
 
 
+def test_recovery_lock_closes_connection_when_rollback_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "store.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+
+    recovery_connection = _RollbackFailingConnection(str(db_path))
+
+    def connect_with_rollback_failure(*_args: object, **_kwargs: object) -> sqlite3.Connection:
+        return recovery_connection
+
+    monkeypatch.setattr(recover_module.sqlite3, "connect", connect_with_rollback_failure)
+
+    with pytest.raises(sqlite3.OperationalError, match="simulated rollback failure"):
+        with recover_module._sqlite_recovery_lock(db_path):
+            pass
+
+    assert recovery_connection.closed
+
+
 def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -199,9 +226,11 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
 
     writer = sqlite3.connect(db_path, timeout=0, isolation_level=None)
     write_attempts: list[str] = []
+    writer_closed_before_replace = False
     real_write_dump = recover_module._write_dump
 
     def _write_dump_then_attempt_source_write(output: Path, dump: str) -> None:
+        nonlocal writer_closed_before_replace
         try:
             writer.execute("BEGIN IMMEDIATE")
             writer.execute("INSERT INTO items (name) VALUES ('raced')")
@@ -210,6 +239,10 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
         except sqlite3.OperationalError as exc:
             writer.rollback()
             write_attempts.append(str(exc).lower())
+            # The operator contract requires external writer handles to be
+            # closed before the probe is released and replacement begins.
+            writer.close()
+            writer_closed_before_replace = True
         real_write_dump(output, dump)
 
     monkeypatch.setattr(recover_module, "_write_dump", _write_dump_then_attempt_source_write)
@@ -222,6 +255,7 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
         writer.close()
 
     assert write_attempts == ["database is locked"]
+    assert writer_closed_before_replace
     with closing(sqlite3.connect(db_path)) as connection:
         connection.execute("INSERT INTO items (name) VALUES ('after')")
         assert connection.execute("SELECT name FROM items ORDER BY rowid").fetchall() == [
@@ -267,6 +301,43 @@ def test_recover_replace_fails_closed_on_partial_sidecar_cleanup(
     assert not (tmp_path / "store.db-wal").exists()
     assert not (tmp_path / "store.db-shm").exists()
     assert not (tmp_path / "store.db-journal").exists()
+
+
+def test_recover_replace_restores_source_when_post_move_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeat cleanup error must roll back the source move."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    real_remove_sidecars = recover_module._remove_sqlite_sidecars
+    source_cleanup_calls = 0
+
+    def fail_post_move_cleanup(path: Path) -> None:
+        nonlocal source_cleanup_calls
+        if path == db_path:
+            source_cleanup_calls += 1
+            if source_cleanup_calls == 2:
+                raise RuntimeError("simulated post-move sidecar cleanup failure")
+        real_remove_sidecars(path)
+
+    monkeypatch.setattr(recover_module, "_remove_sqlite_sidecars", fail_post_move_cleanup)
+
+    with pytest.raises(RuntimeError, match="simulated post-move sidecar cleanup failure"):
+        recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        )
+
+    assert source_cleanup_calls == 2
+    assert db_path.exists()
+    assert output_path.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))
+    with closing(sqlite3.connect(db_path)) as connection:
+        assert connection.execute("SELECT name FROM items").fetchall() == [("base",)]
 
 
 def test_recover_replace_fails_closed_when_source_is_busy(tmp_path: Path) -> None:

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -409,3 +409,34 @@ def test_recover_sidecar_cleanup_treats_wildcard_database_names_literally(tmp_pa
 
     assert not target_master_journal.exists()
     assert unrelated_master_journal.read_bytes() == b"unrelated"
+
+
+@pytest.mark.parametrize(
+    ("source_name", "output_name"),
+    [
+        ("store.db-wal", "store.db"),
+        ("store.db", "store.db-wal"),
+        ("store.db-mj12345678", "store.db"),
+        ("store.db", "store.db-mj12345678"),
+    ],
+)
+@pytest.mark.parametrize("replace", [False, True])
+def test_recover_rejects_source_output_sidecar_overlap(
+    tmp_path: Path,
+    source_name: str,
+    output_name: str,
+    replace: bool,
+) -> None:
+    """Overlapping source/output namespaces must fail before cleanup."""
+    source = tmp_path / source_name
+    output = tmp_path / output_name
+    with closing(sqlite3.connect(source)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    with pytest.raises(ValueError, match="overlaps a SQLite sidecar"):
+        recover_module.recover_sqlite_db(recover_module.RecoveryOptions(source=source, output=output, replace=replace))
+
+    assert source.exists()
+    assert not output.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -169,22 +169,30 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
         connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
         connection.execute("INSERT INTO items (name) VALUES ('base')")
 
+    # Capture a valid WAL containing a row absent from the base file. Restore
+    # the base bytes before recovery so the sidecars can be recreated after the
+    # locked export and prove that cleanup prevents them attaching on rename.
+    base_bytes = db_path.read_bytes()
+    stale_connection = sqlite3.connect(db_path)
+    stale_connection.execute("PRAGMA journal_mode=WAL")
+    stale_connection.execute("PRAGMA wal_autocheckpoint=0")
+    stale_connection.execute("INSERT INTO items (name) VALUES ('stale-after-dump')")
+    stale_connection.commit()
+    stale_sidecars = {suffix: Path(f"{db_path}{suffix}").read_bytes() for suffix in ("-wal", "-shm")}
+    stale_connection.close()
+    db_path.write_bytes(base_bytes)
+    for suffix in ("-wal", "-shm", "-journal"):
+        Path(f"{db_path}{suffix}").unlink(missing_ok=True)
+
     for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
         (tmp_path / f"{output_path.name}{suffix}").write_bytes(b"stale output sidecar")
 
     real_load_dump = recover_module._load_dump
 
-    def _load_dump_then_leave_source_wal(path: Path) -> str:
-        dump = real_load_dump(path)
-        connection = sqlite3.connect(path)
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("PRAGMA wal_autocheckpoint=0")
-        connection.execute("INSERT INTO items (name) VALUES ('stale-after-dump')")
-        connection.commit()
-        source_sidecars = {suffix: Path(f"{path}{suffix}").read_bytes() for suffix in ("-wal", "-shm")}
-        connection.close()
-        for suffix, contents in source_sidecars.items():
-            Path(f"{path}{suffix}").write_bytes(contents)
+    def _load_dump_then_leave_source_wal(connection: sqlite3.Connection) -> str:
+        dump = real_load_dump(connection)
+        for suffix, contents in stale_sidecars.items():
+            Path(f"{db_path}{suffix}").write_bytes(contents)
         return dump
 
     monkeypatch.setattr(recover_module, "_load_dump", _load_dump_then_leave_source_wal)
@@ -213,11 +221,13 @@ def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
             assert not Path(f"{path}{suffix}").exists()
 
 
-def test_recover_replace_blocks_writes_across_the_install_boundary(
+@pytest.mark.parametrize("replace", [False, True])
+def test_recover_blocks_writes_during_locked_snapshot_export(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    replace: bool,
 ) -> None:
-    """An active source connection cannot write while recovery replaces it."""
+    """An active source connection cannot write during the locked export."""
     db_path = tmp_path / "store.db"
     output_path = tmp_path / "recovered.db"
     with closing(sqlite3.connect(db_path)) as connection, connection:
@@ -226,11 +236,12 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
 
     writer = sqlite3.connect(db_path, timeout=0, isolation_level=None)
     write_attempts: list[str] = []
-    writer_closed_before_replace = False
-    real_write_dump = recover_module._write_dump
+    writer_closed_before_lock_release = False
+    real_load_dump = recover_module._load_dump
 
-    def _write_dump_then_attempt_source_write(output: Path, dump: str) -> None:
-        nonlocal writer_closed_before_replace
+    def _load_dump_then_attempt_source_write(connection: sqlite3.Connection) -> str:
+        nonlocal writer_closed_before_lock_release
+        dump = real_load_dump(connection)
         try:
             writer.execute("BEGIN IMMEDIATE")
             writer.execute("INSERT INTO items (name) VALUES ('raced')")
@@ -239,29 +250,30 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
         except sqlite3.OperationalError as exc:
             writer.rollback()
             write_attempts.append(str(exc).lower())
+        finally:
             # The operator contract requires external writer handles to be
-            # closed before the probe is released and replacement begins.
+            # closed before the recovery lock is released.
             writer.close()
-            writer_closed_before_replace = True
-        real_write_dump(output, dump)
+            writer_closed_before_lock_release = True
+        return dump
 
-    monkeypatch.setattr(recover_module, "_write_dump", _write_dump_then_attempt_source_write)
+    monkeypatch.setattr(recover_module, "_load_dump", _load_dump_then_attempt_source_write)
 
     try:
-        recover_module.recover_sqlite_db(
-            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        outcome = recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=replace)
         )
     finally:
         writer.close()
 
     assert write_attempts == ["database is locked"]
-    assert writer_closed_before_replace
+    assert writer_closed_before_lock_release
+    assert outcome.replaced is replace
+    assert db_path.exists()
+    assert output_path.exists() is not replace
     with closing(sqlite3.connect(db_path)) as connection:
         connection.execute("INSERT INTO items (name) VALUES ('after')")
-        assert connection.execute("SELECT name FROM items ORDER BY rowid").fetchall() == [
-            ("base",),
-            ("after",),
-        ]
+        assert connection.execute("SELECT name FROM items ORDER BY rowid").fetchall()[-1] == ("after",)
 
 
 def test_recover_replace_fails_closed_on_partial_sidecar_cleanup(

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -80,6 +80,15 @@ def test_recover_cli_closes_connections_before_replacing_database(
         connection.execute("INSERT INTO items (name) VALUES ('alpha')")
 
     connections = _track_connections(monkeypatch)
+    rename_checks: list[bool] = []
+    path_type = type(db_path)
+    real_replace = path_type.replace
+
+    def replace_without_open_sqlite_handles(path: Path, target: str | Path) -> Path:
+        rename_checks.append(all(connection.closed for connection in connections))
+        return real_replace(path, target)
+
+    monkeypatch.setattr(path_type, "replace", replace_without_open_sqlite_handles)
 
     try:
         exit_code = recover_module.main(
@@ -99,6 +108,7 @@ def test_recover_cli_closes_connections_before_replacing_database(
         assert not output_path.exists()
         assert connections
         assert all(connection.closed for connection in connections)
+        assert rename_checks == [True, True]
 
         with closing(sqlite3.connect(db_path)) as connection:
             assert connection.execute("SELECT name FROM items").fetchall() == [("alpha",)]
@@ -194,6 +204,69 @@ def test_recover_replace_blocks_writes_across_the_install_boundary(
             ("base",),
             ("after",),
         ]
+
+
+def test_recover_replace_fails_closed_on_partial_sidecar_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sidecar removal error must not move either database."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    blocked_sidecar = tmp_path / "store.db-mj12345678"
+    blocked_sidecar.write_bytes(b"unremovable")
+    for suffix in ("-wal", "-shm", "-journal"):
+        (tmp_path / f"store.db{suffix}").write_bytes(b"stale")
+
+    real_unlink = type(blocked_sidecar).unlink
+
+    def unlink_with_partial_failure(path: Path, *, missing_ok: bool = False) -> None:
+        if path == blocked_sidecar:
+            raise PermissionError("simulated sidecar cleanup failure")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(type(blocked_sidecar), "unlink", unlink_with_partial_failure)
+
+    with pytest.raises(RuntimeError, match="failed to remove SQLite sidecars"):
+        recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        )
+
+    assert db_path.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))
+    assert output_path.exists()
+    assert blocked_sidecar.exists()
+    assert not (tmp_path / "store.db-wal").exists()
+    assert not (tmp_path / "store.db-shm").exists()
+    assert not (tmp_path / "store.db-journal").exists()
+
+
+def test_recover_replace_fails_closed_when_source_is_busy(tmp_path: Path) -> None:
+    """A conflicting source writer must prevent replacement before any rename."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    writer = sqlite3.connect(db_path, timeout=0, isolation_level=None)
+    writer.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(RuntimeError, match="could not acquire exclusive SQLite recovery lock"):
+            recover_module.recover_sqlite_db(
+                recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+            )
+    finally:
+        writer.rollback()
+        writer.close()
+
+    assert db_path.exists()
+    assert not output_path.exists()
+    assert not list(tmp_path.glob("store.db.corrupt-*"))
 
 
 def test_recover_sidecar_cleanup_treats_wildcard_database_names_literally(tmp_path: Path) -> None:

--- a/tests/unit/test_db_sqlite_maintenance.py
+++ b/tests/unit/test_db_sqlite_maintenance.py
@@ -104,3 +104,49 @@ def test_recover_cli_closes_connections_before_replacing_database(
             assert connection.execute("SELECT name FROM items").fetchall() == [("alpha",)]
     finally:
         _close_connections(connections)
+
+
+def test_recover_replace_removes_sqlite_sidecars_before_installing_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source WAL must not attach to the recovered database after rename."""
+    db_path = tmp_path / "store.db"
+    output_path = tmp_path / "recovered.db"
+    with closing(sqlite3.connect(db_path)) as connection, connection:
+        connection.execute("CREATE TABLE items (name TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (name) VALUES ('base')")
+
+    for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
+        (tmp_path / f"{output_path.name}{suffix}").write_bytes(b"stale output sidecar")
+
+    held_source_connections: list[sqlite3.Connection] = []
+    real_load_dump = recover_module._load_dump
+
+    def _load_dump_then_leave_source_wal(path: Path) -> str:
+        dump = real_load_dump(path)
+        connection = sqlite3.connect(path)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute("INSERT INTO items (name) VALUES ('stale-after-dump')")
+        connection.commit()
+        held_source_connections.append(connection)
+        return dump
+
+    monkeypatch.setattr(recover_module, "_load_dump", _load_dump_then_leave_source_wal)
+
+    try:
+        recover_module.recover_sqlite_db(
+            recover_module.RecoveryOptions(source=db_path, output=output_path, replace=True)
+        )
+        held_source_connections[0].close()
+
+        with closing(sqlite3.connect(db_path)) as connection:
+            assert connection.execute("SELECT name FROM items").fetchall() == [("base",)]
+
+        for path in (db_path, output_path):
+            for suffix in ("-wal", "-shm", "-journal", "-mj12345678"):
+                assert not Path(f"{path}{suffix}").exists()
+    finally:
+        for connection in held_source_connections:
+            connection.close()


### PR DESCRIPTION
## Problem

SQLite recovery can leave WAL, shared-memory, rollback-journal, or master-journal files beside the source or replacement database. Installing a recovered database with those sidecars present can attach stale state, and recovery must close its SQLite handles before filesystem renames on Windows.

## Why this PR exists

This is a focused repair for SQLite replacement recovery and the Windows handle regression discussed in #1526. It is separate from clean-start sentinel work in #1866/#1907 and from proxy/bridge changes.

Refs #1526.

## How this PR solves the problem

- Removes fixed SQLite sidecars before and after dump import, matching master journals against a literal database basename.
- Rejects source/output paths that overlap either path's fixed or master-journal sidecar namespace before cleanup or writes, checking lexical names before symlink resolution so a sidecar symlink cannot be unlinked accidentally.
- Acquires `BEGIN EXCLUSIVE` before source export, generates the dump from that lock-holding connection, and keeps the lock through output import.
- Closes every recovery-owned SQLite connection before sidecar cleanup or either filesystem rename; fails closed when the source is busy or cleanup fails.
- Restores the original source if installing the replacement fails after the source move, and reports both errors if restoration also fails.
- Keeps the bounded close-to-rename window explicit in the operator-only recovery contract.

OpenSpec: `openspec/changes/clean-recovery-sqlite-sidecars/`

## Scope

This PR owns recovery sidecar cleanup and replacement fencing only. It adds no setting, migration, dashboard, attribution, clean-shutdown, or runtime-container change. Contributor metadata is intentionally not duplicated; #1902 has now merged the sole attribution change.

## Verification

Exact candidate: `e482795231abb7c0da31d967cf768b9c5815c035`  
Tree: `a484263d2186bc05ab20ffbc2280985d045db777`  
Base/merge-base: `dc016c741dc5c85862ccd3de3f8c9f79c11f9f5e` (`upstream/main`, including merged #1902)

- Affected SQLite recovery tests: 21 passed.
- The exact-head symlink regression proves a `store.db-wal -> real.db` source symlink is rejected before cleanup and remains intact in both output-only and replacement flows.
- `uv run ruff check app/db/recover.py tests/unit/test_db_sqlite_maintenance.py`: passed.
- `uv run ruff format --check app/db/recover.py tests/unit/test_db_sqlite_maintenance.py`: passed.
- `uv run ty check app/db/recover.py`: passed.
- `make migration-check`: passed (`schema_drift=none`).
- Strict targeted OpenSpec validation: passed.
- `git diff --check`: passed.
- Tests cover stale sidecars, literal wildcard names, source/output overlap in both modes, symlinked sidecar overlap, lock-held snapshot export, Windows-style tracked handles, partial cleanup, and second-rename rollback.

## Current status

The branch is linearly rebased onto `upstream/main` at merged #1902 without carrying unrelated mainline commits. The exact-head CodeRabbit symlink-overlap finding is fixed in `e4827952`; hosted exact-head checks and a fresh CodeRabbit review are rerunning after this push. The Contributors attribution dependency is cleared by #1902. Human maintainer review and merge remain pending; no merge or deployment was performed.
