### PR TITLE
fix(dashboard): contain mobile usage donuts

### DIFF
--- a/frontend/browser-smoke/dashboard.spec.ts
+++ b/frontend/browser-smoke/dashboard.spec.ts
@@ -2,6 +2,17 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { AuthSessionSchema } from "../src/features/auth/schemas";
 import { DashboardProjectionsSchema } from "../src/features/dashboard/schemas";
+import {
+  createAccountSummary,
+  createDashboardAuthSession,
+  createDashboardOverview,
+  createDashboardProjections,
+  createDashboardSettings,
+  createRequestLogEntry,
+  createRequestLogFilterOptions,
+  createRequestLogsResponse,
+  createTelemetryConsent,
+} from "../src/test/mocks/factories";
 
 const REQUIRED_API_PATHS = [
   "/api/dashboard-auth/session",
@@ -11,6 +22,46 @@ const REQUIRED_API_PATHS = [
   "/api/request-logs",
   "/api/settings/telemetry",
 ] as const;
+
+async function installMobileContainmentFixtures(page: Page): Promise<void> {
+  const accounts = [
+    createAccountSummary({
+      accountId: "acc_primary",
+      email: "primary-operator@northstar",
+      displayName: "primary-operator@northstar",
+      usage: { primaryRemainingPercent: 82, secondaryRemainingPercent: 67 },
+    }),
+    createAccountSummary({
+      accountId: "acc_secondary",
+      email: "secondary-operator@northstar",
+      displayName: "secondary-operator@northstar",
+      usage: { primaryRemainingPercent: 45, secondaryRemainingPercent: 12 },
+    }),
+  ];
+  const fixtures: Record<string, unknown> = {
+    "/api/dashboard-auth/session": createDashboardAuthSession({ authenticated: true, passwordRequired: true }),
+    "/api/dashboard/overview": createDashboardOverview({ accounts }),
+    "/api/dashboard/projections": createDashboardProjections(),
+    "/api/request-logs/options": createRequestLogFilterOptions({ accountIds: accounts.map((account) => account.accountId) }),
+    "/api/request-logs": createRequestLogsResponse([createRequestLogEntry({ accountId: "acc_primary", requestId: "req_mobile_containment" })], 1, false),
+    "/api/settings/telemetry": createTelemetryConsent({ state: "enabled", source: "persisted", active: true }),
+    "/api/settings": createDashboardSettings(),
+    "/api/accounts": { accounts },
+  };
+
+  await page.route("**/api/**", async (route) => {
+    const payload = fixtures[new URL(route.request().url()).pathname];
+    if (payload === undefined) {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "not_found", message: "Not found" } }),
+      });
+      return;
+    }
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(payload) });
+  });
+}
 
 async function acceptTelemetryConsent(page: Page, consentDialog: Locator): Promise<void> {
   const consentDecision = page.waitForResponse(
@@ -114,6 +165,86 @@ test("the built dashboard accepts real backend responses", async ({ page }) => {
   expect(apiFailures).toEqual([]);
   expect(pageErrors).toEqual([]);
   expect(consoleErrors).toEqual([]);
+});
+
+test("dashboard usage donuts stay within supported viewports", async ({ page }) => {
+  const viewportCases = [
+    { size: { width: 320, height: 568 }, donutColumns: 1 },
+    { size: { width: 390, height: 844 }, donutColumns: 1 },
+    { size: { width: 1440, height: 900 }, donutColumns: 2 },
+  ] as const;
+
+  await installMobileContainmentFixtures(page);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.setViewportSize(viewportCases[0].size);
+  await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+  const usageHeadings = page.getByRole("heading", { level: 3 }).filter({ hasText: "Credits" });
+  await expect(usageHeadings).toHaveCount(2);
+  const requestTable = page.getByRole("table").first();
+  await expect(requestTable).toBeVisible();
+
+  for (const viewportCase of viewportCases) {
+    await page.setViewportSize(viewportCase.size);
+
+    const usageMetrics = await usageHeadings.evaluateAll((headings) =>
+      headings.map((heading) => {
+        const card = heading.parentElement?.parentElement;
+        const row = heading.parentElement?.nextElementSibling;
+        const chart = row?.querySelector("svg")?.parentElement;
+        const legend = row?.querySelector('[data-testid="donut-legend-list"]');
+        if (!card || !row || !chart || !legend) {
+          throw new Error("Expected the rendered donut card structure");
+        }
+        const bounds = (element: Element) => {
+          const box = element.getBoundingClientRect();
+          return { left: box.left, right: box.right, width: box.width };
+        };
+        return {
+          card: bounds(card),
+          row: bounds(row),
+          chart: bounds(chart),
+          legend: bounds(legend),
+          gridColumns: getComputedStyle(card.parentElement!).gridTemplateColumns.split(" ").filter(Boolean).length,
+        };
+      }),
+    );
+    const documentMetrics = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    const summaryRight = await page
+      .getByTestId("dashboard-account-summary-line")
+      .evaluate((element) => element.getBoundingClientRect().right);
+    const tableMetrics = await requestTable.evaluate((table) => {
+      const scroller = table.closest('[data-slot="table-container"]');
+      if (!scroller) {
+        throw new Error("Expected the request table's local scroller");
+      }
+      const box = scroller.getBoundingClientRect();
+      return {
+        tableScrollWidth: table.scrollWidth,
+        scrollerClientWidth: scroller.clientWidth,
+        scrollerLeft: box.left,
+        scrollerRight: box.right,
+        overflowX: getComputedStyle(scroller).overflowX,
+      };
+    });
+
+    expect(documentMetrics.scrollWidth).toBeLessThanOrEqual(documentMetrics.clientWidth);
+    expect(summaryRight).toBeLessThanOrEqual(documentMetrics.clientWidth);
+    for (const metrics of usageMetrics) {
+      expect(metrics.gridColumns).toBe(viewportCase.donutColumns);
+      for (const bounds of [metrics.card, metrics.row, metrics.chart, metrics.legend]) {
+        expect(bounds.left).toBeGreaterThanOrEqual(0);
+        expect(bounds.right).toBeLessThanOrEqual(documentMetrics.clientWidth);
+      }
+    }
+    expect(tableMetrics.overflowX).toBe("auto");
+    expect(tableMetrics.tableScrollWidth).toBeGreaterThan(tableMetrics.scrollerClientWidth);
+    expect(tableMetrics.scrollerLeft).toBeGreaterThanOrEqual(0);
+    expect(tableMetrics.scrollerRight).toBeLessThanOrEqual(documentMetrics.clientWidth);
+  }
 });
 
 test("desktop route navigation resets new pages without overriding query, history, or hash scrolling", async ({ page }) => {

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -173,13 +173,13 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
   };
 
   return (
-    <div className="rounded-xl border bg-card p-5">
+    <div className="min-w-0 rounded-xl border bg-card p-5">
       <div className="mb-5">
         <h3 className="text-sm font-semibold">{title}</h3>
         {subtitle ? <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p> : null}
       </div>
 
-      <div className="flex items-center gap-6">
+      <div className="flex min-w-0 items-center gap-6">
         <div className="flex shrink-0 flex-col items-center gap-2">
           <div className="relative h-[152px] w-[152px] overflow-visible">
             <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
@@ -261,7 +261,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
         </div>
 
         <div
-          className="flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="min-w-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           data-testid="donut-legend-list"
           style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
         >

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -429,7 +429,7 @@ export function DashboardPage() {
 
           <section className="space-y-4">
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex min-w-0 items-center gap-3">
+              <div className="flex min-w-0 flex-wrap items-center gap-3">
                 <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">{t("accounts.page.title")}</h2>
                 <AccountSummaryLine accounts={overview?.accounts ?? []} />
               </div>

--- a/frontend/src/features/dashboard/components/usage-donuts.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.tsx
@@ -59,7 +59,7 @@ export function UsageDonuts({
 
 	return (
 		<Suspense fallback={<div className="grid gap-4 lg:grid-cols-2" />}>
-			<div className="grid gap-4 lg:grid-cols-2">
+			<div className="grid min-w-0 gap-4 lg:grid-cols-2">
 			<DonutChart
 				title={t("dashboard.usage.fiveHourCredits")}
 				items={primaryChartItems}

--- a/openspec/changes/fix-mobile-donut-overflow/.openspec.yaml
+++ b/openspec/changes/fix-mobile-donut-overflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/fix-mobile-donut-overflow/design.md
+++ b/openspec/changes/fix-mobile-donut-overflow/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`UsageDonuts` renders a one-column mobile grid whose `DonutChart` items retain the intrinsic minimum of a horizontal row containing a non-shrinking 152px chart, a 24px gap, and a legend. At 320x568 and 390x844, the card resolves to 475px inside a 288px or 358px content area and widens the document. The request table is intentionally wider than its local `overflow-x-auto` scroller and does not own the page overflow.
+
+A browser-only min-width perturbation reduced the 320px document width from 491px to 324px. The remaining 4px was traced separately to the unbreakable account-section heading/summary group: its heading, gap, and `whitespace-nowrap` summary exceed the 288px content row by a few rendered pixels. It is not caused by the donut, chart overflow, or request table.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep both usage donut cards and their rows, fixed charts, and legends within the mobile dashboard content width at 320x568 and 390x844.
+- Keep the document horizontally contained at those supported mobile viewports, including removal of the independently identified 4px account-summary residual.
+- Preserve the desktop two-column donut layout and the request table's existing local horizontal scrolling.
+- Prove the behavior through the rendered `/dashboard` route with deterministic, privacy-safe fixture data.
+
+**Non-Goals:**
+- Resize the 152px donut chart, change labels or data, or redesign the cards.
+- Hide page overflow globally or clip a still-oversized donut card.
+- Change the request table, dashboard APIs, navigation, or unrelated visual styles.
+- Introduce a new responsive-layout abstraction.
+
+## Decisions
+
+1. **Reset intrinsic minimums at each owning donut seam.** Add the existing Tailwind `min-w-0` utility to the `UsageDonuts` grid, the `DonutChart` card, its horizontal flex row, and its flexing legend. The chart remains `shrink-0` at 152px; the legend receives the remaining width and uses its existing truncation behavior.
+
+   Alternative: apply `overflow-x-hidden` to the page or card. Rejected because it would hide the symptom while leaving the layout wider than its container.
+
+2. **Let the account heading and summary wrap as separate flex items on the narrowest width.** The existing section header already permits wrapping at its outer level; allowing its inner heading/summary group to wrap removes the separately measured 4px residual while preserving the summary's own one-line text and all wider layouts.
+
+   Alternative: shorten localized copy or add another horizontal scroller. Rejected because copy width varies by locale and this compact header does not need scrolling.
+
+3. **Test the externally failing rendered seam.** Extend the existing dashboard browser smoke with deterministic route fixtures, then assert document containment and both usage-card edges at 320x568 and 390x844. Assert separately that the request table remains wider than, and contained by, its local horizontal scroller. Include 1440x900 as the desktop negative control.
+
+   Alternative: assert authored Tailwind classes in a component test. Rejected because class assertions cannot prove CSS grid and flex min-content behavior in a real layout engine.
+
+## Risks / Trade-offs
+
+- [A narrow legend has little horizontal space beside the fixed chart] → Keep the existing `truncate` label behavior and verify both labels and values remain in the contained card.
+- [The account summary may move below its heading at 320px] → Preserve the summary as one line and allow only the established flex group to wrap; verify 390px and desktop remain unchanged.
+- [A wide table could be mistaken for document overflow] → Assert both table/scroller width relationships and page-level containment in the same browser regression.
+- [Responsive changes could alter desktop sizing] → Exercise 1440x900 with the same fixture and assert two columns plus document containment.

--- a/openspec/changes/fix-mobile-donut-overflow/proposal.md
+++ b/openspec/changes/fix-mobile-donut-overflow/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+At 320x568 and 390x844 viewports, dashboard usage donut cards resolve to a 475px intrinsic width and widen the document beyond the mobile content area. Operators need the usage cards to remain readable and contained without changing the request table's intentional local horizontal scrolling or the desktop layout.
+
+## What Changes
+
+- Constrain the usage donut grid items and the donut card, row, and legend min-content seams so they can shrink within the mobile dashboard content width.
+- Allow the existing account-section heading and summary group to wrap at the smallest viewport, removing the separately identified 4px residual without clipping or global overflow suppression.
+- Preserve the fixed-size chart, existing legend truncation and scrolling behavior, and desktop two-column layout.
+- Add rendered browser-smoke coverage for document and usage-card containment while proving the request table still scrolls only inside its local scroller.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Require dashboard usage donut cards to remain within supported mobile content widths while preserving local horizontal scrolling for the request table.
+
+## Impact
+
+- Affected dashboard components: `frontend/src/features/dashboard/components/usage-donuts.tsx`, `frontend/src/components/donut-chart.tsx`, and the account-section header in `frontend/src/features/dashboard/components/dashboard-page.tsx`.
+- Affected test surface: focused dashboard browser smoke at 320x568, 390x844, and desktop.
+- No API, schema, persistence, dependency, configuration, request-table, navigation, or unrelated visual-style changes.

--- a/openspec/changes/fix-mobile-donut-overflow/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-mobile-donut-overflow/specs/frontend-architecture/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Dashboard usage content remains contained on mobile
+
+The dashboard MUST keep the document width within the visible viewport at 320x568 and 390x844. Both usage donut cards, their horizontal content rows, fixed-size charts, and legends MUST remain within the dashboard content width. The request table MAY exceed the viewport width only inside its own horizontal scroller and MUST NOT widen the document. The dashboard SHALL preserve the two-column usage layout and page-level containment at a 1440x900 desktop viewport.
+
+#### Scenario: Usage donuts fit the smallest supported mobile viewport
+
+- **WHEN** an authenticated operator opens `/dashboard` at 320x568 with account usage in both quota windows
+- **THEN** the document does not scroll horizontally
+- **AND** both usage donut cards and their rendered content remain within the dashboard content width
+- **AND** the account-section heading and summary remain within the document width
+
+#### Scenario: Usage donuts fit the larger mobile viewport
+
+- **WHEN** the same dashboard data renders at 390x844
+- **THEN** the document does not scroll horizontally
+- **AND** both usage donut cards remain within the dashboard content width
+
+#### Scenario: Request table keeps local horizontal scrolling
+
+- **WHEN** the request table's columns require more width than the mobile content area
+- **THEN** the table remains wider than its local horizontal scroller
+- **AND** the scroller contains that width without widening the document
+
+#### Scenario: Desktop layout remains contained
+
+- **WHEN** the same dashboard data renders at 1440x900
+- **THEN** the usage donuts render in two columns
+- **AND** the document remains horizontally contained
+- **AND** the request table retains its local horizontal scrolling when its columns exceed the available section width

--- a/openspec/changes/fix-mobile-donut-overflow/tasks.md
+++ b/openspec/changes/fix-mobile-donut-overflow/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add a rendered dashboard browser-smoke regression with privacy-safe usage and request data at 320x568, 390x844, and 1440x900.
+- [x] 1.2 Assert document and usage-card containment plus the request table's local horizontal scrolling, then run the focused test against the baseline and record the expected failure.
+
+## 2. Mobile containment
+
+- [x] 2.1 Add minimum-width containment at the usage donut grid, card, horizontal row, and legend seams while preserving the fixed 152px chart.
+- [x] 2.2 Allow the account-section heading and summary group to wrap at the smallest viewport, removing the independently measured 4px residual without clipping page overflow.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused browser regression green, affected frontend component tests, typecheck, lint, format, and build checks.
+- [x] 3.2 Validate the scoped OpenSpec change and affected `frontend-architecture` spec, then verify implementation completeness, correctness, and coherence.
+- [x] 3.3 Exercise the real rendered dashboard at 320x568, 390x844, and 1440x900, inspect page/card/table measurements, and capture privacy-safe matching before/after evidence outside the repository.


### PR DESCRIPTION
## Summary

Contain dashboard usage donut cards within the mobile content width. At 320px and 390px the previous min-content sizing widened the document to 491px and each card to 475px; the fix resets intrinsic minimum widths at the existing grid, card, flex-row, and legend seams without hiding overflow or changing the request table's local scroller.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — bounded issue and PR searches for `donut`, `overflow`, and `mobile` found no overlapping implementation.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-mobile-donut-overflow/`

## Changes

- Add a rendered dashboard regression covering 320x568, 390x844, and 1440x900, including document/card containment and the request table's independent horizontal scrolling.
- Allow the existing usage grid, donut card, chart row, and legend to shrink within their parent while preserving the fixed 152px chart.
- Let the account-section heading row wrap at 320px, removing the independently measured 4px residual document overflow.

## Simplicity

No setting, required setup, README section, dashboard navigation item, or default is added. The change uses existing layout seams and introduces no component or abstraction.

## Test plan

- Baseline-focused browser regression failed as expected at 320px (`document.scrollWidth` 491 vs `clientWidth` 320; card width 475px).
- `cd frontend && bun run test -- src/components/donut-chart.test.tsx src/features/dashboard/components/usage-donuts.test.tsx`
- `cd frontend && bun run typecheck`
- Focused ESLint over the changed frontend files.
- `cd frontend && bun run build`
- `make test-dashboard-browser-smoke` — 5 passed, including containment at 320x568 and 390x844, desktop two-column behavior at 1440x900, and local request-table scrolling.
- `openspec validate fix-mobile-donut-overflow --strict --no-interactive`
- OpenSpec apply status reports all scoped tasks complete; independent Standard-risk committed-diff review found no actionable findings.

The project-wide test suite and full local CI were intentionally not run. The unchanged main `frontend-architecture` spec currently has pre-existing strict-validation failures at requirements 128–130; the scoped change validates strictly and does not modify that main spec.

## Screenshots / output

| Before — 320x568 | After — 320x568 |
| --- | --- |
| <img width="320" height="568" alt="Dashboard before: usage donut card overflows the mobile viewport" src="https://github.com/user-attachments/assets/29d46db4-bd3b-41c4-96d0-af07fd5ba9e3" /> | <img width="320" height="568" alt="Dashboard after: usage donut card stays within the mobile viewport" src="https://github.com/user-attachments/assets/4bb2a4ea-f63f-4485-9c0b-85a2585aa510" /> |

Both captures use the same privacy-safe fixture data and viewport.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — no matching issue exists.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused `make`/frontend subsets locally; full local CI was intentionally not run.
- [x] If touching specs: the scoped change validates strictly and implementation verification is clean.
- [x] Simplicity gates reviewed: no new setup, setting, nav, README section, or default.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile dashboard horizontal overflow affecting usage donut charts, legends, and account summaries.
  * Account section headings now wrap cleanly on narrow screens.
  * Preserved local horizontal scrolling for oversized request tables without affecting the page layout.
  * Maintained the desktop two-column dashboard layout.

* **Tests**
  * Added responsive browser coverage across mobile and desktop viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->