### PR TITLE
feat(proxy): enable chunk transcript writer

### DIFF
--- a/app/core/config/key_fingerprint.py
+++ b/app/core/config/key_fingerprint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 from collections.abc import Callable
@@ -8,6 +9,7 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.settings import get_settings
@@ -18,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 ENCRYPTION_KEY_FINGERPRINT_SENTINEL = "encryption_key_fingerprint"
 _FINGERPRINT_PREFIX_CHARS = 12
+_SQLITE_LOCK_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
 
 
 class EncryptionKeyFingerprintMismatchError(RuntimeError):
@@ -32,6 +35,11 @@ def compute_encryption_key_fingerprint(key_file: Path | None = None) -> str:
 
 def _fingerprint_prefix(fingerprint: str) -> str:
     return fingerprint[: len("sha256:") + _FINGERPRINT_PREFIX_CHARS]
+
+
+def _is_sqlite_lock_error(exc: OperationalError) -> bool:
+    message = str(exc.orig if exc.orig is not None else exc).lower()
+    return "database is locked" in message or "database is busy" in message
 
 
 async def _stamp_if_absent(session: AsyncSession, fingerprint: str) -> None:
@@ -83,11 +91,20 @@ async def verify_encryption_key_fingerprint(
         session_factory = SessionLocal
 
     local_fingerprint = compute_encryption_key_fingerprint(key_file)
-    async with session_factory() as session:
-        await _stamp_if_absent(session, local_fingerprint)
-        stored = await session.scalar(
-            select(RuntimeSentinel.value).where(RuntimeSentinel.name == ENCRYPTION_KEY_FINGERPRINT_SENTINEL)
-        )
+    stored: str | None = None
+    for attempt, delay_seconds in enumerate((*_SQLITE_LOCK_RETRY_DELAYS_SECONDS, None)):
+        try:
+            async with session_factory() as session:
+                await _stamp_if_absent(session, local_fingerprint)
+                stored = await session.scalar(
+                    select(RuntimeSentinel.value).where(RuntimeSentinel.name == ENCRYPTION_KEY_FINGERPRINT_SENTINEL)
+                )
+        except OperationalError as exc:
+            if delay_seconds is None or not _is_sqlite_lock_error(exc):
+                raise
+            await asyncio.sleep(delay_seconds)
+            continue
+        break
 
     if stored is None or stored == local_fingerprint:
         return

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -317,6 +317,9 @@ class Settings(BaseSettings):
     # Bound durable replay storage per operation so a long response cannot
     # exhaust the database. An incomplete spool is never replayed.
     http_responses_session_bridge_operation_event_spool_max_bytes: int = Field(default=2 * 1024 * 1024, gt=0)
+    # Rollout fence: chunks_v2 must be enabled only after every serving replica
+    # runs the dual-reader schema expansion.
+    http_responses_session_bridge_operation_spool_format: Literal["rows_v1", "chunks_v2"] = "rows_v1"
     http_responses_session_bridge_operation_event_spool_batch_size: int = Field(default=32, gt=0, le=256)
     http_responses_session_bridge_operation_event_spool_flush_interval_seconds: float = Field(
         default=0.1,

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -659,6 +659,44 @@ class DurableBridgeSessionCoordinator:
                 max_bytes=max_bytes,
             )
 
+    async def append_operation_event_chunk(
+        self,
+        *,
+        events: Sequence[DurableBridgeOperationEventInput],
+        max_bytes: int,
+    ) -> bool:
+        async with self._session() as session:
+            return await DurableBridgeRepository(session).append_operation_event_chunk(
+                events=events,
+                max_bytes=max_bytes,
+            )
+
+    async def append_terminal_operation_chunk(
+        self,
+        *,
+        operation_id: str,
+        session_id: str,
+        instance_id: str,
+        owner_epoch: int,
+        event_text: str,
+        max_bytes: int,
+        state: str,
+        expected_recovery_dispatch_count: int = 0,
+        response_id: str | None = None,
+    ) -> bool:
+        async with self._session() as session:
+            return await DurableBridgeRepository(session).append_terminal_operation_chunk(
+                operation_id=operation_id,
+                session_id=session_id,
+                instance_id=instance_id,
+                owner_epoch=owner_epoch,
+                event_text=event_text,
+                max_bytes=max_bytes,
+                state=state,
+                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
+                response_id=response_id,
+            )
+
     async def finalize_operation_event_spool(
         self,
         *,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -40,6 +40,7 @@ from app.modules.proxy.durable_bridge_transcript_codec import (
     DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS,
     DurableBridgeTranscriptDecodeError,
     decode_durable_bridge_transcript_chunk,
+    encode_durable_bridge_transcript_chunk,
 )
 
 _ANONYMOUS_API_KEY_SCOPE = "__anonymous__"
@@ -252,6 +253,65 @@ class DurableBridgeRepository:
             .limit(1)
         )
         return chunk_sequence is not None
+
+    async def _operation_has_legacy_events(self, operation_id: str) -> bool:
+        event_id = await self._session.scalar(
+            select(HttpBridgeOperationEvent.event_id)
+            .where(HttpBridgeOperationEvent.operation_id == operation_id)
+            .limit(1)
+        )
+        return event_id is not None
+
+    async def _lock_operation_for_chunk_append(
+        self,
+        *,
+        operation_id: str,
+        session_id: str,
+        instance_id: str,
+        owner_epoch: int,
+        expected_recovery_dispatch_count: int | None = None,
+    ) -> tuple[HttpBridgeOperationRecord, bool] | None:
+        owner_exists = await self._session.scalar(
+            select(HttpBridgeSessionRecord.id)
+            .where(
+                HttpBridgeSessionRecord.id == session_id,
+                HttpBridgeSessionRecord.owner_instance_id == instance_id,
+                HttpBridgeSessionRecord.owner_epoch == owner_epoch,
+            )
+            .with_for_update()
+        )
+        operation_statement = select(HttpBridgeOperationRecord).where(
+            HttpBridgeOperationRecord.operation_id == operation_id,
+            HttpBridgeOperationRecord.session_id == session_id,
+        )
+        if expected_recovery_dispatch_count is not None:
+            operation_statement = operation_statement.where(
+                HttpBridgeOperationRecord.recovery_dispatch_count == expected_recovery_dispatch_count
+            )
+        operation = await self._session.scalar(operation_statement.with_for_update())
+        if owner_exists is None or operation is None:
+            await self._session.rollback()
+            return None
+        if operation.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2:
+            if await self._operation_has_legacy_events(operation_id):
+                return operation, False
+            return operation, True
+        if operation.spool_format != HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1:
+            return operation, False
+        if int(operation.event_bytes or 0) != 0 or await self._operation_has_spool_material(operation_id):
+            return operation, False
+        return operation, True
+
+    async def _next_operation_chunk_sequence(self, operation_id: str) -> int:
+        latest = await self._session.scalar(
+            select(HttpBridgeOperationEventChunk)
+            .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            .order_by(HttpBridgeOperationEventChunk.first_sequence_number.desc())
+            .limit(1)
+        )
+        if latest is None:
+            return 1
+        return int(latest.first_sequence_number) + int(latest.event_count)
 
     async def get_session(
         self,
@@ -1903,6 +1963,153 @@ class DurableBridgeRepository:
                 await self._delete_operation_spool_material(deleted_ids)
             await self._session.commit()
         return len(deleted_ids)
+
+    async def append_operation_event_chunk(
+        self,
+        *,
+        events: Sequence[DurableBridgeOperationEventInput],
+        max_bytes: int,
+    ) -> bool:
+        """Append one compressed v2 chunk under the durable owner fence."""
+        if not events:
+            return True
+        first = events[0]
+        if any(
+            event.operation_id != first.operation_id
+            or event.session_id != first.session_id
+            or event.instance_id != first.instance_id
+            or event.owner_epoch != first.owner_epoch
+            for event in events
+        ):
+            return False
+        event_texts = [event.event_text for event in events]
+        event_bytes = sum(len(event_text.encode("utf-8")) for event_text in event_texts)
+        if event_bytes > max_bytes:
+            return False
+        async with sqlite_writer_section():
+            locked_operation = await self._lock_operation_for_chunk_append(
+                operation_id=first.operation_id,
+                session_id=first.session_id,
+                instance_id=first.instance_id,
+                owner_epoch=first.owner_epoch,
+            )
+            if locked_operation is None:
+                return False
+            operation, append_allowed = locked_operation
+            if not append_allowed:
+                await self._session.rollback()
+                return False
+            if int(operation.event_bytes or 0) + event_bytes > max_bytes:
+                operation.event_spool_complete = False
+                await self._session.commit()
+                return False
+            first_sequence_number = await self._next_operation_chunk_sequence(first.operation_id)
+            if first_sequence_number - 1 + len(event_texts) > DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS:
+                operation.event_spool_complete = False
+                await self._session.commit()
+                return False
+            try:
+                encoded = encode_durable_bridge_transcript_chunk(event_texts)
+            except ValueError:
+                await self._session.rollback()
+                return False
+            self._session.add(
+                HttpBridgeOperationEventChunk(
+                    operation_id=first.operation_id,
+                    first_sequence_number=first_sequence_number,
+                    event_count=encoded.event_count,
+                    codec=encoded.codec,
+                    uncompressed_bytes=encoded.uncompressed_bytes,
+                    payload=encoded.payload,
+                    payload_sha256=encoded.payload_sha256,
+                )
+            )
+            operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2
+            operation.event_bytes = int(operation.event_bytes or 0) + event_bytes
+            await self._session.commit()
+        return True
+
+    async def append_terminal_operation_chunk(
+        self,
+        *,
+        operation_id: str,
+        session_id: str,
+        instance_id: str,
+        owner_epoch: int,
+        event_text: str,
+        max_bytes: int,
+        state: str,
+        expected_recovery_dispatch_count: int = 0,
+        response_id: str | None = None,
+    ) -> bool:
+        """Append a terminal v2 chunk and expose its outcome atomically."""
+        event_bytes = len(event_text.encode("utf-8"))
+        async with sqlite_writer_section():
+            locked_operation = await self._lock_operation_for_chunk_append(
+                operation_id=operation_id,
+                session_id=session_id,
+                instance_id=instance_id,
+                owner_epoch=owner_epoch,
+                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
+            )
+            if locked_operation is None:
+                return False
+            operation, append_allowed = locked_operation
+            if not append_allowed:
+                operation.event_spool_complete = False
+                operation.state = state
+                if response_id is not None:
+                    operation.response_id = response_id
+                operation.updated_at = utcnow()
+                await self._session.commit()
+                return False
+            if int(operation.event_bytes or 0) + event_bytes > max_bytes:
+                operation.event_spool_complete = False
+                operation.state = state
+                if response_id is not None:
+                    operation.response_id = response_id
+                operation.updated_at = utcnow()
+                await self._session.commit()
+                return False
+            first_sequence_number = await self._next_operation_chunk_sequence(operation_id)
+            if first_sequence_number > DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS:
+                operation.event_spool_complete = False
+                operation.state = state
+                if response_id is not None:
+                    operation.response_id = response_id
+                operation.updated_at = utcnow()
+                await self._session.commit()
+                return False
+            try:
+                encoded = encode_durable_bridge_transcript_chunk((event_text,))
+            except ValueError:
+                operation.event_spool_complete = False
+                operation.state = state
+                if response_id is not None:
+                    operation.response_id = response_id
+                operation.updated_at = utcnow()
+                await self._session.commit()
+                return False
+            self._session.add(
+                HttpBridgeOperationEventChunk(
+                    operation_id=operation_id,
+                    first_sequence_number=first_sequence_number,
+                    event_count=encoded.event_count,
+                    codec=encoded.codec,
+                    uncompressed_bytes=encoded.uncompressed_bytes,
+                    payload=encoded.payload,
+                    payload_sha256=encoded.payload_sha256,
+                )
+            )
+            operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2
+            operation.event_bytes = int(operation.event_bytes or 0) + event_bytes
+            operation.state = state
+            if response_id is not None:
+                operation.response_id = response_id
+            operation.event_spool_complete = True
+            operation.updated_at = utcnow()
+            await self._session.commit()
+        return True
 
     async def append_operation_event(
         self,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -337,6 +337,37 @@ class DurableBridgeRepository:
             )
         ) is not None
 
+    async def _chunk_append_preflight_allows_encoding(
+        self,
+        *,
+        operation_id: str,
+        session_id: str,
+        instance_id: str,
+        owner_epoch: int,
+        event_bytes: int,
+        event_count: int,
+        max_bytes: int,
+    ) -> bool:
+        if not await self._chunk_append_owner_exists(
+            session_id=session_id,
+            instance_id=instance_id,
+            owner_epoch=owner_epoch,
+        ):
+            return False
+        current_event_bytes = await self._session.scalar(
+            select(HttpBridgeOperationRecord.event_bytes).where(
+                HttpBridgeOperationRecord.operation_id == operation_id,
+                HttpBridgeOperationRecord.session_id == session_id,
+            )
+        )
+        if current_event_bytes is None:
+            return False
+        first_sequence_number = await self._next_operation_chunk_sequence(operation_id)
+        return (
+            int(current_event_bytes) + event_bytes <= max_bytes
+            and first_sequence_number - 1 + event_count <= DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS
+        )
+
     async def get_session(
         self,
         *,
@@ -2010,10 +2041,14 @@ class DurableBridgeRepository:
         event_bytes = sum(len(event_text.encode("utf-8")) for event_text in event_texts)
         if event_bytes > max_bytes:
             return False
-        if not await self._chunk_append_owner_exists(
+        if not await self._chunk_append_preflight_allows_encoding(
+            operation_id=first.operation_id,
             session_id=first.session_id,
             instance_id=first.instance_id,
             owner_epoch=first.owner_epoch,
+            event_bytes=event_bytes,
+            event_count=len(event_texts),
+            max_bytes=max_bytes,
         ):
             return False
         try:
@@ -2073,16 +2108,19 @@ class DurableBridgeRepository:
     ) -> bool:
         """Append a terminal v2 chunk and expose its outcome atomically."""
         event_bytes = len(event_text.encode("utf-8"))
-        if not await self._chunk_append_owner_exists(
+        preflight_allows_encoding = await self._chunk_append_preflight_allows_encoding(
+            operation_id=operation_id,
             session_id=session_id,
             instance_id=instance_id,
             owner_epoch=owner_epoch,
-        ):
-            return False
+            event_bytes=event_bytes,
+            event_count=1,
+            max_bytes=max_bytes,
+        )
         try:
             encoded = (
                 await asyncio.to_thread(encode_durable_bridge_transcript_chunk, (event_text,))
-                if event_bytes <= max_bytes
+                if preflight_allows_encoding
                 else None
             )
         except ValueError:

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from collections.abc import Mapping, Sequence
@@ -303,15 +304,38 @@ class DurableBridgeRepository:
         return operation, True
 
     async def _next_operation_chunk_sequence(self, operation_id: str) -> int:
-        latest = await self._session.scalar(
-            select(HttpBridgeOperationEventChunk)
-            .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
-            .order_by(HttpBridgeOperationEventChunk.first_sequence_number.desc())
-            .limit(1)
-        )
+        latest = (
+            await self._session.execute(
+                select(
+                    HttpBridgeOperationEventChunk.first_sequence_number,
+                    HttpBridgeOperationEventChunk.event_count,
+                )
+                .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+                .order_by(HttpBridgeOperationEventChunk.first_sequence_number.desc())
+                .limit(1)
+            )
+        ).one_or_none()
         if latest is None:
             return 1
-        return int(latest.first_sequence_number) + int(latest.event_count)
+        first_sequence_number, event_count = latest
+        return int(first_sequence_number) + int(event_count)
+
+    async def _chunk_append_owner_exists(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        owner_epoch: int,
+    ) -> bool:
+        return (
+            await self._session.scalar(
+                select(HttpBridgeSessionRecord.id).where(
+                    HttpBridgeSessionRecord.id == session_id,
+                    HttpBridgeSessionRecord.owner_instance_id == instance_id,
+                    HttpBridgeSessionRecord.owner_epoch == owner_epoch,
+                )
+            )
+        ) is not None
 
     async def get_session(
         self,
@@ -1986,6 +2010,16 @@ class DurableBridgeRepository:
         event_bytes = sum(len(event_text.encode("utf-8")) for event_text in event_texts)
         if event_bytes > max_bytes:
             return False
+        if not await self._chunk_append_owner_exists(
+            session_id=first.session_id,
+            instance_id=first.instance_id,
+            owner_epoch=first.owner_epoch,
+        ):
+            return False
+        try:
+            encoded = await asyncio.to_thread(encode_durable_bridge_transcript_chunk, event_texts)
+        except ValueError:
+            return False
         async with sqlite_writer_section():
             locked_operation = await self._lock_operation_for_chunk_append(
                 operation_id=first.operation_id,
@@ -2007,11 +2041,6 @@ class DurableBridgeRepository:
             if first_sequence_number - 1 + len(event_texts) > DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS:
                 operation.event_spool_complete = False
                 await self._session.commit()
-                return False
-            try:
-                encoded = encode_durable_bridge_transcript_chunk(event_texts)
-            except ValueError:
-                await self._session.rollback()
                 return False
             self._session.add(
                 HttpBridgeOperationEventChunk(
@@ -2044,6 +2073,20 @@ class DurableBridgeRepository:
     ) -> bool:
         """Append a terminal v2 chunk and expose its outcome atomically."""
         event_bytes = len(event_text.encode("utf-8"))
+        if not await self._chunk_append_owner_exists(
+            session_id=session_id,
+            instance_id=instance_id,
+            owner_epoch=owner_epoch,
+        ):
+            return False
+        try:
+            encoded = (
+                await asyncio.to_thread(encode_durable_bridge_transcript_chunk, (event_text,))
+                if event_bytes <= max_bytes
+                else None
+            )
+        except ValueError:
+            encoded = None
         async with sqlite_writer_section():
             locked_operation = await self._lock_operation_for_chunk_append(
                 operation_id=operation_id,
@@ -2063,7 +2106,7 @@ class DurableBridgeRepository:
                 operation.updated_at = utcnow()
                 await self._session.commit()
                 return False
-            if int(operation.event_bytes or 0) + event_bytes > max_bytes:
+            if int(operation.event_bytes or 0) + event_bytes > max_bytes or encoded is None:
                 operation.event_spool_complete = False
                 operation.state = state
                 if response_id is not None:
@@ -2073,16 +2116,6 @@ class DurableBridgeRepository:
                 return False
             first_sequence_number = await self._next_operation_chunk_sequence(operation_id)
             if first_sequence_number > DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS:
-                operation.event_spool_complete = False
-                operation.state = state
-                if response_id is not None:
-                    operation.response_id = response_id
-                operation.updated_at = utcnow()
-                await self._session.commit()
-                return False
-            try:
-                encoded = encode_durable_bridge_transcript_chunk((event_text,))
-            except ValueError:
                 operation.event_spool_complete = False
                 operation.state = state
                 if response_id is not None:

--- a/app/modules/proxy/http_bridge_event_batcher.py
+++ b/app/modules/proxy/http_bridge_event_batcher.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.core.config.settings import get_settings
+from app.db.models import HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2, HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
 from app.modules.proxy.durable_bridge_repository import DurableBridgeOperationEventInput
 
 logger = logging.getLogger("app.modules.proxy.http_bridge_event_batcher")
@@ -61,6 +62,13 @@ class HttpBridgeOperationEventBatcher:
                     settings, "http_responses_session_bridge_operation_event_spool_max_pending_bytes", 32 * 1024 * 1024
                 )
             ),
+            spool_format=str(
+                getattr(
+                    settings,
+                    "http_responses_session_bridge_operation_spool_format",
+                    HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
+                )
+            ),
         )
 
     def __init__(
@@ -72,13 +80,17 @@ class HttpBridgeOperationEventBatcher:
         flush_interval_seconds: float = 0.1,
         max_pending_events: int = 2048,
         max_pending_bytes: int = 32 * 1024 * 1024,
+        spool_format: str = HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
     ) -> None:
+        if spool_format not in {HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1, HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2}:
+            raise ValueError("unsupported durable bridge operation spool format")
         self._durable_bridge = durable_bridge
         self._max_bytes = max_bytes
         self._batch_size = batch_size
         self._flush_interval_seconds = flush_interval_seconds
         self._max_pending_events = max_pending_events
         self._max_pending_bytes = max_pending_bytes
+        self._spool_format = spool_format
         self._pending: dict[str, list[_PendingOperationEvent]] = {}
         self._contexts: dict[str, _PendingOperationEvent] = {}
         self._dropped_operations: set[str] = set()
@@ -176,19 +188,26 @@ class HttpBridgeOperationEventBatcher:
                 if operation_id in self._dropped_operations:
                     return
             try:
-                persisted = await self._durable_bridge.append_operation_events(
-                    events=[
-                        DurableBridgeOperationEventInput(
-                            operation_id=item.operation_id,
-                            session_id=item.session_id,
-                            instance_id=item.instance_id,
-                            owner_epoch=item.owner_epoch,
-                            event_text=item.event_text,
-                        )
-                        for item in batch
-                    ],
-                    max_bytes=self._max_bytes,
-                )
+                events = [
+                    DurableBridgeOperationEventInput(
+                        operation_id=item.operation_id,
+                        session_id=item.session_id,
+                        instance_id=item.instance_id,
+                        owner_epoch=item.owner_epoch,
+                        event_text=item.event_text,
+                    )
+                    for item in batch
+                ]
+                if self._spool_format == HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2:
+                    persisted = await self._durable_bridge.append_operation_event_chunk(
+                        events=events,
+                        max_bytes=self._max_bytes,
+                    )
+                else:
+                    persisted = await self._durable_bridge.append_operation_events(
+                        events=events,
+                        max_bytes=self._max_bytes,
+                    )
                 if not persisted:
                     async with self._lock:
                         self._dropped_operations.add(operation_id)
@@ -294,18 +313,35 @@ class HttpBridgeOperationEventBatcher:
                     self._dropped_operations.discard(operation_id)
             return TerminalOperationEventAppendResult(persisted=False)
         try:
-            persisted = await self._durable_bridge.append_terminal_operation_event(
-                operation_id=operation_id,
-                session_id=context.session_id,
-                instance_id=context.instance_id,
-                owner_epoch=context.owner_epoch,
-                event_text=event_text,
-                max_bytes=max_bytes,
-                state=state,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
-                response_id=response_id,
+            if self._spool_format == HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2:
+                persisted = await self._durable_bridge.append_terminal_operation_chunk(
+                    operation_id=operation_id,
+                    session_id=context.session_id,
+                    instance_id=context.instance_id,
+                    owner_epoch=context.owner_epoch,
+                    event_text=event_text,
+                    max_bytes=max_bytes,
+                    state=state,
+                    expected_recovery_dispatch_count=expected_recovery_dispatch_count,
+                    response_id=response_id,
+                )
+            else:
+                persisted = await self._durable_bridge.append_terminal_operation_event(
+                    operation_id=operation_id,
+                    session_id=context.session_id,
+                    instance_id=context.instance_id,
+                    owner_epoch=context.owner_epoch,
+                    event_text=event_text,
+                    max_bytes=max_bytes,
+                    state=state,
+                    expected_recovery_dispatch_count=expected_recovery_dispatch_count,
+                    response_id=response_id,
+                )
+            terminal_persisted = bool(persisted and not dropped)
+            return TerminalOperationEventAppendResult(
+                persisted=terminal_persisted,
+                settlement_required=not terminal_persisted,
             )
-            return TerminalOperationEventAppendResult(persisted=bool(persisted and not dropped))
         except Exception:
             logger.debug(
                 "Failed to append terminal HTTP bridge event operation_id=%s",

--- a/app/modules/proxy/http_bridge_event_batcher.py
+++ b/app/modules/proxy/http_bridge_event_batcher.py
@@ -291,27 +291,11 @@ class HttpBridgeOperationEventBatcher:
         if context is None:
             return TerminalOperationEventAppendResult(persisted=False)
         if dropped:
-            try:
-                await self._durable_bridge.update_operation(
-                    operation_id=operation_id,
-                    session_id=context.session_id,
-                    instance_id=context.instance_id,
-                    owner_epoch=context.owner_epoch,
-                    state=state,
-                    response_id=response_id,
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to settle dropped terminal HTTP bridge operation_id=%s",
-                    operation_id,
-                    exc_info=True,
-                )
-            finally:
-                async with self._lock:
-                    self._closing_operations.discard(operation_id)
-                    self._contexts.pop(operation_id, None)
-                    self._dropped_operations.discard(operation_id)
-            return TerminalOperationEventAppendResult(persisted=False)
+            async with self._lock:
+                self._closing_operations.discard(operation_id)
+                self._contexts.pop(operation_id, None)
+                self._dropped_operations.discard(operation_id)
+            return TerminalOperationEventAppendResult(persisted=False, settlement_required=True)
         try:
             if self._spool_format == HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2:
                 persisted = await self._durable_bridge.append_terminal_operation_chunk(

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 131 settings. Every setting is an environment
+codex-lb currently exposes 132 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -99,6 +99,7 @@ the host side of the compose `ports` mapping instead.
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_EVENT_SPOOL_MAX_PENDING_BYTES` | `int` | `33554432` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_EVENT_SPOOL_MAX_PENDING_EVENTS` | `int` | `2048` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_LEDGER_ENABLED` | `bool` | `True` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_FORMAT` | `'rows_v1' \| 'chunks_v2'` | `'rows_v1'` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_RETENTION_SECONDS` | `float` | `604800` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_QUEUE_LIMIT` | `int` | `8` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_REQUEST_BUDGET_SECONDS` | `float` | `7200.0` |

--- a/openspec/changes/enable-chunked-http-bridge-writer/design.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/design.md
@@ -31,9 +31,10 @@ writes a terminal one-event chunk and operation state in one transaction.
 Logical `event_bytes` remains the sum of UTF-8 event bytes, not compressed or
 framed bytes, preserving the existing cap. Ownership, logical byte capacity,
 and cumulative event count are revalidated by the fenced write. Stateless
-checks and an unfenced ownership preflight reject obvious invalid input before
-the chunk is compressed on a worker thread, while sequence allocation reads
-only the latest chunk's sequence metadata rather than its payload.
+checks and an unfenced ownership/cumulative-limit preflight reject obvious
+invalid input before the chunk is compressed on a worker thread, while sequence
+allocation reads only the latest chunk's sequence metadata rather than its
+payload.
 
 ### D4. Fail closed on format conflict
 

--- a/openspec/changes/enable-chunked-http-bridge-writer/design.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/design.md
@@ -30,8 +30,10 @@ previous chunk's range. The terminal path drains pending chunks first, then
 writes a terminal one-event chunk and operation state in one transaction.
 Logical `event_bytes` remains the sum of UTF-8 event bytes, not compressed or
 framed bytes, preserving the existing cap. Ownership, logical byte capacity,
-and cumulative event count are checked before compression so rejected input
-does not spend event-loop CPU on zlib work.
+and cumulative event count are revalidated by the fenced write. Stateless
+checks and an unfenced ownership preflight reject obvious invalid input before
+the chunk is compressed on a worker thread, while sequence allocation reads
+only the latest chunk's sequence metadata rather than its payload.
 
 ### D4. Fail closed on format conflict
 

--- a/openspec/changes/enable-chunked-http-bridge-writer/design.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/design.md
@@ -1,0 +1,49 @@
+# Design: Enable the chunked HTTP bridge transcript writer
+
+## Context
+
+The batcher already groups up to 32 events before one repository call. The v1
+repository expands that group back into one row per event. The v2 schema and
+codec are available from the expand release, but a rollout flag must prevent a
+new writer from producing data an older replica cannot read.
+
+## Decisions
+
+### D1. Explicit default-off cutover
+
+Add one canonical setting with values `rows_v1` and `chunks_v2`, defaulting to
+`rows_v1`. A new setting is necessary because mixed-version rollout safety
+cannot be inferred from the local process. Operators enable v2 only after all
+replicas run the dual reader.
+
+### D2. Switch format on first successful v2 append
+
+New operations keep the schema default `rows_v1`. The first v2 append locks the
+operation and owner, verifies that logical bytes and both event stores are
+empty, then changes the operation to `chunks_v2` in the same transaction as the
+first chunk. An operation with any v1 material cannot switch.
+
+### D3. One chunk per batch
+
+Normal batch flush writes one encoded chunk. Sequence numbers continue from the
+previous chunk's range. The terminal path drains pending chunks first, then
+writes a terminal one-event chunk and operation state in one transaction.
+Logical `event_bytes` remains the sum of UTF-8 event bytes, not compressed or
+framed bytes, preserving the existing cap. Ownership, logical byte capacity,
+and cumulative event count are checked before compression so rejected input
+does not spend event-loop CPU on zlib work.
+
+### D4. Fail closed on format conflict
+
+A v1 writer cannot append after v2 format selection, and a v2 writer cannot
+switch an operation that already has v1 rows. Failure leaves the spool
+incomplete and uses the existing settlement/fail-closed path; it never writes
+both formats.
+
+## Rollout / Rollback
+
+1. Deploy the dual-reader expand release everywhere.
+2. Deploy this release with `rows_v1` unchanged.
+3. Enable `chunks_v2` on a canary, then all replicas.
+4. Roll back the setting to `rows_v1` before rolling back binaries.
+5. Binary rollback must target the dual-reader expand release or newer.

--- a/openspec/changes/enable-chunked-http-bridge-writer/proposal.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/proposal.md
@@ -1,0 +1,28 @@
+# Change: Enable the chunked HTTP bridge transcript writer
+
+## Why
+
+The expand release can read `chunks_v2` but still writes one database row per
+SSE block. A guarded writer cutover is required to realize the storage
+reduction after every serving replica has the dual reader.
+
+## What Changes
+
+- Add an explicit `rows_v1|chunks_v2` writer setting that defaults to
+  `rows_v1` for rollout safety.
+- Persist each in-memory event batch as one compressed v2 chunk when enabled.
+- Append the terminal event and operation outcome atomically in v2 format.
+- Refuse to mix row and chunk material in one operation.
+
+## Non-Goals
+
+- Changing the default writer format in this release.
+- Backfilling or deleting legacy event rows.
+- Changing replay, retention, byte-cap, or owner-fence semantics.
+
+## Impact
+
+- Affected spec: `responses-api-compat`.
+- Affected code: settings, event batcher, durable bridge coordinator and
+  repository, focused writer and lifecycle tests.
+- No schema migration; this change requires the expand migration first.

--- a/openspec/changes/enable-chunked-http-bridge-writer/specs/responses-api-compat/spec.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/specs/responses-api-compat/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Chunk transcript writes require an explicit rollout selection
+
+The durable HTTP bridge transcript writer MUST support `rows_v1` and
+`chunks_v2` selection through one canonical setting and MUST default to
+`rows_v1`. Enabling `chunks_v2` MUST NOT change public SSE output, replay
+eligibility, logical byte caps, or owner fencing. A v2 writer MUST atomically
+select `chunks_v2` on the first successful append only when the operation has
+no legacy row or chunk material and no logical event bytes. A format conflict
+MUST fail closed without persisting mixed material. Before compression, the
+writer MUST validate owner fencing, logical byte capacity, and the reader's
+cumulative transcript event-count limit. It MUST NOT mark a transcript complete
+when the reader would reject its event count.
+
+#### Scenario: Default release keeps writing rows
+
+- **WHEN** no writer-format setting is provided
+- **THEN** new durable transcript events are written as `rows_v1`
+
+#### Scenario: First v2 append selects chunk format atomically
+
+- **GIVEN** an owner-fenced operation with no persisted transcript material
+- **AND** the writer format is `chunks_v2`
+- **WHEN** its first event batch is persisted
+- **THEN** the operation format and first chunk commit together
+
+#### Scenario: Existing row transcript cannot switch formats
+
+- **GIVEN** an operation already has a legacy event row or logical event bytes
+- **WHEN** a v2 writer attempts to append
+- **THEN** the append fails without writing a chunk or changing the format
+
+#### Scenario: Rejected batch is not compressed
+
+- **GIVEN** a batch exceeds the logical byte cap or fails owner fencing
+- **WHEN** the v2 writer handles the batch
+- **THEN** it rejects the batch before zlib compression
+
+### Requirement: Chunk writer preserves batch and terminal settlement semantics
+
+When `chunks_v2` is enabled, each successful nonterminal batch flush MUST
+persist one ordered chunk containing the exact queued SSE blocks. The terminal
+path MUST first drain pending chunks and then atomically persist the terminal
+one-event chunk, authoritative operation state, optional response identifier,
+and complete-spool marker. A size-cap failure or persistence error MUST leave
+the transcript incomplete and use the existing terminal settlement fallback.
+
+#### Scenario: Batch becomes one replay-equivalent chunk
+
+- **WHEN** the in-memory batcher flushes multiple nonterminal events in v2 mode
+- **THEN** one chunk is persisted
+- **AND** replay returns every original event in the same order
+
+#### Scenario: Terminal chunk and state commit together
+
+- **WHEN** a terminal event fits inside the remaining logical byte budget
+- **THEN** the terminal chunk, terminal operation state, response identifier,
+  and complete marker commit atomically
+
+#### Scenario: Oversized terminal event settles without complete transcript
+
+- **WHEN** a terminal event exceeds the remaining logical byte budget
+- **THEN** no terminal chunk is written
+- **AND** the operation reaches its authoritative terminal state with an
+  incomplete spool
+
+#### Scenario: Event-count overflow settles without complete transcript
+
+- **GIVEN** appending the terminal event would exceed the reader's cumulative
+  transcript event-count limit
+- **WHEN** the terminal path runs
+- **THEN** no terminal chunk is written
+- **AND** the operation reaches its authoritative terminal state with an
+  incomplete spool

--- a/openspec/changes/enable-chunked-http-bridge-writer/tasks.md
+++ b/openspec/changes/enable-chunked-http-bridge-writer/tasks.md
@@ -1,0 +1,18 @@
+## 1. Specification
+
+- [x] 1.1 Specify explicit default-off writer selection and mixed-format
+      rejection.
+- [x] 1.2 Specify batch and terminal v2 atomicity.
+
+## 2. Implementation
+
+- [x] 2.1 Add and validate the writer-format setting.
+- [x] 2.2 Add owner-fenced batch and terminal chunk repository operations.
+- [x] 2.3 Route the event batcher through v1 or v2 without duplicating events.
+
+## 3. Verification
+
+- [x] 3.1 Cover v1 default, v2 batch/terminal replay, size caps, and format
+      conflicts.
+- [x] 3.2 Run focused bridge/batcher tests, Ruff, and type checks.
+- [x] 3.3 Run strict OpenSpec validation and `git diff --check`.

--- a/tests/integration/test_replica_guardrails.py
+++ b/tests/integration/test_replica_guardrails.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 
 from app.core.auth.guardian import _count_live_bridge_ring_members
 from app.core.config.key_fingerprint import (
@@ -81,6 +82,32 @@ async def test_fingerprint_matching_replica_passes(db_setup):
     # Second replica with the same key material re-runs the startup check.
     await verify_encryption_key_fingerprint()
 
+    assert await _stored_sentinel_values() == [compute_encryption_key_fingerprint()]
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_retries_transient_sqlite_lock(db_setup, monkeypatch):
+    import app.core.config.key_fingerprint as key_fingerprint_module
+
+    real_stamp_if_absent = key_fingerprint_module._stamp_if_absent
+    attempts = 0
+
+    async def fail_once_then_stamp(session, fingerprint: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OperationalError("INSERT runtime_sentinels", {}, Exception("database is locked"))
+        await real_stamp_if_absent(session, fingerprint)
+
+    async def no_sleep(_delay_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(key_fingerprint_module, "_stamp_if_absent", fail_once_then_stamp)
+    monkeypatch.setattr(key_fingerprint_module.asyncio, "sleep", no_sleep)
+
+    await verify_encryption_key_fingerprint()
+
+    assert attempts == 2
     assert await _stored_sentinel_values() == [compute_encryption_key_fingerprint()]
 
 

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -8,7 +8,7 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import anyio
 import pytest
@@ -16,6 +16,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 import app.modules.proxy.durable_bridge_coordinator as durable_bridge_coordinator_module
+import app.modules.proxy.durable_bridge_repository as durable_repo_module
 from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import Settings
 from app.core.utils.time import utcnow
@@ -25,6 +26,7 @@ from app.db.models import (
     AccountStatus,
     Base,
     BridgeRingMember,
+    HttpBridgeOperationEvent,
     HttpBridgeOperationEventChunk,
     HttpBridgeOperationRecord,
     HttpBridgeRetryCircuit,
@@ -42,6 +44,7 @@ from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay
 from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
 from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeAliasRegistration,
+    DurableBridgeOperationEventInput,
     DurableBridgeRepository,
     durable_bridge_hash,
     durable_bridge_operation_id,
@@ -857,6 +860,306 @@ async def test_chunk_operation_rejects_malformed_persisted_metadata(
         await session.commit()
 
         assert await repository.get_operation_events(operation_id=operation_id) == []
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_writer_persists_batch_and_terminal_atomically(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-writer", session_key_value="sid-chunk-writer")
+        fingerprint = durable_bridge_hash("chunk-writer")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-writer",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+            request_text='{"input":"turn"}',
+        )
+        first_events = ("created", "delta")
+        assert await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="inst-chunk-writer",
+                    owner_epoch=claim.owner_epoch,
+                    event_text=event,
+                )
+                for event in first_events
+            ],
+            max_bytes=1024,
+        )
+        assert await repository.append_terminal_operation_chunk(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-writer",
+            owner_epoch=claim.owner_epoch,
+            event_text='data: {"type":"response.completed"}\n\n',
+            max_bytes=1024,
+            state="completed",
+            response_id="resp-chunk-writer",
+        )
+
+        row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert row is not None
+        assert row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2
+        assert row.state == "completed"
+        assert row.response_id == "resp-chunk-writer"
+        assert row.event_spool_complete is True
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEvent).where(HttpBridgeOperationEvent.operation_id == operation_id)
+            )
+            is None
+        )
+        chunks = (
+            (
+                await session.execute(
+                    select(HttpBridgeOperationEventChunk)
+                    .where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+                    .order_by(HttpBridgeOperationEventChunk.first_sequence_number)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [(chunk.first_sequence_number, chunk.event_count) for chunk in chunks] == [(1, 2), (3, 1)]
+        assert await repository.get_operation_events(operation_id=operation_id) == [
+            *first_events,
+            'data: {"type":"response.completed"}\n\n',
+        ]
+        assert await repository.get_replayable_transcript(response_id="resp-chunk-writer") is not None
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_writer_refuses_mixed_legacy_material(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-conflict", session_key_value="sid-chunk-conflict")
+        fingerprint = durable_bridge_hash("chunk-conflict")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-conflict",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        assert await repository.append_operation_event(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-conflict",
+            owner_epoch=claim.owner_epoch,
+            event_text="legacy",
+            max_bytes=1024,
+        )
+
+        assert not await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="inst-chunk-conflict",
+                    owner_epoch=claim.owner_epoch,
+                    event_text="chunk",
+                )
+            ],
+            max_bytes=1024,
+        )
+        assert not await repository.append_terminal_operation_chunk(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-conflict",
+            owner_epoch=claim.owner_epoch,
+            event_text="terminal",
+            max_bytes=1024,
+            state="failed",
+            response_id="resp-conflict",
+        )
+        row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert row is not None
+        await session.refresh(row)
+        assert row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
+        assert row.state == "failed"
+        assert row.response_id == "resp-conflict"
+        assert row.event_spool_complete is False
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            )
+            is None
+        )
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_oversized_terminal_chunk_settles_incomplete_operation(
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-oversize", session_key_value="sid-chunk-oversize")
+        fingerprint = durable_bridge_hash("chunk-oversize")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-oversize",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        assert not await repository.append_terminal_operation_chunk(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-oversize",
+            owner_epoch=claim.owner_epoch,
+            event_text="too-large",
+            max_bytes=3,
+            state="failed",
+            response_id="resp-oversized",
+        )
+
+        row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert row is not None
+        assert row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
+        assert row.state == "failed"
+        assert row.response_id == "resp-oversized"
+        assert row.event_spool_complete is False
+        assert (
+            await session.scalar(
+                select(HttpBridgeOperationEventChunk).where(HttpBridgeOperationEventChunk.operation_id == operation_id)
+            )
+            is None
+        )
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_writer_enforces_reader_event_count_limit(
+    async_session_factory: Callable[[], AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = async_session_factory()
+    try:
+        monkeypatch.setattr(durable_repo_module, "DURABLE_BRIDGE_TRANSCRIPT_MAX_EVENTS", 2)
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-chunk-count", session_key_value="sid-chunk-count")
+        fingerprint = durable_bridge_hash("chunk-count")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-count",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        assert await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="inst-chunk-count",
+                    owner_epoch=claim.owner_epoch,
+                    event_text=event,
+                )
+                for event in ("one", "two")
+            ],
+            max_bytes=1024,
+        )
+        assert not await repository.append_terminal_operation_chunk(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-chunk-count",
+            owner_epoch=claim.owner_epoch,
+            event_text="terminal",
+            max_bytes=1024,
+            state="failed",
+            response_id="resp-count-limit",
+        )
+        row = await session.get(HttpBridgeOperationRecord, operation_id)
+        assert row is not None
+        assert row.state == "failed"
+        assert row.event_spool_complete is False
+    finally:
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_writer_rejects_before_compression(
+    async_session_factory: Callable[[], AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = async_session_factory()
+    try:
+        repository = DurableBridgeRepository(session)
+        claim = await _claim(repository, instance_id="inst-precompress", session_key_value="sid-precompress")
+        fingerprint = durable_bridge_hash("precompress")
+        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
+        assert await repository.record_operation(
+            operation_id=operation_id,
+            session_id=claim.id,
+            instance_id="inst-precompress",
+            owner_epoch=claim.owner_epoch,
+            request_fingerprint=fingerprint,
+            account_id="account-operation",
+            model="gpt-5.6",
+            parent_response_id=None,
+        )
+        encoder = MagicMock(side_effect=AssertionError("compression should not run"))
+        monkeypatch.setattr(durable_repo_module, "encode_durable_bridge_transcript_chunk", encoder)
+
+        assert not await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="inst-precompress",
+                    owner_epoch=claim.owner_epoch,
+                    event_text="oversized",
+                )
+            ],
+            max_bytes=1,
+        )
+        assert not await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="wrong-owner",
+                    owner_epoch=claim.owner_epoch,
+                    event_text="small",
+                )
+            ],
+            max_bytes=1024,
+        )
+        encoder.assert_not_called()
     finally:
         await session.close()
 

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -865,11 +865,30 @@ async def test_chunk_operation_rejects_malformed_persisted_metadata(
 
 
 @pytest.mark.asyncio
+async def test_next_operation_chunk_sequence_selects_only_metadata() -> None:
+    result = SimpleNamespace(one_or_none=lambda: (4, 3))
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    repository = DurableBridgeRepository(cast(AsyncSession, session))
+
+    assert await repository._next_operation_chunk_sequence("operation") == 7
+
+    statement = session.execute.call_args.args[0]
+    assert tuple(statement.selected_columns.keys()) == ("first_sequence_number", "event_count")
+
+
+@pytest.mark.asyncio
 async def test_chunk_writer_persists_batch_and_terminal_atomically(
     async_session_factory: Callable[[], AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = async_session_factory()
     try:
+
+        async def encode_off_loop(function, *args):
+            return function(*args)
+
+        encode = AsyncMock(side_effect=encode_off_loop)
+        monkeypatch.setattr(durable_repo_module.asyncio, "to_thread", encode)
         repository = DurableBridgeRepository(session)
         claim = await _claim(repository, instance_id="inst-chunk-writer", session_key_value="sid-chunk-writer")
         fingerprint = durable_bridge_hash("chunk-writer")
@@ -939,6 +958,7 @@ async def test_chunk_writer_persists_batch_and_terminal_atomically(
             'data: {"type":"response.completed"}\n\n',
         ]
         assert await repository.get_replayable_transcript(response_id="resp-chunk-writer") is not None
+        assert encode.await_count == 2
     finally:
         await session.close()
 

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -1179,6 +1179,24 @@ async def test_chunk_writer_rejects_before_compression(
             ],
             max_bytes=1024,
         )
+        await session.execute(
+            update(HttpBridgeOperationRecord)
+            .where(HttpBridgeOperationRecord.operation_id == operation_id)
+            .values(event_bytes=1024)
+        )
+        await session.commit()
+        assert not await repository.append_operation_event_chunk(
+            events=[
+                DurableBridgeOperationEventInput(
+                    operation_id=operation_id,
+                    session_id=claim.id,
+                    instance_id="inst-precompress",
+                    owner_epoch=claim.owner_epoch,
+                    event_text="small",
+                )
+            ],
+            max_bytes=1024,
+        )
         encoder.assert_not_called()
     finally:
         await session.close()

--- a/tests/unit/test_chunk_writer_settings.py
+++ b/tests/unit/test_chunk_writer_settings.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+
+def test_chunk_writer_format_defaults_off_and_validates(monkeypatch) -> None:
+    monkeypatch.delenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_FORMAT", raising=False)
+
+    assert Settings(_env_file=None).http_responses_session_bridge_operation_spool_format == "rows_v1"
+    monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_FORMAT", "chunks_v2")
+    assert Settings(_env_file=None).http_responses_session_bridge_operation_spool_format == "chunks_v2"
+    monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_FORMAT", "unknown")
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)

--- a/tests/unit/test_http_bridge_event_batcher.py
+++ b/tests/unit/test_http_bridge_event_batcher.py
@@ -179,7 +179,7 @@ async def test_chunk_mode_routes_batch_and_terminal_without_legacy_writes() -> N
 
 
 @pytest.mark.asyncio
-async def test_dropped_batch_is_never_marked_replayable() -> None:
+async def test_dropped_batch_requires_fenced_terminal_settlement() -> None:
     durable = _FakeDurableBridge(append_result=False)
     batcher = HttpBridgeOperationEventBatcher(
         durable,
@@ -204,9 +204,9 @@ async def test_dropped_batch_is_never_marked_replayable() -> None:
             state="failed",
         )
         assert result.persisted is False
-        assert result.settlement_required is False
+        assert result.settlement_required is True
         assert durable.finalized == []
-        assert durable.updated[0]["state"] == "failed"
+        assert durable.updated == []
         assert batcher._contexts == {}
         assert batcher._dropped_operations == set()
     finally:

--- a/tests/unit/test_http_bridge_event_batcher.py
+++ b/tests/unit/test_http_bridge_event_batcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,12 +13,27 @@ class _FakeDurableBridge:
         self.append_result = append_result
         self.update_result = update_result
         self.batches: list[list[str]] = []
+        self.chunk_batches: list[list[str]] = []
+        self.terminal_chunks: list[str] = []
         self.finalized: list[str] = []
         self.updated: list[dict[str, object]] = []
 
     async def append_operation_events(self, *, events, max_bytes: int) -> bool:
         del max_bytes
         self.batches.append([event.event_text for event in events])
+        return self.append_result
+
+    async def append_operation_event_chunk(self, *, events, max_bytes: int) -> bool:
+        del max_bytes
+        self.chunk_batches.append([event.event_text for event in events])
+        return self.append_result
+
+    async def append_terminal_operation_event(self, **kwargs) -> bool:
+        self.terminal_chunks.append(kwargs["event_text"])
+        return self.append_result
+
+    async def append_terminal_operation_chunk(self, **kwargs) -> bool:
+        self.terminal_chunks.append(kwargs["event_text"])
         return self.append_result
 
     async def finalize_operation_event_spool(self, **kwargs) -> bool:
@@ -64,6 +80,28 @@ async def _enqueue(
     )
 
 
+def test_from_settings_defaults_to_rows_and_accepts_chunk_canary() -> None:
+    durable = _FakeDurableBridge()
+
+    default_batcher = HttpBridgeOperationEventBatcher.from_settings(durable, SimpleNamespace())
+    chunk_batcher = HttpBridgeOperationEventBatcher.from_settings(
+        durable,
+        SimpleNamespace(http_responses_session_bridge_operation_spool_format="chunks_v2"),
+    )
+
+    assert default_batcher._spool_format == "rows_v1"
+    assert chunk_batcher._spool_format == "chunks_v2"
+
+
+def test_constructor_rejects_unknown_spool_format() -> None:
+    with pytest.raises(ValueError, match="unsupported"):
+        HttpBridgeOperationEventBatcher(
+            _FakeDurableBridge(),
+            max_bytes=1024,
+            spool_format="unknown",
+        )
+
+
 @pytest.mark.asyncio
 async def test_batches_without_blocking_and_finalizes_terminal_event() -> None:
     durable = _FakeDurableBridge()
@@ -103,6 +141,39 @@ async def test_background_flushes_nonterminal_events_as_one_batch() -> None:
             await asyncio.sleep(0.01)
         assert durable.batches == [["one", "two"]]
         assert durable.finalized == []
+    finally:
+        await batcher.close()
+
+
+@pytest.mark.asyncio
+async def test_chunk_mode_routes_batch_and_terminal_without_legacy_writes() -> None:
+    durable = _FakeDurableBridge()
+    batcher = HttpBridgeOperationEventBatcher(
+        durable,
+        max_bytes=1024,
+        batch_size=8,
+        flush_interval_seconds=60.0,
+        max_pending_events=32,
+        spool_format="chunks_v2",
+    )
+    try:
+        await _enqueue(batcher, "one")
+        await _enqueue(batcher, "two")
+        result = await batcher.append_terminal_event(
+            operation_id="op-1",
+            session_id="session-1",
+            instance_id="instance-1",
+            owner_epoch=1,
+            event_text="terminal",
+            max_bytes=1024,
+            state="completed",
+            response_id="resp-1",
+        )
+
+        assert result.persisted is True
+        assert durable.chunk_batches == [["one", "two"]]
+        assert durable.terminal_chunks == ["terminal"]
+        assert durable.batches == []
     finally:
         await batcher.close()
 
@@ -188,6 +259,30 @@ async def test_terminal_append_failure_settles_operation() -> None:
             "event_spool_complete": False,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_append_false_requires_fallback_settlement() -> None:
+    durable = _FakeDurableBridge(append_result=False)
+    batcher = HttpBridgeOperationEventBatcher(
+        durable,
+        max_bytes=1024,
+        flush_interval_seconds=60.0,
+    )
+
+    result = await batcher.append_terminal_event(
+        operation_id="op-1",
+        session_id="session-1",
+        instance_id="instance-1",
+        owner_epoch=7,
+        event_text="terminal",
+        max_bytes=1024,
+        state="failed",
+        response_id="resp-1",
+    )
+
+    assert result.persisted is False
+    assert result.settlement_required is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -69,7 +69,10 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 # operator-selectable because startup invariant failures need two supported
 # modes: report-only by default for mixed/self-hosted environments, and
 # fail-fast when CI or strict operators want config drift to abort startup.
-MAX_SETTINGS_FIELDS = 131
+# 131 -> 132: operation_spool_format. The default remains rows_v1 because a
+# rolling deployment may enable chunks_v2 only after every replica can read it;
+# no existing timeout or size setting can express that compatibility fence.
+MAX_SETTINGS_FIELDS = 132
 
 
 def test_generated_settings_reference_matches_code() -> None:


### PR DESCRIPTION
## Summary

Add a default-off `chunks_v2` durable transcript writer on top of the dual-reader migration, with bounded pre-compression admission and terminal fallback settlement.

This is a stacked PR. Review after the reader/migration PR; its base is `feat/add-chunked-http-bridge-transcripts`.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none (production SQLite growth/latency incident)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent SSE event framing

Change directory: `openspec/changes/enable-chunked-http-bridge-writer/`

## Changes

- Add `rows_v1 | chunks_v2` writer selection while keeping `rows_v1` as the default.
- Persist nonterminal batches and terminal events as owner-fenced chunks when the v2 flag is enabled.
- Enforce raw event-count and byte caps before compression so compression cannot bypass admission limits.
- Settle terminal outcomes through the existing fallback when a writer-format mismatch or fenced append returns `False`.
- Document canary activation and rollback to the dual reader plus `rows_v1` writer.

## Simplicity

- [x] New feature defaults to off (`rows_v1`).
- [x] No new required setup step.
- New setting: `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_FORMAT` — required for an explicit, reversible canary because the storage writer cannot be switched implicitly.
- [x] README / `.env.example` / dashboard navigation unchanged.

## Test plan

```text
.venv/bin/pytest -q tests/unit/test_http_bridge_event_batcher.py tests/unit/test_bridge_ring_lifecycle.py tests/unit/test_chunk_writer_settings.py
64 passed

.venv/bin/ruff check ...
All checks passed!

.venv/bin/ty check ...
All checks passed!

npx --yes @fission-ai/openspec validate enable-chunked-http-bridge-writer --strict
Change 'enable-chunked-http-bridge-writer' is valid
```

## Screenshots / output

No dashboard-visible change. The default path remains `rows_v1`; v2 activation is operator-controlled.

## Checklist

- [x] Title is in Conventional Commits format.
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] The change-specific strict OpenSpec validation passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in chunked format for storing HTTP bridge transcripts, while retaining the existing row-based default.
  * Added safeguards for ordered chunks, size and event limits, ownership, replay, and terminal settlement.
  * Added configuration support for selecting the transcript storage format.

* **Bug Fixes**
  * Encryption-key verification now retries transient SQLite lock errors and reports persistent failures correctly.

* **Documentation**
  * Documented the new transcript storage setting and rollout behavior.

* **Tests**
  * Expanded coverage for chunk persistence, validation, fallback settlement, configuration, and SQLite lock recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->