### PR TITLE
fix(proxy): skip session anchors for safe full resends

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -257,6 +257,36 @@ def _http_bridge_durable_recovery_predecessor_proven(request_state: _WebSocketRe
     return request_state.previous_response_id is not None or request_state.operation_parent_response_id is not None
 
 
+def _http_bridge_full_resend_has_safe_fresh_context(
+    input_items: list[JsonValue],
+    *,
+    stored_count: int,
+    pending_tool_calls: Mapping[str, str] | None,
+) -> bool:
+    replay_projection = project_responses_input_for_account_neutral_fresh_replay(
+        input_items,
+        stored_count=stored_count,
+        # Classification only: inline Responses-Lite developer IDs must
+        # remain visible until the proof rejects response-owned messages.
+        preserve_developer_message_ids=True,
+    )
+    if replay_projection is None:
+        return False
+    return responses_input_suffix_retains_prior_output(
+        replay_projection.input_items,
+        stored_count=replay_projection.stored_prefix_count,
+        canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
+    ) or (
+        pending_tool_calls is not None
+        and responses_input_suffix_matches_pending_tool_calls(
+            replay_projection.input_items,
+            stored_count=replay_projection.stored_prefix_count,
+            pending_tool_calls=pending_tool_calls,
+            canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
+        )
+    )
+
+
 class _VerifiedDurableFullResend:
     """Immutable proof that one payload contains a durable turn's complete context."""
 
@@ -359,31 +389,12 @@ class _VerifiedDurableFullResend:
         ):
             return None
         input_items = cast(list[JsonValue], payload.input)
-        replay_projection = project_responses_input_for_account_neutral_fresh_replay(
+        pending_tool_calls = durable_lookup.latest_pending_tool_calls
+        if not _http_bridge_full_resend_has_safe_fresh_context(
             input_items,
             stored_count=stored_count,
-            # Classification only, mirroring classify_durable_full_resend:
-            # inline Responses-Lite developer IDs must remain visible until
-            # the exact-manifest check rejects response-owned messages.
-            preserve_developer_message_ids=True,
-        )
-        pending_tool_calls = durable_lookup.latest_pending_tool_calls
-        if replay_projection is None:
-            return None
-        safe_fresh_context = responses_input_suffix_retains_prior_output(
-            replay_projection.input_items,
-            stored_count=replay_projection.stored_prefix_count,
-            canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-        ) or (
-            pending_tool_calls is not None
-            and responses_input_suffix_matches_pending_tool_calls(
-                replay_projection.input_items,
-                stored_count=replay_projection.stored_prefix_count,
-                pending_tool_calls=pending_tool_calls,
-                canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-            )
-        )
-        if not safe_fresh_context:
+            pending_tool_calls=pending_tool_calls,
+        ):
             return None
         return cls(
             _token=cls.__construction_token,
@@ -1368,30 +1379,11 @@ class _HTTPBridgeStreamingMixin:
                 or not isinstance(payload.input, list)
             ):
                 return None, None, False
-            replay_projection = project_responses_input_for_account_neutral_fresh_replay(
+            safe_fresh_context = _http_bridge_full_resend_has_safe_fresh_context(
                 cast(list[JsonValue], payload.input),
                 stored_count=stored_count,
-                # Classification only: inline Responses-Lite developer IDs
-                # must remain visible until the exact-manifest check rejects
-                # response-owned messages. Cross-account replay uses the
-                # default ID-stripping projection below.
-                preserve_developer_message_ids=True,
+                pending_tool_calls=lookup.latest_pending_tool_calls,
             )
-            safe_fresh_context = False
-            if replay_projection is not None:
-                safe_fresh_context = responses_input_suffix_retains_prior_output(
-                    replay_projection.input_items,
-                    stored_count=replay_projection.stored_prefix_count,
-                    canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-                ) or (
-                    lookup.latest_pending_tool_calls is not None
-                    and responses_input_suffix_matches_pending_tool_calls(
-                        replay_projection.input_items,
-                        stored_count=replay_projection.stored_prefix_count,
-                        pending_tool_calls=lookup.latest_pending_tool_calls,
-                        canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-                    )
-                )
             return stored_count, lookup.latest_input_full_fingerprint, safe_fresh_context
 
         if durable_lookup is not None:
@@ -2645,6 +2637,18 @@ class _HTTPBridgeStreamingMixin:
             stored_count=stored_count_preview,
             stored_fingerprint=stored_fingerprint_preview,
         )
