### PR TITLE
fix(proxy): defer keyed pre-created retry health writes until settlement

### DIFF
--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -71,6 +71,10 @@ class _ApiKeyUsageServiceProtocol(Protocol):
     _stream_api_key_release_retry_semaphore: asyncio.Semaphore
     _load_balancer: Any
 
+    async def _handle_stream_error(
+        self, account: Account, error: Any, code: str, http_status: int | None = None
+    ) -> Any: ...
+
 
 def _normalize_service_tier_value(value: Any) -> str | None:
     if not isinstance(value, str):
@@ -168,8 +172,15 @@ class _ApiKeyUsageMixin:
         pending_backoffs = (
             lifecycle.pending_backoffs if lifecycle is not None else request_state.deferred_account_error_backoffs
         )
-        if pending_backoffs:
-            await self._drain_deferred_account_error_backoffs(pending_backoffs)
+        try:
+            if pending_backoffs:
+                await self._drain_deferred_account_error_backoffs(pending_backoffs)
+        finally:
+            # Backoffs and queued stream-health penalties own independent
+            # post-settlement lanes: a failed backoff write must not orphan
+            # the deferred health write.
+            if request_state.deferred_keyed_stream_health:
+                await self._drain_deferred_keyed_stream_health(request_state)
 
     async def _drain_deferred_account_error_backoffs(
         self,
@@ -185,6 +196,67 @@ class _ApiKeyUsageMixin:
             except BaseException:
                 pending_backoffs.setdefault(account_id, account)
                 raise
+
+    async def _drain_deferred_keyed_stream_health(
+        self,
+        request_state: _WebSocketRequestState,
+    ) -> None:
+        """Apply health writes deferred until reservation settlement.
+
+        Each entry is claimed atomically (popped without an intervening
+        await), so the idempotent release and terminal-finalize paths can
+        drain the same request state concurrently without applying a penalty
+        twice or corrupting the queue.
+
+        Each attempt runs as an owned task awaited through ``asyncio.shield``
+        (the ``_await_task_deferring_cancellation`` pattern; importing it from
+        ``http_bridge.helpers`` would cycle through that module's import of
+        this one). Caller cancellation therefore cannot abandon a
+        half-applied penalty for a later drain to replay: every claimed entry
+        is drained to completion first — no later path owns the queue once
+        terminal ownership is relinquished — and the cancellation re-raises
+        only after the queue is empty.
+
+        An attempt that raises is logged and dropped rather than retained or
+        re-raised: settlement has already committed, and the
+        settlement-ordering contract only requires an unconfirmed settlement
+        to leave health unapplied — a failed health write must not abort the
+        remaining terminal finalization (request-log write, retirement).
+        """
+        proxy = cast(_ApiKeyUsageServiceProtocol, self)
+        deferred_cancellation: asyncio.CancelledError | None = None
+        penalties = request_state.deferred_keyed_stream_health
+        # The anyio shield keeps a level-cancelled Starlette scope from
+        # re-raising into every ``await``, which would otherwise busy-spin
+        # this loop until the owned task completes; the inner asyncio.shield
+        # loop defers edge task cancellation the same way.
+        with anyio.CancelScope(shield=True):
+            while penalties:
+                penalty = penalties.pop(0)
+                apply_task = asyncio.create_task(
+                    proxy._handle_stream_error(penalty.account, penalty.error, penalty.code)
+                )
+                while True:
+                    try:
+                        await asyncio.shield(apply_task)
+                        break
+                    except asyncio.CancelledError as exc:
+                        if apply_task.cancelled():
+                            penalties.insert(0, penalty)
+                            raise
+                        deferred_cancellation = deferred_cancellation or exc
+                    except Exception:
+                        logger.warning(
+                            "Deferred keyed stream-health write failed after settlement; dropping penalty "
+                            "account_id=%s code=%s request_id=%s",
+                            penalty.account.id,
+                            penalty.code,
+                            get_request_id(),
+                            exc_info=True,
+                        )
+                        break
+        if deferred_cancellation is not None:
+            raise deferred_cancellation
 
     async def _maybe_touch_api_key_reservation(
         self,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar, cast
 
 import anyio
 
+from app.core.balancer.types import UpstreamError
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
 from app.core.clients.files import finalize_file as core_finalize_file  # noqa: F401
 from app.core.clients.proxy import CodexControlResponse as CodexControlResponse
@@ -49,6 +50,7 @@ from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.db.models import Account
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
 )
@@ -145,6 +147,7 @@ from app.modules.proxy._service.support import (
     _clear_websocket_deferred_reasoning_downstream_texts,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
+    _DeferredKeyedStreamHealthPenalty,
     _HTTPBridgeCompletedDeliveryScope,
     _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
@@ -1785,6 +1788,35 @@ class _HTTPBridgeUpstreamEventsMixin:
                     except asyncio.QueueFull:
                         pass
 
+    async def _handle_or_defer_precreated_stream_health(
+        self: Any,
+        request_state: _WebSocketRequestState | None,
+        account: Account,
+        error: UpstreamError,
+        code: str,
+    ) -> None:
+        """Write account health now, or defer it until reservation settlement.
+
+        Keyed pre-created retry branches run while the request's API-key
+        reservation is still open. An immediate ``_handle_stream_error`` would
+        mutate account health before the reservation settles, violating the
+        settlement-ordering invariant (api-keys spec: the health write waits
+        for settlement, and unconfirmed settlement leaves health unapplied).
+        Queue the classified write on the request state instead;
+        ``_drain_deferred_keyed_stream_health`` applies it after settlement or
+        fallback release commits. Unkeyed requests keep the immediate write.
+        ``account_health_error_handled`` is set either way so terminal
+        finalization does not apply a duplicate penalty.
+        """
+        if request_state is not None and request_state.api_key_reservation is not None:
+            request_state.deferred_keyed_stream_health.append(
+                _DeferredKeyedStreamHealthPenalty(account=account, error=error, code=code)
+            )
+        else:
+            await self._handle_stream_error(account, error, code)
+        if request_state is not None:
+            setattr(request_state, "account_health_error_handled", True)
+
     async def _process_parsed_http_bridge_upstream_event(
         self: Any,
         session: "_HTTPBridgeSession",
@@ -2398,12 +2430,12 @@ class _HTTPBridgeUpstreamEventsMixin:
                     status_request_state.response_id = None
             if status_request_state.propagate_http_errors:
                 _signal_http_bridge_capacity_startup_wait(status_request_state)
-            await self._handle_stream_error(
+            await self._handle_or_defer_precreated_stream_health(
+                status_request_state,
                 session.account,
                 {"message": retry_error_message or "Upstream error"},
                 retry_error_code,
             )
-            setattr(status_request_state, "account_health_error_handled", True)
             retry_consumer_attached = (
                 retry_consumer_attached
                 and status_request_state.event_queue is not None
@@ -2464,13 +2496,12 @@ class _HTTPBridgeUpstreamEventsMixin:
                         if _http_bridge_request_counts_against_queue(status_request_state):
                             session.queued_request_count = max(0, session.queued_request_count - 1)
         elif owner_pinned_quota_error is not None and not is_previous_response_not_found_event:
-            await self._handle_stream_error(
+            await self._handle_or_defer_precreated_stream_health(
+                status_request_state,
                 session.account,
                 {"message": retry_error_message or "Upstream error"},
                 owner_pinned_quota_error,
             )
-            if status_request_state is not None:
-                setattr(status_request_state, "account_health_error_handled", True)
             if (
                 status_request_state is not None
                 and status_request_state.previous_response_id is not None
@@ -2590,13 +2621,12 @@ class _HTTPBridgeUpstreamEventsMixin:
             and retry_error_code != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
             and not is_previous_response_not_found_event
         ):
-            await self._handle_stream_error(
+            await self._handle_or_defer_precreated_stream_health(
+                status_request_state,
                 session.account,
                 {"message": retry_error_message or "Upstream error"},
                 retry_error_code,
             )
-            if status_request_state is not None:
-                setattr(status_request_state, "account_health_error_handled", True)
             if status_request_state is not None and status_request_state.previous_response_id is None:
                 async with session.pending_lock:
                     if status_request_state not in session.pending_requests:

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -884,6 +884,15 @@ class _DeferredAccountBackoffTracker:
     current_lifecycle: _DeferredAccountBackoffLifecycle | None = None
 
 
+@dataclass(slots=True)
+class _DeferredKeyedStreamHealthPenalty:
+    """Classified account-health write deferred until reservation settlement."""
+
+    account: Account
+    error: UpstreamError
+    code: str
+
+
 @dataclass(eq=False, slots=True)
 class _HTTPBridgeResponseCreateAttempt:
     ordinal: int
@@ -1157,6 +1166,12 @@ class _WebSocketRequestState:
     deferred_account_error_backoffs: dict[str, Account] = field(default_factory=dict)
     deferred_account_backoff_tracker: _DeferredAccountBackoffTracker | None = None
     deferred_account_backoff_lifecycle: _DeferredAccountBackoffLifecycle | None = None
+    # Classified health writes (mark_rate_limit / mark_quota_exceeded /
+    # record_error) deferred by keyed pre-created retry branches until this
+    # request's API-key reservation settles or its fallback release commits
+    # (settlement-ordering invariant). Entries drop unapplied when neither
+    # confirms.
+    deferred_keyed_stream_health: list[_DeferredKeyedStreamHealthPenalty] = field(default_factory=list)
     deferred_reasoning_downstream_texts: list[str] = field(default_factory=list)
     suppress_next_created_downstream: bool = False
     replay_downstream_response_id: str | None = None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -6082,6 +6082,7 @@ class _WebSocketMixin:
                 or settlement.account_health_error
                 or settlement.record_success
                 or bool(request_state.deferred_account_error_backoffs)
+                or bool(request_state.deferred_keyed_stream_health)
             ),
         )
         # Settlement responsibility has transferred (the settle path tracks
@@ -6096,8 +6097,15 @@ class _WebSocketMixin:
             pending_backoffs = (
                 lifecycle.pending_backoffs if lifecycle is not None else request_state.deferred_account_error_backoffs
             )
-            if pending_backoffs:
-                await proxy._drain_deferred_account_error_backoffs(pending_backoffs)
+            try:
+                if pending_backoffs:
+                    await proxy._drain_deferred_account_error_backoffs(pending_backoffs)
+            finally:
+                # Backoffs and queued stream-health penalties own independent
+                # post-settlement lanes: a failed backoff write must not
+                # orphan the deferred health write.
+                if request_state.deferred_keyed_stream_health:
+                    await proxy._drain_deferred_keyed_stream_health(request_state)
         latency_ms = int((time.monotonic() - request_state.started_at) * 1000)
         cached_input_tokens = usage.input_tokens_details.cached_tokens if usage and usage.input_tokens_details else None
         reasoning_tokens = (

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -13,6 +13,7 @@ class _WebSocketServiceProtocol(Protocol):
     _decide_websocket_failover_action: Any
     _downstream_websocket_is_idle: Any
     _drain_deferred_account_error_backoffs: Any
+    _drain_deferred_keyed_stream_health: Any
     _emit_pending_websocket_keepalive: Any
     _emit_websocket_connect_failure: Any
     _emit_websocket_connect_timeout: Any

--- a/openspec/changes/defer-bridge-precreated-health-until-settlement/.openspec.yaml
+++ b/openspec/changes/defer-bridge-precreated-health-until-settlement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/defer-bridge-precreated-health-until-settlement/proposal.md
+++ b/openspec/changes/defer-bridge-precreated-health-until-settlement/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The HTTP bridge's pre-created retry arms (model-capacity wait, owner-pinned
+quota, and the generic retryable arm) wrote load-balancer account health
+immediately while the request's API-key reservation was still unsettled, then
+suppressed the finalizer's settlement-gated health write. The unordered write
+was therefore the only write, a successful retry penalized the account without
+any settlement, and an unconfirmed settlement could not leave health unapplied
+— violating the settlement-ordering invariant the keyed SSE retry path already
+enforces.
+
+## What Changes
+
+- Keyed HTTP-bridge pre-created retry failures queue the classified
+  account-health write on the request state instead of applying it
+  immediately; unkeyed requests keep the immediate write.
+- The queued penalty drains only after the reservation settles or its fallback
+  release commits; when neither confirms, it stays unapplied.
+- Deferred account-backoff writes and deferred stream-health writes drain on
+  independent post-settlement lanes, so a failure in one cannot orphan the
+  other.
+- A deferred health write that itself fails after a committed settlement is
+  logged and dropped without aborting the remaining terminal finalization.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `api-keys`: Extend the stream reservation settlement-ordering requirement to
+  the HTTP bridge's pre-created retry handling, including independent
+  post-settlement drain lanes and failed-write isolation.
+
+## Impact
+
+- Affected implementation: HTTP-bridge upstream event processing, the
+  reservation release/settlement drain helpers, and the websocket finalizer's
+  post-settlement drain lanes.
+- Affected verification: unit regressions driving the real bridge event
+  processor for keyed and unkeyed pre-created failures, settle-then-health
+  ordering on release, unconfirmed-release retention, lane independence,
+  cancellation, and failed-write isolation.
+- No public API, wire contract, database schema, setting, deployment, or
+  dashboard change.

--- a/openspec/changes/defer-bridge-precreated-health-until-settlement/specs/api-keys/spec.md
+++ b/openspec/changes/defer-bridge-precreated-health-until-settlement/specs/api-keys/spec.md
@@ -1,0 +1,105 @@
+## MODIFIED Requirements
+
+### Requirement: Stream reservation settlement is detached from the response path
+
+Settling a stream API-key reservation MUST NOT block the response/stream close,
+with one deliberate exception: when a keyed websocket stream terminates with an
+account-health error, the finalizer MUST wait for the settlement to commit
+before the load-balancer health write (the settlement-ordering invariant), so
+that error path intentionally blocks on settlement. If the primary settlement
+fails, the finalizer MUST wait for fallback release to commit before recording
+account health. If neither operation confirms settlement, the account-health
+write MUST remain unapplied. Tracked persistence ownership MUST remain
+registered through an ordering-sensitive fallback release, including
+cancellation before the primary coroutine starts or during that release, so
+graceful shutdown drains both phases. When the existing stream-retry path
+deliberately defers an
+account-health penalty until the same ordering-sensitive settlement, it MUST
+likewise apply neither that penalty nor an immediately following terminal health
+write unless settlement is confirmed, and it MUST NOT start a second settlement
+for the transferred reservation. The HTTP bridge's pre-created retry handling
+(model-capacity wait, owner-pinned quota, and generic retryable pre-created
+failures) MUST likewise defer a keyed request's classified account-health
+write until that request's reservation settles or its fallback release
+commits, MUST leave the deferred write unapplied when neither confirms, and
+MUST keep the immediate write for unkeyed requests. After a committed
+settlement or fallback release, deferred account-backoff writes and deferred
+stream-health writes MUST drain on independent lanes so a failure in one
+cannot orphan the other, and a deferred health write that itself fails MUST be
+logged and dropped without aborting the remaining terminal finalization. In
+all other cases the settlement MUST run as
+a tracked background task; when it fails or is cancelled, the reservation MUST
+still be released by the tracking fallback, and the request's finalization path
+MUST NOT double-release a transferred settlement. Reservations MUST continue to
+count toward key limits until finalized or released, so deferred settlement can
+never admit usage a synchronous settlement would have rejected.
+
+#### Scenario: Response close precedes settlement completion
+
+- **GIVEN** a keyed stream whose settlement transaction is still running
+- **WHEN** the stream closes
+- **THEN** the close does not wait for the settlement
+- **AND** the settlement finalizes the reservation exactly once in the background
+
+#### Scenario: Failed detached settlement still releases the reservation
+
+- **GIVEN** a detached settlement whose finalize raises
+- **WHEN** the settlement task completes
+- **THEN** the tracking fallback releases the reservation
+
+#### Scenario: Websocket health-error settlement precedes the health write
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** the finalizer settles the reservation
+- **THEN** it waits for the settlement to commit before recording the account-health error
+
+#### Scenario: Websocket health waits for fallback settlement
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **AND** its primary settlement fails
+- **WHEN** fallback release remains in progress
+- **THEN** the finalizer does not record the account-health error
+- **AND** it records the error only after fallback release commits
+
+#### Scenario: Unconfirmed websocket settlement leaves health unapplied
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** both primary settlement and fallback release fail
+- **THEN** the finalizer does not record the account-health error
+- **AND** the upstream connection is still scheduled for reconnect and retirement
+
+#### Scenario: Unconfirmed retry settlement drops deferred health
+
+- **GIVEN** a keyed stream retry has deferred an account-health penalty until replacement selection
+- **WHEN** neither primary settlement nor fallback release confirms settlement
+- **THEN** the deferred penalty and any immediately following terminal health write remain unapplied
+- **AND** the retry path does not start a second settlement for the transferred reservation
+
+#### Scenario: Keyed pre-created retry defers the health write
+
+- **GIVEN** a keyed HTTP-bridge request whose reservation is unsettled
+- **WHEN** a retryable pre-created failure (model capacity, owner-pinned quota, or another retryable error) is handled
+- **THEN** no load-balancer health write occurs before settlement
+- **AND** the classified penalty is queued on the request state
+- **AND** an equivalent unkeyed request keeps the immediate health write
+
+#### Scenario: Deferred pre-created penalty applies after settlement commits
+
+- **GIVEN** a keyed HTTP-bridge request with a queued pre-created health penalty
+- **WHEN** its reservation settlement or fallback release commits
+- **THEN** the queued penalty is applied after the commit
+- **AND** each queued entry is applied exactly once
+
+#### Scenario: Failed deferred health write does not abort finalization
+
+- **GIVEN** a committed settlement with a queued pre-created health penalty
+- **WHEN** the deferred health write fails
+- **THEN** the failure is logged and the penalty is dropped
+- **AND** the remaining terminal finalization continues
+- **AND** a deferred account-backoff failure does not prevent the deferred health drain
+
+#### Scenario: Shutdown drains pending settlements
+
+- **WHEN** the service shuts down gracefully with settlements in flight
+- **THEN** shutdown waits for them up to the configured drain timeout
+- **AND** a pending ordering-sensitive fallback release remains part of that drain despite cancellation before primary startup or during fallback

--- a/openspec/changes/defer-bridge-precreated-health-until-settlement/tasks.md
+++ b/openspec/changes/defer-bridge-precreated-health-until-settlement/tasks.md
@@ -1,0 +1,22 @@
+## 1. Defer keyed pre-created health writes
+
+- [x] 1.1 Route the three pre-created retry arms through a defer-or-handle
+      helper that queues keyed penalties on the request state and keeps the
+      immediate write for unkeyed requests
+- [x] 1.2 Drain the queue after committed settlement in the websocket
+      finalizer and after fallback release in the reservation release helper,
+      on a lane independent of the deferred account-backoff drain
+- [x] 1.3 Run each drain attempt as an owned shielded task so caller
+      cancellation consumes the entry exactly once, and log-and-drop an
+      attempt that fails after settlement committed
+
+## 2. Regression coverage
+
+- [x] 2.1 Keyed capacity and keyed usage-limit pre-created failures through
+      the real bridge event processor: no health write before settlement,
+      penalty queued, retry flow preserved
+- [x] 2.2 Settle-then-health order on release; unconfirmed release keeps the
+      penalty unapplied and retained
+- [x] 2.3 Backoff-lane failure still drains the health lane; cancellation
+      consumes the entry exactly once; a failed health write is dropped
+      without aborting finalization

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -32238,3 +32238,450 @@ async def test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_
     remaining = await asyncio.gather(*waiters[25:], return_exceptions=True)
     assert all(isinstance(result, ProxyResponseError) and result.status_code == 429 for result in remaining)
     assert key not in service._http_bridge_inflight_sessions
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_precreated_usage_limit_defers_keyed_health_until_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keyed pre-created retry must queue the health write, not apply it while
+    the API-key reservation is still unsettled (settlement-ordering invariant)."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-keyed-precreated-limit",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"hello"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        key_value="bridge-keyed-precreated-limit",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    handle_stream_error = AsyncMock()
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "plan_type": "team",
+                    "resets_at": 1_778_790_595,
+                    "resets_in_seconds": 14_555,
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    handle_stream_error.assert_not_awaited()
+    retry_precreated.assert_awaited_once_with(session)
+    assert len(request_state.deferred_keyed_stream_health) == 1
+    penalty = request_state.deferred_keyed_stream_health[0]
+    assert penalty.account is session.account
+    assert penalty.code == "usage_limit_reached"
+    assert getattr(request_state, "account_health_error_handled", False) is True
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_retry_defers_keyed_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The model-capacity retry branch must not mutate account health while the
+    request's API-key reservation is open; the penalty settles later."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-keyed-model-capacity",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        propagate_http_errors=True,
+        capacity_startup_wait_event=asyncio.Event(),
+        capacity_startup_ready_event=asyncio.Event(),
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        key_value="bridge-keyed-model-capacity",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    handle_stream_error = AsyncMock()
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_wait_before_http_bridge_model_capacity_retry",
+        AsyncMock(return_value=True),
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    handle_stream_error.assert_not_awaited()
+    assert len(request_state.deferred_keyed_stream_health) == 1
+    penalty = request_state.deferred_keyed_stream_health[0]
+    assert penalty.account is session.account
+    assert getattr(request_state, "account_health_error_handled", False) is True
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_drains_deferred_keyed_health_after_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deferred keyed health writes apply only after the reservation's fallback
+    release commits, in settle-then-health order."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    account = SimpleNamespace(id="acc-deferred-health")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-deferred-health-release",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=1.0,
+    )
+    request_state.deferred_keyed_stream_health.append(
+        proxy_support_module._DeferredKeyedStreamHealthPenalty(
+            account=cast(Any, account),
+            error={"message": "The usage limit has been reached"},
+            code="usage_limit_reached",
+        )
+    )
+    order: list[str] = []
+
+    async def record_release(reservation: Any) -> None:
+        del reservation
+        order.append("settle")
+
+    async def record_health(failed_account: Any, error: Any, code: str) -> None:
+        del error
+        assert failed_account is account
+        order.append(f"health:{code}")
+
+    monkeypatch.setattr(service, "_release_websocket_reservation", record_release)
+    monkeypatch.setattr(service, "_handle_stream_error", record_health)
+
+    await service._release_websocket_request_state_reservation(request_state)
+
+    assert order == ["settle", "health:usage_limit_reached"]
+    assert request_state.deferred_keyed_stream_health == []
+    assert request_state.api_key_reservation is None
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_leaves_deferred_health_unapplied_when_release_fails() -> None:
+    """Unconfirmed settlement (release raises) must leave the deferred
+    account-health write unapplied and retained."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-deferred-health-release-failure",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=1.0,
+    )
+    request_state.deferred_keyed_stream_health.append(
+        proxy_support_module._DeferredKeyedStreamHealthPenalty(
+            account=cast(Any, SimpleNamespace(id="acc-unapplied")),
+            error={"message": "The usage limit has been reached"},
+            code="usage_limit_reached",
+        )
+    )
+    handle_stream_error = AsyncMock()
+    release = AsyncMock(side_effect=RuntimeError("release failed"))
+    service._release_websocket_reservation = release  # type: ignore[method-assign]
+    service._handle_stream_error = handle_stream_error  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="release failed"):
+        await service._release_websocket_request_state_reservation(request_state)
+
+    handle_stream_error.assert_not_awaited()
+    assert len(request_state.deferred_keyed_stream_health) == 1
+
+
+@pytest.mark.asyncio
+async def test_release_reservation_drains_deferred_health_when_backoff_drain_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backoffs and deferred stream-health penalties own independent lanes:
+    a failed backoff write must not orphan the deferred health write."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    account = SimpleNamespace(id="acc-independent-lanes")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-independent-lanes",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=1.0,
+    )
+    request_state.deferred_account_error_backoffs["acc-backoff"] = cast(Any, SimpleNamespace(id="acc-backoff"))
+    request_state.deferred_keyed_stream_health.append(
+        proxy_support_module._DeferredKeyedStreamHealthPenalty(
+            account=cast(Any, account),
+            error={"message": "The usage limit has been reached"},
+            code="usage_limit_reached",
+        )
+    )
+    handle_stream_error = AsyncMock()
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(
+        service,
+        "_load_balancer",
+        SimpleNamespace(record_error_backoff=AsyncMock(side_effect=RuntimeError("backoff failed"))),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="backoff failed"):
+        await service._release_websocket_request_state_reservation(request_state)
+
+    handle_stream_error.assert_awaited_once()
+    assert request_state.deferred_keyed_stream_health == []
+
+
+@pytest.mark.asyncio
+async def test_drain_deferred_keyed_health_drains_full_queue_under_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller cancellation must not abandon queued penalties for a later drain
+    to replay: every shielded attempt completes, the queue empties, and the
+    cancellation re-raises only afterwards."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-drain-cancelled",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    for index in ("first", "second"):
+        request_state.deferred_keyed_stream_health.append(
+            proxy_support_module._DeferredKeyedStreamHealthPenalty(
+                account=cast(Any, SimpleNamespace(id=f"acc-cancelled-{index}")),
+                error={"message": "The usage limit has been reached"},
+                code=f"usage_limit_reached_{index}",
+            )
+        )
+    attempt_started = asyncio.Event()
+    attempt_gate = asyncio.Event()
+    calls: list[str] = []
+
+    async def blocked_health(account: Any, error: Any, code: str) -> None:
+        del account, error
+        calls.append(code)
+        attempt_started.set()
+        await attempt_gate.wait()
+
+    monkeypatch.setattr(service, "_handle_stream_error", blocked_health)
+
+    drain = asyncio.create_task(service._drain_deferred_keyed_stream_health(request_state))
+    await attempt_started.wait()
+    drain.cancel()
+    await asyncio.sleep(0)
+    attempt_gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await drain
+
+    assert calls == ["usage_limit_reached_first", "usage_limit_reached_second"]
+    assert request_state.deferred_keyed_stream_health == []
+
+
+@pytest.mark.asyncio
+async def test_drain_deferred_keyed_health_drops_failed_write_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deferred health write that fails after settlement committed is logged
+    and dropped: it must not abort finalization or leak an unowned entry."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-drain-write-failure",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    for code in ("usage_limit_reached", "server_is_overloaded"):
+        request_state.deferred_keyed_stream_health.append(
+            proxy_support_module._DeferredKeyedStreamHealthPenalty(
+                account=cast(Any, SimpleNamespace(id=f"acc-{code}")),
+                error={"message": code},
+                code=code,
+            )
+        )
+    applied: list[str] = []
+
+    async def flaky_health(account: Any, error: Any, code: str) -> None:
+        del account, error
+        if code == "usage_limit_reached":
+            raise RuntimeError("health persistence failed")
+        applied.append(code)
+
+    monkeypatch.setattr(service, "_handle_stream_error", flaky_health)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.service"):
+        await service._drain_deferred_keyed_stream_health(request_state)
+
+    assert applied == ["server_is_overloaded"]
+    assert request_state.deferred_keyed_stream_health == []
+    assert any("dropping penalty" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_finalize_waits_for_settlement_when_keyed_health_penalties_are_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A queued pre-created penalty makes the terminal settle ordering-sensitive:
+    the finalizer must wait for settlement before the drain can write health,
+    even when account_health_error_handled suppressed the terminal health flags."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-wait-for-queued-penalty",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=cast(Any, object()),
+        started_at=1.0,
+        awaiting_response_created=False,
+        response_id="resp-wait-for-queued-penalty",
+        response_event_count=1,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"hello"}',
+        transport="http",
+        enforce_openai_sdk_contract=False,
+        skip_request_log=True,
+    )
+    request_state.deferred_keyed_stream_health.append(
+        proxy_support_module._DeferredKeyedStreamHealthPenalty(
+            account=cast(Any, SimpleNamespace(id="acc-wait-queued")),
+            error={"message": "The usage limit has been reached"},
+            code="usage_limit_reached",
+        )
+    )
+    setattr(request_state, "account_health_error_handled", True)
+    session = _make_bridge_session(
+        key_value="bridge-wait-for-queued-penalty",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    settle_calls: list[dict[str, Any]] = []
+
+    async def record_settle(*args: Any, **kwargs: Any) -> bool:
+        settle_calls.append(kwargs)
+        return True
+
+    drained: list[str] = []
+
+    async def record_health(account: Any, error: Any, code: str) -> None:
+        del account, error
+        drained.append(code)
+
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", record_settle)
+    monkeypatch.setattr(service, "_handle_stream_error", record_health)
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "error": {
+                    "type": "server_error",
+                    "code": "server_error",
+                    "message": "boom",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert len(settle_calls) == 1
+    assert settle_calls[0].get("wait_for_settlement") is True
+    assert drained == ["usage_limit_reached"]
+    assert request_state.deferred_keyed_stream_health == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_drains_apply_each_deferred_penalty_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The idempotent release path and the terminal finalizer can drain the
+    same request state concurrently: each entry is claimed atomically, so no
+    penalty applies twice and the queue never corrupts."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-concurrent-drains",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    for code in ("usage_limit_reached", "server_is_overloaded"):
+        request_state.deferred_keyed_stream_health.append(
+            proxy_support_module._DeferredKeyedStreamHealthPenalty(
+                account=cast(Any, SimpleNamespace(id=f"acc-{code}")),
+                error={"message": code},
+                code=code,
+            )
+        )
+    first_started = asyncio.Event()
+    gate = asyncio.Event()
+    applied: list[str] = []
+
+    async def slow_health(account: Any, error: Any, code: str) -> None:
+        del account, error
+        applied.append(code)
+        first_started.set()
+        await gate.wait()
+
+    monkeypatch.setattr(service, "_handle_stream_error", slow_health)
+
+    drain_a = asyncio.create_task(service._drain_deferred_keyed_stream_health(request_state))
+    await first_started.wait()
+    drain_b = asyncio.create_task(service._drain_deferred_keyed_stream_health(request_state))
+    await asyncio.sleep(0)
+    gate.set()
+    await asyncio.gather(drain_a, drain_b)
+
+    assert sorted(applied) == ["server_is_overloaded", "usage_limit_reached"]
+    assert request_state.deferred_keyed_stream_health == []


### PR DESCRIPTION
## Summary

The HTTP bridge's pre-created retry branches (`wait_for_model_capacity`, owner-pinned quota, and the generic retryable arm in `_process_parsed_http_bridge_upstream_event`) awaited `_handle_stream_error` directly, mutating load-balancer account health (`mark_rate_limit` / `mark_quota_exceeded` / `record_error`) while the request's API-key reservation was still unsettled. Each arm then set `account_health_error_handled=True`, which suppresses the finalizer's settlement-gated health write — so the unordered write was the *only* write, and a successful retry penalized the account without any settlement at all. This bypasses the settlement-ordering invariant the keyed SSE retry path already enforces via `_handle_or_defer_keyed_stream_health` and `defer_account_health_writes`.

Now keyed requests queue the classified write on the request state (`deferred_keyed_stream_health`) and drain it after the reservation settles (`_finalize_websocket_request_state`) or its fallback release commits (`_release_websocket_request_state_reservation`); when neither confirms, the penalty stays unapplied. Unkeyed requests keep the immediate write. Backoff and stream-health lanes are independent after settlement (a failed backoff write cannot orphan the deferred health write), each drain attempt runs as an owned shielded task so caller cancellation cannot abandon a half-applied penalty for a later drain to replay, and a health write that fails after a committed settlement is logged and dropped so it cannot abort the remaining terminal finalization or leak an unowned retry entry.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: none (discovery finding `CLB-20260826-01`)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/defer-bridge-precreated-health-until-settlement/` (modified capability: `api-keys`; `openspec validate defer-bridge-precreated-health-until-settlement --type change --strict` passes). Extends the existing "Stream reservation settlement is detached from the response path" requirement to the bridge's pre-created retry arms, independent post-settlement drain lanes, and failed-write isolation.

## Changes

- `upstream_events.py`: the three pre-created retry arms route through a new `_handle_or_defer_precreated_stream_health` — keyed: queue + suppress duplicate terminal write; unkeyed: unchanged immediate write
- `support.py`: `_DeferredKeyedStreamHealthPenalty` + `_WebSocketRequestState.deferred_keyed_stream_health`
- `api_key_usage.py`: `_drain_deferred_keyed_stream_health` (owned shielded attempt per entry, consumed exactly once; an attempt that fails after committed settlement is logged and dropped) + drain after fallback release, in a `finally` lane independent of the backoff drain
- `websocket/mixin.py`: drain after committed settlement in the finalizer, same independent-lane shape as the SSE retry path's settle-then-flush
- `openspec/changes/defer-bridge-precreated-health-until-settlement/`: delta spec for the `api-keys` settlement-ordering requirement
- 7 unit regressions: keyed capacity + keyed usage-limit branches through the real event processor (red pre-fix: `_handle_stream_error` awaited while the reservation was open), settle-then-health order on release, unconfirmed release leaves health unapplied and retained, backoff-failure lane independence, cancellation consumes the entry exactly once, failed write dropped without aborting the drain

## Test plan

```
uv run pytest tests/unit/test_proxy_http_bridge.py -q
# 678 passed, 1 failed: test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses
# — pre-existing on clean upstream/main (09dd9348) in this environment, unrelated to this diff

uv run pytest tests/unit/test_proxy_utils.py -k "settle or settlement or deferred_backoff or account_health" -q   # 48 passed
uv run pytest tests/unit/test_api_keys_service.py -q                                                              # 86 passed

uv run ty check          # All checks passed!
uv run ruff check app/ tests/unit/test_proxy_http_bridge.py
uv run ruff format --check app/modules/proxy/_service/ tests/unit/test_proxy_http_bridge.py
python scripts/check_proxy_architecture.py   # proxy architecture checks passed
openspec validate defer-bridge-precreated-health-until-settlement --type change --strict
```

Intentionally unrun locally: full `local-ci`, integration suite (covered by required CI).

## Related work

- #1558, #1717, #1861 (merged) enforce the same settle-before-health invariant on the websocket finalizer, compact failover, and keyed SSE mid-loop paths; #1853 was superseded by #1861. This PR closes the remaining gap in the HTTP-bridge pre-created retry arms.
- #1856 (open) is adjacent but a different invariant (account-neutral classification of model-scoped rejections); no overlap in touched lines.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused local subset above.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account-health handling during WebSocket and HTTP bridge requests.
  - Ensured usage-limit, model-capacity, and retry-related health updates wait for API-key reservation settlement.
  - Prevented health updates from being lost when reservation release or backoff persistence fails.
  - Improved cancellation handling so pending health updates complete reliably and are processed only once.
  - Preserved immediate health updates for requests without API-key reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->