### PR TITLE
chore: release v1.25.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.24.0"  # x-release-please-version
+__version__ = "1.25.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.24.0
-appVersion: 1.24.0
+version: 1.25.0-beta.1
+appVersion: 1.25.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.25.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.24.0"
+version = "1.25.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.24.0"
+version = "1.25.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.1 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.24.0
- fix(api-keys): preserve usage on limit patches (#1888) (
b72afb)
- fix(proxy): own cancellable usage refresh sessions (#1887) (
48eff5)
- fix(ui): restore settings dialog focus (#1883) (
5dc49e)
- fix(tooling): reject dashboard smoke runs without rebuild (#1880) (
37a9cd)
- fix(proxy): release cancelled embeddings reservations (#1874) (
b55189)
- fix(settings): show initial load failures (#1873) (
00c07f)
- fix(settings): allow clearing capacity overrides (#1871) (
e3fc08)
- fix(proxy): settle keyed mid-loop health after reservation (#1861) (
19dad4)
- fix(proxy): release grouped terminal append barriers on hard spool errors (#1860) (
5b3e07)
- fix(helm): default Codex prewarm off to match Settings (#1855) (
8cb0f2)
- fix(helm): honor external database port in network policy (#1838) (
a9a474)
- fix(proxy): preserve explicit null embedding fields (#1836) (
254839)
- fix(ui): restore scroll on route navigation (#1882) (
501eae)
- fix(proxy): enforce OpenSpec architecture ratchets (#1892) (
c3c1db)
- fix(proxy): recover stale previous response anchors (#1863) (
a34791)
- fix(proxy): exclude previous_response_id from model-source routing (#1859) (
09dd93)
- fix(ui): constrain API key dialog to viewport (#1884) (
ef1130)
- fix(proxy): defer keyed pre-created retry health writes until settlement (#1926) (
f9965f)
- fix(proxy): keep source Responses SSE alive and normalized (#1854) (
6d7886)
- fix(dashboard): contain mobile usage donuts (#1937) (
6c00ac)
- fix(proxy): release cancelled audio reservations (#1936) (
50ddee)
- feat(db): add chunk transcript reader (#1930) (
57d908)
- feat(proxy): fall back to HTTP transport when the upstream websocket is unavailable (#1886) (
9bc5cf)
- feat(proxy): enable chunk transcript writer (#1931) (
c7916f)
- fix(proxy): preserve agent-control outputs during slimming (takeover of #1893) (#1940) (
4e0332)
- fix(proxy): surface continuity_owner_conflict ahead of affinity (takeover of #1732) (#1941) (
2268f8)
- fix(retention): bound durable bridge cleanup work (#1929) (
02113f)
- fix(proxy): enforce prohibited priority service tier (#1961) (
d6fe7e)
- fix(accounts): probe with a valid upstream token floor (#1963) (
2a1668)
- fix(proxy): stop defer-cancellation shield waits from starving the event loop (#1969) (
6abb2a)
- fix(http-bridge): retire denied anchors without redispatch (#1902) (
dc016c)
- fix(db): clean stale SQLite sidecars during recovery (#1906) (
1d9332)
- fix(proxy): stop holding pending_lock across the settings-cache DB await (#1972) (
69f08d)
- fix(proxy): name the pre-response eventless timeout honestly and derive its budget from settings (#1974) (
0d283d)
- fix(http-bridge): re-check liveness before retiring a stale pending session (#1973) (
68d372)
- fix(proxy): refuse disabled model sources and spare account health from model-scoped rejections (#1978) (
54fca6)
- fix(quota,ops): expirable warmup claims, post-drain cleanup budget, bounded shutdown drain (#1977) (
343d8f)
- fix(proxy): pin same-owner stale-anchor replay (#1957) (
806b74)

## Release-candidate validation
Validated candidate: e59c79c2e49444131a793f8a812525e248b24596

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green on the candidate SHA: pytest unit / integration-core(-1..3) / integration-bridge / e2e / PostgreSQL, alembic migration checks (sqlite+pg), ruff, ty
- [x] Frontend tests/build — CI green on the candidate SHA: vite build, vitest + coverage, tsc, eslint, Playwright dashboard smoke
- [x] Wheel/package validation — CI `Package (build)` green on the candidate SHA
- [x] Docker/container smoke — CI `Docker build` + `Helm smoke install (kind)` green on the candidate SHA; additionally built the image locally from this exact SHA and booted it (sqlite): migrations ran to `20260830_000000_add_quota_warmup_claim_expiry`, `/health/ready` 200, `/health` ok, `app.__version__ == 1.25.0-beta.1`, zero errors in logs
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — backend-internal resilience fixes (#1969/#1972 event-loop livelock + pending_lock wedge); live validation happens at the soju07 zdt deploy with its 180s observation window and auto-rollback

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

