### PR TITLE
fix(proxy): clear expired retry cooldown transitions

### DIFF
--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -278,6 +278,8 @@ class _HTTPBridgeRetryCircuitMixin:
             if persisted.updated_at_epoch > state.persisted_updated_at_epoch and not local_failure_is_newer:
                 state.consecutive_failures = max(0, persisted.consecutive_failures)
                 state.cooldown_until = persisted_cooldown_until
+                if persisted_cooldown_until <= 0.0:
+                    state.half_open_until = 0.0
                 state.last_detail = persisted.last_detail
             else:
                 state.consecutive_failures = max(state.consecutive_failures, max(0, persisted.consecutive_failures))
@@ -291,6 +293,7 @@ class _HTTPBridgeRetryCircuitMixin:
                     # monotonic deadline instead of turning that expiry into
                     # a half-open probe.
                     state.cooldown_until = 0.0
+                    state.half_open_until = 0.0
                 else:
                     state.cooldown_until = max(state.cooldown_until, persisted_cooldown_until)
                 if local_failure_is_newer:

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -258,7 +258,16 @@ class _HTTPBridgeRetryCircuitMixin:
             return True
 
         cooldown_remaining = max(0.0, persisted.cooldown_until_epoch - now_epoch)
-        persisted_cooldown_until = now_monotonic + cooldown_remaining
+        # ``cooldown_until`` is a monotonic deadline whose zero means "this key
+        # is not cooling down". A durable row whose cooldown already elapsed --
+        # or which never had one, because ``persist_retry_circuit`` writes
+        # ``now_wall`` for a below-threshold failure count -- must load as that
+        # zero. Loading it as ``now_monotonic`` instead makes it simultaneously
+        # non-zero and expired, which is exactly the condition
+        # ``_http_bridge_precreated_retry_allowed`` reads as "a cooldown just
+        # ended", so it burns a half-open probe lease on a key that was never
+        # cooling down and suppresses every other request for that lease.
+        persisted_cooldown_until = now_monotonic + cooldown_remaining if cooldown_remaining > 0.0 else 0.0
         async with self._http_bridge_retry_circuit_lock:
             self._http_bridge_retry_circuit_persisted_keys.add(session.key)
             state = self._http_bridge_retry_circuits.get(session.key)

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -281,7 +281,18 @@ class _HTTPBridgeRetryCircuitMixin:
                 state.last_detail = persisted.last_detail
             else:
                 state.consecutive_failures = max(state.consecutive_failures, max(0, persisted.consecutive_failures))
-                state.cooldown_until = max(state.cooldown_until, persisted_cooldown_until)
+                if (
+                    not local_failure_is_newer
+                    and persisted.updated_at_epoch >= state.persisted_updated_at_epoch
+                    and persisted_cooldown_until <= 0.0
+                ):
+                    # An equal-version durable reload can observe the same
+                    # row after its cooldown elapsed. Clear the old local
+                    # monotonic deadline instead of turning that expiry into
+                    # a half-open probe.
+                    state.cooldown_until = 0.0
+                else:
+                    state.cooldown_until = max(state.cooldown_until, persisted_cooldown_until)
                 if local_failure_is_newer:
                     state.last_detail = state.last_detail or persisted.last_detail
                 else:

--- a/openspec/changes/normalize-expired-retry-cooldown/.openspec.yaml
+++ b/openspec/changes/normalize-expired-retry-cooldown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/normalize-expired-retry-cooldown/proposal.md
+++ b/openspec/changes/normalize-expired-retry-cooldown/proposal.md
@@ -1,0 +1,17 @@
+# Normalize expired durable retry cooldowns
+
+## Summary
+
+An expired durable retry-circuit cooldown must reload as an open circuit with
+no cooldown, not as a newly ended cooldown that consumes a half-open probe.
+
+## What Changes
+
+- Map an elapsed or absent durable cooldown to the zero in-memory deadline.
+- Preserve future cooldown deadlines and all existing threshold, persistence,
+  ownership, and backoff behavior.
+
+## Impact
+
+This is an internal retry-circuit admission fix. It adds no setting, schema,
+wire-format, or operator action.

--- a/openspec/changes/normalize-expired-retry-cooldown/specs/responses-api-compat/spec.md
+++ b/openspec/changes/normalize-expired-retry-cooldown/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Expired durable retry cooldowns do not consume a half-open lease
+
+When a durable retry-circuit row has an absent or elapsed cooldown, the proxy
+MUST load the in-memory cooldown deadline as zero. It MUST NOT interpret that
+row as a cooldown that just ended, consume an exclusive half-open probe lease,
+or suppress subsequent requests solely because the persisted cooldown elapsed.
+Future cooldown deadlines MUST remain represented as a positive in-memory
+deadline, with thresholds, backoff, persistence, ownership, and retry
+classification unchanged.
+
+#### Scenario: Elapsed cooldown reloads open without a probe lease
+
+- **GIVEN** a hard-affinity durable retry row whose cooldown deadline is in the past
+- **WHEN** retry admission loads the row
+- **THEN** the in-memory cooldown deadline is zero
+- **AND** the half-open lease is zero
+- **AND** repeated admission checks remain allowed
+
+#### Scenario: Future cooldown remains enforced
+
+- **GIVEN** a hard-affinity durable retry row whose cooldown deadline is in the future
+- **WHEN** retry admission loads the row
+- **THEN** the positive cooldown remains enforced until it expires

