### PR TITLE
fix(retention): bound durable bridge cleanup work

### DIFF
--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -302,6 +302,28 @@ if PROMETHEUS_AVAILABLE:
         ["outcome"],
         registry=REGISTRY,
     )
+    http_bridge_spool_cleanup_runs_total = Counter(
+        "codex_lb_http_bridge_spool_cleanup_runs_total",
+        "Total durable HTTP bridge transcript cleanup passes by outcome",
+        ["outcome"],
+        registry=REGISTRY,
+    )
+    http_bridge_spool_cleanup_deleted_operations_total = Counter(
+        "codex_lb_http_bridge_spool_cleanup_deleted_operations_total",
+        "Total durable HTTP bridge operations deleted by transcript retention",
+        registry=REGISTRY,
+    )
+    http_bridge_spool_cleanup_duration_seconds = Histogram(
+        "codex_lb_http_bridge_spool_cleanup_duration_seconds",
+        "Durable HTTP bridge transcript cleanup pass duration",
+        registry=REGISTRY,
+    )
+    http_bridge_spool_cleanup_backlog_likely = Gauge(
+        "codex_lb_http_bridge_spool_cleanup_backlog_likely",
+        "Whether the latest durable transcript cleanup pass stopped with likely backlog",
+        registry=REGISTRY,
+        **({"multiprocess_mode": "livemostrecent"} if MULTIPROCESS_MODE else {}),
+    )
     event_loop_lag_seconds = Gauge(
         "codex_lb_event_loop_lag_seconds",
         "Sampled event-loop scheduling lag (asyncio.sleep drift) in seconds",
@@ -396,6 +418,10 @@ else:
     http_bridge_prewarm_total: CounterLike | None = None
     http_bridge_stuck_retire_total: CounterLike | None = None
     http_bridge_retry_circuit_total: CounterLike | None = None
+    http_bridge_spool_cleanup_runs_total: CounterLike | None = None
+    http_bridge_spool_cleanup_deleted_operations_total: CounterLike | None = None
+    http_bridge_spool_cleanup_duration_seconds: HistogramLike | None = None
+    http_bridge_spool_cleanup_backlog_likely: GaugeLike | None = None
     event_loop_lag_seconds: GaugeLike | None = None
     event_loop_lag_warnings_total: CounterLike | None = None
     stream_keepalive_sent_total: CounterLike | None = None
@@ -447,6 +473,10 @@ __all__ = [
     "continuity_owner_resolution_total",
     "http_bridge_prewarm_total",
     "http_bridge_retry_circuit_total",
+    "http_bridge_spool_cleanup_backlog_likely",
+    "http_bridge_spool_cleanup_deleted_operations_total",
+    "http_bridge_spool_cleanup_duration_seconds",
+    "http_bridge_spool_cleanup_runs_total",
     "http_bridge_stuck_retire_total",
     "stream_keepalive_sent_total",
     "stream_idle_timeout_total",

--- a/app/main.py
+++ b/app/main.py
@@ -110,6 +110,7 @@ from app.modules.sticky_sessions.cleanup_scheduler import (
     _abandoned_bridge_retention_seconds,
     _record_operation_retention_cleanup,
     build_sticky_session_cleanup_scheduler,
+    operation_retention_metrics_enabled,
 )
 from app.modules.telemetry import api as telemetry_api
 from app.modules.telemetry.scheduler import build_telemetry_scheduler
@@ -355,7 +356,7 @@ async def _purge_operation_spool_on_startup(*, retention_seconds: float) -> int:
         duration_seconds=max(time.monotonic() - started_at, 0.0),
     )
     _record_operation_retention_cleanup(result)
-    if not PROMETHEUS_AVAILABLE:
+    if not operation_retention_metrics_enabled():
         logger.info(
             "HTTP bridge operation transcript startup retention "
             "deleted_operations=%s batches=%s outcome=%s "

--- a/app/main.py
+++ b/app/main.py
@@ -320,6 +320,45 @@ def _log_non_multiproc_metrics_bind_conflict(port: int) -> None:
     )
 
 
+async def _purge_operation_spool_on_startup(*, retention_seconds: float) -> int:
+    """Run one bounded transcript purge and record a sanitized aggregate result."""
+
+    started_at = time.monotonic()
+    try:
+        operation_purge_result = await DurableBridgeSessionCoordinator(SessionLocal).purge_operation_spool_batch(
+            cutoff=utcnow() - timedelta(seconds=retention_seconds),
+        )
+    except Exception as exc:
+        result = OperationRetentionCleanupResult(
+            deleted_operations=0,
+            batches=0,
+            backlog_likely=True,
+            outcome="failed",
+            duration_seconds=max(time.monotonic() - started_at, 0.0),
+        )
+        _record_operation_retention_cleanup(result)
+        logger.warning(
+            "HTTP bridge operation transcript startup retention failed "
+            "deleted_operations=0 batches=0 outcome=failed backlog_likely=true "
+            "duration_seconds=%.3f error_type=%s",
+            result.duration_seconds,
+            type(exc).__name__,
+        )
+        raise RuntimeError("HTTP bridge operation transcript startup retention failed") from None
+
+    backlog_likely = operation_purge_result.selected_operations >= DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    _record_operation_retention_cleanup(
+        OperationRetentionCleanupResult(
+            deleted_operations=operation_purge_result.deleted_operations,
+            batches=1,
+            backlog_likely=backlog_likely,
+            outcome="batch_budget_exhausted" if backlog_likely else "completed",
+            duration_seconds=max(time.monotonic() - started_at, 0.0),
+        )
+    )
+    return operation_purge_result.deleted_operations
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     import app.core.startup as startup_module
@@ -372,24 +411,9 @@ async def lifespan(app: FastAPI):
                     "deleted": deleted_bridge_rows,
                 },
             )