+        session_payload_looks_like_full_resend = _http_bridge_payload_looks_like_full_resend(effective_payload)
+        session_full_resend_has_safe_fresh_context = False
+        if (
+            session_payload_looks_like_full_resend
+            and session_anchor_trimmable
+            and isinstance(incoming_input_preview, list)
+        ):
+            session_full_resend_has_safe_fresh_context = _http_bridge_full_resend_has_safe_fresh_context(
+                cast(list[JsonValue], incoming_input_preview),
+                stored_count=stored_count_preview,
+                pending_tool_calls=session.last_pending_tool_calls or None,
+            )
         # A previous_response_id is account-scoped upstream: only the account that
         # created the response can resume it. If this session's serving account is
         # not the anchor's owner (e.g. the session failed over after the durable
@@ -2659,7 +2663,7 @@ class _HTTPBridgeStreamingMixin:
         recovery_session_can_anchor = is_http_bridge_account_neutral_replay(
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
-        ) and (not _http_bridge_payload_looks_like_full_resend(effective_payload) or session_anchor_trimmable)
+        ) and (not session_payload_looks_like_full_resend or session_anchor_trimmable)
         session_anchor_candidate = (
             session.codex_session
             # Honor the quarantine decision end to end: the durable anchor
@@ -2670,7 +2674,21 @@ class _HTTPBridgeStreamingMixin:
             and session.last_completed_response_id is not None
             and (session_anchor_trimmable or recovery_session_can_anchor)
         )
-        if session_anchor_candidate and not session_anchor_account_owned:
+        # A verified self-contained full resend already carries its
+        # continuity. Send it unchanged because a matching stored prefix does
+        # not prove that the session response ID remains valid upstream.
+        if session_anchor_candidate and session_anchor_account_owned and session_full_resend_has_safe_fresh_context:
+            _log_http_bridge_event(
+                "session_anchor_injection_skipped",
+                session.key,
+                account_id=session.account.id,
+                model=effective_payload.model,
+                detail="reason=full_resend_safe_fresh_context",
+                cache_key_family=session.key.affinity_kind,
+                model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                owner_check_applied=False,
+            )
+        elif session_anchor_candidate and not session_anchor_account_owned:
             _log_http_bridge_event(
                 "cross_account_anchor_declined",
                 session.key,
@@ -2686,11 +2704,8 @@ class _HTTPBridgeStreamingMixin:
                 model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
                 owner_check_applied=True,
             )
-        if session_anchor_candidate and session_anchor_account_owned:
+        elif session_anchor_candidate and session_anchor_account_owned:
             fresh_upstream_request_text = text_data
-            session_level_payload_looks_like_full_resend = _http_bridge_payload_looks_like_full_resend(
-                effective_payload
-            )
             effective_payload = effective_payload.model_copy(
                 update={"previous_response_id": session.last_completed_response_id}
             )
@@ -2707,7 +2722,7 @@ class _HTTPBridgeStreamingMixin:
             request_state.preferred_account_id = durable_lookup.account_id if durable_lookup is not None else None
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             request_state.proxy_injected_previous_response_id = True
-            request_state.proxy_injected_anchor_had_full_resend_payload = session_level_payload_looks_like_full_resend
+            request_state.proxy_injected_anchor_had_full_resend_payload = session_payload_looks_like_full_resend
             request_state.fresh_upstream_request_text = fresh_upstream_request_text
             # Session-level anchor injection may be attached to a payload
             # that relied on the anchor for context (for example a

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -272,18 +272,17 @@ def _http_bridge_full_resend_has_safe_fresh_context(
     )
     if replay_projection is None:
         return False
