### PR TITLE
Fix invalid refresh tokens not surfacing re-auth action

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -29,6 +29,10 @@ PERMANENT_FAILURE_CODES = {
     "app_session_terminated": "ChatGPT session ended - re-login required",
     "account_session_expired": "ChatGPT session ended - re-login required",
     "account_auth_invalidated": "Authentication failed after token refresh - re-login required",
+    # The OAuth endpoint uses this code for an invalid/revoked refresh token.
+    # Keep it in the permanent set so the account is surfaced for re-auth
+    # instead of remaining active while every request retries the dead token.
+    "invalid_refresh_token": "Refresh token invalid - re-login required",
     "account_deactivated": "Account has been deactivated",
     "account_suspended": "Account has been suspended",
     "account_deleted": "Account has been deleted",
@@ -45,6 +49,7 @@ REAUTH_REQUIRED_FAILURE_CODES = frozenset(
         "app_session_terminated",
         "account_session_expired",
         "account_auth_invalidated",
+        "invalid_refresh_token",
     }
 )
 

--- a/openspec/changes/treat-invalid-refresh-token-as-reauth/proposal.md
+++ b/openspec/changes/treat-invalid-refresh-token-as-reauth/proposal.md
@@ -1,0 +1,21 @@
+# Treat Invalid Refresh Token as Reauth
+
+## Why
+
+Upstream OAuth can reject a stored refresh token with `invalid_refresh_token`.
+Leaving that code outside the permanent failure set keeps the account active even
+though every fresh upstream attempt will retry dead credentials.
+
+## What Changes
+
+- Classify `invalid_refresh_token` as a permanent refresh failure.
+- Persist affected accounts as re-authentication required through the guarded
+  refresh-account status path.
+- Keep those accounts excluded from normal routing until an operator reauthenticates
+  or imports fresh credentials.
+
+## Impact
+
+- Affected specs: `account-routing`
+- Affected code: `app/core/auth/refresh.py`, `app/core/balancer/logic.py`,
+  `app/modules/accounts/auth_manager.py`

--- a/openspec/changes/treat-invalid-refresh-token-as-reauth/specs/account-routing/spec.md
+++ b/openspec/changes/treat-invalid-refresh-token-as-reauth/specs/account-routing/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Invalid refresh tokens require account re-authentication
+
+The system MUST classify an upstream OAuth `invalid_refresh_token` refresh
+failure as permanent, persist the affected account as re-authentication required
+through the guarded refresh-account status path, and exclude that account from
+normal account selection until an operator reauthenticates or imports fresh
+credentials.
+
+#### Scenario: OAuth invalid-refresh-token response removes the account from routing
+
+- **GIVEN** an active account attempts a token refresh
+- **WHEN** upstream OAuth returns `invalid_refresh_token`
+- **THEN** the refresh path persists the account status as `reauth_required`
+- **AND** the account is not selected for subsequent routed requests until fresh
+  credentials are supplied

--- a/openspec/changes/treat-invalid-refresh-token-as-reauth/tasks.md
+++ b/openspec/changes/treat-invalid-refresh-token-as-reauth/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] Classify `invalid_refresh_token` as a permanent OAuth refresh failure.
+- [x] Map `invalid_refresh_token` to `AccountStatus.REAUTH_REQUIRED`.
+- [x] Cover the guarded refresh-account path for the upstream code.
+
+## 2. Validation
+
+- [x] Run focused auth-refresh tests.
+- [x] Run strict OpenSpec validation for this change.

--- a/tests/integration/test_token_refresh_claims.py
+++ b/tests/integration/test_token_refresh_claims.py
@@ -14,12 +14,16 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import timedelta
 
 import pytest
 from sqlalchemy import select
 
+from app.core.auth import refresh as refresh_module
 from app.core.auth.refresh import RefreshError, TokenRefreshResult
+from app.core.balancer import AccountState, select_account
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountRefreshClaim, AccountStatus, StickySession, StickySessionKind
@@ -121,6 +125,61 @@ async def _commit_peer_reauth(account_id: str, *, refresh_token: str) -> None:
         account.status = AccountStatus.ACTIVE
         account.deactivation_reason = None
         await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_invalid_refresh_token_payload_requires_reauth_and_excludes_routing(db_setup, monkeypatch):