-        operation_retention_started_at = time.monotonic()
-        operation_purge_result = await DurableBridgeSessionCoordinator(SessionLocal).purge_operation_spool_batch(
-            cutoff=utcnow()
-            - timedelta(seconds=settings.http_responses_session_bridge_operation_spool_retention_seconds),
+        purged_operation_rows = await _purge_operation_spool_on_startup(
+            retention_seconds=settings.http_responses_session_bridge_operation_spool_retention_seconds,
         )
-        operation_backlog_likely = (
-            operation_purge_result.selected_operations >= DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
-        )
-        _record_operation_retention_cleanup(
-            OperationRetentionCleanupResult(
-                deleted_operations=operation_purge_result.deleted_operations,
-                batches=1,
-                backlog_likely=operation_backlog_likely,
-                outcome="batch_budget_exhausted" if operation_backlog_likely else "completed",
-                duration_seconds=max(time.monotonic() - operation_retention_started_at, 0.0),
-            )
-        )
-        purged_operation_rows = operation_purge_result.deleted_operations
         if purged_operation_rows > 0:
             logger.info(
                 "Purged expired durable HTTP bridge operation transcript rows",

--- a/app/main.py
+++ b/app/main.py
@@ -85,7 +85,10 @@ from app.modules.oauth import api as oauth_api
 from app.modules.proxy import api as proxy_api
 from app.modules.proxy.cap_partitioning import refresh_cap_partition
 from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
-from app.modules.proxy.durable_bridge_repository import missing_durable_bridge_tables
+from app.modules.proxy.durable_bridge_repository import (
+    DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
+    missing_durable_bridge_tables,
+)
 from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_epoch
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.proxy.ring_membership import (
@@ -103,7 +106,9 @@ from app.modules.runtime import api as runtime_api
 from app.modules.settings import api as settings_api
 from app.modules.sticky_sessions import api as sticky_sessions_api
 from app.modules.sticky_sessions.cleanup_scheduler import (
+    OperationRetentionCleanupResult,
     _abandoned_bridge_retention_seconds,
+    _record_operation_retention_cleanup,
     build_sticky_session_cleanup_scheduler,
 )
 from app.modules.telemetry import api as telemetry_api
@@ -367,10 +372,24 @@ async def lifespan(app: FastAPI):
                     "deleted": deleted_bridge_rows,
                 },
             )
-        purged_operation_rows = await DurableBridgeSessionCoordinator(SessionLocal).purge_operation_spool(
+        operation_retention_started_at = time.monotonic()
+        operation_purge_result = await DurableBridgeSessionCoordinator(SessionLocal).purge_operation_spool_batch(
             cutoff=utcnow()
             - timedelta(seconds=settings.http_responses_session_bridge_operation_spool_retention_seconds),
         )
+        operation_backlog_likely = (
+            operation_purge_result.selected_operations >= DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+        )
+        _record_operation_retention_cleanup(
+            OperationRetentionCleanupResult(
+                deleted_operations=operation_purge_result.deleted_operations,
+                batches=1,
+                backlog_likely=operation_backlog_likely,
+                outcome="batch_budget_exhausted" if operation_backlog_likely else "completed",
+                duration_seconds=max(time.monotonic() - operation_retention_started_at, 0.0),
+            )
+        )
+        purged_operation_rows = operation_purge_result.deleted_operations
         if purged_operation_rows > 0:
             logger.info(
                 "Purged expired durable HTTP bridge operation transcript rows",

--- a/app/main.py
+++ b/app/main.py
@@ -347,15 +347,25 @@ async def _purge_operation_spool_on_startup(*, retention_seconds: float) -> int:
         raise RuntimeError("HTTP bridge operation transcript startup retention failed") from None
 
     backlog_likely = operation_purge_result.selected_operations >= DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
-    _record_operation_retention_cleanup(
-        OperationRetentionCleanupResult(
-            deleted_operations=operation_purge_result.deleted_operations,
-            batches=1,
-            backlog_likely=backlog_likely,
-            outcome="batch_budget_exhausted" if backlog_likely else "completed",
-            duration_seconds=max(time.monotonic() - started_at, 0.0),
-        )
+    result = OperationRetentionCleanupResult(
+        deleted_operations=operation_purge_result.deleted_operations,
+        batches=1,
+        backlog_likely=backlog_likely,
+        outcome="batch_budget_exhausted" if backlog_likely else "completed",
+        duration_seconds=max(time.monotonic() - started_at, 0.0),
     )
+    _record_operation_retention_cleanup(result)
+    if not PROMETHEUS_AVAILABLE:
+        logger.info(
+            "HTTP bridge operation transcript startup retention "
+            "deleted_operations=%s batches=%s outcome=%s "
+            "backlog_likely=%s duration_seconds=%.3f",
+            result.deleted_operations,
+            result.batches,
+            result.outcome,
+            result.backlog_likely,
+            result.duration_seconds,
+        )
     return operation_purge_result.deleted_operations
 
 

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -18,6 +18,7 @@ from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeAliasRegistration,
     DurableBridgeAliasRegistrationReceipt,
     DurableBridgeOperationEventInput,
+    DurableBridgeOperationPurgeBatchResult,
     DurableBridgeOperationSnapshot,
     DurableBridgeRecoveryAttemptSnapshot,
     DurableBridgeRepository,
@@ -593,8 +594,16 @@ class DurableBridgeSessionCoordinator:
         cutoff: datetime,
         batch_size: int = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
     ) -> int:
+        return (await self.purge_operation_spool_batch(cutoff=cutoff, batch_size=batch_size)).deleted_operations
+
+    async def purge_operation_spool_batch(
+        self,
+        *,
+        cutoff: datetime,
+        batch_size: int = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
+    ) -> DurableBridgeOperationPurgeBatchResult:
         async with self._session() as session:
-            return await DurableBridgeRepository(session).purge_operation_spool(
+            return await DurableBridgeRepository(session).purge_operation_spool_batch(
                 cutoff=cutoff,
                 batch_size=batch_size,
             )

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -14,6 +14,7 @@ from app.db.models import HttpBridgeSessionState
 from app.db.session import close_session
 from app.modules.proxy.continuity import is_http_bridge_account_neutral_replay
 from app.modules.proxy.durable_bridge_repository import (
+    DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
     DurableBridgeAliasRegistration,
     DurableBridgeAliasRegistrationReceipt,
     DurableBridgeOperationEventInput,
@@ -586,7 +587,12 @@ class DurableBridgeSessionCoordinator:
                 max_bytes=max_bytes,
             )
 
-    async def purge_operation_spool(self, *, cutoff: datetime, batch_size: int = 500) -> int:
+    async def purge_operation_spool(
+        self,
+        *,
+        cutoff: datetime,
+        batch_size: int = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
+    ) -> int:
         async with self._session() as session:
             return await DurableBridgeRepository(session).purge_operation_spool(
                 cutoff=cutoff,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -1759,7 +1759,7 @@ class DurableBridgeRepository:
         self,
         *,
         cutoff: datetime,
-        batch_size: int = 500,
+        batch_size: int = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
     ) -> DurableBridgeOperationPurgeBatchResult:
         """Delete eligible transcript material past retention.
 

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -44,6 +44,7 @@ REQUIRED_DURABLE_BRIDGE_TABLES = (
     "http_bridge_operation_events",
 )
 DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS = 3600.0
+DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE = 50
 _PURGE_CLOSED_BATCH_SIZE = 500
 # Claim retry budget: insert races and epoch-CAS losses re-read and retry;
 # each round has a winner, so a small budget converges under any realistic
@@ -1832,7 +1833,12 @@ class DurableBridgeRepository:
             deleted_operations=len(deleted_ids),
         )
 
-    async def purge_operation_spool(self, *, cutoff: datetime, batch_size: int = 500) -> int:
+    async def purge_operation_spool(
+        self,
+        *,
+        cutoff: datetime,
+        batch_size: int = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
+    ) -> int:
         """Delete one eligible transcript batch and return actual deletes."""
         result = await self.purge_operation_spool_batch(cutoff=cutoff, batch_size=batch_size)
         return result.deleted_operations

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -211,6 +211,12 @@ class DurableBridgeOperationEventInput:
     event_text: str
 
 
+@dataclass(frozen=True, slots=True)
+class DurableBridgeOperationPurgeBatchResult:
+    selected_operations: int
+    deleted_operations: int
+
+
 class DurableBridgeRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -1748,7 +1754,12 @@ class DurableBridgeRepository:
         turns.reverse()
         return turns
 
-    async def purge_operation_spool(self, *, cutoff: datetime, batch_size: int = 500) -> int:
+    async def purge_operation_spool_batch(
+        self,
+        *,
+        cutoff: datetime,
+        batch_size: int = 500,
+    ) -> DurableBridgeOperationPurgeBatchResult:
         """Delete eligible transcript material past retention.
 
         Nonterminal rows are purgeable only after their owning session is
@@ -1797,7 +1808,10 @@ class DurableBridgeRepository:
             operation_ids = [str(operation.operation_id) for operation in selected.scalars().all()]
             if not operation_ids:
                 await self._session.commit()
-                return 0
+                return DurableBridgeOperationPurgeBatchResult(
+                    selected_operations=0,
+                    deleted_operations=0,
+                )
             deleted = await self._session.execute(
                 delete(HttpBridgeOperationRecord)
                 .where(
@@ -1813,7 +1827,15 @@ class DurableBridgeRepository:
                     delete(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id.in_(deleted_ids))
                 )
             await self._session.commit()
-        return len(deleted_ids)
+        return DurableBridgeOperationPurgeBatchResult(
+            selected_operations=len(operation_ids),
+            deleted_operations=len(deleted_ids),
+        )
+
+    async def purge_operation_spool(self, *, cutoff: datetime, batch_size: int = 500) -> int:
+        """Delete one eligible transcript batch and return actual deletes."""
+        result = await self.purge_operation_spool_batch(cutoff=cutoff, batch_size=batch_size)
+        return result.deleted_operations
 
     async def append_operation_event(
         self,

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -325,8 +325,8 @@ class StickySessionCleanupScheduler:
                 error_type or "none",
             )
         self._operation_retention_attempt_failed = result.outcome == "failed"
+        self._operation_retention_cancelled_backlog_likely = result.backlog_likely
         if cancellation is not None:
-            self._operation_retention_cancelled_backlog_likely = result.backlog_likely
             raise cancellation
         return result.backlog_likely
 

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -82,6 +82,12 @@ class OperationRetentionCleanupError(RuntimeError):
         self.error_type = error_type
 
 
+class OperationRetentionCleanupCancelledError(asyncio.CancelledError):
+    def __init__(self, result: OperationRetentionCleanupResult) -> None:
+        super().__init__("durable operation retention batch cancelled")
+        self.result = result
+
+
 async def _purge_operation_spool_with_budget(
     bridge_repo: DurableBridgeRepository,
     *,
@@ -92,34 +98,44 @@ async def _purge_operation_spool_with_budget(
     batches = 0
     outcome: OperationRetentionOutcome = "completed"
 
-    while True:
-        try:
+    try:
+        while True:
             batch_result = await bridge_repo.purge_operation_spool_batch(
                 cutoff=cutoff,
                 batch_size=_OPERATION_RETENTION_BATCH_SIZE,
             )
-        except Exception as exc:
-            raise OperationRetentionCleanupError(
-                OperationRetentionCleanupResult(
-                    deleted_operations=deleted_operations,
-                    batches=batches,
-                    backlog_likely=True,
-                    outcome="failed",
-                    duration_seconds=max(time.monotonic() - started_at, 0.0),
-                ),
-                error_type=type(exc).__name__,
-            ) from None
-        deleted_operations += batch_result.deleted_operations
-        batches += 1
-        if batch_result.selected_operations < _OPERATION_RETENTION_BATCH_SIZE:
-            break
-        if time.monotonic() - started_at >= _OPERATION_RETENTION_TIME_BUDGET_SECONDS:
-            outcome = "time_budget_exhausted"
-            break
-        if batches >= _OPERATION_RETENTION_MAX_BATCHES:
-            outcome = "batch_budget_exhausted"
-            break
-        await asyncio.sleep(0)
+            deleted_operations += batch_result.deleted_operations
+            batches += 1
+            if batch_result.selected_operations < _OPERATION_RETENTION_BATCH_SIZE:
+                break
+            if time.monotonic() - started_at >= _OPERATION_RETENTION_TIME_BUDGET_SECONDS:
+                outcome = "time_budget_exhausted"
+                break
+            if batches >= _OPERATION_RETENTION_MAX_BATCHES:
+                outcome = "batch_budget_exhausted"
+                break
+            await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        raise OperationRetentionCleanupCancelledError(
+            OperationRetentionCleanupResult(
+                deleted_operations=deleted_operations,
+                batches=batches,
+                backlog_likely=True,
+                outcome="failed",
+                duration_seconds=max(time.monotonic() - started_at, 0.0),
+            )
+        ) from None
+    except Exception as exc:
+        raise OperationRetentionCleanupError(
+            OperationRetentionCleanupResult(
+                deleted_operations=deleted_operations,
+                batches=batches,
+                backlog_likely=True,
+                outcome="failed",
+                duration_seconds=max(time.monotonic() - started_at, 0.0),
+            ),
+            error_type=type(exc).__name__,
+        ) from None
 
     return OperationRetentionCleanupResult(
         deleted_operations=deleted_operations,
@@ -141,6 +157,10 @@ def _record_operation_retention_cleanup(result: OperationRetentionCleanupResult)
     http_bridge_spool_cleanup_deleted_operations_total.inc(result.deleted_operations)
     http_bridge_spool_cleanup_duration_seconds.observe(result.duration_seconds)
     http_bridge_spool_cleanup_backlog_likely.set(1.0 if result.backlog_likely else 0.0)
+
+
+def operation_retention_metrics_enabled() -> bool:
+    return PROMETHEUS_AVAILABLE and bool(getattr(get_settings(), "metrics_enabled", False))
 
 
 def _next_cleanup_delay_seconds(
@@ -204,6 +224,7 @@ class StickySessionCleanupScheduler:
     _stop: asyncio.Event = field(default_factory=asyncio.Event)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _operation_retention_attempt_failed: bool = False
+    _operation_retention_cancelled_backlog_likely: bool | None = None
 
     async def start(self) -> None:
         if not self.enabled and not self.operation_retention_enabled:
@@ -256,10 +277,14 @@ class StickySessionCleanupScheduler:
                 continue
 
     async def _cleanup_once(self) -> bool | None:
-        return await _get_leader_election().run_if_leader(self._cleanup_as_leader)
+        self._operation_retention_cancelled_backlog_likely = None
+        result = await _get_leader_election().run_if_leader(self._cleanup_as_leader)
+        return result if result is not None else self._operation_retention_cancelled_backlog_likely
 
     async def _cleanup_operation_retention_once(self) -> bool | None:
-        return await _get_leader_election().run_if_leader(self._cleanup_operation_retention_as_leader)
+        self._operation_retention_cancelled_backlog_likely = None
+        result = await _get_leader_election().run_if_leader(self._cleanup_operation_retention_as_leader)
+        return result if result is not None else self._operation_retention_cancelled_backlog_likely
 
     async def _run_operation_retention(self, bridge_repo: DurableBridgeRepository) -> bool | None:
         operation_cutoff = utcnow() - timedelta(
@@ -267,8 +292,13 @@ class StickySessionCleanupScheduler:
         )
         retention_started_at = time.monotonic()
         error_type: str | None = None
+        cancellation: OperationRetentionCleanupCancelledError | None = None
         try:
             result = await _purge_operation_spool_with_budget(bridge_repo, cutoff=operation_cutoff)
+        except OperationRetentionCleanupCancelledError as exc:
+            result = exc.result
+            error_type = "CancelledError"
+            cancellation = exc
         except OperationRetentionCleanupError as exc:
             result = exc.result
             error_type = exc.error_type
@@ -282,7 +312,7 @@ class StickySessionCleanupScheduler:
             )
             error_type = type(exc).__name__
         _record_operation_retention_cleanup(result)
-        if not PROMETHEUS_AVAILABLE or result.deleted_operations > 0 or result.backlog_likely:
+        if not operation_retention_metrics_enabled() or result.deleted_operations > 0 or result.backlog_likely:
             logger.info(
                 "HTTP bridge operation transcript retention "
                 "deleted_operations=%s batches=%s outcome=%s "
@@ -295,6 +325,9 @@ class StickySessionCleanupScheduler:
                 error_type or "none",
             )
         self._operation_retention_attempt_failed = result.outcome == "failed"
+        if cancellation is not None:
+            self._operation_retention_cancelled_backlog_likely = result.backlog_likely
+            raise cancellation
         return result.backlog_likely
 
     async def _cleanup_operation_retention_as_leader(self) -> bool | None:

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -219,7 +219,10 @@ class StickySessionCleanupScheduler:
         backlog_likely = False
         while not self._stop.is_set():
             if loop.time() >= next_full_cleanup_at:
-                backlog_likely = await self._cleanup_once()
+                backlog_likely = _merge_backlog_signal(
+                    backlog_likely,
+                    await self._cleanup_once(),
+                )
                 next_full_cleanup_at = loop.time() + float(self.interval_seconds)
             elif backlog_likely:
                 backlog_likely = _merge_backlog_signal(
@@ -239,8 +242,8 @@ class StickySessionCleanupScheduler:
             except asyncio.TimeoutError:
                 continue
 
-    async def _cleanup_once(self) -> bool:
-        return bool(await _get_leader_election().run_if_leader(self._cleanup_as_leader))
+    async def _cleanup_once(self) -> bool | None:
+        return await _get_leader_election().run_if_leader(self._cleanup_as_leader)
 
     async def _cleanup_operation_retention_once(self) -> bool | None:
         return await _get_leader_election().run_if_leader(self._cleanup_operation_retention_as_leader)

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -23,6 +23,7 @@ from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
 from app.db.session import SessionLocal, get_background_session
 from app.modules.proxy.durable_bridge_repository import (
+    DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
     DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS,
     DurableBridgeRepository,
     missing_durable_bridge_tables,
@@ -51,10 +52,9 @@ _STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS = 6 * 3600
 # Keep each pass large enough to outpace steady-state expiry, but small enough
 # that a historical backlog is resumed across scheduler ticks instead of
 # monopolizing the database in one drain-all loop.
-_OPERATION_RETENTION_BATCH_SIZE = 50
+_OPERATION_RETENTION_BATCH_SIZE = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
 _OPERATION_RETENTION_MAX_BATCHES = 4
 _OPERATION_RETENTION_TIME_BUDGET_SECONDS = 5.0
-_OPERATION_RETENTION_BACKLOG_RETRY_SECONDS = 5.0
 
 
 OperationRetentionOutcome = Literal[
@@ -144,7 +144,7 @@ def _record_operation_retention_cleanup(result: OperationRetentionCleanupResult)
 
 def _next_cleanup_delay_seconds(delay_to_full_cleanup: float, *, backlog_likely: bool) -> float:
     if backlog_likely:
-        return min(delay_to_full_cleanup, _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
+        return 0.0
     return delay_to_full_cleanup
 
 
@@ -309,9 +309,10 @@ class StickySessionCleanupScheduler:
                 )
                 return True
 
-    async def _cleanup_as_leader(self) -> bool:
+    async def _cleanup_as_leader(self) -> bool | None:
         async with self._lock:
             backlog_likely = False
+            retention_attempted = False
             try:
                 async with get_background_session() as session:
                     settings_repo = SettingsRepository(session)
@@ -363,6 +364,7 @@ class StickySessionCleanupScheduler:
                                     retry_circuit_deleted_count,
                                 )
                         if self.operation_retention_enabled:
+                            retention_attempted = True
                             backlog_likely = await self._run_operation_retention(bridge_repo)
                 if self.enabled:
                     ring_cutoff = utcnow() - timedelta(seconds=RING_MEMBER_RETENTION_SECONDS)
@@ -371,7 +373,7 @@ class StickySessionCleanupScheduler:
                         logger.info("Purged stale bridge ring members deleted_count=%s", ring_deleted_count)
             except Exception:
                 logger.exception("Sticky session cleanup loop failed")
-                return backlog_likely
+                return backlog_likely if retention_attempted else None
             return backlog_likely
 
 

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -282,7 +282,7 @@ class StickySessionCleanupScheduler:
             )
             error_type = type(exc).__name__
         _record_operation_retention_cleanup(result)
-        if result.deleted_operations > 0 or result.backlog_likely:
+        if not PROMETHEUS_AVAILABLE or result.deleted_operations > 0 or result.backlog_likely:
             logger.info(
                 "HTTP bridge operation transcript retention "
                 "deleted_operations=%s batches=%s outcome=%s "

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -203,6 +203,7 @@ class StickySessionCleanupScheduler:
     _task: asyncio.Task[None] | None = None
     _stop: asyncio.Event = field(default_factory=asyncio.Event)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _operation_retention_attempt_failed: bool = False
 
     async def start(self) -> None:
         if not self.enabled and not self.operation_retention_enabled:
@@ -244,7 +245,7 @@ class StickySessionCleanupScheduler:
             delay_seconds = _next_cleanup_delay_seconds(
                 delay_to_full_cleanup,
                 backlog_likely=backlog_likely,
-                retry_immediately=retention_attempted is True,
+                retry_immediately=retention_attempted is True and not self._operation_retention_attempt_failed,
             )
             try:
                 await asyncio.wait_for(
@@ -293,8 +294,7 @@ class StickySessionCleanupScheduler:
                 result.duration_seconds,
                 error_type or "none",
             )
-        if result.outcome == "failed":
-            return result.backlog_likely if result.deleted_operations > 0 else None
+        self._operation_retention_attempt_failed = result.outcome == "failed"
         return result.backlog_likely
 
     async def _cleanup_operation_retention_as_leader(self) -> bool | None:
@@ -321,7 +321,8 @@ class StickySessionCleanupScheduler:
                     result.duration_seconds,
                     type(exc).__name__,
                 )
-                return None
+                self._operation_retention_attempt_failed = True
+                return True
 
     async def _cleanup_as_leader(self) -> bool | None:
         async with self._lock:

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -142,10 +142,10 @@ def _record_operation_retention_cleanup(result: OperationRetentionCleanupResult)
     http_bridge_spool_cleanup_backlog_likely.set(1.0 if result.backlog_likely else 0.0)
 
 
-def _next_cleanup_delay_seconds(interval_seconds: int, *, backlog_likely: bool) -> float:
+def _next_cleanup_delay_seconds(delay_to_full_cleanup: float, *, backlog_likely: bool) -> float:
     if backlog_likely:
-        return min(float(interval_seconds), _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
-    return float(interval_seconds)
+        return min(delay_to_full_cleanup, _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
+    return delay_to_full_cleanup
 
 
 def _merge_backlog_signal(previous: bool, attempted: bool | None) -> bool:
@@ -227,10 +227,9 @@ class StickySessionCleanupScheduler:
                     await self._cleanup_operation_retention_once(),
                 )
             delay_to_full_cleanup = max(next_full_cleanup_at - loop.time(), 0.0)
-            delay_seconds = (
-                min(delay_to_full_cleanup, _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
-                if backlog_likely
-                else delay_to_full_cleanup
+            delay_seconds = _next_cleanup_delay_seconds(
+                delay_to_full_cleanup,
+                backlog_likely=backlog_likely,
             )
             try:
                 await asyncio.wait_for(

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -55,6 +55,7 @@ _STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS = 6 * 3600
 _OPERATION_RETENTION_BATCH_SIZE = DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
 _OPERATION_RETENTION_MAX_BATCHES = 4
 _OPERATION_RETENTION_TIME_BUDGET_SECONDS = 5.0
+_OPERATION_RETENTION_BACKLOG_RETRY_SECONDS = 5.0
 
 
 OperationRetentionOutcome = Literal[
@@ -142,9 +143,16 @@ def _record_operation_retention_cleanup(result: OperationRetentionCleanupResult)
     http_bridge_spool_cleanup_backlog_likely.set(1.0 if result.backlog_likely else 0.0)
 
 
-def _next_cleanup_delay_seconds(delay_to_full_cleanup: float, *, backlog_likely: bool) -> float:
-    if backlog_likely:
+def _next_cleanup_delay_seconds(
+    delay_to_full_cleanup: float,
+    *,
+    backlog_likely: bool,
+    retry_immediately: bool,
+) -> float:
+    if backlog_likely and retry_immediately:
         return 0.0
+    if backlog_likely:
+        return min(delay_to_full_cleanup, _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
     return delay_to_full_cleanup
 
 
@@ -218,21 +226,25 @@ class StickySessionCleanupScheduler:
         next_full_cleanup_at = loop.time()
         backlog_likely = False
         while not self._stop.is_set():
+            retention_attempted: bool | None = None
             if loop.time() >= next_full_cleanup_at:
+                retention_attempted = await self._cleanup_once()
                 backlog_likely = _merge_backlog_signal(
                     backlog_likely,
-                    await self._cleanup_once(),
+                    retention_attempted,
                 )
                 next_full_cleanup_at = loop.time() + float(self.interval_seconds)
             elif backlog_likely:
+                retention_attempted = await self._cleanup_operation_retention_once()
                 backlog_likely = _merge_backlog_signal(
                     backlog_likely,
-                    await self._cleanup_operation_retention_once(),
+                    retention_attempted,
                 )
             delay_to_full_cleanup = max(next_full_cleanup_at - loop.time(), 0.0)
             delay_seconds = _next_cleanup_delay_seconds(
                 delay_to_full_cleanup,
                 backlog_likely=backlog_likely,
+                retry_immediately=retention_attempted is True,
             )
             try:
                 await asyncio.wait_for(
@@ -248,7 +260,7 @@ class StickySessionCleanupScheduler:
     async def _cleanup_operation_retention_once(self) -> bool | None:
         return await _get_leader_election().run_if_leader(self._cleanup_operation_retention_as_leader)
 
-    async def _run_operation_retention(self, bridge_repo: DurableBridgeRepository) -> bool:
+    async def _run_operation_retention(self, bridge_repo: DurableBridgeRepository) -> bool | None:
         operation_cutoff = utcnow() - timedelta(
             seconds=get_settings().http_responses_session_bridge_operation_spool_retention_seconds
         )
@@ -281,9 +293,9 @@ class StickySessionCleanupScheduler:
                 result.duration_seconds,
                 error_type or "none",
             )
-        return result.backlog_likely
+        return None if result.outcome == "failed" else result.backlog_likely
 
-    async def _cleanup_operation_retention_as_leader(self) -> bool:
+    async def _cleanup_operation_retention_as_leader(self) -> bool | None:
         async with self._lock:
             started_at = time.monotonic()
             try:
@@ -307,7 +319,7 @@ class StickySessionCleanupScheduler:
                     result.duration_seconds,
                     type(exc).__name__,
                 )
-                return True
+                return None
 
     async def _cleanup_as_leader(self) -> bool | None:
         async with self._lock:

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -7,11 +7,18 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import timedelta
-from typing import Protocol, TypeVar, cast
+from datetime import datetime, timedelta
+from typing import Literal, Protocol, TypeVar, cast
 
 from app.core import startup as startup_module
 from app.core.config.settings import Settings, get_settings
+from app.core.metrics.prometheus import (
+    PROMETHEUS_AVAILABLE,
+    http_bridge_spool_cleanup_backlog_likely,
+    http_bridge_spool_cleanup_deleted_operations_total,
+    http_bridge_spool_cleanup_duration_seconds,
+    http_bridge_spool_cleanup_runs_total,
+)
 from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
 from app.db.session import SessionLocal, get_background_session
@@ -39,6 +46,110 @@ _CLEANUP_INTERVAL_SECONDS = 300
 # an owner stuck unavailable well past when it should have recovered gets
 # its mapping dropped (never rebound) so the next request re-resolves fresh.
 _STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS = 6 * 3600
+
+# Transcript cleanup shares SQLite with request traffic and leader renewal.
+# Keep each pass large enough to outpace steady-state expiry, but small enough
+# that a historical backlog is resumed across scheduler ticks instead of
+# monopolizing the database in one drain-all loop.
+_OPERATION_RETENTION_BATCH_SIZE = 50
+_OPERATION_RETENTION_MAX_BATCHES = 4
+_OPERATION_RETENTION_TIME_BUDGET_SECONDS = 5.0
+_OPERATION_RETENTION_BACKLOG_RETRY_SECONDS = 5.0
+
+
+OperationRetentionOutcome = Literal[
+    "completed",
+    "batch_budget_exhausted",
+    "time_budget_exhausted",
+    "failed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class OperationRetentionCleanupResult:
+    deleted_operations: int
+    batches: int
+    backlog_likely: bool
+    outcome: OperationRetentionOutcome
+    duration_seconds: float
+
+
+class OperationRetentionCleanupError(RuntimeError):
+    def __init__(self, result: OperationRetentionCleanupResult, *, error_type: str) -> None:
+        super().__init__("durable operation retention batch failed")
+        self.result = result
+        self.error_type = error_type
+
+
+async def _purge_operation_spool_with_budget(
+    bridge_repo: DurableBridgeRepository,
+    *,
+    cutoff: datetime,
+) -> OperationRetentionCleanupResult:
+    started_at = time.monotonic()
+    deleted_operations = 0
+    batches = 0
+    outcome: OperationRetentionOutcome = "completed"
+
+    while True:
+        try:
+            batch_result = await bridge_repo.purge_operation_spool_batch(
+                cutoff=cutoff,
+                batch_size=_OPERATION_RETENTION_BATCH_SIZE,
+            )
+        except Exception as exc:
+            raise OperationRetentionCleanupError(
+                OperationRetentionCleanupResult(
+                    deleted_operations=deleted_operations,
+                    batches=batches,
+                    backlog_likely=True,
+                    outcome="failed",
+                    duration_seconds=max(time.monotonic() - started_at, 0.0),
+                ),
+                error_type=type(exc).__name__,
+            ) from None
+        deleted_operations += batch_result.deleted_operations
+        batches += 1
+        if batch_result.selected_operations < _OPERATION_RETENTION_BATCH_SIZE:
+            break
+        if time.monotonic() - started_at >= _OPERATION_RETENTION_TIME_BUDGET_SECONDS:
+            outcome = "time_budget_exhausted"
+            break
+        if batches >= _OPERATION_RETENTION_MAX_BATCHES:
+            outcome = "batch_budget_exhausted"
+            break
+        await asyncio.sleep(0)
+
+    return OperationRetentionCleanupResult(
+        deleted_operations=deleted_operations,
+        batches=batches,
+        backlog_likely=outcome != "completed",
+        outcome=outcome,
+        duration_seconds=max(time.monotonic() - started_at, 0.0),
+    )
+
+
+def _record_operation_retention_cleanup(result: OperationRetentionCleanupResult) -> None:
+    if not PROMETHEUS_AVAILABLE:
+        return
+    assert http_bridge_spool_cleanup_runs_total is not None
+    assert http_bridge_spool_cleanup_deleted_operations_total is not None
+    assert http_bridge_spool_cleanup_duration_seconds is not None
+    assert http_bridge_spool_cleanup_backlog_likely is not None
+    http_bridge_spool_cleanup_runs_total.labels(outcome=result.outcome).inc()
+    http_bridge_spool_cleanup_deleted_operations_total.inc(result.deleted_operations)
+    http_bridge_spool_cleanup_duration_seconds.observe(result.duration_seconds)
+    http_bridge_spool_cleanup_backlog_likely.set(1.0 if result.backlog_likely else 0.0)
+
+
+def _next_cleanup_delay_seconds(interval_seconds: int, *, backlog_likely: bool) -> float:
+    if backlog_likely:
+        return min(float(interval_seconds), _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
+    return float(interval_seconds)
+
+
+def _merge_backlog_signal(previous: bool, attempted: bool | None) -> bool:
+    return previous if attempted is None else attempted
 
 
 _T = TypeVar("_T")
@@ -103,18 +214,102 @@ class StickySessionCleanupScheduler:
         self._task = None
 
     async def _run_loop(self) -> None:
+        loop = asyncio.get_running_loop()
+        next_full_cleanup_at = loop.time()
+        backlog_likely = False
         while not self._stop.is_set():
-            await self._cleanup_once()
+            if loop.time() >= next_full_cleanup_at:
+                backlog_likely = await self._cleanup_once()
+                next_full_cleanup_at = loop.time() + float(self.interval_seconds)
+            elif backlog_likely:
+                backlog_likely = _merge_backlog_signal(
+                    backlog_likely,
+                    await self._cleanup_operation_retention_once(),
+                )
+            delay_to_full_cleanup = max(next_full_cleanup_at - loop.time(), 0.0)
+            delay_seconds = (
+                min(delay_to_full_cleanup, _OPERATION_RETENTION_BACKLOG_RETRY_SECONDS)
+                if backlog_likely
+                else delay_to_full_cleanup
+            )
             try:
-                await asyncio.wait_for(self._stop.wait(), timeout=self.interval_seconds)
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=delay_seconds,
+                )
             except asyncio.TimeoutError:
                 continue
 
-    async def _cleanup_once(self) -> None:
-        await _get_leader_election().run_if_leader(self._cleanup_as_leader)
+    async def _cleanup_once(self) -> bool:
+        return bool(await _get_leader_election().run_if_leader(self._cleanup_as_leader))
 
-    async def _cleanup_as_leader(self) -> None:
+    async def _cleanup_operation_retention_once(self) -> bool | None:
+        return await _get_leader_election().run_if_leader(self._cleanup_operation_retention_as_leader)
+
+    async def _run_operation_retention(self, bridge_repo: DurableBridgeRepository) -> bool:
+        operation_cutoff = utcnow() - timedelta(
+            seconds=get_settings().http_responses_session_bridge_operation_spool_retention_seconds
+        )
+        retention_started_at = time.monotonic()
+        error_type: str | None = None
+        try:
+            result = await _purge_operation_spool_with_budget(bridge_repo, cutoff=operation_cutoff)
+        except OperationRetentionCleanupError as exc:
+            result = exc.result
+            error_type = exc.error_type
+        except Exception as exc:
+            result = OperationRetentionCleanupResult(
+                deleted_operations=0,
+                batches=0,
+                backlog_likely=True,
+                outcome="failed",
+                duration_seconds=max(time.monotonic() - retention_started_at, 0.0),
+            )
+            error_type = type(exc).__name__
+        _record_operation_retention_cleanup(result)
+        if result.deleted_operations > 0 or result.backlog_likely:
+            logger.info(
+                "HTTP bridge operation transcript retention "
+                "deleted_operations=%s batches=%s outcome=%s "
+                "backlog_likely=%s duration_seconds=%.3f error_type=%s",
+                result.deleted_operations,
+                result.batches,
+                result.outcome,
+                result.backlog_likely,
+                result.duration_seconds,
+                error_type or "none",
+            )
+        return result.backlog_likely
+
+    async def _cleanup_operation_retention_as_leader(self) -> bool:
         async with self._lock:
+            started_at = time.monotonic()
+            try:
+                async with get_background_session() as session:
+                    if not startup_module._bridge_durable_schema_ready and await missing_durable_bridge_tables(session):
+                        return False
+                    return await self._run_operation_retention(DurableBridgeRepository(session))
+            except Exception as exc:
+                result = OperationRetentionCleanupResult(
+                    deleted_operations=0,
+                    batches=0,
+                    backlog_likely=True,
+                    outcome="failed",
+                    duration_seconds=max(time.monotonic() - started_at, 0.0),
+                )
+                _record_operation_retention_cleanup(result)
+                logger.warning(
+                    "HTTP bridge operation transcript retention failed before batching "
+                    "deleted_operations=0 batches=0 outcome=failed backlog_likely=true "
+                    "duration_seconds=%.3f error_type=%s",
+                    result.duration_seconds,
+                    type(exc).__name__,
+                )
+                return True
+
+    async def _cleanup_as_leader(self) -> bool:
+        async with self._lock:
+            backlog_likely = False
             try:
                 async with get_background_session() as session:
                     settings_repo = SettingsRepository(session)
@@ -166,23 +361,7 @@ class StickySessionCleanupScheduler:
                                     retry_circuit_deleted_count,
                                 )
                         if self.operation_retention_enabled:
-                            operation_cutoff = utcnow() - timedelta(
-                                seconds=get_settings().http_responses_session_bridge_operation_spool_retention_seconds
-                            )
-                            operation_deleted_count = 0
-                            # Drain all eligible batches. A single startup pass is
-                            # bounded to protect latency, but a long-lived process
-                            # must continue pruning old prompt/output transcripts.
-                            while True:
-                                deleted_batch = await bridge_repo.purge_operation_spool(cutoff=operation_cutoff)
-                                operation_deleted_count += deleted_batch
-                                if deleted_batch < 500:
-                                    break
-                            if operation_deleted_count > 0:
-                                logger.info(
-                                    "Purged expired HTTP bridge operation transcript rows deleted_count=%s",
-                                    operation_deleted_count,
-                                )
+                            backlog_likely = await self._run_operation_retention(bridge_repo)
                 if self.enabled:
                     ring_cutoff = utcnow() - timedelta(seconds=RING_MEMBER_RETENTION_SECONDS)
                     ring_deleted_count = await RingMembershipService(SessionLocal).purge_stale_before(ring_cutoff)
@@ -190,6 +369,8 @@ class StickySessionCleanupScheduler:
                         logger.info("Purged stale bridge ring members deleted_count=%s", ring_deleted_count)
             except Exception:
                 logger.exception("Sticky session cleanup loop failed")
+                return backlog_likely
+            return backlog_likely
 
 
 def build_sticky_session_cleanup_scheduler() -> StickySessionCleanupScheduler:

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -293,7 +293,9 @@ class StickySessionCleanupScheduler:
                 result.duration_seconds,
                 error_type or "none",
             )
-        return None if result.outcome == "failed" else result.backlog_likely
+        if result.outcome == "failed":
+            return result.backlog_likely if result.deleted_operations > 0 else None
+        return result.backlog_likely
 
     async def _cleanup_operation_retention_as_leader(self) -> bool | None:
         async with self._lock:

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
@@ -1,0 +1,49 @@
+# Design: Bound durable bridge spool cleanup
+
+## Context
+
+`StickySessionCleanupScheduler` currently loops until
+`purge_operation_spool()` returns fewer than 500 deleted operations. Each call
+owns its own transaction, but a large backlog still chains an unbounded number
+of SQLite write transactions inside one leader-gated task. Production evidence
+showed leader renewals and dashboard reads timing out while a multi-million-row
+event spool was present.
+
+## Decisions
+
+### D1. Fixed internal budgets
+
+Use fixed internal constants rather than new settings: a small repository
+batch, a maximum number of batches, and a monotonic wall-clock budget. Tests
+may patch these constants. At least one batch is attempted so a slow database
+still makes bounded forward progress.
+
+### D2. Resume instead of drain
+
+A short batch proves the eligible backlog is drained. A full final batch when
+the count or time budget is exhausted is reported as likely backlog and left
+for the next scheduler tick. Repository eligibility and owner fencing stay
+unchanged, so retries are idempotent across ticks and leaders.
+
+### D3. Low-cardinality observability
+
+Record duration, deleted-operation count, run outcome, and a binary
+backlog-likely signal. Do not label metrics with operation, session, account,
+or model identifiers. Log only aggregate values.
+
+## Risks / Trade-offs
+
+- A very large first backlog takes multiple ticks to drain. The fixed budget is
+  deliberately sized to exceed steady-state expiration volume while protecting
+  request latency.
+- A full final batch is only a backlog hint; it may be exactly the last batch.
+  The next tick resolves that ambiguity cheaply.
+- One repository batch can still exceed the wall-clock budget. Keeping the
+  batch small bounds that unavoidable unit without splitting owner-fenced
+  deletion semantics in this change.
+
+## Rollback
+
+This change has no schema or data-format transition. Reverting restores the
+previous drain-all scheduler behavior; rows already deleted were eligible under
+the unchanged retention contract.

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
@@ -27,6 +27,8 @@ so the aggregate catch-up rate is not artificially capped below ingest
 throughput. Leader-election skips and failed attempts retain the backlog signal
 but use the bounded retry delay. Repository eligibility and owner fencing stay
 unchanged, so retries are idempotent across ticks and leaders.
+When a failed pass has already committed deletions, its full selected batch is
+evidence of remaining backlog and therefore keeps the retry-bearing signal.
 
 ### D3. Low-cardinality observability
 

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
@@ -21,9 +21,10 @@ still makes bounded forward progress.
 ### D2. Resume instead of drain
 
 A short batch proves the eligible backlog is drained. A full final batch when
-the count or time budget is exhausted is reported as likely backlog and left
-for the next scheduler tick. Repository eligibility and owner fencing stay
-unchanged, so retries are idempotent across ticks and leaders.
+the count or time budget is exhausted is reported as likely backlog and retried
+immediately in another bounded pass, so the aggregate catch-up rate is not
+artificially capped below ingest throughput. Repository eligibility and owner
+fencing stay unchanged, so retries are idempotent across ticks and leaders.
 
 ### D3. Low-cardinality observability
 

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/design.md
@@ -22,9 +22,11 @@ still makes bounded forward progress.
 
 A short batch proves the eligible backlog is drained. A full final batch when
 the count or time budget is exhausted is reported as likely backlog and retried
-immediately in another bounded pass, so the aggregate catch-up rate is not
-artificially capped below ingest throughput. Repository eligibility and owner
-fencing stay unchanged, so retries are idempotent across ticks and leaders.
+immediately in another bounded pass only after a successful retention attempt,
+so the aggregate catch-up rate is not artificially capped below ingest
+throughput. Leader-election skips and failed attempts retain the backlog signal
+but use the bounded retry delay. Repository eligibility and owner fencing stay
+unchanged, so retries are idempotent across ticks and leaders.
 
 ### D3. Low-cardinality observability
 

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/proposal.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/proposal.md
@@ -1,0 +1,33 @@
+# Change: Bound durable bridge spool cleanup
+
+## Why
+
+Durable HTTP bridge transcript retention currently drains every eligible
+operation in one leader-gated scheduler pass. A large SQLite backlog can keep
+that pass inside repeated delete transactions long enough to starve ordinary
+database work and leader-lease renewal. Cleanup must continue making progress
+without monopolizing the shared database.
+
+## What Changes
+
+- Limit each scheduler pass to fixed, small operation batches and a wall-clock
+  budget, then resume any remaining backlog on a later tick.
+- Emit low-cardinality logs and Prometheus metrics for cleanup duration,
+  deleted operations, outcome, and whether the pass stopped with likely
+  backlog remaining.
+- Preserve the existing retention cutoff, owner fencing, terminal/nonterminal
+  eligibility, and sticky-cleanup independence.
+
+## Non-Goals
+
+- Changing transcript format, compression, or the seven-day retention window.
+- Changing request-log or usage-history retention defaults.
+- Running SQLite vacuum or deleting production data outside normal retention.
+- Adding operator configuration for cleanup tuning.
+
+## Impact
+
+- Affected specs: `responses-api-compat`, `proxy-runtime-observability`.
+- Affected code: sticky-session cleanup scheduler, durable bridge repository
+  call pattern, Prometheus metric declarations, focused unit tests.
+- No API, schema, migration, or environment-variable change.

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Durable transcript cleanup exposes bounded aggregate telemetry
+
+Each durable operation transcript cleanup pass MUST expose low-cardinality
+telemetry for pass duration, deleted-operation count, completion outcome, and
+whether the pass stopped with likely eligible backlog remaining. Logs and
+metrics MUST NOT include prompt/output text, operation identifiers, session
+keys, account identifiers, or model names.
+
+If a later batch fails after earlier batches committed, failure telemetry MUST
+include the operations deleted and batches completed before that failure.
+
+#### Scenario: Budget exhaustion is observable
+
+- **GIVEN** eligible transcript operations remain after a cleanup pass reaches
+  its fixed budget
+- **WHEN** the pass stops
+- **THEN** aggregate telemetry reports the deleted count and a budget-exhausted
+  outcome
+- **AND** reports that backlog is likely to remain
+
+#### Scenario: A drained pass clears the backlog signal
+
+- **WHEN** a cleanup pass selects fewer operations than the repository batch
+  size, even if ownership rechecks deleted fewer rows from an earlier full
+  selection
+- **THEN** aggregate telemetry reports a completed outcome
+- **AND** clears the backlog-likely signal
+
+#### Scenario: Failed pass preserves partial progress telemetry
+
+- **GIVEN** one or more cleanup batches commit before a later batch fails
+- **WHEN** failure telemetry is recorded
+- **THEN** it includes the committed deletion and batch counts
+
+#### Scenario: Cleanup telemetry contains no sensitive labels
+
+- **WHEN** cleanup succeeds or fails
+- **THEN** its logs and metric labels contain no operation, session, account,
+  prompt, output, or model values

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/specs/responses-api-compat/spec.md
@@ -7,10 +7,12 @@ and MUST delete eligible operations in bounded batches. A scheduler pass MUST
 stop after it drains the eligible backlog or reaches its fixed batch-count or
 wall-clock budget, and a later pass MUST be able to resume from the oldest
 remaining eligible operation without changing retention eligibility or owner
-fencing. When a pass reports likely backlog, the scheduler MUST retry after a
-short bounded catch-up delay instead of waiting the normal maintenance
-interval. Catch-up passes MUST run only operation transcript retention rather
-than accelerating unrelated sticky, bridge-session, or ring maintenance.
+fencing. When a successful pass reports likely backlog, the scheduler MUST
+retry immediately instead of waiting the normal maintenance interval. When a
+leader-election skip or failed pass preserves the backlog signal, the scheduler
+MUST use a short bounded catch-up delay. Catch-up passes MUST run only operation
+transcript retention rather than accelerating unrelated sticky, bridge-session,
+or ring maintenance.
 Disabling the existing sticky-session mapping cleanup switch MUST NOT disable
 operation transcript retention; that switch MAY skip sticky mapping
 maintenance while durable operation retention continues.
@@ -35,14 +37,21 @@ maintenance while durable operation retention continues.
 - **AND** a later leader-gated pass resumes deletion from the oldest remaining
   eligible operation
 
-#### Scenario: Backlog schedules prompt catch-up
+#### Scenario: Successful backlog schedules immediate catch-up
 
 - **GIVEN** a cleanup pass stops on a full final batch at its count or time
   budget
 - **WHEN** the scheduler chooses the next delay
-- **THEN** it uses the bounded backlog retry delay rather than the normal
-  maintenance interval
+- **THEN** it retries immediately rather than waiting the normal maintenance
+  interval
 - **AND** the catch-up pass does not rerun unrelated maintenance
+
+#### Scenario: Skipped or failed backlog uses bounded retry
+
+- **GIVEN** the backlog signal remains after leader-election skips or a failed
+  retention pass
+- **WHEN** the scheduler chooses the next delay
+- **THEN** it uses the bounded backlog retry delay
 
 #### Scenario: Sticky cleanup toggle does not disable transcript retention
 

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/specs/responses-api-compat/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Continuous transcript retention
+
+Operation transcript cleanup MUST run periodically in a leader-gated scheduler
+and MUST delete eligible operations in bounded batches. A scheduler pass MUST
+stop after it drains the eligible backlog or reaches its fixed batch-count or
+wall-clock budget, and a later pass MUST be able to resume from the oldest
+remaining eligible operation without changing retention eligibility or owner
+fencing. When a pass reports likely backlog, the scheduler MUST retry after a
+short bounded catch-up delay instead of waiting the normal maintenance
+interval. Catch-up passes MUST run only operation transcript retention rather
+than accelerating unrelated sticky, bridge-session, or ring maintenance.
+Disabling the existing sticky-session mapping cleanup switch MUST NOT disable
+operation transcript retention; that switch MAY skip sticky mapping
+maintenance while durable operation retention continues.
+
+#### Scenario: Retention drains a small backlog
+
+- **WHEN** fewer operations are eligible than one scheduler-pass budget
+- **THEN** the pass removes every eligible operation
+- **AND** reports that no backlog is known to remain
+
+#### Scenario: Retention drains all eligible batches
+
+- **GIVEN** every eligible operation fits within one scheduler-pass budget
+- **WHEN** transcript retention runs
+- **THEN** that pass removes every eligible batch
+
+#### Scenario: Retention yields with a large backlog
+
+- **GIVEN** more operations are eligible than one scheduler-pass budget
+- **WHEN** the pass reaches its batch-count or wall-clock budget
+- **THEN** it commits the completed bounded batches and stops
+- **AND** a later leader-gated pass resumes deletion from the oldest remaining
+  eligible operation
+
+#### Scenario: Backlog schedules prompt catch-up
+
+- **GIVEN** a cleanup pass stops on a full final batch at its count or time
+  budget
+- **WHEN** the scheduler chooses the next delay
+- **THEN** it uses the bounded backlog retry delay rather than the normal
+  maintenance interval
+- **AND** the catch-up pass does not rerun unrelated maintenance
+
+#### Scenario: Sticky cleanup toggle does not disable transcript retention
+
+- **WHEN** sticky-session cleanup is disabled and the durable bridge schema is
+  available
+- **THEN** the leader-gated scheduler still deletes bounded batches of expired
+  operation transcript rows while skipping sticky mapping cleanup

--- a/openspec/changes/bound-durable-bridge-spool-cleanup/tasks.md
+++ b/openspec/changes/bound-durable-bridge-spool-cleanup/tasks.md
@@ -1,0 +1,18 @@
+## 1. Specification
+
+- [x] 1.1 Modify continuous transcript retention to require bounded,
+      resumable scheduler passes.
+- [x] 1.2 Specify aggregate cleanup observability without sensitive labels.
+
+## 2. Implementation
+
+- [x] 2.1 Add fixed batch/count/time budgets and a typed cleanup result.
+- [x] 2.2 Stop on a short batch or budget exhaustion and log aggregate result.
+- [x] 2.3 Add Prometheus duration, deletion, outcome, and backlog metrics.
+
+## 3. Verification
+
+- [x] 3.1 Cover complete drain, count-budget stop, time-budget stop, disabled
+      sticky cleanup, and cleanup failure.
+- [x] 3.2 Run focused tests and changed-file Ruff checks.
+- [x] 3.3 Run strict OpenSpec validation and `git diff --check`.

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -735,7 +735,6 @@ async def test_codex_goal_restart_cannot_retire_owner_outside_api_key_scope(
     _install_proxy_settings_cache(
         monkeypatch,
         sticky_threads_enabled=False,
-        proxy_request_budget_seconds=0.05,
     )
 
     async def fail_stream(*args, **kwargs):

--- a/tests/integration/test_startup_bridge_cleanup.py
+++ b/tests/integration/test_startup_bridge_cleanup.py
@@ -126,3 +126,21 @@ async def test_startup_operation_retention_success_logs_aggregate_without_promet
     assert result.outcome == "completed"
     assert "deleted_operations=0 batches=1 outcome=completed backlog_likely=False" in caplog.text
     assert "duration_seconds=" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_startup_operation_retention_success_logs_aggregate_when_metrics_disabled(monkeypatch, caplog) -> None:
+    recorded = Mock()
+    purge = AsyncMock(return_value=SimpleNamespace(deleted_operations=0, selected_operations=0))
+    coordinator = SimpleNamespace(purge_operation_spool_batch=purge)
+
+    monkeypatch.setattr(main_module, "DurableBridgeSessionCoordinator", lambda _session_factory: coordinator)
+    monkeypatch.setattr(main_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(main_module, "operation_retention_metrics_enabled", lambda: False)
+    monkeypatch.setattr(main_module, "_record_operation_retention_cleanup", recorded)
+
+    with caplog.at_level("INFO", logger=main_module.__name__):
+        assert await main_module._purge_operation_spool_on_startup(retention_seconds=60.0) == 0
+
+    recorded.assert_called_once()
+    assert "deleted_operations=0 batches=1 outcome=completed backlog_likely=False" in caplog.text

--- a/tests/integration/test_startup_bridge_cleanup.py
+++ b/tests/integration/test_startup_bridge_cleanup.py
@@ -103,3 +103,26 @@ async def test_startup_operation_retention_failure_records_sanitized_aggregate(m
     assert "error_type=RuntimeError" in caplog.text
     assert "operation_id=secret" not in caplog.text
     assert "DELETE FROM" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_startup_operation_retention_success_logs_aggregate_without_prometheus(monkeypatch, caplog) -> None:
+    recorded = Mock()
+    purge = AsyncMock(return_value=SimpleNamespace(deleted_operations=0, selected_operations=0))
+    coordinator = SimpleNamespace(purge_operation_spool_batch=purge)
+
+    monkeypatch.setattr(main_module, "DurableBridgeSessionCoordinator", lambda _session_factory: coordinator)
+    monkeypatch.setattr(main_module, "PROMETHEUS_AVAILABLE", False)
+    monkeypatch.setattr(main_module, "_record_operation_retention_cleanup", recorded)
+
+    with caplog.at_level("INFO", logger=main_module.__name__):
+        assert await main_module._purge_operation_spool_on_startup(retention_seconds=60.0) == 0
+
+    purge.assert_awaited_once()
+    result = recorded.call_args.args[0]
+    assert result.deleted_operations == 0
+    assert result.batches == 1
+    assert result.backlog_likely is False
+    assert result.outcome == "completed"
+    assert "deleted_operations=0 batches=1 outcome=completed backlog_likely=False" in caplog.text
+    assert "duration_seconds=" in caplog.text

--- a/tests/integration/test_startup_bridge_cleanup.py
+++ b/tests/integration/test_startup_bridge_cleanup.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from sqlalchemy import select
 
+import app.main as main_module
 from app.core.config.settings import get_settings
 from app.core.utils.time import utcnow
 from app.db.models import HttpBridgeSessionRecord, HttpBridgeSessionState
 from app.db.session import SessionLocal
-from app.main import create_app
 
 pytestmark = pytest.mark.integration
 
@@ -59,7 +61,7 @@ async def test_lifespan_startup_purges_abandoned_ownerless_bridge_rows(db_setup,
         )
         await session.commit()
 
-    app = create_app()
+    app = main_module.create_app()
     async with app.router.lifespan_context(app):
         async with SessionLocal() as session:
             remaining_keys = set(
@@ -76,3 +78,28 @@ async def test_lifespan_startup_purges_abandoned_ownerless_bridge_rows(db_setup,
             )
 
     assert remaining_keys == {"sid-recent-ownerless-startup"}
+
+
+@pytest.mark.asyncio
+async def test_startup_operation_retention_failure_records_sanitized_aggregate(monkeypatch, caplog) -> None:
+    recorded = Mock()
+    purge = AsyncMock(side_effect=RuntimeError("operation_id=secret SQL DELETE FROM transcript"))
+    coordinator = SimpleNamespace(purge_operation_spool_batch=purge)
+
+    monkeypatch.setattr(main_module, "DurableBridgeSessionCoordinator", lambda _session_factory: coordinator)
+    monkeypatch.setattr(main_module, "_record_operation_retention_cleanup", recorded)
+
+    with caplog.at_level("WARNING", logger=main_module.__name__):
+        with pytest.raises(RuntimeError, match="startup retention failed") as captured:
+            await main_module._purge_operation_spool_on_startup(retention_seconds=60.0)
+
+    assert captured.value.__cause__ is None
+    purge.assert_awaited_once()
+    result = recorded.call_args.args[0]
+    assert result.deleted_operations == 0
+    assert result.batches == 0
+    assert result.backlog_likely is True
+    assert result.outcome == "failed"
+    assert "error_type=RuntimeError" in caplog.text
+    assert "operation_id=secret" not in caplog.text
+    assert "DELETE FROM" not in caplog.text

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -445,9 +445,7 @@ async def test_full_cleanup_cancellation_records_partial_result_and_preserves_ba
 @pytest.mark.asyncio
 async def test_operation_retention_cleanup_cancellation_keeps_partial_progress(monkeypatch) -> None:
     bridge_repo = AsyncMock()
-    bridge_repo.purge_operation_spool_batch = AsyncMock(
-        side_effect=[_purge_batch(3), asyncio.CancelledError()]
-    )
+    bridge_repo.purge_operation_spool_batch = AsyncMock(side_effect=[_purge_batch(3), asyncio.CancelledError()])
     monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
 
     with pytest.raises(cleanup_scheduler.OperationRetentionCleanupCancelledError) as captured:

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
@@ -346,7 +347,10 @@ async def test_operation_retention_noop_avoids_duplicate_log_with_prometheus(mon
     monkeypatch.setattr(
         cleanup_scheduler,
         "get_settings",
-        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_operation_spool_retention_seconds=604800.0,
+            metrics_enabled=True,
+        ),
     )
     monkeypatch.setattr(cleanup_scheduler, "PROMETHEUS_AVAILABLE", True)
     monkeypatch.setattr(cleanup_scheduler, "_record_operation_retention_cleanup", Mock())
@@ -357,6 +361,102 @@ async def test_operation_retention_noop_avoids_duplicate_log_with_prometheus(mon
 
     assert backlog_likely is False
     assert "HTTP bridge operation transcript retention" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_noop_logs_aggregate_when_metrics_disabled(monkeypatch, caplog) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_operation_spool_retention_seconds=604800.0,
+            metrics_enabled=False,
+        ),
+    )
+    monkeypatch.setattr(cleanup_scheduler, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(cleanup_scheduler, "_record_operation_retention_cleanup", Mock())
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
+        backlog_likely = await scheduler._run_operation_retention(bridge_repo)
+
+    assert backlog_likely is False
+    assert "deleted_operations=0 batches=1 outcome=completed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_full_cleanup_cancellation_records_partial_result_and_preserves_backlog(monkeypatch) -> None:
+    partial_result = cleanup_scheduler.OperationRetentionCleanupResult(
+        deleted_operations=3,
+        batches=1,
+        backlog_likely=True,
+        outcome="failed",
+        duration_seconds=1.0,
+    )
+    recorded = Mock()
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    class LeaseLossLeader:
+        cancellation_seen = False
+
+        async def run_if_leader(self, fn: Callable[[], Awaitable[object]]) -> object | None:
+            try:
+                return await fn()
+            except asyncio.CancelledError:
+                self.cancellation_seen = True
+                return None
+
+    leader = LeaseLossLeader()
+
+    async def cancelled_retention(self) -> bool | None:
+        return await self._run_operation_retention(AsyncMock())
+
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_operation_spool_retention_seconds=604800.0,
+            metrics_enabled=True,
+        ),
+    )
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "_purge_operation_spool_with_budget",
+        AsyncMock(side_effect=cleanup_scheduler.OperationRetentionCleanupCancelledError(partial_result)),
+    )
+    monkeypatch.setattr(cleanup_scheduler, "_record_operation_retention_cleanup", recorded)
+    monkeypatch.setattr(cleanup_scheduler, "_get_leader_election", lambda: leader)
+    monkeypatch.setattr(
+        cleanup_scheduler.StickySessionCleanupScheduler,
+        "_cleanup_as_leader",
+        cancelled_retention,
+    )
+
+    backlog_likely = await scheduler._cleanup_once()
+
+    assert leader.cancellation_seen is True
+    assert backlog_likely is True
+    assert scheduler._operation_retention_attempt_failed is True
+    recorded.assert_called_once_with(partial_result)
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_cancellation_keeps_partial_progress(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(
+        side_effect=[_purge_batch(3), asyncio.CancelledError()]
+    )
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+
+    with pytest.raises(cleanup_scheduler.OperationRetentionCleanupCancelledError) as captured:
+        await cleanup_scheduler._purge_operation_spool_with_budget(bridge_repo, cutoff=utcnow())
+
+    assert captured.value.result.deleted_operations == 3
+    assert captured.value.result.batches == 1
+    assert captured.value.result.backlog_likely is True
+    assert captured.value.result.outcome == "failed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import inspect
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
@@ -20,6 +22,8 @@ from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeOperationPurgeBatchResult,
     DurableBridgeRepository,
 )
+
+leader_election_module = importlib.import_module("app.core.scheduling.leader_election")
 
 pytestmark = pytest.mark.unit
 
@@ -185,7 +189,15 @@ def test_cleanup_delay_retries_immediately_while_backlog_is_likely() -> None:
 def test_startup_and_scheduler_share_the_bounded_spool_purge_size() -> None:
     assert cleanup_scheduler._OPERATION_RETENTION_BATCH_SIZE == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
     assert (
+        inspect.signature(DurableBridgeRepository.purge_operation_spool_batch).parameters["batch_size"].default
+        == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    )
+    assert (
         inspect.signature(DurableBridgeRepository.purge_operation_spool).parameters["batch_size"].default
+        == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    )
+    assert (
+        inspect.signature(DurableBridgeSessionCoordinator.purge_operation_spool_batch).parameters["batch_size"].default
         == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
     )
     assert (
@@ -440,6 +452,82 @@ async def test_full_cleanup_cancellation_records_partial_result_and_preserves_ba
     assert backlog_likely is True
     assert scheduler._operation_retention_attempt_failed is True
     recorded.assert_called_once_with(partial_result)
+
+
+@pytest.mark.asyncio
+async def test_full_cleanup_lease_loss_during_session_teardown_preserves_confirmed_backlog(monkeypatch) -> None:
+    teardown_started = asyncio.Event()
+    never = asyncio.Event()
+    leader = leader_election_module.LeaderElection(leader_id="node-a")
+    lease_session = MagicMock()
+    lease_session.get_bind.return_value = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    lease_session.execute = AsyncMock(
+        side_effect=(
+            SimpleNamespace(first=lambda: (5.0,)),
+            SimpleNamespace(first=lambda: None),
+        )
+    )
+    lease_session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def leader_session():
+        yield lease_session
+
+    class SessionThatBlocksOnExit:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *_args: object) -> None:
+            teardown_started.set()
+            await never.wait()
+
+    completed_full_batch = cleanup_scheduler.OperationRetentionCleanupResult(
+        deleted_operations=50,
+        batches=1,
+        backlog_likely=True,
+        outcome="batch_budget_exhausted",
+        duration_seconds=0.01,
+    )
+    monkeypatch.setattr(
+        leader_election_module,
+        "get_settings",
+        lambda: SimpleNamespace(leader_election_enabled=True, leader_election_ttl_seconds=5),
+    )
+    monkeypatch.setattr(leader_election_module, "get_background_session", leader_session)
+    monkeypatch.setattr(cleanup_scheduler, "_get_leader_election", lambda: leader)
+    monkeypatch.setattr(cleanup_scheduler, "get_background_session", SessionThatBlocksOnExit)
+    monkeypatch.setattr(cleanup_scheduler.startup_module, "_bridge_durable_schema_ready", True)
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_operation_spool_retention_seconds=604800.0,
+            metrics_enabled=False,
+        ),
+    )
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "_purge_operation_spool_with_budget",
+        AsyncMock(return_value=completed_full_batch),
+    )
+    monkeypatch.setattr(cleanup_scheduler, "_record_operation_retention_cleanup", Mock())
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=300, enabled=False)
+
+    attempted = await asyncio.wait_for(scheduler._cleanup_once(), timeout=3.0)
+    backlog_likely = cleanup_scheduler._merge_backlog_signal(False, attempted)
+
+    assert teardown_started.is_set()
+    assert lease_session.execute.await_count == 2
+    assert attempted is True
+    assert backlog_likely is True
+    assert (
+        cleanup_scheduler._next_cleanup_delay_seconds(
+            300.0,
+            backlog_likely=backlog_likely,
+            retry_immediately=attempted is True and not scheduler._operation_retention_attempt_failed,
+        )
+        == 0.0
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -317,6 +317,35 @@ async def test_operation_retention_failure_log_omits_exception_detail(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_operation_retention_partial_failure_keeps_backlog_retry(monkeypatch) -> None:
+    partial_failure = cleanup_scheduler.OperationRetentionCleanupError(
+        cleanup_scheduler.OperationRetentionCleanupResult(
+            deleted_operations=3,
+            batches=1,
+            backlog_likely=True,
+            outcome="failed",
+            duration_seconds=1.0,
+        ),
+        error_type="RuntimeError",
+    )
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+    )
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "_purge_operation_spool_with_budget",
+        AsyncMock(side_effect=partial_failure),
+    )
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    backlog_likely = await scheduler._run_operation_retention(AsyncMock())
+
+    assert backlog_likely is True
+
+
+@pytest.mark.asyncio
 async def test_operation_retention_catchup_does_not_run_other_maintenance(monkeypatch) -> None:
     bridge_repo = AsyncMock()
     run_retention = AsyncMock(return_value=False)

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -309,7 +309,9 @@ async def test_operation_retention_failure_log_omits_exception_detail(monkeypatc
     with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
         backlog_likely = await scheduler._run_operation_retention(bridge_repo)
 
-    assert backlog_likely is None
+    assert backlog_likely is True
+    assert scheduler._operation_retention_attempt_failed is True
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True, retry_immediately=False) == 5.0
     assert "deleted_operations=0 batches=0" in caplog.text
     assert "error_type=RuntimeError" in caplog.text
     assert "operation_id=secret" not in caplog.text
@@ -343,6 +345,7 @@ async def test_operation_retention_partial_failure_keeps_backlog_retry(monkeypat
     backlog_likely = await scheduler._run_operation_retention(AsyncMock())
 
     assert backlog_likely is True
+    assert scheduler._operation_retention_attempt_failed is True
 
 
 @pytest.mark.asyncio
@@ -399,7 +402,8 @@ async def test_prebatch_retention_failure_records_aggregate_metrics(monkeypatch,
     ):
         backlog_likely = await scheduler._cleanup_operation_retention_as_leader()
 
-    assert backlog_likely is None
+    assert backlog_likely is True
+    assert scheduler._operation_retention_attempt_failed is True
     result = recorded.call_args.args[0]
     assert result.outcome == "failed"
     assert result.deleted_operations == 0

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -174,9 +174,11 @@ async def test_operation_retention_cleanup_failure_preserves_committed_progress(
 
 
 def test_cleanup_delay_retries_immediately_while_backlog_is_likely() -> None:
-    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True) == 0.0
-    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True) == 0.0
-    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=False) == 300.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True, retry_immediately=True) == 0.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True, retry_immediately=True) == 0.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True, retry_immediately=False) == 5.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True, retry_immediately=False) == 3.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=False, retry_immediately=False) == 300.0
 
 
 def test_startup_and_scheduler_share_the_bounded_spool_purge_size() -> None:
@@ -307,7 +309,7 @@ async def test_operation_retention_failure_log_omits_exception_detail(monkeypatc
     with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
         backlog_likely = await scheduler._run_operation_retention(bridge_repo)
 
-    assert backlog_likely is True
+    assert backlog_likely is None
     assert "deleted_operations=0 batches=0" in caplog.text
     assert "error_type=RuntimeError" in caplog.text
     assert "operation_id=secret" not in caplog.text
@@ -368,7 +370,7 @@ async def test_prebatch_retention_failure_records_aggregate_metrics(monkeypatch,
     ):
         backlog_likely = await scheduler._cleanup_operation_retention_as_leader()
 
-    assert backlog_likely is True
+    assert backlog_likely is None
     result = recorded.call_args.args[0]
     assert result.outcome == "failed"
     assert result.deleted_operations == 0

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from types import SimpleNamespace
@@ -12,7 +13,12 @@ import app.modules.sticky_sessions.cleanup_scheduler as cleanup_scheduler
 from app.core.config.settings import Settings
 from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
-from app.modules.proxy.durable_bridge_repository import DurableBridgeOperationPurgeBatchResult
+from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
+from app.modules.proxy.durable_bridge_repository import (
+    DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE,
+    DurableBridgeOperationPurgeBatchResult,
+    DurableBridgeRepository,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -167,12 +173,22 @@ async def test_operation_retention_cleanup_failure_preserves_committed_progress(
     assert captured.value.__cause__ is None
 
 
-def test_cleanup_delay_accelerates_while_backlog_is_likely(monkeypatch) -> None:
-    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BACKLOG_RETRY_SECONDS", 5.0)
-
-    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True) == 5.0
-    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True) == 3.0
+def test_cleanup_delay_retries_immediately_while_backlog_is_likely() -> None:
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True) == 0.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True) == 0.0
     assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=False) == 300.0
+
+
+def test_startup_and_scheduler_share_the_bounded_spool_purge_size() -> None:
+    assert cleanup_scheduler._OPERATION_RETENTION_BATCH_SIZE == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    assert (
+        inspect.signature(DurableBridgeRepository.purge_operation_spool).parameters["batch_size"].default
+        == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    )
+    assert (
+        inspect.signature(DurableBridgeSessionCoordinator.purge_operation_spool).parameters["batch_size"].default
+        == DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE
+    )
 
 
 def test_leader_skip_preserves_existing_backlog_signal() -> None:
@@ -363,7 +379,7 @@ async def test_prebatch_retention_failure_records_aggregate_metrics(monkeypatch,
 
 
 @pytest.mark.asyncio
-async def test_unrelated_cleanup_failure_does_not_request_fast_retention_retry(monkeypatch) -> None:
+async def test_unrelated_cleanup_failure_preserves_existing_backlog_retry(monkeypatch) -> None:
     class FakeSession:
         async def __aenter__(self):
             return AsyncMock()
@@ -380,7 +396,8 @@ async def test_unrelated_cleanup_failure_does_not_request_fast_retention_retry(m
     ):
         backlog_likely = await scheduler._cleanup_as_leader()
 
-    assert backlog_likely is False
+    assert backlog_likely is None
+    assert cleanup_scheduler._merge_backlog_signal(True, backlog_likely) is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -12,6 +12,7 @@ import app.modules.sticky_sessions.cleanup_scheduler as cleanup_scheduler
 from app.core.config.settings import Settings
 from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
+from app.modules.proxy.durable_bridge_repository import DurableBridgeOperationPurgeBatchResult
 
 pytestmark = pytest.mark.unit
 
@@ -23,6 +24,16 @@ class _FakeLeader:
         return await fn()
 
 
+def _purge_batch(
+    selected: int,
+    deleted: int | None = None,
+) -> DurableBridgeOperationPurgeBatchResult:
+    return DurableBridgeOperationPurgeBatchResult(
+        selected_operations=selected,
+        deleted_operations=selected if deleted is None else deleted,
+    )
+
+
 def test_build_sticky_session_cleanup_scheduler_respects_enabled_setting(monkeypatch) -> None:
     settings = SimpleNamespace(sticky_session_cleanup_enabled=False)
     monkeypatch.setattr(cleanup_scheduler, "get_settings", lambda: settings)
@@ -32,6 +43,332 @@ def test_build_sticky_session_cleanup_scheduler_respects_enabled_setting(monkeyp
 
     assert scheduler.interval_seconds == 42
     assert scheduler.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_drains_small_backlog(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(side_effect=[_purge_batch(3), _purge_batch(1)])
+    cutoff = utcnow()
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+    monkeypatch.setattr(cleanup_scheduler, "time", SimpleNamespace(monotonic=lambda: 10.0))
+
+    result = await cleanup_scheduler._purge_operation_spool_with_budget(
+        bridge_repo,
+        cutoff=cutoff,
+    )
+
+    assert result == cleanup_scheduler.OperationRetentionCleanupResult(
+        deleted_operations=4,
+        batches=2,
+        backlog_likely=False,
+        outcome="completed",
+        duration_seconds=0.0,
+    )
+    assert bridge_repo.purge_operation_spool_batch.await_count == 2
+    bridge_repo.purge_operation_spool_batch.assert_awaited_with(
+        cutoff=cutoff,
+        batch_size=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_stops_at_batch_budget(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(
+        side_effect=[_purge_batch(3), _purge_batch(3), AssertionError("extra batch")]
+    )
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_MAX_BATCHES", 2)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_TIME_BUDGET_SECONDS", 60.0)
+    monkeypatch.setattr(cleanup_scheduler, "time", SimpleNamespace(monotonic=lambda: 10.0))
+
+    result = await cleanup_scheduler._purge_operation_spool_with_budget(
+        bridge_repo,
+        cutoff=utcnow(),
+    )
+
+    assert result.deleted_operations == 6
+    assert result.batches == 2
+    assert result.backlog_likely is True
+    assert result.outcome == "batch_budget_exhausted"
+    assert bridge_repo.purge_operation_spool_batch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_stops_at_time_budget(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(side_effect=[_purge_batch(3), AssertionError("extra batch")])
+    monotonic_values = iter((10.0, 16.0, 16.0))
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_MAX_BATCHES", 10)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_TIME_BUDGET_SECONDS", 5.0)
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "time",
+        SimpleNamespace(monotonic=lambda: next(monotonic_values)),
+    )
+
+    result = await cleanup_scheduler._purge_operation_spool_with_budget(
+        bridge_repo,
+        cutoff=utcnow(),
+    )
+
+    assert result.deleted_operations == 3
+    assert result.batches == 1
+    assert result.duration_seconds == 6.0
+    assert result.backlog_likely is True
+    assert result.outcome == "time_budget_exhausted"
+    assert bridge_repo.purge_operation_spool_batch.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_full_selection_with_short_delete_keeps_backlog(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(side_effect=[_purge_batch(3, 1)])
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_MAX_BATCHES", 1)
+    monkeypatch.setattr(cleanup_scheduler, "time", SimpleNamespace(monotonic=lambda: 10.0))
+
+    result = await cleanup_scheduler._purge_operation_spool_with_budget(
+        bridge_repo,
+        cutoff=utcnow(),
+    )
+
+    assert result.deleted_operations == 1
+    assert result.batches == 1
+    assert result.backlog_likely is True
+    assert result.outcome == "batch_budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_failure_preserves_committed_progress(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(
+        side_effect=[_purge_batch(3), RuntimeError("db unavailable operation_id=secret")]
+    )
+    monotonic_values = iter((10.0, 10.0, 12.0))
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BATCH_SIZE", 3)
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_MAX_BATCHES", 3)
+    monkeypatch.setattr(cleanup_scheduler, "time", SimpleNamespace(monotonic=lambda: next(monotonic_values)))
+
+    with pytest.raises(cleanup_scheduler.OperationRetentionCleanupError) as captured:
+        await cleanup_scheduler._purge_operation_spool_with_budget(
+            bridge_repo,
+            cutoff=utcnow(),
+        )
+
+    assert captured.value.result.deleted_operations == 3
+    assert captured.value.result.batches == 1
+    assert captured.value.result.backlog_likely is True
+    assert captured.value.result.outcome == "failed"
+    assert captured.value.result.duration_seconds == 2.0
+    assert captured.value.error_type == "RuntimeError"
+    assert captured.value.__cause__ is None
+
+
+def test_cleanup_delay_accelerates_while_backlog_is_likely(monkeypatch) -> None:
+    monkeypatch.setattr(cleanup_scheduler, "_OPERATION_RETENTION_BACKLOG_RETRY_SECONDS", 5.0)
+
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=True) == 5.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(3, backlog_likely=True) == 3.0
+    assert cleanup_scheduler._next_cleanup_delay_seconds(300, backlog_likely=False) == 300.0
+
+
+def test_leader_skip_preserves_existing_backlog_signal() -> None:
+    assert cleanup_scheduler._merge_backlog_signal(True, None) is True
+    assert cleanup_scheduler._merge_backlog_signal(True, False) is False
+    assert cleanup_scheduler._merge_backlog_signal(False, True) is True
+
+
+def test_operation_retention_cleanup_records_low_cardinality_metrics(monkeypatch) -> None:
+    runs = MagicMock()
+    deleted = MagicMock()
+    duration = MagicMock()
+    backlog = MagicMock()
+    monkeypatch.setattr(cleanup_scheduler, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(cleanup_scheduler, "http_bridge_spool_cleanup_runs_total", runs)
+    monkeypatch.setattr(cleanup_scheduler, "http_bridge_spool_cleanup_deleted_operations_total", deleted)
+    monkeypatch.setattr(cleanup_scheduler, "http_bridge_spool_cleanup_duration_seconds", duration)
+    monkeypatch.setattr(cleanup_scheduler, "http_bridge_spool_cleanup_backlog_likely", backlog)
+
+    cleanup_scheduler._record_operation_retention_cleanup(
+        cleanup_scheduler.OperationRetentionCleanupResult(
+            deleted_operations=50,
+            batches=1,
+            backlog_likely=True,
+            outcome="time_budget_exhausted",
+            duration_seconds=5.25,
+        )
+    )
+
+    runs.labels.assert_called_once_with(outcome="time_budget_exhausted")
+    runs.labels.return_value.inc.assert_called_once_with()
+    deleted.inc.assert_called_once_with(50)
+    duration.observe.assert_called_once_with(5.25)
+    backlog.set.assert_called_once_with(1.0)
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_cleanup_failure_is_observable(monkeypatch) -> None:
+    recorded = MagicMock()
+    bridge_repo = AsyncMock()
+
+    class FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+    )
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    with (
+        patch.object(cleanup_scheduler, "get_background_session", FakeSession),
+        patch.object(cleanup_scheduler, "SettingsRepository"),
+        patch.object(cleanup_scheduler, "StickySessionsRepository"),
+        patch.object(cleanup_scheduler, "DurableBridgeRepository", return_value=bridge_repo),
+        patch.object(cleanup_scheduler, "_get_leader_election", lambda: _FakeLeader()),
+        patch.object(cleanup_scheduler.startup_module, "_bridge_durable_schema_ready", True),
+        patch.object(
+            cleanup_scheduler,
+            "_purge_operation_spool_with_budget",
+            AsyncMock(
+                side_effect=cleanup_scheduler.OperationRetentionCleanupError(
+                    cleanup_scheduler.OperationRetentionCleanupResult(
+                        deleted_operations=50,
+                        batches=1,
+                        backlog_likely=True,
+                        outcome="failed",
+                        duration_seconds=1.5,
+                    ),
+                    error_type="RuntimeError",
+                )
+            ),
+        ),
+        patch.object(cleanup_scheduler, "_record_operation_retention_cleanup", recorded),
+    ):
+        await scheduler._cleanup_once()
+
+    recorded.assert_called_once()
+    result = recorded.call_args.args[0]
+    assert result.deleted_operations == 50
+    assert result.batches == 1
+    assert result.backlog_likely is True
+    assert result.outcome == "failed"
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_failure_log_omits_exception_detail(monkeypatch, caplog) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(
+        side_effect=RuntimeError("operation_id=secret SQL DELETE FROM transcript")
+    )
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+    )
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
+        backlog_likely = await scheduler._run_operation_retention(bridge_repo)
+
+    assert backlog_likely is True
+    assert "deleted_operations=0 batches=0" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert "operation_id=secret" not in caplog.text
+    assert "DELETE FROM" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_catchup_does_not_run_other_maintenance(monkeypatch) -> None:
+    bridge_repo = AsyncMock()
+    run_retention = AsyncMock(return_value=False)
+
+    class FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *args):
+            pass
+
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=True)
+    with (
+        patch.object(cleanup_scheduler, "get_background_session", FakeSession),
+        patch.object(cleanup_scheduler, "DurableBridgeRepository", return_value=bridge_repo),
+        patch.object(cleanup_scheduler, "SettingsRepository") as settings_repository,
+        patch.object(cleanup_scheduler, "StickySessionsRepository") as sticky_repository,
+        patch.object(cleanup_scheduler, "RingMembershipService") as ring_membership_service,
+        patch.object(cleanup_scheduler.startup_module, "_bridge_durable_schema_ready", True),
+        patch.object(
+            cleanup_scheduler.StickySessionCleanupScheduler,
+            "_run_operation_retention",
+            run_retention,
+        ),
+    ):
+        backlog_likely = await scheduler._cleanup_operation_retention_as_leader()
+
+    assert backlog_likely is False
+    run_retention.assert_awaited_once_with(bridge_repo)
+    settings_repository.assert_not_called()
+    sticky_repository.assert_not_called()
+    ring_membership_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prebatch_retention_failure_records_aggregate_metrics(monkeypatch, caplog) -> None:
+    recorded = MagicMock()
+
+    class FailingSession:
+        async def __aenter__(self):
+            raise RuntimeError("operation_id=secret")
+
+        async def __aexit__(self, *args):
+            pass
+
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+    with (
+        patch.object(cleanup_scheduler, "get_background_session", FailingSession),
+        patch.object(cleanup_scheduler, "_record_operation_retention_cleanup", recorded),
+        caplog.at_level("WARNING", logger=cleanup_scheduler.__name__),
+    ):
+        backlog_likely = await scheduler._cleanup_operation_retention_as_leader()
+
+    assert backlog_likely is True
+    result = recorded.call_args.args[0]
+    assert result.outcome == "failed"
+    assert result.deleted_operations == 0
+    assert result.batches == 0
+    assert result.backlog_likely is True
+    assert "error_type=RuntimeError" in caplog.text
+    assert "operation_id=secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unrelated_cleanup_failure_does_not_request_fast_retention_retry(monkeypatch) -> None:
+    class FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *args):
+            pass
+
+    settings_repo = AsyncMock()
+    settings_repo.get_or_create = AsyncMock(side_effect=RuntimeError("settings unavailable"))
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=True)
+    with (
+        patch.object(cleanup_scheduler, "get_background_session", FakeSession),
+        patch.object(cleanup_scheduler, "SettingsRepository", return_value=settings_repo),
+    ):
+        backlog_likely = await scheduler._cleanup_as_leader()
+
+    assert backlog_likely is False
 
 
 @pytest.mark.asyncio