-    return responses_input_suffix_retains_prior_output(
-        replay_projection.input_items,
-        stored_count=replay_projection.stored_prefix_count,
-        canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
-    ) or (
-        pending_tool_calls is not None
-        and responses_input_suffix_matches_pending_tool_calls(
+    if pending_tool_calls:
+        return responses_input_suffix_matches_pending_tool_calls(
             replay_projection.input_items,
             stored_count=replay_projection.stored_prefix_count,
             pending_tool_calls=pending_tool_calls,
             canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
         )
+    return responses_input_suffix_retains_prior_output(
+        replay_projection.input_items,
+        stored_count=replay_projection.stored_prefix_count,
+        canonical_lite_developer_index=replay_projection.canonical_lite_developer_index,
     )
 
 

--- a/openspec/changes/skip-session-anchors-on-full-resends/.openspec.yaml
+++ b/openspec/changes/skip-session-anchors-on-full-resends/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/skip-session-anchors-on-full-resends/design.md
+++ b/openspec/changes/skip-session-anchors-on-full-resends/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The HTTP Responses bridge may retain the last completed response ID and a fingerprint of its stored input prefix. Current session-level optimization injects that response ID when an incoming request matches the prefix, including requests that already contain a full resend. Production showed that the retained response ID can become invalid even though the full resend remains self-contained.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep verified self-contained full resends unanchored at the session-level optimization.
+- Keep their complete input intact while unsafe cumulative prompts remain anchored.
+- Preserve existing anchor behavior for non-full-resend continuations.
+
+**Non-Goals:**
+
+- Change durable-anchor verification, quarantine, account ownership, or fresh-bridge recovery.
+- Change client-supplied `previous_response_id` handling.
+- Change cleanup, retry, account health, or database behavior.
+
+## Decisions
+
+- Classify the effective payload once beside the existing prefix-match check and exclude only verified self-contained full resends from session-anchor injection.
+  - This keeps the decision at the boundary that would otherwise inject and trim the payload.
+  - The verification reuses the existing replay projection, retained-output proof, and pending-tool-call proof.
+  - The existing classifier treats any multi-item sequence or a single item of at least 4 KiB as a possible full resend; the safety proof prevents that broad classifier from suppressing required anchors.
+- Preserve the existing session-anchor candidate and account-ownership checks for non-full-resend requests.
+  - Moving the rule into durable lookup or account selection would change unrelated recovery paths.
+- Retain a structured `session_anchor_injection_skipped` bridge event for the full-resend decision.
+  - This makes production verification possible without logging request content.
+
+## Risks / Trade-offs
+
+- A full resend that omits prior output cannot safely continue without its anchor. → Require retained-output or exact pending-tool-call proof and cover the unsafe control.
+- Full resends may send more input than an anchored, trimmed request. → Accept the input cost because the request already supplies continuity and correctness takes priority.
+- Existing upstream recovery code may change around this seam. → Keep the patch local to the candidate predicate and verify the public route plus current beta-4 lifecycle tests.

--- a/openspec/changes/skip-session-anchors-on-full-resends/proposal.md
+++ b/openspec/changes/skip-session-anchors-on-full-resends/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+An HTTP Responses full resend can match a live bridge session's stored input prefix and receive that session's `previous_response_id`. The proxy then trims a verified self-contained request even though it already carries its own continuity, and a stale upstream response ID can make every retry fail.
+
+## What Changes
+
+- Do not inject a session-level `previous_response_id` into a full resend verified to retain prior completed output or exactly settle the session's pending direct tool calls.
+- Forward that verified self-contained input without session-anchor-based prefix trimming.
+- Keep the existing anchor and trim behavior when the resend does not prove that context.
+- Preserve session-anchor injection for compatible non-full-resend continuations.
+- Add bridge-level regression coverage for both paths.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Full resends remain self-contained when a reusable HTTP bridge session already has a completed response anchor.
+
+## Impact
+
+- Affected code: HTTP Responses bridge session-anchor selection in `app/modules/proxy/_service/http_bridge/streaming.py`.
+- Affected tests: focused HTTP bridge unit coverage.
+- No endpoint, schema, setting, dependency, account-selection, or database change.

--- a/openspec/changes/skip-session-anchors-on-full-resends/specs/responses-api-compat/spec.md
+++ b/openspec/changes/skip-session-anchors-on-full-resends/specs/responses-api-compat/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Verified self-contained full resends do not receive session-level previous-response anchors
+
+The HTTP Responses bridge MUST NOT inject a retained session `previous_response_id` into a full resend whose matching stored prefix is followed by retained completed assistant output or by direct tool call/output items that exactly settle the session's pending call manifest. It MUST forward that verified self-contained input without session-anchor-based prefix trimming. A cumulative resend that omits required prior output or pending tool results MUST retain the existing session-anchor and trim behavior. This rule MUST NOT remove an explicit client-provided `previous_response_id`.
+
+#### Scenario: Self-contained trimmable full resend remains unanchored
+
+- **WHEN** a full resend matches the stored input prefix of a reusable bridge session and retains completed assistant output before fresh user input
+- **THEN** the proxy sends the request without injecting that session response ID
+- **AND** the proxy forwards the complete input instead of trimming the stored prefix
+
+#### Scenario: Cumulative prompt without prior output remains anchored
+
+- **WHEN** a matching cumulative prompt contains fresh user input but omits the prior assistant output
+- **THEN** the proxy injects the compatible account-owned session response ID
+- **AND** the proxy applies the existing stored-prefix trim behavior
+
+#### Scenario: Complete pending tool loop remains unanchored
+
+- **WHEN** a matching full resend exactly settles every direct tool call in the session's pending call manifest
+- **THEN** the proxy sends the complete tool-loop resend without injecting the retained session response ID
+
+#### Scenario: Omitted pending tool output remains anchored
+
+- **WHEN** a matching full resend omits any direct tool output required by the session's pending call manifest
+- **THEN** the proxy retains the compatible session response ID and existing interrupted-tool-output repair
+
+#### Scenario: Explicit client anchor is preserved
+
+- **WHEN** a client supplies its own `previous_response_id`
+- **THEN** the full-resend session-anchor suppression does not remove or replace that client value

--- a/openspec/changes/skip-session-anchors-on-full-resends/tasks.md
+++ b/openspec/changes/skip-session-anchors-on-full-resends/tasks.md
@@ -1,0 +1,15 @@
+## 1. Bridge behavior
+
+- [x] 1.1 Exclude verified self-contained full resends from session-level previous-response anchor injection while preserving unsafe resend, durable, quarantine, and account-ownership rules.
+- [x] 1.2 Add bridge and public-route regression coverage for safe and unsafe trimmable full resends.
+
+## 2. Focused verification
+
+- [x] 2.1 Run the full-resend, terminal-delivery, shared-future, warning-rate, and idle-sweep regression slices.
+- [x] 2.2 Run the relevant HTTP bridge integration and migration checks without typechecking.
+- [x] 2.3 Run Ruff, formatting, proxy architecture checks, and strict OpenSpec validation.
+
+## 3. Candidate proof
+
+- [x] 3.1 Build the source-based beta-4 candidate without copying older overlay files.
+- [x] 3.2 Verify migration, representative multi-turn behavior, and rollback on an isolated clone before production handoff.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8919,9 +8919,9 @@ async def test_backend_responses_http_bridge_declines_cross_account_anchor_and_s
     assert bridge_session.last_completed_response_id == "resp_cross_account_serving_1"
     assert bridge_session.last_completed_response_account_id == serving_account.id
 
-    # Same-account continuity is untouched: once the durable record names the
-    # account that actually created the response, the very next turn anchors on
-    # it instead of resending the whole history.
+    # The next same-account full resend retains completed assistant output, so
+    # it is self-contained and must not receive the session anchor even though
+    # its stored prefix matches.
     durable_record = _durable_record(
         account_id=serving_account.id,
         latest_response_id="resp_cross_account_serving_1",
@@ -8953,7 +8953,17 @@ async def test_backend_responses_http_bridge_declines_cross_account_anchor_and_s
     _assert_created_text_delta_completed(second_events)
     assert len(serving_upstream.sent_text) == 2
     follow_up_payload = json.loads(serving_upstream.sent_text[1])
-    assert follow_up_payload["previous_response_id"] == "resp_cross_account_serving_1"
+    assert "previous_response_id" not in follow_up_payload
+    assert follow_up_payload["input"] == [
+        *compacted_resend,
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "OK"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "third question"}]},
+    ]
     assert bridge_session.response_create_gate.locked() is False
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -11474,6 +11474,7 @@ async def _run_session_anchor_owner_stream(
     anchor_owner_account_id: str | None,
     self_contained_full_resend: bool,
     pending_tool_loop_complete: bool | None = None,
+    pending_tool_calls_without_suffix: bool = False,
 ) -> tuple[list[proxy_service.ResponsesRequest], list[dict[str, Any]], list[str]]:
     """Drive _stream_via_http_bridge for a session-anchor decision.
 
@@ -11520,6 +11521,8 @@ async def _run_session_anchor_owner_stream(
                 "content": [{"type": "output_text", "text": "prior answer"}],
             }
         )
+    if pending_tool_calls_without_suffix:
+        pending_tool_calls = {"call_lookup": "function_call"}
     input_items = [*prefix_items, *retained_output]
     if pending_tool_loop_complete is None:
         input_items.append(continuation_item)
@@ -11754,6 +11757,32 @@ async def test_stream_via_http_bridge_repairs_missing_pending_tool_output_on_anc
             "arguments": "{}",
         },
     ]
+    assert sent_frames[-1]["previous_response_id"] == "resp_session_latest"
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_does_not_let_retained_output_bypass_pending_tool_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+        monkeypatch,
+        account_id="acc-1",
+        anchor_owner_account_id="acc-1",
+        self_contained_full_resend=True,
+        pending_tool_calls_without_suffix=True,
+    )
+
+    assert prepared[-1].previous_response_id == "resp_session_latest"
+    assert isinstance(prepared[-1].input, list)
+    assert prepared[-1].input[0] == {
+        "type": "function_call_output",
+        "call_id": "call_lookup",
+        "output": (
+            "Tool call was not executed because the previous turn was interrupted before tool output was available."
+        ),
+    }
     assert sent_frames[-1]["previous_response_id"] == "resp_session_latest"
     assert sent_frames[-1]["input"] == prepared[-1].input
     assert any("response.completed" in chunk for chunk in chunks)

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -11472,12 +11472,14 @@ async def _run_session_anchor_owner_stream(
     *,
     account_id: str,
     anchor_owner_account_id: str | None,
-) -> list[proxy_service.ResponsesRequest]:
-    """Drive _stream_via_http_bridge for a trimmable session-anchor turn.
+    self_contained_full_resend: bool,
+    pending_tool_loop_complete: bool | None = None,
+) -> tuple[list[proxy_service.ResponsesRequest], list[dict[str, Any]], list[str]]:
+    """Drive _stream_via_http_bridge for a session-anchor decision.
 
-    The stored prefix matches the incoming input (so the trim branch WOULD
-    apply); the only variable is whether the serving account owns the anchor.
-    Returns the payloads passed to each prepare call.
+    The full resend always matches the stored prefix. Its fresh suffix either
+    retains completed assistant output or omits that context. Returns every
+    payload passed to the prepare boundary.
     """
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     prefix_items: list[proxy_service.JsonValue] = [
@@ -11485,40 +11487,88 @@ async def _run_session_anchor_owner_stream(
         {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
         {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
     ]
+    continuation_item: proxy_service.JsonValue = {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "d"}],
+    }
+    retained_output: list[proxy_service.JsonValue] = []
+    pending_tool_calls: dict[str, str] = {}
+    if pending_tool_loop_complete is not None:
+        pending_tool_calls = {"call_lookup": "function_call"}
+        retained_output.append(
+            {
+                "type": "function_call",
+                "call_id": "call_lookup",
+                "name": "lookup",
+                "arguments": "{}",
+            }
+        )
+        if pending_tool_loop_complete:
+            retained_output.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_lookup",
+                    "output": "result",
+                }
+            )
+    elif self_contained_full_resend:
+        retained_output.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "prior answer"}],
+            }
+        )
+    input_items = [*prefix_items, *retained_output]
+    if pending_tool_loop_complete is None:
+        input_items.append(continuation_item)
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.4",
             "instructions": "hi",
