### PR TITLE
chore: release v1.24.1-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.24.0"  # x-release-please-version
+__version__ = "1.24.1-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.24.0
-appVersion: 1.24.0
+version: 1.24.1-beta.1
+appVersion: 1.24.1-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.1-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.24.0"
+version = "1.24.1-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.24.0"
+version = "1.24.1-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.24.1-beta.1 for the 1.24.1 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.24.1-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.24.0
- fix(api-keys): preserve usage on limit patches (#1888) (
b72afb)
- fix(proxy): own cancellable usage refresh sessions (#1887) (
48eff5)
- fix(ui): restore settings dialog focus (#1883) (
5dc49e)
- fix(tooling): reject dashboard smoke runs without rebuild (#1880) (
37a9cd)
- fix(proxy): release cancelled embeddings reservations (#1874) (
b55189)
- fix(settings): show initial load failures (#1873) (
00c07f)
- fix(settings): allow clearing capacity overrides (#1871) (
e3fc08)
- fix(proxy): settle keyed mid-loop health after reservation (#1861) (
19dad4)
- fix(proxy): release grouped terminal append barriers on hard spool errors (#1860) (
5b3e07)
- fix(helm): default Codex prewarm off to match Settings (#1855) (
8cb0f2)
- fix(helm): honor external database port in network policy (#1838) (
a9a474)
- fix(proxy): preserve explicit null embedding fields (#1836) (
254839)
- fix(ui): restore scroll on route navigation (#1882) (
501eae)
- fix(proxy): enforce OpenSpec architecture ratchets (#1892) (
c3c1db)
- fix(proxy): recover stale previous response anchors (#1863) (
a34791)
- fix(proxy): exclude previous_response_id from model-source routing (#1859) (
09dd93)
- fix(ui): constrain API key dialog to viewport (#1884) (
ef1130)
- fix(proxy): defer keyed pre-created retry health writes until settlement (#1926) (
f9965f)
- fix(proxy): keep source Responses SSE alive and normalized (#1854) (
6d7886)
- fix(dashboard): contain mobile usage donuts (#1937) (
6c00ac)
- fix(proxy): release cancelled audio reservations (#1936) (
50ddee)
- feat(db): add chunk transcript reader (#1930) (
57d908)

## Release-candidate validation
Validated candidate: ae66b61f79a4f15aff4b5420e1fd74fc399a506c

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.24.1b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.24.1-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.24.1-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.24.1.