@@ -65,7 +402,7 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     bridge_repo.purge_closed_before = AsyncMock(return_value=2)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=1)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=3)
-    bridge_repo.purge_operation_spool = AsyncMock(return_value=0)
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
     ring_service = AsyncMock()
     ring_service.purge_stale_before = AsyncMock(return_value=0)
 
@@ -97,7 +434,7 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     bridge_repo.purge_closed_before.assert_called_once()
     bridge_repo.purge_abandoned_before.assert_called_once()
     bridge_repo.purge_retry_circuits_before.assert_called_once()
-    bridge_repo.purge_operation_spool.assert_called_once()
+    bridge_repo.purge_operation_spool_batch.assert_called_once()
     ring_service.purge_stale_before.assert_called_once()
     sticky_repo.purge_stale_hard_codex_session_mappings.assert_called_once()
     passed_cutoff = sticky_repo.purge_stale_hard_codex_session_mappings.call_args.args[0]
@@ -131,7 +468,7 @@ async def test_cleanup_once_skips_bridge_purge_when_schema_is_not_ready(monkeypa
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)
-    bridge_repo.purge_operation_spool = AsyncMock(return_value=0)
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
     ring_service = AsyncMock()
     ring_service.purge_stale_before = AsyncMock(return_value=0)
 