-            "input": [*prefix_items, {"role": "user", "content": [{"type": "input_text", "text": "d"}]}],
+            "input": input_items,
         },
     )
-    request_state = proxy_service._WebSocketRequestState(
-        request_id="req-session-anchor-owner",
-        model="gpt-5.4",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=1.0,
-        event_queue=asyncio.Queue(),
-        transport="http",
-    )
-    event_queue = request_state.event_queue
-    assert event_queue is not None
-    await event_queue.put(None)
     prepared_payloads: list[proxy_service.ResponsesRequest] = []
+    sent_frames: list[dict[str, Any]] = []
+    real_prepare = service._prepare_http_bridge_request
 
-    def fake_prepare(
+    def recording_prepare(
         prepared_payload: proxy_service.ResponsesRequest,
-        _headers: dict[str, str] | Any,
+        prepared_headers: dict[str, str] | Any,
         *,
         api_key: proxy_service.ApiKeyData | None,
         api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
         request_id: str,
         client_ip: str | None = None,
     ) -> tuple[proxy_service._WebSocketRequestState, str]:
-        del api_key, api_key_reservation, request_id, client_ip
         prepared_payloads.append(prepared_payload)
-        return request_state, '{"type":"response.create"}'
+        return real_prepare(
+            prepared_payload,
+            prepared_headers,
+            api_key=api_key,
+            api_key_reservation=api_key_reservation,
+            request_id=request_id,
+            client_ip=client_ip,
+        )
+
+    async def fake_submit(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del _session, queue_limit
+        sent_frames.append(json.loads(text_data))
+        event_queue = request_state.event_queue
+        assert event_queue is not None
+        await event_queue.put(
+            'data: {"type":"response.completed","response":'
+            '{"id":"resp_session_test","status":"completed","output":[]}}\n\n'
+        )
+        await event_queue.put(None)
 
     session = proxy_service._HTTPBridgeSession(
         key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-anchor-owner", None),
@@ -11542,6 +11592,7 @@ async def _run_session_anchor_owner_stream(
         last_completed_response_account_id=anchor_owner_account_id,
         last_completed_input_count=3,
         last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(prefix_items),
+        last_pending_tool_calls=pending_tool_calls,
     )
 
     monkeypatch.setattr(
@@ -11564,56 +11615,182 @@ async def _run_session_anchor_owner_stream(
     )
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
-    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", recording_prepare)
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
-    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_submit_http_bridge_request", fake_submit)
     monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
 
-    async for _chunk in service._stream_via_http_bridge(
-        payload,
-        headers={"x-codex-session-id": "sid-anchor-owner"},
-        codex_session_affinity=True,
-        propagate_http_errors=False,
-        openai_cache_affinity=False,
-        api_key=None,
-        api_key_reservation=None,
-        suppress_text_done_events=False,
-        idle_ttl_seconds=120.0,
-        codex_idle_ttl_seconds=1800.0,
-        max_sessions=8,
-        queue_limit=4,
-    ):
-        pass
-    return prepared_payloads
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-session-id": "sid-anchor-owner"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+    return prepared_payloads, sent_frames, chunks
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_injects_session_anchor_when_account_owns_it(
+async def test_stream_via_http_bridge_skips_session_anchor_for_self_contained_full_resend(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+            monkeypatch,
+            account_id="acc-1",
+            anchor_owner_account_id="acc-1",
+            self_contained_full_resend=True,
+        )
+
+    assert all(payload.previous_response_id is None for payload in prepared)
+    assert prepared[-1].input == [
+        {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "prior answer"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "d"}]},
+    ]
+    assert "session_anchor_injection_skipped" in caplog.text
+    assert "reason=full_resend_safe_fresh_context" in caplog.text
+    assert "previous_response_id" not in sent_frames[-1]
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_keeps_session_anchor_for_unsafe_full_resend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Serving account owns the anchor -> the compact anchor is injected as normal.
-    prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-1", anchor_owner_account_id="acc-1")
-    # Injection re-prepares the payload, so the final (sent) request carries the anchor.
+    prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+        monkeypatch,
+        account_id="acc-1",
+        anchor_owner_account_id="acc-1",
+        self_contained_full_resend=False,
+    )
+
     assert prepared[-1].previous_response_id == "resp_session_latest"
+    assert prepared[-1].input == [
+        {"role": "user", "content": [{"type": "input_text", "text": "d"}]},
+    ]
+    assert sent_frames[-1]["previous_response_id"] == "resp_session_latest"
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_skips_session_anchor_for_complete_pending_tool_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+        monkeypatch,
+        account_id="acc-1",
+        anchor_owner_account_id="acc-1",
+        self_contained_full_resend=False,
+        pending_tool_loop_complete=True,
+    )
+
+    assert all(payload.previous_response_id is None for payload in prepared)
+    assert isinstance(prepared[-1].input, list)
+    assert prepared[-1].input[-2:] == [
+        {
+            "type": "function_call",
+            "call_id": "call_lookup",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_lookup",
+            "output": "result",
+        },
+    ]
+    assert "previous_response_id" not in sent_frames[-1]
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_repairs_missing_pending_tool_output_on_anchored_resend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+        monkeypatch,
+        account_id="acc-1",
+        anchor_owner_account_id="acc-1",
+        self_contained_full_resend=False,
+        pending_tool_loop_complete=False,
+    )
+
+    assert prepared[-1].previous_response_id == "resp_session_latest"
+    assert isinstance(prepared[-1].input, list)
+    assert prepared[-1].input[0] == {
+        "type": "function_call_output",
+        "call_id": "call_lookup",
+        "output": (
+            "Tool call was not executed because the previous turn was interrupted before tool output was available."
+        ),
+    }
+    assert prepared[-1].input[1:] == [
+        {
+            "type": "function_call",
+            "call_id": "call_lookup",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    assert sent_frames[-1]["previous_response_id"] == "resp_session_latest"
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
 
 
 @pytest.mark.asyncio
 async def test_stream_via_http_bridge_skips_session_anchor_after_cross_account_failover(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Anchor was created on acc-1 but the session now serves on acc-2 (failover).
-    # A previous_response_id is account-scoped upstream, so injecting it here would
-    # send an unresolvable anchor with the history trimmed away -> upstream never
-    # emits response.created -> the response-create gate wedges. It must be skipped
-    # and the full history resent instead.
-    prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-2", anchor_owner_account_id="acc-1")
+    # A previous_response_id is account-scoped upstream, so the session path
+    # must not send an acc-1 anchor through acc-2.
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        prepared, sent_frames, chunks = await _run_session_anchor_owner_stream(
+            monkeypatch,
+            account_id="acc-2",
+            anchor_owner_account_id="acc-1",
+            self_contained_full_resend=True,
+        )
     assert all(payload.previous_response_id != "resp_session_latest" for payload in prepared)
     assert prepared[-1].input == [
         {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
         {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
         {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "prior answer"}],
+        },
         {"role": "user", "content": [{"type": "input_text", "text": "d"}]},
     ]
+    assert "event=cross_account_anchor_declined" in caplog.text
+    assert "previous_response_id" not in sent_frames[-1]
+    assert sent_frames[-1]["input"] == prepared[-1].input
+    assert any("response.completed" in chunk for chunk in chunks)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- keep a verified self-contained full resend unanchored when it reuses the same account-owned HTTP bridge session
- retain session anchoring and prefix trimming when cumulative input omits prior assistant output or pending tool results
- centralize the retained-output and pending-tool safety proof across durable and live-session paths
- add OpenSpec, unit dispatch, pending-tool, account-owner, and public route coverage

## Type of change

- [x] fix: bug fix
- [ ] feat: new user-facing capability
- [ ] refactor: internal-only change
- [ ] docs: documentation only
- [ ] chore / ci / build
- [ ] breaking change

Linked issue: None — reproduced from a production deployment incident.
Related reliability work: #1527 and #1842.

## Root cause

A live HTTP bridge session can retain a completed `previous_response_id` and a matching input-prefix fingerprint. A later full resend that contains complete retained assistant output or exactly settles the prior pending tool calls is already self-contained, but the session optimization still injected the retained response ID and trimmed the stored prefix.

If that response ID is no longer valid on the upstream socket, every retry can fail even though the client supplied enough input to continue without it.

## Changes

- use the existing replay projection and one shared safety predicate for durable and live-session classification
- suppress session-anchor injection only when:
  - the full resend matches the stored prefix
  - the session still serves the account that owns the anchor
  - the suffix retains completed assistant output or exactly settles the session pending-tool manifest
- keep unsafe cumulative prompts anchored and keep interrupted-tool-output repair reachable
- emit `http_bridge_event event=session_anchor_injection_skipped ... detail=reason=full_resend_safe_fresh_context`
- preserve client-supplied anchors, cross-account decline behavior, quarantine, durable recovery, and account selection

## OpenSpec

- [x] `openspec/changes/skip-session-anchors-on-full-resends/`
- [x] strict change validation passed
- [x] all 57 repository specs passed strict validation

## Verification

Focused and complete relevant gates:

- 46 lifecycle, terminal-delivery, shared-future, loop-lag, idle-sweep, and new decision tests passed
- 215 replay-safety and selected HTTP/WebSocket integration tests passed
- full `tests/integration/test_http_responses_bridge.py`: 131 passed
- full `tests/unit/test_proxy_http_bridge.py`: 642 passed; one pre-existing fixture failure (`file_account_pins` table absent), identical to the failure documented on current-main bridge PRs
- four focused migration tests passed
- SQLite migration check reached `20260816_000000_add_model_source_embeddings` with `schema_drift=none`
- Ruff check and format passed
- proxy architecture checks passed
- strict OpenSpec change validation passed
- strict validation passed for all 57 repository specs
- typecheck was not run locally

Production-shaped isolated proof:

- source-built candidate migrated a cloned 4 GB production SQLite volume to the current head
- cold `PRAGMA integrity_check` returned `ok`; all 10 accounts remained present
- two-turn cumulative Codex canary returned HTTP 200 and exactly one `response.completed` per turn
- second turn reused the same bridge and emitted the new session-anchor suppression event
- zero proxy errors, close timeouts, or cancellation timeouts occurred during that canary
- exact prior image started from the untouched pre-migration clone and completed a real upstream canary, proving snapshot-based rollback

## Non-goals / residual behavior

- no changes to terminal-delivery ownership, shared-future admission, cleanup timeout policy, account health, or database schema
- bounded bridge cleanup can still exceed a 30-second container stop grace period; this PR does not change that existing behavior
- reverted `continuity_owner_conflict` and duplicate-tool-terminal changes remain separate work

## Simplicity

- zero configuration
- no new setting, environment variable, dependency, schema, endpoint, or setup step
- no README, dashboard, or navigation change

## Screenshots / output

Not applicable; no dashboard-visible change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Full HTTP Responses resends containing complete continuity are now processed without stale session anchors.
  - Self-contained resends forward their complete request history, preventing incorrect response linking and unnecessary prefix trimming.
  - Incomplete resends and other continuations retain existing anchoring behavior.
  - Explicit client-provided anchors remain unchanged.

- **Tests**
  - Added coverage for complete and incomplete resends, pending tool-call flows, and cross-account recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->