### PR TITLE
feat(db): add chunk transcript reader

### DIFF
--- a/app/db/alembic/versions/20260826_000000_add_http_bridge_event_chunks.py
+++ b/app/db/alembic/versions/20260826_000000_add_http_bridge_event_chunks.py
@@ -1,0 +1,101 @@
+"""add versioned HTTP bridge event chunks
+
+Revision ID: 20260826_000000_add_http_bridge_event_chunks
+Revises: 20260821_000000_add_retry_circuit_admission_generation
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260826_000000_add_http_bridge_event_chunks"
+down_revision = "20260821_000000_add_retry_circuit_admission_generation"
+branch_labels = None
+depends_on = None
+
+_OPERATIONS_TABLE = "http_bridge_operations"
+_CHUNKS_TABLE = "http_bridge_operation_event_chunks"
+_FORMAT_COLUMN = "spool_format"
+_ROWS_V1 = "rows_v1"
+_CHUNKS_V2 = "chunks_v2"
+
+
+def _has_table(connection: Connection, table_name: str) -> bool:
+    return sa.inspect(connection).has_table(table_name)
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    if not _has_table(connection, table_name):
+        return set()
+    return {str(column["name"]) for column in sa.inspect(connection).get_columns(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _has_table(bind, _OPERATIONS_TABLE) and _FORMAT_COLUMN not in _columns(bind, _OPERATIONS_TABLE):
+        op.add_column(
+            _OPERATIONS_TABLE,
+            sa.Column(
+                _FORMAT_COLUMN,
+                sa.String(16),
+                nullable=False,
+                server_default=sa.text(f"'{_ROWS_V1}'"),
+            ),
+        )
+    if _has_table(bind, _CHUNKS_TABLE):
+        return
+    op.create_table(
+        _CHUNKS_TABLE,
+        sa.Column("operation_id", sa.String(80), nullable=False),
+        sa.Column("first_sequence_number", sa.Integer(), nullable=False),
+        sa.Column("event_count", sa.Integer(), nullable=False),
+        sa.Column("codec", sa.String(64), nullable=False),
+        sa.Column("uncompressed_bytes", sa.Integer(), nullable=False),
+        sa.Column("payload", sa.LargeBinary(), nullable=False),
+        sa.Column("payload_sha256", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "first_sequence_number > 0",
+            name="ck_http_bridge_event_chunks_first_sequence_positive",
+        ),
+        sa.CheckConstraint("event_count > 0", name="ck_http_bridge_event_chunks_event_count_positive"),
+        sa.CheckConstraint(
+            "uncompressed_bytes >= 0",
+            name="ck_http_bridge_event_chunks_bytes_nonnegative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["operation_id"],
+            [f"{_OPERATIONS_TABLE}.operation_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("operation_id", "first_sequence_number"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _has_table(bind, _CHUNKS_TABLE):
+        chunk_exists = bind.execute(sa.text(f"SELECT 1 FROM {_CHUNKS_TABLE} LIMIT 1")).first() is not None
+        if chunk_exists:
+            raise RuntimeError("cannot downgrade while durable transcript chunks exist")
+    if _FORMAT_COLUMN in _columns(bind, _OPERATIONS_TABLE):
+        v2_operation_exists = (
+            bind.execute(
+                sa.text(f"SELECT 1 FROM {_OPERATIONS_TABLE} WHERE {_FORMAT_COLUMN} = :spool_format LIMIT 1"),
+                {"spool_format": _CHUNKS_V2},
+            ).first()
+            is not None
+        )
+        if v2_operation_exists:
+            raise RuntimeError("cannot downgrade while chunks_v2 operations exist")
+    if _has_table(bind, _CHUNKS_TABLE):
+        op.drop_table(_CHUNKS_TABLE)
+    if _FORMAT_COLUMN in _columns(bind, _OPERATIONS_TABLE):
+        if bind.dialect.name == "sqlite":
+            with op.batch_alter_table(_OPERATIONS_TABLE) as batch_op:
+                batch_op.drop_column(_FORMAT_COLUMN)
+        else:
+            op.drop_column(_OPERATIONS_TABLE, _FORMAT_COLUMN)

--- a/app/db/alembic/versions/20260826_000000_add_http_bridge_event_chunks.py
+++ b/app/db/alembic/versions/20260826_000000_add_http_bridge_event_chunks.py
@@ -95,7 +95,13 @@ def downgrade() -> None:
         op.drop_table(_CHUNKS_TABLE)
     if _FORMAT_COLUMN in _columns(bind, _OPERATIONS_TABLE):
         if bind.dialect.name == "sqlite":
-            with op.batch_alter_table(_OPERATIONS_TABLE) as batch_op:
-                batch_op.drop_column(_FORMAT_COLUMN)
+            # SQLite batch migrations recreate and drop the parent table. Keep
+            # its legacy event rows from cascading away while that happens.
+            bind.execute(sa.text("PRAGMA foreign_keys=OFF"))
+            try:
+                with op.batch_alter_table(_OPERATIONS_TABLE) as batch_op:
+                    batch_op.drop_column(_FORMAT_COLUMN)
+            finally:
+                bind.execute(sa.text("PRAGMA foreign_keys=ON"))
         else:
             op.drop_column(_OPERATIONS_TABLE, _FORMAT_COLUMN)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1848,6 +1848,10 @@ class HttpBridgeRecoveryAttemptState(str, Enum):
     REPLAYED = "replayed"
 
 
+HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1 = "rows_v1"
+HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2 = "chunks_v2"
+
+
 class HttpBridgeOperationState(str, Enum):
     SUBMITTED = "submitted"
     UNKNOWN = "unknown"
@@ -1990,6 +1994,12 @@ class HttpBridgeOperationRecord(Base):
     recovery_dispatch_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     event_bytes: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     event_spool_complete: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    spool_format: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
+        server_default=text("'rows_v1'"),
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now(), server_default=func.now()
     )
@@ -2039,6 +2049,33 @@ class HttpBridgeOperationEvent(Base):
             name="uq_http_bridge_operation_events_operation_fingerprint",
         ),
         Index("idx_http_bridge_operation_events_operation_sequence", "operation_id", "sequence_number"),
+    )
+
+
+class HttpBridgeOperationEventChunk(Base):
+    """Compressed, ordered SSE blocks for a future chunk-format operation."""
+
+    __tablename__ = "http_bridge_operation_event_chunks"
+
+    operation_id: Mapped[str] = mapped_column(
+        String(80),
+        ForeignKey("http_bridge_operations.operation_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    first_sequence_number: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    codec: Mapped[str] = mapped_column(String(64), nullable=False)
+    uncompressed_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    payload: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    payload_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=func.now(), server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint("first_sequence_number > 0", name="ck_http_bridge_event_chunks_first_sequence_positive"),
+        CheckConstraint("event_count > 0", name="ck_http_bridge_event_chunks_event_count_positive"),
+        CheckConstraint("uncompressed_bytes >= 0", name="ck_http_bridge_event_chunks_bytes_nonnegative"),
     )
 
 

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.clients.proxy import ProxyResponseError
+from app.core.config.settings import get_settings
 from app.core.errors import openai_error
 from app.core.utils.time import to_utc_naive
 from app.db.models import HttpBridgeSessionState
@@ -570,7 +571,14 @@ class DurableBridgeSessionCoordinator:
 
     async def get_operation_events(self, *, operation_id: str) -> list[str]:
         async with self._session() as session:
-            return await DurableBridgeRepository(session).get_operation_events(operation_id=operation_id)
+            return await DurableBridgeRepository(session).get_operation_events(
+                operation_id=operation_id,
+                max_bytes=int(
+                    getattr(
+                        get_settings(), "http_responses_session_bridge_operation_event_spool_max_bytes", 2 * 1024 * 1024
+                    )
+                ),
+            )
 
     async def get_replayable_transcript(
         self,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -1729,7 +1729,9 @@ class DurableBridgeRepository:
         if operation is None:
             return []
         spool_format = str(operation.spool_format)
-        expected_event_bytes = int(operation.event_bytes or 0)
+        if type(operation.event_bytes) is not int:
+            return []
+        expected_event_bytes = operation.event_bytes
         if expected_event_bytes < 0 or expected_event_bytes > max_bytes:
             return []
         if spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1:
@@ -1757,6 +1759,8 @@ class DurableBridgeRepository:
         remaining_bytes = expected_event_bytes
         events: list[str] = []
         for chunk in chunks:
+            if type(chunk.event_count) is not int or not isinstance(chunk.payload, bytes):
+                return []
             if chunk.first_sequence_number != expected_sequence:
                 return []
             total_event_count += chunk.event_count

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -17,7 +17,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
+    HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+    HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
     HttpBridgeOperationEvent,
+    HttpBridgeOperationEventChunk,
     HttpBridgeOperationRecord,
     HttpBridgeRecoveryAttemptRecord,
     HttpBridgeRecoveryAttemptState,
@@ -33,6 +36,11 @@ from app.modules.proxy.continuity import (
     HTTP_BRIDGE_ACCOUNT_NEUTRAL_REPLAY_REBINDABLE_KINDS,
     is_http_bridge_account_neutral_replay,
 )
+from app.modules.proxy.durable_bridge_transcript_codec import (
+    DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS,
+    DurableBridgeTranscriptDecodeError,
+    decode_durable_bridge_transcript_chunk,
+)
 
 _ANONYMOUS_API_KEY_SCOPE = "__anonymous__"
 REQUIRED_DURABLE_BRIDGE_TABLES = (
@@ -42,6 +50,7 @@ REQUIRED_DURABLE_BRIDGE_TABLES = (
     "http_bridge_recovery_attempts",
     "http_bridge_operations",
     "http_bridge_operation_events",
+    "http_bridge_operation_event_chunks",
 )
 DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS = 3600.0
 _PURGE_CLOSED_BATCH_SIZE = 500
@@ -218,6 +227,31 @@ class DurableBridgeRepository:
     async def _commit_writer_section(self) -> None:
         async with sqlite_writer_section():
             await self._session.commit()
+
+    async def _delete_operation_spool_material(self, operation_ids: Sequence[str]) -> None:
+        if not operation_ids:
+            return
+        await self._session.execute(
+            delete(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id.in_(operation_ids))
+        )
+        await self._session.execute(
+            delete(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id.in_(operation_ids))
+        )
+
+    async def _operation_has_spool_material(self, operation_id: str) -> bool:
+        legacy_event = await self._session.scalar(
+            select(HttpBridgeOperationEvent.event_id)
+            .where(HttpBridgeOperationEvent.operation_id == operation_id)
+            .limit(1)
+        )
+        if legacy_event is not None:
+            return True
+        chunk_sequence = await self._session.scalar(
+            select(HttpBridgeOperationEventChunk.first_sequence_number)
+            .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            .limit(1)
+        )
+        return chunk_sequence is not None
 
     async def get_session(
         self,
@@ -1394,13 +1428,10 @@ class DurableBridgeRepository:
                     # previous attempt's SSE spool atomically so a later
                     # successful retry cannot replay a stale response.failed
                     # event before its fresh response.created sequence.
-                    await self._session.execute(
-                        delete(HttpBridgeOperationEvent).where(
-                            HttpBridgeOperationEvent.operation_id == operation.operation_id
-                        )
-                    )
+                    await self._delete_operation_spool_material((operation.operation_id,))
                     operation.event_bytes = 0
                     operation.event_spool_complete = False
+                    operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
                     operation.updated_at = utcnow()
                     rebound = True
                 if request_text is not None and operation.request_text is None:
@@ -1430,6 +1461,7 @@ class DurableBridgeRepository:
                 # relying on a backend-specific schema default (notably the
                 # pre-existing SQLite default on migrated databases).
                 event_spool_complete=False,
+                spool_format=HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
             )
             self._session.add(operation)
             try:
@@ -1497,11 +1529,10 @@ class DurableBridgeRepository:
             if owner_exists is None or operation is None:
                 await self._session.rollback()
                 return False
-            await self._session.execute(
-                delete(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id == operation_id)
-            )
+            await self._delete_operation_spool_material((operation_id,))
             operation.event_bytes = 0
             operation.event_spool_complete = False
+            operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
             operation.updated_at = utcnow()
             await self._session.commit()
         return True
@@ -1548,14 +1579,13 @@ class DurableBridgeRepository:
             if max_recovery_dispatches is not None and operation.recovery_dispatch_count >= max_recovery_dispatches:
                 await self._session.rollback()
                 return False
-            await self._session.execute(
-                delete(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id == operation_id)
-            )
+            await self._delete_operation_spool_material((operation_id,))
             operation.state = "submitted"
             operation.response_id = None
             operation.recovery_dispatch_count += 1
             operation.event_bytes = 0
             operation.event_spool_complete = False
+            operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
             operation.updated_at = utcnow()
             await self._session.commit()
         return True
@@ -1653,12 +1683,7 @@ class DurableBridgeRepository:
             if owner_exists is None or operation is None:
                 await self._session.rollback()
                 return False
-            has_events = await self._session.scalar(
-                select(HttpBridgeOperationEvent.event_id)
-                .where(HttpBridgeOperationEvent.operation_id == operation_id)
-                .limit(1)
-            )
-            if has_events is not None:
+            if await self._operation_has_spool_material(operation_id):
                 await self._session.rollback()
                 return False
             if restore_rebound:
@@ -1692,13 +1717,69 @@ class DurableBridgeRepository:
         operation = await self._session.scalar(statement)
         return _to_operation_snapshot(operation) if operation is not None else None
 
-    async def get_operation_events(self, *, operation_id: str) -> list[str]:
-        result = await self._session.execute(
-            select(HttpBridgeOperationEvent.event_text)
-            .where(HttpBridgeOperationEvent.operation_id == operation_id)
-            .order_by(HttpBridgeOperationEvent.sequence_number.asc())
-        )
-        return [str(value) for value in result.scalars().all()]
+    async def get_operation_events(self, *, operation_id: str, max_bytes: int = 8 * 1024 * 1024) -> list[str]:
+        operation = (
+            await self._session.execute(
+                select(
+                    HttpBridgeOperationRecord.spool_format,
+                    HttpBridgeOperationRecord.event_bytes,
+                ).where(HttpBridgeOperationRecord.operation_id == operation_id)
+            )
+        ).one_or_none()
+        if operation is None:
+            return []
+        spool_format = str(operation.spool_format)
+        expected_event_bytes = int(operation.event_bytes or 0)
+        if expected_event_bytes < 0 or expected_event_bytes > max_bytes:
+            return []
+        if spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1:
+            result = await self._session.execute(
+                select(HttpBridgeOperationEvent.event_text)
+                .where(HttpBridgeOperationEvent.operation_id == operation_id)
+                .order_by(HttpBridgeOperationEvent.sequence_number.asc())
+            )
+            events = [str(value) for value in result.scalars().all()]
+            if sum(len(event.encode("utf-8")) for event in events) != expected_event_bytes:
+                return []
+            return events
+        if spool_format != HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2:
+            return []
+
+        chunks = (
+            await self._session.execute(
+                select(HttpBridgeOperationEventChunk)
+                .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+                .order_by(HttpBridgeOperationEventChunk.first_sequence_number.asc())
+            )
+        ).scalars()
+        expected_sequence = 1
+        total_event_count = 0
+        remaining_bytes = expected_event_bytes
+        events: list[str] = []
+        for chunk in chunks:
+            if chunk.first_sequence_number != expected_sequence:
+                return []
+            total_event_count += chunk.event_count
+            if total_event_count > DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS:
+                return []
+            try:
+                decoded = decode_durable_bridge_transcript_chunk(
+                    codec=chunk.codec,
+                    payload=bytes(chunk.payload),
+                    event_count=chunk.event_count,
+                    uncompressed_bytes=chunk.uncompressed_bytes,
+                    payload_sha256=chunk.payload_sha256,
+                    max_uncompressed_bytes=remaining_bytes + 4 * chunk.event_count,
+                )
+            except DurableBridgeTranscriptDecodeError:
+                return []
+            decoded_bytes = sum(len(event.encode("utf-8")) for event in decoded)
+            if decoded_bytes > remaining_bytes:
+                return []
+            events.extend(decoded)
+            remaining_bytes -= decoded_bytes
+            expected_sequence += chunk.event_count
+        return events if remaining_bytes == 0 else []
 
     async def get_operation_by_response_id(self, *, response_id: str) -> DurableBridgeOperationSnapshot | None:
         operation = await self._session.scalar(
@@ -1732,7 +1813,13 @@ class DurableBridgeRepository:
             operation = await self.get_operation_by_response_id(response_id=current_response_id)
             if operation is None or operation.request_text is None or not operation.event_spool_complete:
                 return None
-            events = await self.get_operation_events(operation_id=operation.operation_id)
+            remaining_event_bytes = max_bytes - total_bytes - len(operation.request_text.encode("utf-8"))
+            if remaining_event_bytes < 0:
+                return None
+            events = await self.get_operation_events(
+                operation_id=operation.operation_id,
+                max_bytes=remaining_event_bytes,
+            )
             if not events or not any(
                 "response.completed" in event or "response.incomplete" in event for event in events
             ):
@@ -1809,9 +1896,7 @@ class DurableBridgeRepository:
             )
             deleted_ids = [str(value) for value in deleted.scalars().all()]
             if deleted_ids:
-                await self._session.execute(
-                    delete(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id.in_(deleted_ids))
-                )
+                await self._delete_operation_spool_material(deleted_ids)
             await self._session.commit()
         return len(deleted_ids)
 
@@ -1841,6 +1926,7 @@ class DurableBridgeRepository:
                 .where(
                     HttpBridgeOperationRecord.operation_id == operation_id,
                     HttpBridgeOperationRecord.session_id == session_id,
+                    HttpBridgeOperationRecord.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
                 )
                 .with_for_update()
             )
@@ -1902,6 +1988,7 @@ class DurableBridgeRepository:
                     HttpBridgeOperationRecord.operation_id == operation_id,
                     HttpBridgeOperationRecord.session_id == session_id,
                     HttpBridgeOperationRecord.recovery_dispatch_count == expected_recovery_dispatch_count,
+                    HttpBridgeOperationRecord.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
                 )
                 .with_for_update()
             )
@@ -1979,6 +2066,7 @@ class DurableBridgeRepository:
                 .where(
                     HttpBridgeOperationRecord.operation_id == first.operation_id,
                     HttpBridgeOperationRecord.session_id == first.session_id,
+                    HttpBridgeOperationRecord.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
                 )
                 .with_for_update()
             )
@@ -3083,7 +3171,8 @@ async def missing_durable_bridge_tables(session: AsyncSession) -> tuple[str, ...
                 "SELECT name FROM sqlite_master "
                 "WHERE type = 'table' "
                 "AND name IN ('http_bridge_sessions', 'http_bridge_session_aliases', 'http_bridge_retry_circuits', "
-                "'http_bridge_recovery_attempts', 'http_bridge_operations', 'http_bridge_operation_events')"
+                "'http_bridge_recovery_attempts', 'http_bridge_operations', 'http_bridge_operation_events', "
+                "'http_bridge_operation_event_chunks')"
             )
         )
     else:
@@ -3093,7 +3182,8 @@ async def missing_durable_bridge_tables(session: AsyncSession) -> tuple[str, ...
                 "WHERE table_schema = 'public' "
                 "AND table_name IN ("
                 "'http_bridge_sessions', 'http_bridge_session_aliases', 'http_bridge_retry_circuits', "
-                "'http_bridge_recovery_attempts', 'http_bridge_operations', 'http_bridge_operation_events'"
+                "'http_bridge_recovery_attempts', 'http_bridge_operations', 'http_bridge_operation_events', "
+                "'http_bridge_operation_event_chunks'"
                 ")"
             )
         )

--- a/app/modules/proxy/durable_bridge_transcript_codec.py
+++ b/app/modules/proxy/durable_bridge_transcript_codec.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import hmac
+import struct
+import zlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from hashlib import sha256
+
+DURABLE_BRIDGE_CHUNK_CODEC = "zlib-length-prefixed-utf8-v1"
+DURABLE_BRIDGE_CHUNK_MAX_EVENTS = 256
+DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS = 65_536
+_FRAME_LENGTH = struct.Struct(">I")
+
+
+class DurableBridgeTranscriptDecodeError(ValueError):
+    """Raised when a durable chunk cannot be decoded without ambiguity."""
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedDurableBridgeTranscriptChunk:
+    codec: str
+    payload: bytes
+    event_count: int
+    uncompressed_bytes: int
+    payload_sha256: str
+
+
+def encode_durable_bridge_transcript_chunk(
+    events: Sequence[str],
+) -> EncodedDurableBridgeTranscriptChunk:
+    if not events:
+        raise ValueError("durable transcript chunks require at least one event")
+    if len(events) > DURABLE_BRIDGE_CHUNK_MAX_EVENTS:
+        raise ValueError("durable transcript chunk exceeds event-count limit")
+    framed = bytearray()
+    for event in events:
+        encoded = event.encode("utf-8")
+        if len(encoded) > 0xFFFFFFFF:
+            raise ValueError("durable transcript event exceeds framing limit")
+        framed.extend(_FRAME_LENGTH.pack(len(encoded)))
+        framed.extend(encoded)
+    canonical = bytes(framed)
+    return EncodedDurableBridgeTranscriptChunk(
+        codec=DURABLE_BRIDGE_CHUNK_CODEC,
+        payload=zlib.compress(canonical),
+        event_count=len(events),
+        uncompressed_bytes=len(canonical),
+        payload_sha256=sha256(canonical).hexdigest(),
+    )
+
+
+def decode_durable_bridge_transcript_chunk(
+    *,
+    codec: str,
+    payload: bytes,
+    event_count: int,
+    uncompressed_bytes: int,
+    payload_sha256: str,
+    max_uncompressed_bytes: int,
+) -> tuple[str, ...]:
+    if codec != DURABLE_BRIDGE_CHUNK_CODEC:
+        raise DurableBridgeTranscriptDecodeError("unknown durable transcript chunk codec")
+    if type(event_count) is not int or type(uncompressed_bytes) is not int:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk numeric metadata must be integral")
+    if event_count <= 0:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk event count must be positive")
+    if event_count > DURABLE_BRIDGE_CHUNK_MAX_EVENTS:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk exceeds event-count limit")
+    if uncompressed_bytes < 0 or uncompressed_bytes > max_uncompressed_bytes:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk exceeds decode byte limit")
+
+    decompressor = zlib.decompressobj()
+    try:
+        canonical = decompressor.decompress(payload, uncompressed_bytes + 1)
+    except zlib.error as exc:
+        raise DurableBridgeTranscriptDecodeError("invalid durable transcript compressed payload") from exc
+    if (
+        len(canonical) != uncompressed_bytes
+        or decompressor.unconsumed_tail
+        or decompressor.unused_data
+        or not decompressor.eof
+    ):
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk byte count mismatch")
+    try:
+        expected_digest = bytes.fromhex(payload_sha256)
+    except (TypeError, ValueError) as exc:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk hash is not hexadecimal") from exc
+    if len(expected_digest) != sha256().digest_size:
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk hash has invalid length")
+    if not hmac.compare_digest(sha256(canonical).digest(), expected_digest):
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk hash mismatch")
+
+    events: list[str] = []
+    offset = 0
+    for _ in range(event_count):
+        header_end = offset + _FRAME_LENGTH.size
+        if header_end > len(canonical):
+            raise DurableBridgeTranscriptDecodeError("durable transcript chunk has truncated frame header")
+        (event_size,) = _FRAME_LENGTH.unpack(canonical[offset:header_end])
+        event_end = header_end + event_size
+        if event_end > len(canonical):
+            raise DurableBridgeTranscriptDecodeError("durable transcript chunk has truncated event")
+        try:
+            events.append(canonical[header_end:event_end].decode("utf-8"))
+        except UnicodeDecodeError as exc:
+            raise DurableBridgeTranscriptDecodeError("durable transcript chunk contains invalid UTF-8") from exc
+        offset = event_end
+    if offset != len(canonical):
+        raise DurableBridgeTranscriptDecodeError("durable transcript chunk contains trailing bytes")
+    return tuple(events)
+
+
+__all__ = [
+    "DURABLE_BRIDGE_CHUNK_CODEC",
+    "DURABLE_BRIDGE_CHUNK_MAX_EVENTS",
+    "DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS",
+    "DurableBridgeTranscriptDecodeError",
+    "EncodedDurableBridgeTranscriptChunk",
+    "decode_durable_bridge_transcript_chunk",
+    "encode_durable_bridge_transcript_chunk",
+]

--- a/openspec/changes/add-chunked-http-bridge-transcripts/design.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/design.md
@@ -1,0 +1,62 @@
+# Design: Add chunked HTTP bridge transcript storage
+
+## Context
+
+The event batcher persists several SSE blocks in one transaction, but the
+repository still inserts one `http_bridge_operation_events` row per block.
+Recovery later reads those rows in sequence and requires a complete terminal
+spool. Any replacement format must preserve exact strings, duplicate
+occurrences, ordering, byte limits, owner fences, and fail-closed behavior.
+
+## Decisions
+
+### D1. Additive versioned storage
+
+Add `http_bridge_operations.spool_format` with non-null default `rows_v1` so
+all historical and newly written operations retain current behavior. Add a
+chunk table keyed by `(operation_id, first_sequence_number)`. This change adds
+dual readers but does not enable v2 writes.
+
+### D2. Chunk framing and integrity
+
+Frame each event as a four-byte big-endian length followed by strict UTF-8,
+concatenate the frames, and compress the canonical bytes with zlib. Store the
+codec name, event count, uncompressed byte count, compressed payload, and
+SHA-256 of the canonical bytes. Decoding is bounded by the existing transcript
+byte budget and rejects unknown codecs, oversized output, malformed framing,
+invalid UTF-8, hash mismatch, non-contiguous sequence ranges, and trailing
+bytes.
+
+### D3. Exact fail-closed replay
+
+`rows_v1` uses the existing ordered row query. `chunks_v2` reads chunks in
+`first_sequence_number` order, requires contiguous sequence ranges beginning
+at one, and returns no events on any decode or integrity failure. Existing
+replay eligibility then rejects the incomplete transcript without upstream
+redispatch.
+
+### D4. Dual-format lifecycle cleanup
+
+All spool reset/retry/retention paths delete both legacy rows and chunks for
+the selected operation IDs. Rollback-before-dispatch treats either table as
+evidence that dispatch work exists. Operation state and logical `event_bytes`
+remain the single replay-size authority.
+
+### D5. No eager backfill
+
+Legacy rows remain readable and expire through normal retention. Avoiding a
+multi-million-row rewrite keeps rollout latency bounded and makes the expand
+release safe to deploy before the writer cutover.
+
+## Mixed-Version Operation
+
+This release writes only `rows_v1`, so old and new replicas observe the same
+data. A later writer release may produce `chunks_v2` only after every replica
+can read it. Rollback after v2 activation must target this dual-reader release
+or newer.
+
+## Rollback
+
+The migration downgrade removes the additive table and discriminator only when
+no chunk rows and no `chunks_v2` operations exist. Otherwise it fails before
+destructive DDL. Before writer activation, downgrade is data-preserving.

--- a/openspec/changes/add-chunked-http-bridge-transcripts/design.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/design.md
@@ -33,7 +33,9 @@ bytes.
 `first_sequence_number` order, requires contiguous sequence ranges beginning
 at one, and returns no events on any decode or integrity failure. Existing
 replay eligibility then rejects the incomplete transcript without upstream
-redispatch.
+redispatch. The replay reader uses the configured operation spool byte limit,
+so a valid configured transcript is never rejected by a smaller reader-only
+cap.
 
 ### D4. Dual-format lifecycle cleanup
 

--- a/openspec/changes/add-chunked-http-bridge-transcripts/design.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/design.md
@@ -24,8 +24,10 @@ concatenate the frames, and compress the canonical bytes with zlib. Store the
 codec name, event count, uncompressed byte count, compressed payload, and
 SHA-256 of the canonical bytes. Decoding is bounded by the existing transcript
 byte budget and rejects unknown codecs, oversized output, malformed framing,
-invalid UTF-8, hash mismatch, non-contiguous sequence ranges, and trailing
-bytes.
+invalid UTF-8, hash mismatch, non-contiguous sequence ranges, trailing bytes,
+and more than 65,536 events across one operation. The later chunk writer uses
+the same operation-wide event-count limit, so the reader treats a larger
+persisted value as invalid rather than replaying an unbounded event list.
 
 ### D3. Exact fail-closed replay
 

--- a/openspec/changes/add-chunked-http-bridge-transcripts/proposal.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add chunked HTTP bridge transcript storage
+
+## Why
+
+Durable HTTP bridge recovery currently stores one SQLite row, UUID, hash, and
+index entry for every SSE block. High-volume streams create millions of rows
+per retention window even though the in-memory batcher already groups adjacent
+events. The storage layer needs a compact format without weakening restart
+recovery or rolling-deployment safety.
+
+## What Changes
+
+- Add an additive `http_bridge_operation_event_chunks` table and an explicit
+  `spool_format` discriminator on durable operations.
+- Add a deterministic, bounded compressed chunk codec.
+- Read both legacy row transcripts and chunk transcripts while keeping all
+  production writers on `rows_v1` in this change.
+- Make reset, retry, rollback, and retention cleanup understand both storage
+  tables.
+- Refuse a downgrade that would discard chunk-format transcript data.
+
+## Non-Goals
+
+- Enabling chunk writes or changing the writer default.
+- Backfilling legacy event rows.
+- Changing transcript retention windows or replay eligibility.
+- Dropping the legacy event table or reader.
+
+## Impact
+
+- Affected specs: `responses-api-compat`, `database-migrations`.
+- Affected code: DB models/migration, durable bridge codec and repository,
+  focused migration and bridge lifecycle tests.
+- No public API, dashboard, or environment-variable change.

--- a/openspec/changes/add-chunked-http-bridge-transcripts/specs/database-migrations/spec.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/specs/database-migrations/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Chunk transcript schema expands without rewriting history
+
+The chunk transcript migration MUST add the operation format discriminator and
+chunk table without rewriting existing event rows. Existing operation rows
+MUST be classified as `rows_v1`, the migration graph MUST retain one canonical
+head, and upgrade MUST preserve every existing transcript.
+
+#### Scenario: Existing transcript survives upgrade
+
+- **GIVEN** a database with a completed legacy operation and event rows
+- **WHEN** it upgrades through the chunk transcript migration
+- **THEN** the operation is `rows_v1`
+- **AND** all legacy event rows remain unchanged
+
+#### Scenario: New database has both transcript stores
+
+- **WHEN** an empty database upgrades to the canonical head
+- **THEN** both legacy event and chunk tables exist
+- **AND** Alembic reports one head
+
+### Requirement: Chunk schema downgrade refuses data loss
+
+The chunk transcript migration MUST downgrade only while no chunk row and no
+`chunks_v2` operation exists. If chunk-format data exists, downgrade MUST fail
+before dropping the chunk table or operation format discriminator.
+
+#### Scenario: Empty expansion downgrades safely
+
+- **GIVEN** no chunk-format transcript has been written
+- **WHEN** the migration is downgraded
+- **THEN** only the additive chunk schema is removed
+- **AND** legacy events remain intact
+
+#### Scenario: Populated chunk store blocks downgrade
+
+- **GIVEN** at least one chunk row or `chunks_v2` operation exists
+- **WHEN** downgrade is requested
+- **THEN** downgrade fails before destructive DDL
+- **AND** all transcript data remains present

--- a/openspec/changes/add-chunked-http-bridge-transcripts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/specs/responses-api-compat/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Durable recovery transcripts use an explicit storage format
+
+Each durable HTTP bridge operation MUST identify its transcript storage format.
+Existing operations and new operations created before the chunk-writer cutover
+MUST use `rows_v1`. A dual-reader release MUST replay both `rows_v1` event rows
+and `chunks_v2` event chunks without changing the public SSE blocks or their
+order. This expand release MUST continue writing `rows_v1` so rolling
+deployments do not expose chunk-only data to an older replica.
+
+#### Scenario: Historical row transcript remains replayable
+
+- **GIVEN** an existing completed operation whose format is `rows_v1`
+- **WHEN** recovery loads its transcript after the schema expansion
+- **THEN** it receives the same ordered SSE blocks as before the migration
+
+#### Scenario: Chunk transcript replays exact events
+
+- **GIVEN** a completed `chunks_v2` operation with valid contiguous chunks
+- **WHEN** recovery loads its transcript
+- **THEN** every original SSE block is returned byte-for-byte in sequence order
+
+#### Scenario: Expand release keeps the legacy writer
+
+- **WHEN** the dual-reader release records or appends an ordinary operation
+- **THEN** it persists the operation and events in `rows_v1` format
+
+### Requirement: Chunk transcript decoding fails closed
+
+Chunk decoding MUST enforce the operation's logical transcript byte bound and
+MUST reject unknown codecs, decompression beyond the declared bound, hash or
+byte-count mismatch, non-hexadecimal or incorrectly sized hashes, malformed
+framing, invalid UTF-8, incorrect event count,
+non-contiguous sequence ranges, and trailing bytes. Any rejected chunk MUST
+make the transcript ineligible for recovery and MUST NOT produce a partial
+replay or a new upstream dispatch.
+
+#### Scenario: Corrupt chunk produces no partial transcript
+
+- **GIVEN** a chunk payload whose hash, framing, or declared counts are invalid
+- **WHEN** recovery loads the operation
+- **THEN** the transcript is ineligible and no prefix is replayed
+
+#### Scenario: Sequence gap produces no partial transcript
+
+- **GIVEN** individually valid chunks whose sequence ranges contain a gap or
+  overlap
+- **WHEN** recovery loads the operation
+- **THEN** the transcript is ineligible
+
+#### Scenario: Logical event byte mismatch produces no transcript
+
+- **GIVEN** decoded events do not total the operation's persisted `event_bytes`
+- **WHEN** recovery loads either storage format
+- **THEN** the transcript is ineligible
+
+### Requirement: Transcript lifecycle handles both storage formats
+
+Spool reset, failed-operation retry, rollback-before-dispatch, and retention
+cleanup MUST inspect or delete both legacy event rows and event chunks under
+the existing owner and operation fences. A format transition MUST NOT leave
+stale transcript material that a later retry can mix into a fresh response.
+Any path that clears all transcript material for a retry MUST reset the format
+to `rows_v1` in the same transaction so the expand release remains a usable
+rollback writer.
+
+#### Scenario: Retry clears both transcript stores
+
+- **GIVEN** an operation has legacy or chunk transcript material
+- **WHEN** an owner-fenced retry resets the spool
+- **THEN** both event stores are empty before new output is accepted
+
+#### Scenario: Rollback refuses an operation with chunk evidence
+
+- **GIVEN** an operation has a persisted chunk
+- **WHEN** rollback-before-dispatch checks whether upstream work exists
+- **THEN** it preserves the operation instead of deleting its durable fence

--- a/openspec/changes/add-chunked-http-bridge-transcripts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/specs/responses-api-compat/spec.md
@@ -29,7 +29,9 @@ deployments do not expose chunk-only data to an older replica.
 ### Requirement: Chunk transcript decoding fails closed
 
 Chunk decoding MUST enforce the operation's logical transcript byte bound and
-MUST reject unknown codecs, decompression beyond the declared bound, hash or
+the 65,536-event operation-wide chunk transcript limit. The chunk writer MUST
+reject transcript growth beyond that same limit. Chunk decoding MUST reject
+unknown codecs, decompression beyond the declared bound, hash or
 byte-count mismatch, non-hexadecimal or incorrectly sized hashes, malformed
 framing, invalid UTF-8, incorrect event count,
 non-contiguous sequence ranges, and trailing bytes. Any rejected chunk MUST

--- a/openspec/changes/add-chunked-http-bridge-transcripts/tasks.md
+++ b/openspec/changes/add-chunked-http-bridge-transcripts/tasks.md
@@ -1,0 +1,24 @@
+## 1. Specification
+
+- [x] 1.1 Specify versioned dual-format transcript reads and fail-closed
+      decoding.
+- [x] 1.2 Specify additive migration and guarded downgrade behavior.
+
+## 2. Migration and codec
+
+- [x] 2.1 Add `spool_format` and chunk ORM models plus a single-head Alembic
+      revision.
+- [x] 2.2 Implement deterministic bounded chunk encode/decode helpers.
+- [x] 2.3 Add migration upgrade/downgrade and codec regression coverage.
+
+## 3. Dual reader and lifecycle
+
+- [x] 3.1 Dispatch transcript reads by format without changing the v1 writer.
+- [x] 3.2 Make reset, retry, rollback, and retention delete/check both formats.
+- [x] 3.3 Cover v1/v2 replay equivalence, corrupt chunks, and lifecycle cleanup.
+
+## 4. Verification
+
+- [x] 4.1 Run migration upgrade/check/downgrade coverage.
+- [x] 4.2 Run focused bridge lifecycle, Ruff, and type checks.
+- [x] 4.3 Run strict OpenSpec validation and `git diff --check`.

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -4,7 +4,8 @@ from collections.abc import Callable
 
 import pytest
 from anyio import to_thread
-from sqlalchemy import text
+from sqlalchemy import event, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.core.auth import DEFAULT_PLAN
@@ -1928,6 +1929,13 @@ async def test_http_bridge_event_chunks_migration_preserves_legacy_and_guards_do
             "operation_columns": {column["name"] for column in inspector.get_columns("http_bridge_operations")},
         }
 
+    def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
     await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
     engine = create_async_engine(db_url, future=True)
     try:
@@ -1989,7 +1997,11 @@ async def test_http_bridge_event_chunks_migration_preserves_legacy_and_guards_do
             ).scalar_one() == "legacy-event"
 
         config = _build_alembic_config(db_url)
-        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        event.listen(Engine, "connect", _enable_sqlite_foreign_keys)
+        try:
+            await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        finally:
+            event.remove(Engine, "connect", _enable_sqlite_foreign_keys)
         async with engine.connect() as conn:
             state = await conn.run_sync(_schema_state)
             assert state["has_chunks"] is False

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1908,3 +1908,136 @@ async def test_file_account_pins_migration_upgrade_and_downgrade(tmp_path):
             assert await conn.run_sync(_schema_state) is not None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_event_chunks_migration_preserves_legacy_and_guards_downgrade(tmp_path):
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'http-bridge-event-chunks.sqlite'}"
+    parent_revision = "20260821_000000_add_retry_circuit_admission_generation"
+    chunk_revision = "20260826_000000_add_http_bridge_event_chunks"
+
+    def _schema_state(sync_conn):
+        inspector = sa_inspect(sync_conn)
+        return {
+            "has_chunks": inspector.has_table("http_bridge_operation_event_chunks"),
+            "operation_columns": {column["name"] for column in inspector.get_columns("http_bridge_operations")},
+        }
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_sessions (
+                        id, session_key_kind, session_key_value, session_key_hash,
+                        api_key_scope, owner_epoch, state, created_at, updated_at, last_seen_at
+                    ) VALUES (
+                        'session-legacy', 'session_header', 'legacy', 'legacy-hash',
+                        '__anonymous__', 0, 'closed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_operations (
+                        operation_id, session_id, request_fingerprint, request_text,
+                        state, response_id, recovery_dispatch_count, event_bytes,
+                        event_spool_complete, created_at, updated_at
+                    ) VALUES (
+                        'operation-legacy', 'session-legacy', 'fingerprint-legacy', '{}',
+                        'completed', 'response-legacy', 0, 8, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_operation_events (
+                        event_id, operation_id, sequence_number, event_fingerprint, event_text, created_at
+                    ) VALUES (
+                        'event-legacy', 'operation-legacy', 1, 'event-fingerprint',
+                        'legacy-event', CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, chunk_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+            assert state["has_chunks"] is True
+            assert "spool_format" in state["operation_columns"]
+            assert (
+                await conn.execute(
+                    text("SELECT spool_format FROM http_bridge_operations WHERE operation_id = 'operation-legacy'")
+                )
+            ).scalar_one() == "rows_v1"
+            assert (
+                await conn.execute(
+                    text("SELECT event_text FROM http_bridge_operation_events WHERE event_id = 'event-legacy'")
+                )
+            ).scalar_one() == "legacy-event"
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+            assert state["has_chunks"] is False
+            assert "spool_format" not in state["operation_columns"]
+            assert (
+                await conn.execute(
+                    text("SELECT event_text FROM http_bridge_operation_events WHERE event_id = 'event-legacy'")
+                )
+            ).scalar_one() == "legacy-event"
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, chunk_revision, bootstrap_legacy=False))
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE http_bridge_operations SET spool_format = 'chunks_v2' "
+                    "WHERE operation_id = 'operation-legacy'"
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="cannot downgrade while chunks_v2 operations exist"):
+            await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE http_bridge_operations SET spool_format = 'rows_v1' WHERE operation_id = 'operation-legacy'"
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_operation_event_chunks (
+                        operation_id, first_sequence_number, event_count, codec,
+                        uncompressed_bytes, payload, payload_sha256, created_at
+                    ) VALUES (
+                        'operation-legacy', 1, 1, 'test-codec', 1, X'00', 'chunk-hash', CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="cannot downgrade while durable transcript chunks exist"):
+            await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+            assert state["has_chunks"] is True
+            assert "spool_format" in state["operation_columns"]
+            assert (
+                await conn.execute(text("SELECT COUNT(*) FROM http_bridge_operation_event_chunks"))
+            ).scalar_one() == 1
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -19,9 +19,12 @@ from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import Settings
 from app.core.utils.time import utcnow
 from app.db.models import (
+    HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+    HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
     AccountStatus,
     Base,
     BridgeRingMember,
+    HttpBridgeOperationEventChunk,
     HttpBridgeOperationRecord,
     HttpBridgeRetryCircuit,
     HttpBridgeSessionAlias,
@@ -41,7 +44,9 @@ from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeRepository,
     durable_bridge_hash,
     durable_bridge_operation_id,
+    missing_durable_bridge_tables,
 )
+from app.modules.proxy.durable_bridge_transcript_codec import encode_durable_bridge_transcript_chunk
 from app.modules.proxy.http_bridge_event_batcher import HttpBridgeOperationEventBatcher
 from app.modules.proxy.ring_membership import RingMembershipService
 
@@ -614,6 +619,9 @@ async def test_operation_ledger_is_fenced_and_idempotent(
         assert created.state == "submitted"
         assert created.request_text == '{"model":"gpt-5.6","input":"turn"}'
         assert created.event_spool_complete is False
+        operation_row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert operation_row is not None
+        assert operation_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
 
         existing = await repository.record_operation(
             operation_id=operation_id,
@@ -677,6 +685,309 @@ async def test_operation_ledger_is_fenced_and_idempotent(
         # A missing parent turn makes the chain ineligible rather than
         # silently constructing an incomplete conversation.
         assert await repository.get_replayable_transcript(response_id="resp-completed") is None
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_operation_replays_exact_events(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-replay", session_key_value="sid-chunk-replay")
+        fingerprint = durable_bridge_hash("chunk-replay")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        operation = await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-replay",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+            request_text='{"model":"gpt-5.6","input":"turn"}',
+        )
+        assert operation is not None
+        first_events = (
+            'data: {"type":"response.created"}\n\n',
+            'data: {"type":"response.output_text.delta","delta":"안녕"}\n\n',
+        )
+        terminal_events = (
+            'data: {"type":"response.completed"}\n\n',
+            'data: {"type":"response.completed"}\n\n',
+        )
+        first_chunk = encode_durable_bridge_transcript_chunk(first_events)
+        terminal_chunk = encode_durable_bridge_transcript_chunk(terminal_events)
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(
+                spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+                state="completed",
+                response_id="resp-chunk-completed",
+                event_spool_complete=True,
+                event_bytes=sum(len(event.encode("utf-8")) for event in first_events + terminal_events),
+            )
+        )
+        session.add_all(
+            [
+                HttpBridgeOperationEventChunk(
+                    operation_id=operation_id,
+                    first_sequence_number=1,
+                    event_count=first_chunk.event_count,
+                    codec=first_chunk.codec,
+                    uncompressed_bytes=first_chunk.uncompressed_bytes,
+                    payload=first_chunk.payload,
+                    payload_sha256=first_chunk.payload_sha256,
+                ),
+                HttpBridgeOperationEventChunk(
+                    operation_id=operation_id,
+                    first_sequence_number=3,
+                    event_count=terminal_chunk.event_count,
+                    codec=terminal_chunk.codec,
+                    uncompressed_bytes=terminal_chunk.uncompressed_bytes,
+                    payload=terminal_chunk.payload,
+                    payload_sha256=terminal_chunk.payload_sha256,
+                ),
+            ]
+        )
+        await session.commit()
+
+        expected = list(first_events + terminal_events)
+        assert await repository.get_operation_events(operation_id=operation_id) == expected
+        transcript = await repository.get_replayable_transcript(response_id="resp-chunk-completed")
+        assert transcript is not None
+        assert len(transcript) == 1
+        assert transcript[0].events == tuple(expected)
+
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(event_bytes=sum(len(event.encode("utf-8")) for event in expected) - 1)
+        )
+        await session.commit()
+        assert await repository.get_operation_events(operation_id=operation_id) == []
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first_sequence_number,payload_sha256", [(2, None), (1, "0" * 64)])
+async def test_chunk_operation_rejects_sequence_gap_or_corruption(
+    async_session_factory: Callable[[], AsyncSession],
+    first_sequence_number: int,
+    payload_sha256: str | None,
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-invalid", session_key_value="sid-chunk-invalid")
+        fingerprint = durable_bridge_hash(f"chunk-invalid:{first_sequence_number}:{payload_sha256}")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-invalid",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+            request_text='{"input":"turn"}',
+        )
+        encoded = encode_durable_bridge_transcript_chunk(('data: {"type":"response.completed"}\n\n',))
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(
+                spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+                state="completed",
+                response_id=f"resp-{operation_id}",
+                event_spool_complete=True,
+            )
+        )
+        session.add(
+            HttpBridgeOperationEventChunk(
+                operation_id=operation_id,
+                first_sequence_number=first_sequence_number,
+                event_count=encoded.event_count,
+                codec=encoded.codec,
+                uncompressed_bytes=encoded.uncompressed_bytes,
+                payload=encoded.payload,
+                payload_sha256=payload_sha256 or encoded.payload_sha256,
+            )
+        )
+        await session.commit()
+
+        assert await repository.get_operation_events(operation_id=operation_id) == []
+        assert await repository.get_replayable_transcript(response_id=f"resp-{operation_id}") is None
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_spool_blocks_rollback_and_is_cleared_by_reset(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-reset", session_key_value="sid-chunk-reset")
+        fingerprint = durable_bridge_hash("chunk-reset")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-reset",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        encoded = encode_durable_bridge_transcript_chunk(("event",))
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2)
+        )
+        await session.commit()
+        assert not await repository.append_operation_event(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-reset",
+            owner_epoch=claim.owner_epoch,
+            event_text="must-not-mix-formats",
+            max_bytes=1024,
+        )
+        session.add(
+            HttpBridgeOperationEventChunk(
+                operation_id=operation_id,
+                first_sequence_number=1,
+                event_count=encoded.event_count,
+                codec=encoded.codec,
+                uncompressed_bytes=encoded.uncompressed_bytes,
+                payload=encoded.payload,
+                payload_sha256=encoded.payload_sha256,
+            )
+        )
+        await session.commit()
+
+        assert not await repository.rollback_operation_before_dispatch(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-reset",
+            owner_epoch=claim.owner_epoch,
+        )
+        assert await repository.reset_operation_event_spool(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-reset",
+            owner_epoch=claim.owner_epoch,
+        )
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            )
+            is None
+        )
+        reset_row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert reset_row is not None
+        assert reset_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_durable_bridge_presence_query_includes_chunk_table(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        assert await missing_durable_bridge_tables(session) == ()
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_format_resets_on_failed_rebind_and_unknown_claim(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-format-reset", session_key_value="sid-format-reset")
+        encoded = encode_durable_bridge_transcript_chunk(("event",))
+
+        async def seed(operation_id: str, fingerprint: str, state: str) -> None:
+            assert await repository.record_operation(
+                operation_id=operation_id,
+                session_id=claim.id,
+                instance_id="inst-format-reset",
+                owner_epoch=claim.owner_epoch,
+                request_fingerprint=fingerprint,
+                account_id="account-operation",
+                model="gpt-5.6",
+                parent_response_id=None,
+            )
+            await session.execute(
+                update(HttpBridgeOperationRecord)
+                .where(HttpBridgeOperationRecord.operation_id == operation_id)
+                .values(
+                    state=state,
+                    spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+                    event_bytes=len("event"),
+                )
+            )
+            session.add(
+                HttpBridgeOperationEventChunk(
+                    operation_id=operation_id,
+                    first_sequence_number=1,
+                    event_count=encoded.event_count,
+                    codec=encoded.codec,
+                    uncompressed_bytes=encoded.uncompressed_bytes,
+                    payload=encoded.payload,
+                    payload_sha256=encoded.payload_sha256,
+                )
+            )
+            await session.commit()
+
+        failed_fingerprint = durable_bridge_hash("failed-format-reset")
+        failed_operation_id = durable_bridge_operation_id(claim.id, failed_fingerprint)
+        await seed(failed_operation_id, failed_fingerprint, "failed")
+        rebound = await repository.record_operation(
+            operation_id=failed_operation_id,
+            session_id=claim.id,
+            instance_id="inst-format-reset",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=failed_fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        assert rebound is not None and rebound.rebound is True
+        failed_row = await session.get(HttpBridgeOperationRecord, failed_operation_id)
+        assert failed_row is not None
+        assert failed_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
+        assert failed_row.event_bytes == 0
+
+        unknown_fingerprint = durable_bridge_hash("unknown-format-reset")
+        unknown_operation_id = durable_bridge_operation_id(claim.id, unknown_fingerprint)
+        await seed(unknown_operation_id, unknown_fingerprint, "unknown")
+        assert await repository.claim_unknown_operation_for_recovery(
+            operation_id=unknown_operation_id,
+            session_id=claim.id,
+            instance_id="inst-format-reset",
+            owner_epoch=claim.owner_epoch,
+        )
+        unknown_row = await session.get(HttpBridgeOperationRecord, unknown_operation_id)
+        assert unknown_row is not None
+        await session.refresh(unknown_row)
+        assert unknown_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
+        assert unknown_row.event_bytes == 0
     finally:
         await session.close()
 
@@ -1465,10 +1776,25 @@ async def test_operation_spool_purge_expires_stale_nonterminal_rows(
             owner_epoch=claim.owner_epoch,
             state="unknown",
         )
+        encoded = encode_durable_bridge_transcript_chunk(("stale-event",))
+        session.add(
+            HttpBridgeOperationEventChunk(
+                operation_id=operation_id,
+                first_sequence_number=1,
+                event_count=encoded.event_count,
+                codec=encoded.codec,
+                uncompressed_bytes=encoded.uncompressed_bytes,
+                payload=encoded.payload,
+                payload_sha256=encoded.payload_sha256,
+            )
+        )
         await session.execute(
             update(HttpBridgeOperationRecord)
             .where(HttpBridgeOperationRecord.operation_id == operation_id)
-            .values(updated_at=stale_at)
+            .values(
+                updated_at=stale_at,
+                spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+            )
         )
         await session.commit()
 
@@ -1476,6 +1802,12 @@ async def test_operation_spool_purge_expires_stale_nonterminal_rows(
         # session is still owned and leased; it may be a long-running recovery
         # request whose duplicate-suppression fence must remain intact.
         assert await repository.purge_operation_spool(cutoff=datetime.now(timezone.utc).replace(tzinfo=None)) == 0
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            )
+            is not None
+        )
         await session.execute(
             update(HttpBridgeSessionRecord)
             .where(HttpBridgeSessionRecord.id == claim.id)
@@ -1484,6 +1816,12 @@ async def test_operation_spool_purge_expires_stale_nonterminal_rows(
         await session.commit()
         assert await repository.purge_operation_spool(cutoff=datetime.now(timezone.utc).replace(tzinfo=None)) == 1
         assert await repository.get_operation(operation_id=operation_id) is None
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            )
+            is None
+        )
     finally:
         await session.close()
 

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -15,6 +15,7 @@ import pytest
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+import app.modules.proxy.durable_bridge_coordinator as durable_bridge_coordinator_module
 from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import Settings
 from app.core.utils.time import utcnow
@@ -60,6 +61,28 @@ def _share_proxy_dashboard_settings(monkeypatch: pytest.MonkeyPatch) -> None:
             return proxy_service.get_settings()
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache())
+
+
+@pytest.mark.asyncio
+async def test_operation_event_reader_uses_configured_spool_limit(monkeypatch) -> None:
+    session = AsyncMock()
+    repository = AsyncMock()
+    repository.get_operation_events = AsyncMock(return_value=["event"])
+    close_session = AsyncMock()
+    max_bytes = 9 * 1024 * 1024
+    monkeypatch.setattr(durable_bridge_coordinator_module, "DurableBridgeRepository", lambda _session: repository)
+    monkeypatch.setattr(durable_bridge_coordinator_module, "close_session", close_session)
+    monkeypatch.setattr(
+        durable_bridge_coordinator_module,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_operation_event_spool_max_bytes=max_bytes),
+    )
+    coordinator = DurableBridgeSessionCoordinator(lambda: session)
+
+    assert await coordinator.get_operation_events(operation_id="operation") == ["event"]
+
+    repository.get_operation_events.assert_awaited_once_with(operation_id="operation", max_bytes=max_bytes)
+    close_session.assert_awaited_once_with(session)
 
 
 @pytest.fixture

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock
 
 import anyio
 import pytest
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.clients.proxy import ProxyResponseError
@@ -769,6 +769,70 @@ async def test_chunk_operation_replays_exact_events(
             .values(event_bytes=sum(len(event.encode("utf-8")) for event in expected) - 1)
         )
         await session.commit()
+        assert await repository.get_operation_events(operation_id=operation_id) == []
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("table_name", "column_name", "value"),
+    [
+        ("http_bridge_operations", "event_bytes", 1.5),
+        ("http_bridge_operation_event_chunks", "event_count", "not-an-integer"),
+        ("http_bridge_operation_event_chunks", "payload", "not-binary"),
+    ],
+)
+async def test_chunk_operation_rejects_malformed_persisted_metadata(
+    async_session_factory: Callable[[], AsyncSession],
+    table_name: str,
+    column_name: str,
+    value: object,
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-metadata", session_key_value="sid-chunk-metadata")
+        fingerprint = durable_bridge_hash(f"chunk-metadata:{table_name}:{column_name}")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-metadata",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+            request_text='{"input":"turn"}',
+        )
+        encoded = encode_durable_bridge_transcript_chunk(("a",))
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(
+                spool_format=HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
+                event_bytes=1,
+            )
+        )
+        session.add(
+            HttpBridgeOperationEventChunk(
+                operation_id=operation_id,
+                first_sequence_number=1,
+                event_count=encoded.event_count,
+                codec=encoded.codec,
+                uncompressed_bytes=encoded.uncompressed_bytes,
+                payload=encoded.payload,
+                payload_sha256=encoded.payload_sha256,
+            )
+        )
+        await session.commit()
+        await session.execute(
+            text(f"UPDATE {table_name} SET {column_name} = :value WHERE operation_id = :operation_id"),
+            {"value": value, "operation_id": operation_id},
+        )
+        await session.commit()
+
         assert await repository.get_operation_events(operation_id=operation_id) == []
     finally:
         await session.close()

--- a/tests/unit/test_durable_bridge_transcript_codec.py
+++ b/tests/unit/test_durable_bridge_transcript_codec.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import zlib
+from hashlib import sha256
+from typing import Any, cast
+
+import pytest
+
+from app.modules.proxy.durable_bridge_transcript_codec import (
+    DURABLE_BRIDGE_CHUNK_CODEC,
+    DURABLE_BRIDGE_CHUNK_MAX_EVENTS,
+    DurableBridgeTranscriptDecodeError,
+    decode_durable_bridge_transcript_chunk,
+    encode_durable_bridge_transcript_chunk,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _decode(encoded, *, max_uncompressed_bytes: int | None = None) -> tuple[str, ...]:
+    return decode_durable_bridge_transcript_chunk(
+        codec=encoded.codec,
+        payload=encoded.payload,
+        event_count=encoded.event_count,
+        uncompressed_bytes=encoded.uncompressed_bytes,
+        payload_sha256=encoded.payload_sha256,
+        max_uncompressed_bytes=max_uncompressed_bytes or encoded.uncompressed_bytes,
+    )
+
+
+def test_chunk_codec_round_trips_exact_events_and_duplicates() -> None:
+    events = (
+        'event: response.output_text.delta\ndata: {"delta":"안녕"}\n\n',
+        "",
+        'data: {"type":"response.completed"}\n\n',
+        'data: {"type":"response.completed"}\n\n',
+    )
+
+    encoded = encode_durable_bridge_transcript_chunk(events)
+
+    assert encoded.codec == DURABLE_BRIDGE_CHUNK_CODEC
+    assert encoded.event_count == len(events)
+    assert _decode(encoded) == events
+
+
+def test_chunk_codec_rejects_empty_input() -> None:
+    with pytest.raises(ValueError, match="at least one event"):
+        encode_durable_bridge_transcript_chunk(())
+
+    with pytest.raises(ValueError, match="event-count limit"):
+        encode_durable_bridge_transcript_chunk(tuple("event" for _ in range(DURABLE_BRIDGE_CHUNK_MAX_EVENTS + 1)))
+
+
+def test_chunk_codec_rejects_unknown_codec_and_oversized_output() -> None:
+    encoded = encode_durable_bridge_transcript_chunk(("event",))
+
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="unknown"):
+        decode_durable_bridge_transcript_chunk(
+            codec="unknown",
+            payload=encoded.payload,
+            event_count=encoded.event_count,
+            uncompressed_bytes=encoded.uncompressed_bytes,
+            payload_sha256=encoded.payload_sha256,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="byte limit"):
+        _decode(encoded, max_uncompressed_bytes=encoded.uncompressed_bytes - 1)
+
+
+def test_chunk_codec_rejects_hash_mismatch_and_trailing_stream() -> None:
+    encoded = encode_durable_bridge_transcript_chunk(("event",))
+
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="hash mismatch"):
+        decode_durable_bridge_transcript_chunk(
+            codec=encoded.codec,
+            payload=encoded.payload,
+            event_count=encoded.event_count,
+            uncompressed_bytes=encoded.uncompressed_bytes,
+            payload_sha256="0" * 64,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="byte count mismatch"):
+        decode_durable_bridge_transcript_chunk(
+            codec=encoded.codec,
+            payload=encoded.payload + zlib.compress(b"extra"),
+            event_count=encoded.event_count,
+            uncompressed_bytes=encoded.uncompressed_bytes,
+            payload_sha256=encoded.payload_sha256,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )
+
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="not hexadecimal"):
+        decode_durable_bridge_transcript_chunk(
+            codec=encoded.codec,
+            payload=encoded.payload,
+            event_count=encoded.event_count,
+            uncompressed_bytes=encoded.uncompressed_bytes,
+            payload_sha256="가" * 64,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )
+
+
+def test_chunk_codec_rejects_malformed_framing_and_invalid_utf8() -> None:
+    malformed = b"\x00\x00\x00\x05abc"
+    invalid_utf8 = b"\x00\x00\x00\x01\xff"
+
+    for canonical, message in (
+        (malformed, "truncated event"),
+        (invalid_utf8, "invalid UTF-8"),
+    ):
+        with pytest.raises(DurableBridgeTranscriptDecodeError, match=message):
+            decode_durable_bridge_transcript_chunk(
+                codec=DURABLE_BRIDGE_CHUNK_CODEC,
+                payload=zlib.compress(canonical),
+                event_count=1,
+                uncompressed_bytes=len(canonical),
+                payload_sha256=sha256(canonical).hexdigest(),
+                max_uncompressed_bytes=len(canonical),
+            )
+
+
+def test_chunk_codec_rejects_declared_event_count_with_trailing_bytes() -> None:
+    encoded = encode_durable_bridge_transcript_chunk(("one", "two"))
+
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="trailing bytes"):
+        decode_durable_bridge_transcript_chunk(
+            codec=encoded.codec,
+            payload=encoded.payload,
+            event_count=1,
+            uncompressed_bytes=encoded.uncompressed_bytes,
+            payload_sha256=encoded.payload_sha256,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )
+
+
+@pytest.mark.parametrize(
+    ("event_count", "uncompressed_bytes"),
+    [
+        (1.5, 8),
+        (True, 8),
+        (1, 8.5),
+        (1, False),
+    ],
+)
+def test_chunk_codec_rejects_non_integral_numeric_metadata(
+    event_count: object,
+    uncompressed_bytes: object,
+) -> None:
+    encoded = encode_durable_bridge_transcript_chunk(("test",))
+
+    with pytest.raises(DurableBridgeTranscriptDecodeError, match="must be integral"):
+        decode_durable_bridge_transcript_chunk(
+            codec=encoded.codec,
+            payload=encoded.payload,
+            event_count=cast(Any, event_count),
+            uncompressed_bytes=cast(Any, uncompressed_bytes),
+            payload_sha256=encoded.payload_sha256,
+            max_uncompressed_bytes=encoded.uncompressed_bytes,
+        )


### PR DESCRIPTION
## Summary

Add an additive, versioned chunk representation and dual reader for durable HTTP bridge transcripts, preparing the storage path to avoid one SQLite row per SSE event.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none (production SQLite growth/latency incident)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent SSE event framing

Change directory: `openspec/changes/add-chunked-http-bridge-transcripts/`

## Changes

- Add `spool_format` and `http_bridge_operation_event_chunks` through an additive Alembic migration; existing operations default to `rows_v1`.
- Add a bounded zlib + length-prefixed UTF-8 codec with byte count, event count, and SHA-256 verification.
- Read `rows_v1` and `chunks_v2` transcripts without changing replay ordering or terminal requirements.
- Fail closed on malformed numeric metadata, truncated frames, invalid UTF-8, hash mismatch, or aggregate-byte mismatch.
- Keep downgrade guarded while any v2 operation or chunk exists.

## Simplicity

- [x] New capability defaults to the existing `rows_v1` representation.
- [x] No new required setup step.
- New setting(s): none in this reader/migration PR.
- [x] README / `.env.example` / dashboard navigation unchanged.

## Test plan

```text
.venv/bin/pytest -q tests/unit/test_durable_bridge_transcript_codec.py tests/unit/test_bridge_ring_lifecycle.py tests/integration/test_migrations.py
85 passed, 5 skipped

.venv/bin/ruff check ...
All checks passed!

.venv/bin/ty check ...
All checks passed!

npx --yes @fission-ai/openspec validate add-chunked-http-bridge-transcripts --strict
Change 'add-chunked-http-bridge-transcripts' is valid
```

## Screenshots / output

No dashboard-visible change. Migration integration covers fresh install, upgrade, guarded downgrade, and idempotence.

## Checklist

- [x] Title is in Conventional Commits format.
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] The change-specific strict OpenSpec validation passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact, chunk-based storage for durable HTTP bridge transcripts.
  * Supports replay across legacy and chunked formats with compression, size limits, sequencing, and checksum validation.
  * Added configurable limits for transcript data retrieval.

* **Bug Fixes**
  * Improved transcript cleanup during retries, rollbacks, purges, and recovery.
  * Corrupted or malformed transcript data now fails safely.

* **Compatibility**
  * Existing transcripts remain available without migration or backfill.
  * Rollbacks are protected while chunked transcript data remains present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->