@@ -196,7 +533,7 @@ async def test_cleanup_once_purges_bridge_when_schema_exists_after_startup_flag_
     bridge_repo.purge_closed_before = AsyncMock(return_value=1)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)
-    bridge_repo.purge_operation_spool = AsyncMock(return_value=0)
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
     ring_service = AsyncMock()
     ring_service.purge_stale_before = AsyncMock(return_value=2)
 
@@ -228,7 +565,7 @@ async def test_cleanup_once_purges_bridge_when_schema_exists_after_startup_flag_
     bridge_repo.purge_closed_before.assert_called_once()
     bridge_repo.purge_abandoned_before.assert_called_once()
     bridge_repo.purge_retry_circuits_before.assert_called_once()
-    bridge_repo.purge_operation_spool.assert_called_once()
+    bridge_repo.purge_operation_spool_batch.assert_called_once()
     ring_service.purge_stale_before.assert_called_once()
 
 
@@ -287,7 +624,7 @@ async def test_cleanup_once_gates_abandoned_purge_on_prompt_cache_reuse_ttl(monk
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)
-    bridge_repo.purge_operation_spool = AsyncMock(return_value=0)
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
     ring_service = AsyncMock()
     ring_service.purge_stale_before = AsyncMock(return_value=0)
 
@@ -327,7 +664,7 @@ async def test_cleanup_once_retains_operation_purge_when_sticky_cleanup_disabled
     settings_repo = AsyncMock()
     sticky_repo = AsyncMock()
     bridge_repo = AsyncMock()