+    """Exercise the OAuth payload, guarded DB downgrade, and routing exclusion together."""
+    account_id = "acc_invalid_refresh_token"
+    await _create_account(account_id)
+
+    class InvalidRefreshTokenResponse:
+        status = 400
+
+        async def json(self, *, content_type: object = None) -> dict[str, object]:
+            del content_type
+            return {
+                "error": {
+                    "code": "invalid_refresh_token",
+                    "message": "Refresh token invalid - re-login required.",
+                }
+            }
+
+        async def text(self) -> str:
+            return ""
+
+        async def __aenter__(self) -> InvalidRefreshTokenResponse:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class InvalidRefreshTokenSession:
+        def post(self, *_args: object, **_kwargs: object) -> InvalidRefreshTokenResponse:
+            return InvalidRefreshTokenResponse()
+
+    @asynccontextmanager
+    async def fake_lease_http_session(_session: object) -> AsyncIterator[InvalidRefreshTokenSession]:
+        yield InvalidRefreshTokenSession()
+
+    monkeypatch.setattr(refresh_module, "lease_http_session", fake_lease_http_session)
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        account = await repo.get_by_id(account_id)
+        assert account is not None
+        manager = AuthManager(repo, refresh_claims=RefreshClaimCoordinator(claimant_id="invalid-token-test"))
+
+        with pytest.raises(RefreshError) as exc_info:
+            await manager.refresh_account(account)
+
+    assert exc_info.value.code == "invalid_refresh_token"
+    assert exc_info.value.is_permanent is True
+    status, stored_refresh_token, sticky_present = await _account_snapshot(account_id)
+    assert status == AccountStatus.REAUTH_REQUIRED
+    assert stored_refresh_token == "refresh-old"
+    assert sticky_present is False
+    assert select_account([AccountState(account_id=account_id, status=status)]).account is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -2808,6 +2808,10 @@ async def test_claim_release_error_does_not_mask_refresh_body_error(monkeypatch)
             "app_session_terminated",
             "Your session has been terminated. Please sign in again.",
         ),
+        (
+            "invalid_refresh_token",
+            "Refresh token invalid - re-login required.",
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -13,7 +13,9 @@ from app.core.auth.refresh import (
     refresh_contention_kind,
     should_refresh,
 )
+from app.core.balancer import account_status_for_permanent_failure
 from app.core.utils.time import utcnow
+from app.db.models import AccountStatus
 
 pytestmark = pytest.mark.unit
 
@@ -91,6 +93,7 @@ def test_classify_refresh_error_permanent():
     assert classify_refresh_error("account_deactivated") is True
     assert classify_refresh_error("invalid_grant") is True
     assert classify_refresh_error("app_session_terminated") is True
+    assert classify_refresh_error("invalid_refresh_token") is True
 
 
 def test_classify_refresh_error_token_expired_is_permanent():
@@ -100,6 +103,10 @@ def test_classify_refresh_error_token_expired_is_permanent():
     # the load balancer deactivates the account instead of looping retries.
     # Regression for #383.
     assert classify_refresh_error("token_expired") is True
+
+
+def test_invalid_refresh_token_requires_reauthentication():
+    assert account_status_for_permanent_failure("invalid_refresh_token") == AccountStatus.REAUTH_REQUIRED
 
 
 def test_classify_refresh_error_temporary():


### PR DESCRIPTION
## Summary

- classify the upstream `invalid_refresh_token` error as a permanent authentication failure
- map it to `REAUTH_REQUIRED` so active-looking accounts are removed from routing
- expose the existing Re-authenticate action in the dashboard after refresh-token failure
- add regression coverage for classification and status mapping

## User impact

When CodexLB receives `invalid_refresh_token`, the account will now be marked “Re-auth required” instead of remaining “Active” and retrying a dead token. The Accounts page can then use the existing Re-authenticate action to start a fresh OAuth flow.

## Verification

- `uv run ruff check app/core/balancer/logic.py tests/unit/test_auth_refresh.py`
- `uv run ruff format --check app/core/balancer/logic.py tests/unit/test_auth_refresh.py`
- `uv run pytest tests/unit/test_auth_refresh.py -q` (12 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts with invalid refresh tokens are now marked as requiring re-authentication.
  * Affected accounts are excluded from routing until they sign in again or provide fresh credentials.
  * Existing authentication state is preserved while re-authentication is required.
  * Users receive clearer guidance when a refresh token can no longer be used.

* **Tests**
  * Added coverage for refresh-token failures, routing exclusion, and re-authentication status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->