--- a/openspec/changes/normalize-expired-retry-cooldown/tasks.md
+++ b/openspec/changes/normalize-expired-retry-cooldown/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specification
+
+- [x] Add the expired-cooldown and future-cooldown requirements.
+- [x] Validate the change in strict mode.
+
+## 2. Implementation
+
+- [x] Normalize non-positive durable cooldown remaining time to the zero
+      sentinel while preserving future deadlines.
+- [x] Add regression coverage proving an elapsed row does not burn a
+      half-open probe lease.
+
+## 3. Verification
+
+- [x] Run focused retry-circuit tests, Ruff, and `git diff --check`.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -28315,6 +28315,38 @@ async def test_http_bridge_retry_circuit_counts_stuck_gate_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_elapsed_durable_cooldown_does_not_burn_half_open_probe() -> None:
+    """An already-elapsed durable cooldown is not a cooldown that just ended."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-elapsed-cooldown")
+    # ``persist_retry_circuit`` writes ``now_wall`` when the failure count is
+    # below the threshold, and a real cooldown simply elapses. Both leave a row
+    # whose ``cooldown_until_epoch`` is in the past.
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(
+            return_value=SimpleNamespace(
+                consecutive_failures=2,
+                cooldown_until_epoch=time.time() - 120.0,
+                last_detail="stream_incomplete",
+                updated_at_epoch=time.time(),
+            )
+        ),
+        persist_retry_circuit=AsyncMock(),
+        clear_retry_circuit=AsyncMock(),
+    )
+
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+    state = cast(Any, service)._http_bridge_retry_circuits[hard_session.key]
+    assert state.cooldown_until == 0.0
+    assert state.half_open_until == 0.0
+    assert await service._http_bridge_precreated_retry_cooldown_seconds(hard_session) == 0.0
+    # The decisive part: a key that was never cooling down must not lock every
+    # other request out behind a probe lease it never needed.
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_submit_suppresses_hard_key_during_retry_cooldown() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     hard_session = _make_bridge_session(key_value="bridge-submit-cooldown")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -28375,6 +28375,37 @@ async def test_http_bridge_retry_circuit_expiry_clears_loaded_local_deadline() -
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_expiry_clears_lookup_failure_probe() -> None:
+    """An expired row clears a probe leased during a transient lookup failure."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-expiry-lookup-failure")
+    persisted = SimpleNamespace(
+        consecutive_failures=2,
+        cooldown_until_epoch=time.time() + 0.1,
+        last_detail="stream_incomplete",
+        updated_at_epoch=time.time(),
+    )
+    lookup_retry_circuit = AsyncMock(side_effect=[persisted, RuntimeError("temporary lookup failure"), persisted])
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=AsyncMock(),
+        clear_retry_circuit=AsyncMock(),
+    )
+
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is False
+    state = cast(Any, service)._http_bridge_retry_circuits[hard_session.key]
+    persisted.cooldown_until_epoch = time.time() - 120.0
+    await anyio.sleep(0.15)
+
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+    assert state.half_open_until > time.monotonic()
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+    assert state.cooldown_until == 0.0
+    assert state.half_open_until == 0.0
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_submit_suppresses_hard_key_during_retry_cooldown() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     hard_session = _make_bridge_session(key_value="bridge-submit-cooldown")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -28347,6 +28347,34 @@ async def test_http_bridge_retry_circuit_elapsed_durable_cooldown_does_not_burn_
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_expiry_clears_loaded_local_deadline() -> None:
+    """A cooldown that expires after loading does not create a half-open lease."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-circuit-expiry-transition")
+    persisted = SimpleNamespace(
+        consecutive_failures=2,
+        cooldown_until_epoch=time.time() + 60.0,
+        last_detail="stream_incomplete",
+        updated_at_epoch=time.time(),
+    )
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=persisted),
+        persist_retry_circuit=AsyncMock(),
+        clear_retry_circuit=AsyncMock(),
+    )
+
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is False
+    state = cast(Any, service)._http_bridge_retry_circuits[hard_session.key]
+    assert state.cooldown_until > time.monotonic()
+
+    persisted.cooldown_until_epoch = time.time() - 120.0
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+    assert state.cooldown_until == 0.0
+    assert state.half_open_until == 0.0
+    assert await service._http_bridge_precreated_retry_allowed(hard_session) is True
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_submit_suppresses_hard_key_during_retry_cooldown() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     hard_session = _make_bridge_session(key_value="bridge-submit-cooldown")


### PR DESCRIPTION
## Problem

An absent or elapsed durable retry cooldown was converted into `now_monotonic + 0`. Admission interpreted that value as a real expiry transition and could create a half-open lease when no active cooldown existed.

## Why this PR exists

#1908 identified the arithmetic bug while the broader retry and stale-anchor work was being split. The root problem is real, but this branch also clears active half-open leases on equal or newer expired snapshots. That breaks the one-probe single-flight behavior introduced for #1394.

## How this PR solves it

- Normalize elapsed durable cooldowns during retry-circuit load.
- Clear stale local cooldown and half-open deadlines on equal-version reload.
- Add retry-circuit regressions for elapsed rows and lookup failure.

OpenSpec: `openspec/changes/normalize-expired-retry-cooldown/`

## Scope

This branch changes retry-circuit normalization only. It does not own cooldown-suppressed session retirement from #1947, poisoned-anchor quarantine from #1891, or broad stale-anchor recovery from #1867.

## Verification

Exact candidate: `ed8ee1222999bf6b58164529af3ae5724e09c4ec`

- 37 retry-circuit tests passed.
- Ruff, formatting, `ty`, proxy architecture, strict targeted OpenSpec, and `git diff --check` passed on the historical candidate.

## Current status

Do not merge this branch. The zero-sentinel normalization is being rebuilt on current upstream main in a focused successor that preserves the active owner lease, admits exactly one probe after genuine expiry, and settles only the matching owner and token. #1908 will be superseded and closed after that successor passes exact-head local and hosted review.