-    bridge_repo.purge_operation_spool = AsyncMock(return_value=0)
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
 
     class FakeSession:
         async def __aenter__(self):
@@ -356,4 +693,4 @@ async def test_cleanup_once_retains_operation_purge_when_sticky_cleanup_disabled
     settings_repo.get_or_create.assert_not_awaited()
     sticky_repo.purge_prompt_cache_before.assert_not_awaited()
     bridge_repo.purge_closed_before.assert_not_awaited()
-    bridge_repo.purge_operation_spool.assert_awaited_once()
+    bridge_repo.purge_operation_spool_batch.assert_awaited_once()

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -181,6 +181,18 @@ def test_leader_skip_preserves_existing_backlog_signal() -> None:
     assert cleanup_scheduler._merge_backlog_signal(False, True) is True
 
 
+@pytest.mark.asyncio
+async def test_full_cleanup_leader_skip_preserves_existing_backlog_signal(monkeypatch) -> None:
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=True)
+    leader = SimpleNamespace(run_if_leader=AsyncMock(return_value=None))
+    monkeypatch.setattr(cleanup_scheduler, "_get_leader_election", lambda: leader)
+
+    attempted = await scheduler._cleanup_once()
+
+    assert attempted is None
+    assert cleanup_scheduler._merge_backlog_signal(True, attempted) is True
+
+
 def test_operation_retention_cleanup_records_low_cardinality_metrics(monkeypatch) -> None:
     runs = MagicMock()
     deleted = MagicMock()

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -316,6 +316,47 @@ async def test_operation_retention_failure_log_omits_exception_detail(monkeypatc
     assert "error_type=RuntimeError" in caplog.text
     assert "operation_id=secret" not in caplog.text
     assert "DELETE FROM" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_noop_logs_aggregate_without_prometheus(monkeypatch, caplog) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+    )
+    monkeypatch.setattr(cleanup_scheduler, "PROMETHEUS_AVAILABLE", False)
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
+        backlog_likely = await scheduler._run_operation_retention(bridge_repo)
+
+    assert backlog_likely is False
+    assert "deleted_operations=0 batches=1 outcome=completed" in caplog.text
+    assert "backlog_likely=False" in caplog.text
+    assert "error_type=none" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_operation_retention_noop_avoids_duplicate_log_with_prometheus(monkeypatch, caplog) -> None:
+    bridge_repo = AsyncMock()
+    bridge_repo.purge_operation_spool_batch = AsyncMock(return_value=_purge_batch(0))
+    monkeypatch.setattr(
+        cleanup_scheduler,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_spool_retention_seconds=604800.0),
+    )
+    monkeypatch.setattr(cleanup_scheduler, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(cleanup_scheduler, "_record_operation_retention_cleanup", Mock())
+    scheduler = cleanup_scheduler.StickySessionCleanupScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level("INFO", logger=cleanup_scheduler.__name__):
+        backlog_likely = await scheduler._run_operation_retention(bridge_repo)
+
+    assert backlog_likely is False
+    assert "HTTP bridge operation transcript retention" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bound durable HTTP bridge transcript retention so a historical SQLite backlog cannot monopolize the cleanup leader or repeatedly accelerate unrelated maintenance.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none (production SQLite growth/latency incident)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/bound-durable-bridge-spool-cleanup/`

## Changes

- Limit each retention pass by operation batch size, batch count, and monotonic time budget.
- Retry likely backlog on a short cadence without rerunning sticky, bridge-session, or ring maintenance.
- Preserve backlog state across leader skips and distinguish selected rows from rows actually deleted after the owner-fence recheck.
- Record low-cardinality aggregate metrics/logs, including committed progress before a later batch failure, without leaking operation identifiers or SQL details.

## Simplicity

- [x] New behavior works with zero configuration.
- [x] No new required setup step.
- New setting(s): none; fixed internal budgets keep the operator surface unchanged.
- [x] README / `.env.example` / dashboard navigation unchanged.

## Test plan

```text
.venv/bin/pytest -q tests/unit/test_sticky_session_cleanup_scheduler.py tests/unit/test_bridge_ring_lifecycle.py
61 passed

.venv/bin/ruff check ...
All checks passed!

.venv/bin/ty check ...
All checks passed!

npx --yes @fission-ai/openspec validate bound-durable-bridge-spool-cleanup --strict
Change 'bound-durable-bridge-spool-cleanup' is valid
```

## Screenshots / output

Representative bounded production pass after rollout:

```text
deleted_operations=6 batches=1 outcome=completed backlog_likely=False duration_seconds=0.150 error_type=none
```

## Checklist

- [x] Title is in Conventional Commits format.
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] The change-specific strict OpenSpec validation passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable HTTP bridge transcript cleanup now runs in bounded batches and time windows, preventing long-running cleanup passes.
  * Cleanup resumes across scheduled runs and retries promptly when a backlog remains.
  * Transcript cleanup continues independently of sticky-session cleanup settings.

* **Observability**
  * Added metrics and logs for cleanup duration, deleted operations, completion status, failures, progress, and likely remaining backlog.

* **Documentation**
  * Added design and behavioral documentation covering cleanup limits, retries, monitoring, and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->