### PR TITLE
fix(proxy): preserve stale-anchor error shape presence

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -2,14 +2,61 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Literal, NotRequired, TypedDict
+
+from app.core.types import JsonValue
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAIErrorParam:
+    """Preserve whether an upstream error supplied a ``param`` field."""
+
+    present: bool
+    raw: JsonValue | None = None
+
+    @classmethod
+    def absent(cls) -> "OpenAIErrorParam":
+        return cls(False, None)
+
+    @classmethod
+    def from_mapping(cls, error: Mapping[str, JsonValue]) -> "OpenAIErrorParam":
+        if "param" not in error:
+            return cls.absent()
+        return cls(True, error["param"])
+
+    @property
+    def normalized(self) -> str | None:
+        return self.raw.strip() if isinstance(self.raw, str) else None
+
+    @property
+    def malformed(self) -> bool:
+        return self.present and (self.normalized is None or not self.normalized)
+
+
+def coerce_error_param(param: OpenAIErrorParam | JsonValue) -> OpenAIErrorParam:
+    """Convert legacy raw values to presence-aware error parameter state."""
+
+    if isinstance(param, OpenAIErrorParam):
+        return param
+    if param is None:
+        return OpenAIErrorParam.absent()
+    return OpenAIErrorParam(True, param)
+
+
+def normalize_public_error_param(param: OpenAIErrorParam | JsonValue) -> str | None:
+    """Return only a trimmed, non-empty string safe for a public response."""
+
+    normalized = coerce_error_param(param).normalized
+    return normalized if normalized else None
 
 
 class OpenAIErrorDetail(TypedDict, total=False):
     message: str
     type: str
     code: str
-    param: str
+    param: JsonValue
     plan_type: str
     resets_at: int | float
     resets_in_seconds: int | float
@@ -65,6 +112,7 @@ STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES = frozenset(
 HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE = "bridge_eventless_timeout"
 PREVIOUS_RESPONSE_NOT_FOUND_CODE = "previous_response_not_found"
 PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE = "Previous response was not found; retry without previous_response_id."
+PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON = "previous_response_not_found_malformed_param"
 
 
 def openai_error(
@@ -121,23 +169,64 @@ def previous_response_id_from_not_found_message(message: str | None) -> str | No
     return response_id or None
 
 
+def sanitize_public_error_detail(error: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    """Copy an error detail while omitting malformed ``param`` values."""
+
+    normalized = dict(error)
+    if "param" not in normalized:
+        return normalized
+    public_param = normalize_public_error_param(OpenAIErrorParam.from_mapping(error))
+    if public_param is None:
+        normalized.pop("param", None)
+    else:
+        normalized["param"] = public_param
+    return normalized
+
+
 def is_previous_response_not_found_error(
     *,
     code: str | None,
-    param: object,
+    param: OpenAIErrorParam | JsonValue,
     message: str | None,
 ) -> bool:
+    param_state = coerce_error_param(param)
+    if param_state.malformed:
+        return False
     if code == PREVIOUS_RESPONSE_NOT_FOUND_CODE:
         return True
-    if param is not None and not isinstance(param, str):
-        return False
     if code != "invalid_request_error":
         return False
-    if param is None:
+    if not param_state.present:
         return _is_invalid_previous_response_id_message(message)
-    if param != "previous_response_id":
+    if param_state.normalized != "previous_response_id":
         return False
     return is_previous_response_not_found_message(message) or _is_invalid_previous_response_id_message(message)
+
+
+def is_previous_response_not_found_public_shape(
+    *,
+    code: str | None,
+    param: OpenAIErrorParam | JsonValue,
+    message: str | None,
+) -> bool:
+    """Match stale-anchor errors for masking without authorizing replay."""
+
+    if code == PREVIOUS_RESPONSE_NOT_FOUND_CODE:
+        return True
+    param_state = coerce_error_param(param)
+    if (
+        code == "invalid_request_error"
+        and param_state.present
+        and not param_state.malformed
+        and param_state.normalized != "previous_response_id"
+    ):
+        return False
+    if code == "invalid_request_error" and (
+        _is_invalid_previous_response_id_message(message)
+        or previous_response_id_from_not_found_message(message) is not None
+    ):
+        return True
+    return is_previous_response_not_found_error(code=code, param=param, message=message)
 
 
 def response_failed_event(
@@ -146,13 +235,14 @@ def response_failed_event(
     error_type: str = "server_error",
     response_id: str | None = None,
     created_at: int | None = None,
-    error_param: str | None = None,
+    error_param: OpenAIErrorParam | JsonValue = None,
     resets_at: int | float | None = None,
     incomplete_details: dict[str, str] | None = None,
 ) -> ResponseFailedEvent:
     error = openai_error(code, message, error_type, resets_at=resets_at)["error"]
-    if error_param is not None:
-        error["param"] = error_param
+    public_param = normalize_public_error_param(error_param)
+    if public_param is not None:
+        error["param"] = public_param
     if created_at is None:
         created_at = int(time.time())
     response: ResponseFailedResponse = {

--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import time
 from collections.abc import AsyncIterator, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from app.core.errors import (
+    OpenAIErrorParam,
+    is_previous_response_not_found_public_shape,
+    previous_response_stream_incomplete_error,
+    sanitize_public_error_detail,
+)
 from app.core.openai.models import OpenAIError, OpenAIErrorEnvelope, ResponseUsage
+from app.core.openai.parsing import classify_event_type
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.sse import format_sse_data, parse_sse_data_json
@@ -289,7 +296,7 @@ def iter_chat_chunks(
         payload = _parse_data(line)
         if not payload:
             continue
-        event_type = payload.get("type")
+        event_type = classify_event_type(payload)
         if event_type in ("response.output_text.delta", "response.refusal.delta"):
             delta_text = payload.get("delta")
             role = None
@@ -360,9 +367,21 @@ def iter_chat_chunks(
                 if isinstance(maybe_error, dict) and maybe_error:
                     error = maybe_error
             if error is not None:
-                error_payload: dict[str, JsonValue] = {"error": error}
+                error_mapping = cast(Mapping[str, JsonValue], error)
+                parsed_error = _parse_error_mapping(error_mapping)
+                if parsed_error is not None and is_previous_response_not_found_public_shape(
+                    code=parsed_error.code,
+                    param=parsed_error.param_state,
+                    message=parsed_error.message,
+                ):
+                    error_payload = {"error": cast(JsonValue, previous_response_stream_incomplete_error()["error"])}
+                else:
+                    error_payload = {"error": sanitize_public_error_detail(error_mapping)}
             else:
-                error_payload = _default_error_envelope().model_dump(mode="json", exclude_none=True)
+                error_payload = cast(
+                    dict[str, JsonValue],
+                    _default_error_envelope().model_dump(mode="json", exclude_none=True),
+                )
             yield _dump_sse(error_payload)
             yield "data: [DONE]\n\n"
             return
@@ -471,7 +490,7 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
         payload = _parse_data(line)
         if not payload:
             continue
-        event_type = payload.get("type")
+        event_type = classify_event_type(payload)
         if event_type == "response.output_text.delta":
             delta = payload.get("delta")
             if isinstance(delta, str):
@@ -497,7 +516,21 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
                 maybe_error = payload.get("error")
                 if isinstance(maybe_error, dict):
                     error = maybe_error
-            terminal_error = _error_envelope_from_payload(error) if error is not None else _default_error_envelope()
+            if error is None:
+                terminal_error = _default_error_envelope()
+            else:
+                error_mapping = cast(Mapping[str, JsonValue], error)
+                parsed_error = _parse_error_mapping(error_mapping)
+                if parsed_error is not None and is_previous_response_not_found_public_shape(
+                    code=parsed_error.code,
+                    param=parsed_error.param_state,
+                    message=parsed_error.message,
+                ):
+                    terminal_error = OpenAIErrorEnvelope(
+                        error=OpenAIError.model_validate(previous_response_stream_incomplete_error()["error"])
+                    )
+                else:
+                    terminal_error = _error_envelope_from_payload(error_mapping)
             continue
         if terminal_error is not None:
             continue
@@ -587,7 +620,7 @@ def _dump_chunk(chunk: ChatCompletionChunk, *, include_usage: bool = False) -> s
     return _dump_sse(payload)
 
 
-def _dump_sse(payload: dict[str, JsonValue]) -> str:
+def _dump_sse(payload: Mapping[str, JsonValue]) -> str:
     return format_sse_data(payload)
 
 
@@ -630,14 +663,38 @@ def _default_error_envelope() -> OpenAIErrorEnvelope:
 
 
 def _error_envelope_from_payload(payload: Mapping[str, JsonValue]) -> OpenAIErrorEnvelope:
-    normalized = _normalize_error_payload(payload)
-    if not normalized:
+    error = _parse_error_mapping(sanitize_public_error_detail(payload))
+    if error is None:
         return _default_error_envelope()
+    return OpenAIErrorEnvelope(error=error)
+
+
+def _parse_error_mapping(payload: Mapping[str, JsonValue]) -> OpenAIError | None:
+    """Parse an upstream error while retaining explicit ``param`` presence."""
+
+    normalized = _normalize_error_payload(payload)
+    if not normalized and "param" not in payload:
+        return None
+    param_state = OpenAIErrorParam.from_mapping(payload)
     try:
         error = OpenAIError.model_validate(normalized)
     except ValidationError:
-        return _default_error_envelope()
-    return OpenAIErrorEnvelope(error=error)
+        message = payload.get("message")
+        error_type = payload.get("type")
+        code = payload.get("code")
+        param = payload.get("param")
+        plan_type = payload.get("plan_type")
+        error = OpenAIError(
+            message=message if isinstance(message, str) else None,
+            type=error_type if isinstance(error_type, str) else None,
+            code=code if isinstance(code, str) else None,
+            param=param if isinstance(param, str) else None,
+            plan_type=plan_type if isinstance(plan_type, str) else None,
+            resets_at=_coerce_number(payload.get("resets_at")),
+            resets_in_seconds=_coerce_number(payload.get("resets_in_seconds")),
+        )
+    error.set_param_state(param_state)
+    return error
 
 
 def _normalize_error_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue]:

--- a/app/core/openai/models.py
+++ b/app/core/openai/models.py
@@ -5,6 +5,7 @@ from typing import TypeAlias
 from pydantic import (
     BaseModel,
     ConfigDict,
+    PrivateAttr,
     StrictFloat,
     StrictInt,
     StrictStr,
@@ -12,6 +13,7 @@ from pydantic import (
     field_validator,
 )
 
+from app.core.errors import OpenAIErrorParam
 from app.core.types import JsonValue
 
 type ModelLikeInput = JsonValue | BaseModel
@@ -29,6 +31,8 @@ def _normalize_model_value[T: BaseModel](model_type: type[T], value: ModelLikeIn
 class OpenAIError(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    _param_state: OpenAIErrorParam = PrivateAttr(default_factory=OpenAIErrorParam.absent)
+
     message: StrictStr | None = None
     type: StrictStr | None = None
     code: StrictStr | None = None
@@ -36,6 +40,19 @@ class OpenAIError(BaseModel):
     plan_type: StrictStr | None = None
     resets_at: StrictInt | StrictFloat | None = None
     resets_in_seconds: StrictInt | StrictFloat | None = None
+
+    def model_post_init(self, __context: object) -> None:
+        self._param_state = OpenAIErrorParam(
+            present="param" in self.model_fields_set,
+            raw=self.param,
+        )
+
+    @property
+    def param_state(self) -> OpenAIErrorParam:
+        return self._param_state
+
+    def set_param_state(self, state: OpenAIErrorParam) -> None:
+        self._param_state = state
 
 
 class OpenAIErrorEnvelope(BaseModel):

--- a/app/core/utils/shared_future.py
+++ b/app/core/utils/shared_future.py
@@ -20,9 +20,13 @@ touch the shared future's callback list.
 from __future__ import annotations
 
 import asyncio
-from typing import TypeVar
+from typing import TypeVar, cast
+
+import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 
 _T = TypeVar("_T")
+_TaskResultT = TypeVar("_TaskResultT")
 
 _WAITERS_ATTR = "_shared_future_fanout_waiters"
 
@@ -78,3 +82,37 @@ async def wait_on_shared_future(
         return await asyncio.wait_for(proxy, timeout)
     finally:
         waiters.discard(proxy)
+
+
+async def _await_task_deferring_cancellation(
+    task: asyncio.Task[_TaskResultT],
+) -> tuple[_TaskResultT, asyncio.CancelledError | None]:
+    """Finish critical cleanup while preserving the caller's cancellation."""
+
+    cancellation: asyncio.CancelledError | None = None
+    result: _TaskResultT | None = None
+    # The anyio shield keeps a level-cancelled Starlette scope from re-raising
+    # into every ``await``, which would otherwise busy-spin this loop until the
+    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
+    # off the task's done-callback list: Python 3.14's ``asyncio.shield``
+    # leaks a callback per cancelled wait, so re-shielding a task wedged on a
+    # lock grew 100k+ callbacks and O(n^2) remove scans in the 2026-08-30
+    # production event-loop livelock.
+    with anyio.CancelScope(shield=True):
+        while True:
+            try:
+                result = await wait_on_shared_future(task)
+                break
+            except asyncio.CancelledError as exc:
+                if task.cancelled():
+                    raise
+                cancellation = cancellation or exc
+    if cancellation is None:
+        # The shield also blocks the level cancellation this helper promises
+        # to surface. Probe for it without suspending so callers still get
+        # their cancellation marker after the owned task finished.
+        try:
+            await checkpoint_if_cancelled()
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+    return cast(_TaskResultT, result), cancellation

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -14,9 +14,6 @@ from ipaddress import ip_address
 from typing import Any, Literal, Mapping, TypeVar, cast
 from urllib.parse import urlparse
 
-import anyio
-from anyio.lowlevel import checkpoint_if_cancelled
-
 from app.core import shutdown as shutdown_state
 from app.core.balancer.rendezvous_hash import select_node
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
@@ -73,7 +70,7 @@ from app.core.openai.requests import (
 from app.core.resilience.overload import local_overload_error
 from app.core.types import JsonValue
 from app.core.utils.request_id import get_request_id
-from app.core.utils.shared_future import wait_on_shared_future
+from app.core.utils.shared_future import _await_task_deferring_cancellation, wait_on_shared_future
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
@@ -723,39 +720,6 @@ def _http_bridge_eventless_timeout_message(unmatched_upstream_liveness_count: in
     return _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
 
 
-async def _await_task_deferring_cancellation(
-    task: asyncio.Task[T],
-) -> tuple[T, asyncio.CancelledError | None]:
-    """Finish critical cleanup while preserving the caller's cancellation."""
-
-    cancellation: asyncio.CancelledError | None = None
-    # The anyio shield keeps a level-cancelled Starlette scope from re-raising
-    # into every ``await``, which would otherwise busy-spin this loop until the
-    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
-    # off the task's done-callback list: Python 3.14's ``asyncio.shield``
-    # leaks a callback per cancelled wait, so re-shielding a task wedged on a
-    # lock grew 100k+ callbacks and O(n^2) remove scans in the 2026-08-30
-    # production event-loop livelock.
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                result = await wait_on_shared_future(task)
-                break
-            except asyncio.CancelledError as exc:
-                if task.cancelled():
-                    raise
-                cancellation = cancellation or exc
-    if cancellation is None:
-        # The shield also blocks the level cancellation this helper promises
-        # to surface. Probe for it without suspending so callers still get
-        # their cancellation marker after the owned task finished.
-        try:
-            await checkpoint_if_cancelled()
-        except asyncio.CancelledError as exc:
-            cancellation = exc
-    return result, cancellation
-
-
 @dataclass(frozen=True, slots=True)
 class _HTTPBridgeRuntimeConfig:
     enabled: bool
@@ -1211,15 +1175,12 @@ def _normalize_http_bridge_error_event(
                 stripped = message_value.strip()
                 if stripped:
                     error_message_value = stripped
-            if "param" in payload_error:
-                error_param_value = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], payload_error))
-
     if isinstance(payload, dict):
         raw_error = payload.get("error")
         if not isinstance(raw_error, dict):
             raw_error = _websocket_top_level_error_payload(payload)
         if isinstance(raw_error, dict):
-            if "param" in raw_error:
+            if error_param_value is None and "param" in raw_error:
                 error_param_value = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], raw_error))
             plan_type = raw_error.get("plan_type")
             if isinstance(plan_type, str):

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -48,6 +48,8 @@ from app.core.errors import (
     HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
+    OpenAIErrorParam,
+    coerce_error_param,
     openai_error,
     previous_response_stream_incomplete_error,
     response_failed_event,
@@ -1101,13 +1103,15 @@ def _log_http_bridge_startup_wait_timeout(
     )
 
 
-def _http_bridge_precreated_retry_failure_error(exc: BaseException) -> tuple[int, str, str, str, str | None]:
+def _http_bridge_precreated_retry_failure_error(
+    exc: BaseException,
+) -> tuple[int, str, str, str, OpenAIErrorParam | None]:
     if isinstance(exc, ProxyResponseError):
         parsed = _parse_openai_error(exc.payload)
         code = _normalize_error_code(parsed.code if parsed else None, parsed.type if parsed else None)
         message = parsed.message if parsed and parsed.message else "HTTP bridge pre-created retry failed"
         error_type = parsed.type if parsed and parsed.type else "server_error"
-        error_param = parsed.param if parsed else None
+        error_param = parsed.param_state if parsed else None
         return exc.status_code, code, message, error_type, error_param
     if isinstance(exc, TimeoutError):
         return (
@@ -1175,7 +1179,7 @@ def _normalize_http_bridge_error_event(
     error_code_value: str | None = None
     error_type_value: str | None = None
     error_message_value: str | None = None
-    error_param_value: str | None = None
+    error_param_value: OpenAIErrorParam | None = None
     explicit_error_code = False
     rate_limit_metadata: OpenAIErrorDetail = {}
 
@@ -1183,7 +1187,7 @@ def _normalize_http_bridge_error_event(
         error_code_value = event.error.code
         error_type_value = event.error.type
         error_message_value = event.error.message
-        error_param_value = event.error.param
+        error_param_value = event.error.param_state
         if isinstance(error_code_value, str) and error_code_value.strip():
             explicit_error_code = True
     elif isinstance(payload, dict):
@@ -1207,9 +1211,8 @@ def _normalize_http_bridge_error_event(
                 stripped = message_value.strip()
                 if stripped:
                     error_message_value = stripped
-            param_value = payload_error.get("param")
-            if isinstance(param_value, str):
-                error_param_value = param_value.strip()
+            if "param" in payload_error:
+                error_param_value = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], payload_error))
 
     if isinstance(payload, dict):
         raw_error = payload.get("error")
@@ -1217,8 +1220,7 @@ def _normalize_http_bridge_error_event(
             raw_error = _websocket_top_level_error_payload(payload)
         if isinstance(raw_error, dict):
             if "param" in raw_error:
-                raw_param = raw_error.get("param")
-                error_param_value = raw_param.strip() if isinstance(raw_param, str) else ""
+                error_param_value = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], raw_error))
             plan_type = raw_error.get("plan_type")
             if isinstance(plan_type, str):
                 rate_limit_metadata["plan_type"] = plan_type
@@ -1238,7 +1240,7 @@ def _normalize_http_bridge_error_event(
         if request_state.error_message_override is not None:
             error_message_value = request_state.error_message_override
         if request_state.error_param_override is not None:
-            error_param_value = request_state.error_param_override
+            error_param_value = coerce_error_param(request_state.error_param_override)
 
     normalized_error_code = _normalize_error_code(error_code_value, error_type_value) or "upstream_error"
     if not explicit_error_code and normalized_error_code == "error":

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -3340,6 +3340,9 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     raw_code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else None
     type_value = error.get("type")
     error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else None
+    param_state = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error))
+    if param_state.malformed:
+        return False
     # Normalize like the websocket rewrite path (#1818): upstream frames may
     # carry the classifiable code only in ``type`` (or omit both code and
     # param on the terse previous-response rejection), and a raw read would
@@ -3360,13 +3363,9 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
             "server_anchored_replay_once",
             "server_indefinite_recovery",
         }
-    param_value = error.get("param")
-    if "param" in error and not isinstance(param_value, str):
-        return False
-    param = param_value.strip() if isinstance(param_value, str) else None
     message_value = error.get("message")
     message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else None
-    return _is_previous_response_not_found_error(code=code, param=param, message=message)
+    return _is_previous_response_not_found_error(code=code, param=param_state, message=message)
 
 
 def _http_bridge_is_explicit_previous_response_rejection(exc: ProxyResponseError) -> bool:
@@ -3380,16 +3379,15 @@ def _http_bridge_is_explicit_previous_response_rejection(exc: ProxyResponseError
     raw_code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else None
     type_value = error.get("type")
     error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else None
+    param_state = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error))
+    if param_state.malformed:
+        return False
     code = _normalize_error_code(raw_code, error_type)
     if code == "bridge_previous_response_not_found":
         return True
-    param_value = error.get("param")
-    if "param" in error and not isinstance(param_value, str):
-        return False
-    param = param_value.strip() if isinstance(param_value, str) else None
     message_value = error.get("message")
     message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else None
-    return _is_previous_response_not_found_error(code=code, param=param, message=message)
+    return _is_previous_response_not_found_error(code=code, param=param_state, message=message)
 
 
 def _http_bridge_is_previous_response_owner_unavailable(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -49,7 +49,7 @@ from app.core.errors import (
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
-from app.core.openai.models import OpenAIEvent
+from app.core.openai.models import OpenAIError, OpenAIEvent
 from app.core.openai.parsing import parse_sse_event
 from app.core.resilience.network_recovery import (
     PROCESS_NETWORK_UNAVAILABLE_CODE,
@@ -605,6 +605,14 @@ def _raw_stream_error_fields(
         raw_error_param,
         _normalize_error_code(_websocket_event_error_code(event_type, event_payload), raw_error_type),
     )
+
+
+def _openai_error_fields(
+    error: OpenAIError | None,
+) -> tuple[str | None, str | None, OpenAIErrorParam | None]:
+    if error is None:
+        return None, None, None
+    return error.type, error.message, error.param_state
 
 
 def _raw_stream_error_code_or_upstream(

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -38,14 +38,16 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocket,
 )
 from app.core.errors import (
+    PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
+    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+    OpenAIErrorParam,
+    response_failed_event,
+)
+from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_CODE as PREVIOUS_RESPONSE_NOT_FOUND_CODE,
 )
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
-)
-from app.core.errors import (
-    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
-    response_failed_event,
 )
 from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import parse_sse_event
@@ -519,7 +521,7 @@ def _rewrite_previous_response_stream_error(
     error_code: str | None,
     error_type: str | None,
     error_message: str | None,
-    error_param: str | None,
+    error_param: OpenAIErrorParam | JsonValue,
 ) -> tuple[str, str, str | None] | None:
     if previous_response_id is None:
         return None
@@ -555,6 +557,25 @@ def _rewrite_previous_response_stream_error(
             PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
             None,
         )
+    if _facade()._is_previous_response_not_found_public_shape(
+        code=error_code,
+        param=error_param,
+        message=error_message,
+    ):
+        # Preserve masking when malformed ``param`` metadata makes the
+        # recovery classifier fail closed. This branch never authorizes
+        # replay or account switching.
+        _record_continuity_fail_closed(
+            surface="http_stream",
+            reason=PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
+            previous_response_id=previous_response_id,
+            upstream_error_code=error_code,
+        )
+        return (
+            "stream_incomplete",
+            PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+            None,
+        )
     normalized_code = _normalize_error_code(error_code, error_type)
     if preferred_account_id is not None and normalized_code in _facade()._ACCOUNT_RECOVERY_RETRY_CODES:
         _record_continuity_fail_closed(
@@ -574,7 +595,7 @@ def _rewrite_previous_response_stream_error(
 def _raw_stream_error_fields(
     event_type: str | None,
     event_payload: dict[str, JsonValue] | None,
-) -> tuple[str | None, str | None, str | None, str]:
+) -> tuple[str | None, str | None, OpenAIErrorParam | None, str]:
     raw_error_type = _websocket_event_error_type(event_type, event_payload)
     raw_error_message = _websocket_event_error_message(event_type, event_payload)
     raw_error_param = _websocket_event_error_param(event_type, event_payload)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -665,7 +665,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 else:
                     raw_error_type = error.type if error else None
                     raw_error_message = error.message if error else None
-                    raw_error_param = error.param if error else None
+                    raw_error_param = error.param_state if error else None
                     code = _normalize_error_code(
                         error.code if error else None,
                         raw_error_type,
@@ -848,7 +848,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                             error_code=raw_error_code,
                             error_type=error.type if error else None,
                             error_message=error.message if error else None,
-                            error_param=error.param if error else None,
+                            error_param=error.param_state if error else None,
                         )
                         if rewritten_error is not None:
                             response_id = (
@@ -964,7 +964,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 ),
                 error_type=error.type if error else None,
                 error_message=error.message if error else None,
-                error_param=error.param if error else None,
+                error_param=error.param_state if error else None,
             )
             if rewritten_error is not None:
                 rewritten_code, rewritten_message, upstream_error_code = rewritten_error

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -827,9 +827,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                                 settlement.response_id = response_id
                         else:
                             error = event.error
-                        raw_error_type = error.type if error else None
-                        raw_error_message = error.message if error else None
-                        raw_error_param = error.param_state if error else None
+                        raw_error_type, raw_error_message, raw_error_param = (None, None, None)
                         if preserve_raw_sse_line and error is None:
                             raw_error_type, raw_error_message, raw_error_param, raw_error_code = _raw_error_fields(
                                 event_type,
@@ -837,10 +835,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                             )
                             upstream_error = cast(UpstreamError, {"message": raw_error_message or "Upstream error"})
                         else:
-                            raw_error_code = _normalize_error_code(
-                                error.code if error else None,
-                                raw_error_type,
-                            )
+                            raw_error_code = _normalize_error_code(error.code if error else None, raw_error_type)
                             upstream_error = _upstream_error_from_openai(error)
                         raw_error_code = _raw_stream_error_code_or_upstream(
                             event_type,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -827,15 +827,20 @@ class _StreamingMixin(_StreamingRetryMixin):
                                 settlement.response_id = response_id
                         else:
                             error = event.error
+                        raw_error_type = error.type if error else None
+                        raw_error_message = error.message if error else None
+                        raw_error_param = error.param_state if error else None
                         if preserve_raw_sse_line and error is None:
-                            _, raw_error_message, _, raw_error_code = _raw_error_fields(event_type, event_payload)
+                            raw_error_type, raw_error_message, raw_error_param, raw_error_code = _raw_error_fields(
+                                event_type,
+                                event_payload,
+                            )
                             upstream_error = cast(UpstreamError, {"message": raw_error_message or "Upstream error"})
                         else:
                             raw_error_code = _normalize_error_code(
                                 error.code if error else None,
-                                error.type if error else None,
+                                raw_error_type,
                             )
-                            raw_error_message = error.message if error else None
                             upstream_error = _upstream_error_from_openai(error)
                         raw_error_code = _raw_stream_error_code_or_upstream(
                             event_type,
@@ -846,9 +851,9 @@ class _StreamingMixin(_StreamingRetryMixin):
                             previous_response_id=payload.previous_response_id,
                             preferred_account_id=preferred_account_id,
                             error_code=raw_error_code,
-                            error_type=error.type if error else None,
-                            error_message=error.message if error else None,
-                            error_param=error.param_state if error else None,
+                            error_type=raw_error_type,
+                            error_message=raw_error_message,
+                            error_param=raw_error_param,
                         )
                         if rewritten_error is not None:
                             response_id = (

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -277,12 +277,11 @@ from app.modules.proxy._service.streaming.helpers import (
 from app.modules.proxy._service.streaming.helpers import (
     _mark_downstream_stream_cancelled,
     _mark_upstream_stream_incomplete,
+    _openai_error_fields,
     _raw_stream_error_code_or_upstream,
     _rewrite_malformed_stream_error_event,
 )
-from app.modules.proxy._service.streaming.helpers import (
-    _raw_stream_error_fields as _raw_error_fields,
-)
+from app.modules.proxy._service.streaming.helpers import _raw_stream_error_fields as _raw_error_fields
 from app.modules.proxy._service.streaming.helpers import (
     _resolve_upstream_route_for_account as _resolve_upstream_route_for_account_helper,
 )
@@ -827,7 +826,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                                 settlement.response_id = response_id
                         else:
                             error = event.error
-                        raw_error_type, raw_error_message, raw_error_param = (None, None, None)
+                        raw_error_type, raw_error_message, raw_error_param = _openai_error_fields(error)
                         if preserve_raw_sse_line and error is None:
                             raw_error_type, raw_error_message, raw_error_param, raw_error_code = _raw_error_fields(
                                 event_type,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -7,11 +7,9 @@ import logging
 import sys
 import time
 from dataclasses import replace
-from typing import Any, AsyncGenerator, AsyncIterator, Mapping, TypeVar, cast
+from typing import Any, AsyncGenerator, AsyncIterator, Mapping, cast
 
 import aiohttp
-import anyio
-from anyio.lowlevel import checkpoint_if_cancelled
 
 from app.core.auth.refresh import RefreshError, is_transient_refresh_contention, refresh_contention_kind
 from app.core.balancer import failover_decision
@@ -31,7 +29,7 @@ from app.core.resilience.network_recovery import (
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id
 from app.core.utils.retry import backoff_seconds
-from app.core.utils.shared_future import wait_on_shared_future
+from app.core.utils.shared_future import _await_task_deferring_cancellation
 from app.core.utils.sse import format_sse_event
 from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
@@ -90,38 +88,6 @@ _HTTP_DOWNSTREAM_TRANSPORT_POLICY_DEFAULT = "smart"
 _HTTP_DOWNSTREAM_TRANSPORT_POLICIES = frozenset({"smart", "always_http", "always_websocket", "pinned"})
 
 logger = logging.getLogger(__name__)
-_TaskResultT = TypeVar("_TaskResultT")
-
-
-async def _await_task_deferring_cancellation(
-    task: asyncio.Task[_TaskResultT],
-) -> tuple[_TaskResultT, asyncio.CancelledError | None]:
-    """Finish critical cleanup while preserving the caller's cancellation."""
-
-    cancellation: asyncio.CancelledError | None = None
-    # The anyio shield keeps a level-cancelled Starlette scope from re-raising
-    # into every ``await``, which would otherwise busy-spin this loop until the
-    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
-    # off the task's done-callback list: Python 3.14's ``asyncio.shield``
-    # leaks a callback per cancelled wait (2026-08-30 event-loop livelock).
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                result = await wait_on_shared_future(task)
-                break
-            except asyncio.CancelledError as exc:
-                if task.cancelled():
-                    raise
-                cancellation = cancellation or exc
-    if cancellation is None:
-        # The shield also blocks the level cancellation this helper promises
-        # to surface. Probe for it without suspending so callers still get
-        # their cancellation marker after the owned task finished.
-        try:
-            await checkpoint_if_cancelled()
-        except asyncio.CancelledError as exc:
-            cancellation = exc
-    return result, cancellation
 
 
 def _facade() -> Any:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -460,7 +460,7 @@ class _StreamingRetryMixin:
                 error_message,
                 error_type=(error.type if error else None) or "server_error",
                 response_id=request_id,
-                error_param=error.param if error else None,
+                error_param=error.param_state if error else None,
             )
             _apply_error_metadata(event["response"]["error"], error)
             return format_sse_event(event)
@@ -999,7 +999,7 @@ class _StreamingRetryMixin:
                 error_message,
                 error_type=(error.type if error else None) or "invalid_request_error",
                 response_id=request_id,
-                error_param=error.param if error else None,
+                error_param=error.param_state if error else None,
             )
             _apply_error_metadata(event["response"]["error"], error)
             if not any_attempt_logged:
@@ -2119,7 +2119,7 @@ class _StreamingRetryMixin:
                                     )
                                     error_message = error.message if error else "Upstream error"
                                     error_type = error.type if error else None
-                                    error_param = error.param if error else None
+                                    error_param = error.param_state if error else None
                                     event = response_failed_event(
                                         error_code or "upstream_error",
                                         error_message or "Upstream error",
@@ -2814,7 +2814,7 @@ class _StreamingRetryMixin:
                                     error_message or "Upstream error",
                                     error_type=(error.type if error else None) or "server_error",
                                     response_id=failed_response_id,
-                                    error_param=error.param if error else None,
+                                    error_param=error.param_state if error else None,
                                 )
                                 _apply_error_metadata(event["response"]["error"], error)
                                 _facade().logger.warning(
@@ -2999,7 +2999,7 @@ class _StreamingRetryMixin:
                                 error_message or "Upstream error",
                                 error_type=(error.type if error else None) or "server_error",
                                 response_id=request_id,
-                                error_param=error.param if error else None,
+                                error_param=error.param_state if error else None,
                             )
                             _apply_error_metadata(event["response"]["error"], error)
                             yield format_sse_event(event)
@@ -3039,7 +3039,7 @@ class _StreamingRetryMixin:
                     error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
                     error_message = error.message if error else None
                     error_type = error.type if error else None
-                    error_param = error.param if error else None
+                    error_param = error.param_state if error else None
                     if _facade()._is_security_work_authorization_required_error(error_code, error_message):
                         if (
                             not account.security_work_authorized
@@ -3162,7 +3162,7 @@ class _StreamingRetryMixin:
                         error_message or "Account response-create concurrency limit reached",
                         error_type=(error.type if error else None) or "server_error",
                         response_id=request_id,
-                        error_param=error.param if error else None,
+                        error_param=error.param_state if error else None,
                     )
                     _apply_error_metadata(event["response"]["error"], error)
                     yield format_sse_event(event)

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Mapping
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Literal, NoReturn, Protocol
+from typing import Any, Literal, NoReturn, Protocol, cast
 
 import anyio
 
@@ -22,7 +22,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocket,
 )
 from app.core.config.settings import get_settings
-from app.core.errors import OpenAIErrorEnvelope, openai_error
+from app.core.errors import OpenAIErrorEnvelope, OpenAIErrorParam, openai_error
 from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import classify_event_type
@@ -1125,7 +1125,7 @@ class _WebSocketRequestState:
     error_code_override: str | None = None
     error_message_override: str | None = None
     error_type_override: str | None = None
-    error_param_override: str | None = None
+    error_param_override: OpenAIErrorParam | JsonValue | None = None
     failure_phase_override: str | None = None
     failure_detail_override: str | None = None
     upstream_error_code_override: str | None = None
@@ -1133,7 +1133,14 @@ class _WebSocketRequestState:
     response_event_count: int = 0
     last_upstream_activity_at: float | None = None
     upstream_model_output_seen: bool = False
+    # Terminal WebSocket error sanitization records continuity telemetry once;
+    # later serializers preserve the normalized fields without recording it a
+    # second time.
+    websocket_terminal_error_fields_sanitized: bool = False
     previous_response_not_found_rewritten: bool = False
+    # A canonical stale-anchor code with malformed present ``param`` may be
+    # matched for masking, but must never authorize replay.
+    previous_response_not_found_recovery_blocked: bool = False
     previous_response_owner_lookup_source: str | None = None
     previous_response_owner_lookup_outcome: str | None = None
     previous_response_owner_requested_at: datetime | None = None
@@ -1806,9 +1813,9 @@ def _openai_error_envelope_from_response_failed_payload(
     error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
 
     envelope = openai_error(code, message, error_type)
-    param_value = error_payload.get("param")
     if "param" in error_payload:
-        envelope["error"]["param"] = param_value.strip() if isinstance(param_value, str) else ""
+        param_state = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error_payload))
+        envelope["error"]["param"] = param_state.raw
     error_detail = envelope["error"]
     plan_type = error_payload.get("plan_type")
     if plan_type is not None:

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1163,14 +1163,15 @@ def _sanitize_public_websocket_event_payload(
             if sanitized_error != error_value:
                 normalized = dict(normalized)
                 normalized["error"] = sanitized_error
-        elif "param" in payload:
-            sanitized = dict(payload)
+        if "param" in payload:
+            sanitized = dict(normalized)
             public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
             if public_param is None:
                 sanitized.pop("param", None)
             else:
                 sanitized["param"] = public_param
-            normalized = sanitized
+            if sanitized != normalized:
+                normalized = sanitized
 
     response_value = payload.get("response")
     if isinstance(response_value, dict):

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -5,7 +5,7 @@ import json
 import sys
 import time
 from collections import deque
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -39,13 +39,18 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketMessage,
 )
 from app.core.errors import (
+    PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
     PREVIOUS_RESPONSE_NOT_FOUND_CODE,
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorEnvelope,
+    OpenAIErrorParam,
+    coerce_error_param,
+    normalize_public_error_param,
     openai_error,
     previous_response_stream_incomplete_error,
     response_failed_event,
+    sanitize_public_error_detail,
 )
 from app.core.exceptions import AppError
 from app.core.openai.models import OpenAIEvent
@@ -756,19 +761,14 @@ def _websocket_event_error_type(event_type: str | None, payload: dict[str, JsonV
     return stripped or None
 
 
-def _websocket_event_error_param(event_type: str | None, payload: dict[str, JsonValue] | None) -> str | None:
+def _websocket_event_error_param(
+    event_type: str | None,
+    payload: dict[str, JsonValue] | None,
+) -> OpenAIErrorParam | None:
     error = _websocket_event_error_payload(event_type, payload)
     if not isinstance(error, dict):
         return None
-    if "param" not in error:
-        return None
-    param_value = error.get("param")
-    if not isinstance(param_value, str):
-        # Preserve field presence as a fail-closed, non-matching value. The
-        # upstream classifier must distinguish an absent param from a present
-        # value with the wrong JSON type.
-        return ""
-    return param_value.strip()
+    return OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error))
 
 
 def _websocket_event_error_message(event_type: str | None, payload: dict[str, JsonValue] | None) -> str | None:
@@ -866,8 +866,11 @@ def _websocket_precreated_replay_fallback_error(
     error_message = request_state.error_message_override or "Upstream rejected the requested model for this account"
     error_type = request_state.error_type_override or "invalid_request_error"
     payload = openai_error(error_code, error_message, error_type=error_type)
-    if request_state.error_param_override is not None:
-        payload["error"]["param"] = request_state.error_param_override
+    error_param_override = coerce_error_param(request_state.error_param_override)
+    if error_param_override.present:
+        public_param = normalize_public_error_param(error_param_override)
+        if public_param is not None:
+            payload["error"]["param"] = public_param
     return (
         request_state.error_http_status_override or 400,
         payload,
@@ -1111,8 +1114,7 @@ def _websocket_top_level_error_payload(payload: dict[str, JsonValue]) -> dict[st
         if isinstance(value, str) and value.strip():
             error[error_field] = value.strip()
     if "param" in payload:
-        param = payload.get("param")
-        error["param"] = param.strip() if isinstance(param, str) else ""
+        error["param"] = payload["param"]
     error_type = payload.get("error_type")
     if isinstance(error_type, str) and error_type.strip():
         error["type"] = error_type.strip()
@@ -1144,6 +1146,43 @@ def _websocket_event_error_payload(
         error = response.get("error") if isinstance(response, dict) else None
         return error if isinstance(error, dict) else None
     return None
+
+
+def _sanitize_public_websocket_event_payload(
+    payload: dict[str, JsonValue],
+    *,
+    event_type: str | None,
+) -> dict[str, JsonValue]:
+    """Copy a terminal event with only a client-safe ``error.param``."""
+
+    normalized = payload
+    if event_type == "error":
+        error_value = payload.get("error")
+        if isinstance(error_value, dict):
+            sanitized_error = sanitize_public_error_detail(error_value)
+            if sanitized_error != error_value:
+                normalized = dict(normalized)
+                normalized["error"] = sanitized_error
+        elif "param" in payload:
+            sanitized = dict(payload)
+            public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
+            if public_param is None:
+                sanitized.pop("param", None)
+            else:
+                sanitized["param"] = public_param
+            normalized = sanitized
+
+    response_value = payload.get("response")
+    if isinstance(response_value, dict):
+        error_value = response_value.get("error")
+        if isinstance(error_value, dict):
+            sanitized_error = sanitize_public_error_detail(error_value)
+            if sanitized_error != error_value:
+                normalized_response = dict(response_value)
+                normalized_response["error"] = sanitized_error
+                normalized = dict(normalized)
+                normalized["response"] = normalized_response
+    return normalized
 
 
 def _websocket_event_incomplete_reason(
@@ -1186,6 +1225,15 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
         message=error_message,
     )
     reason = "previous_response_not_found"
+    if not should_rewrite and _facade()._is_previous_response_not_found_public_shape(
+        code=error_code,
+        param=error_param,
+        message=error_message,
+    ):
+        # Mask malformed stale-anchor metadata without allowing replay.
+        should_rewrite = True
+        reason = PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON
+        request_state.previous_response_not_found_recovery_blocked = True
     if not should_rewrite:
         if request_state.previous_response_id is None:
             return event, payload, event_type, original_text
@@ -1198,7 +1246,9 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
     if not should_rewrite:
         return event, payload, event_type, original_text
 
-    reconnect_requested = reason == "missing_tool_output" or request_state.preferred_account_id is not None
+    reconnect_requested = reason != PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON and (
+        reason == "missing_tool_output" or request_state.preferred_account_id is not None
+    )
     return _rewrite_websocket_continuity_corruption_event(
         request_state=request_state,
         upstream_control=upstream_control,
@@ -1347,6 +1397,9 @@ def _rewrite_websocket_continuity_corruption_event(
             reason=reason,
             previous_response_id=request_state.previous_response_id,
             session_id=request_state.session_id,
+            upstream_error_code=(
+                PREVIOUS_RESPONSE_NOT_FOUND_CODE if reason == PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON else None
+            ),
         )
     rewritten_code, rewritten_message = _websocket_continuity_error_fields(
         reason=reason,
@@ -1452,16 +1505,25 @@ def _sanitize_websocket_previous_response_error(
     reason = "previous_response_not_found"
     should_rewrite = _facade()._is_previous_response_not_found_error(
         code=normalized_code,
-        param=parsed_error.param if parsed_error else None,
+        param=parsed_error.param_state if parsed_error else OpenAIErrorParam.absent(),
         message=normalized_message,
     )
     if not should_rewrite:
         should_rewrite = _facade()._is_missing_tool_output_error(
             code=normalized_code,
-            param=parsed_error.param if parsed_error else None,
+            param=parsed_error.param_state if parsed_error else OpenAIErrorParam.absent(),
             message=normalized_message,
         )
         reason = "missing_tool_output"
+    if not should_rewrite and _facade()._is_previous_response_not_found_public_shape(
+        code=normalized_code,
+        param=parsed_error.param_state if parsed_error else OpenAIErrorParam.absent(),
+        message=normalized_message,
+    ):
+        should_rewrite = True
+        reason = PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON
+        if request_state is not None:
+            request_state.previous_response_not_found_recovery_blocked = True
     if not should_rewrite:
         return status_code, payload, error_code, error_message
 
@@ -1501,24 +1563,48 @@ def _sanitize_websocket_terminal_error_fields(
     error_code: str,
     error_message: str,
     error_type: str,
-    error_param: str | None,
-) -> tuple[str, str, str, str | None]:
+    error_param: OpenAIErrorParam | JsonValue | None,
+) -> tuple[str, str, str, OpenAIErrorParam | None]:
+    error_param_state = coerce_error_param(error_param)
+    if request_state.websocket_terminal_error_fields_sanitized:
+        return (
+            error_code,
+            error_message,
+            error_type,
+            error_param_state if error_param_state.present else None,
+        )
     normalized_code = _normalize_error_code(error_code, error_type)
-    if not _facade()._is_previous_response_not_found_error(
+    recoverable = _facade()._is_previous_response_not_found_error(
         code=normalized_code,
-        param=error_param,
+        param=error_param_state,
+        message=error_message,
+    )
+    if not recoverable and not _facade()._is_previous_response_not_found_public_shape(
+        code=normalized_code,
+        param=error_param_state,
         message=error_message,
     ):
-        return error_code, error_message, error_type, error_param
-    _record_websocket_stale_anchor_failure(
-        request_state,
-        surface="websocket_terminal",
-        upstream_error_code=normalized_code,
-    )
+        return error_code, error_message, error_type, error_param_state
+    if recoverable:
+        _record_websocket_stale_anchor_failure(
+            request_state,
+            surface="websocket_terminal",
+            upstream_error_code=normalized_code,
+        )
+    else:
+        request_state.previous_response_not_found_recovery_blocked = True
+        _record_continuity_fail_closed(
+            surface="websocket_terminal",
+            reason=PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
+            previous_response_id=request_state.previous_response_id,
+            session_id=request_state.session_id,
+            upstream_error_code=normalized_code,
+        )
     rewritten_code, rewritten_message = _websocket_continuity_error_fields(
-        reason="previous_response_not_found",
+        reason="previous_response_not_found" if recoverable else PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
         expose_stale_previous_response_classifier=request_state.expose_stale_previous_response_classifier,
     )
+    request_state.websocket_terminal_error_fields_sanitized = True
     return (
         rewritten_code,
         rewritten_message,
@@ -1943,9 +2029,9 @@ def _wrapped_websocket_error_event(
         error.get("code"),
         error.get("type"),
     )
-    error_param = error.get("param")
+    error_param = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error))
     error_message = error.get("message")
-    if _facade()._is_previous_response_not_found_error(
+    if _facade()._is_previous_response_not_found_public_shape(
         code=error_code,
         param=error_param,
         message=error_message,
@@ -1956,9 +2042,17 @@ def _wrapped_websocket_error_event(
         # do not re-mask it back to stream_incomplete. Every other caller
         # (public /v1, or a raw error this function is seeing for the first
         # time) keeps the existing stream_incomplete safety net.
-        if not expose_stale_previous_response_classifier:
+        expose = expose_stale_previous_response_classifier and _facade()._is_previous_response_not_found_error(
+            code=error_code,
+            param=error_param,
+            message=error_message,
+        )
+        if not expose:
             payload = previous_response_stream_incomplete_error()
-    error_payload = cast(JsonValue, dict(payload["error"]))
+    error_payload = cast(
+        JsonValue,
+        sanitize_public_error_detail(cast(Mapping[str, JsonValue], payload["error"])),
+    )
     event: dict[str, JsonValue] = {
         "type": "error",
         "status": status_code,

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1156,7 +1156,7 @@ def _sanitize_public_websocket_event_payload(
     """Copy a terminal event with only a client-safe ``error.param``."""
 
     normalized = payload
-    if event_type == "error":
+    if event_type in {"error", "response.failed"}:
         error_value = payload.get("error")
         if isinstance(error_value, dict):
             sanitized_error = sanitize_public_error_detail(error_value)
@@ -1735,6 +1735,13 @@ def _match_websocket_request_state_for_previous_response_error(
     return None
 
 
+def _is_unanchored_previous_response_error_message(message: str | None) -> bool:
+    if message is None:
+        return False
+    normalized = " ".join(message.casefold().replace("`", "").split()).removesuffix(".").rstrip()
+    return normalized == "invalid previous_response_id"
+
+
 def _matching_websocket_request_states_for_previous_response_error(
     pending_requests: deque[_WebSocketRequestState],
     *,
@@ -1776,6 +1783,16 @@ def _matching_websocket_request_states_for_previous_response_error(
         }
         if len(unique_previous_response_ids) == 1:
             return unresolved_followups
+    if (
+        allow_unanchored_previous_response_error
+        and len(followup_requests) == 1
+        and _is_unanchored_previous_response_error_message(error_message)
+    ):
+        # A post-created terminal error may omit both its response id and the
+        # rejected anchor id. When exactly one follow-up is pending, its
+        # previous-response ownership is the only safe correlation seam even
+        # after ``response.created`` assigned a response id.
+        return followup_requests
     return []
 
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -65,7 +65,10 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.errors import (
     STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES,
+    PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
+    PREVIOUS_RESPONSE_NOT_FOUND_CODE,
     OpenAIErrorEnvelope,
+    OpenAIErrorParam,
     openai_error,
     response_failed_event,
 )
@@ -411,6 +414,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _rewrite_websocket_downstream_response_id,
     _rewrite_websocket_previous_response_owner_unavailable_event,
     _rewrite_websocket_suppressed_duplicate_tool_call_completion_event,
+    _sanitize_public_websocket_event_payload,
     _sanitize_websocket_connect_failure,
     _sanitize_websocket_previous_response_error,
     _sanitize_websocket_terminal_error_fields,
@@ -703,6 +707,17 @@ def _websocket_archive_request_state_for_payload(
         param=_websocket_event_error_param(event_type, payload),
         message=error_message,
     )
+    is_previous_response_not_found_matching_event = (
+        is_previous_response_not_found_event
+        or _facade()._is_previous_response_not_found_public_shape(
+            code=_normalize_error_code(
+                _websocket_event_error_code(event_type, payload),
+                _websocket_event_error_type(event_type, payload),
+            ),
+            param=_websocket_event_error_param(event_type, payload),
+            message=error_message,
+        )
+    )
     is_missing_tool_output_event = _facade()._is_missing_tool_output_error(
         code=_normalize_error_code(
             _websocket_event_error_code(event_type, payload),
@@ -713,10 +728,11 @@ def _websocket_archive_request_state_for_payload(
     )
     return _match_websocket_request_state_for_anonymous_event(
         pending_requests,
-        prefer_previous_response_not_found=is_previous_response_not_found_event or is_missing_tool_output_event,
+        prefer_previous_response_not_found=is_previous_response_not_found_matching_event
+        or is_missing_tool_output_event,
         previous_response_id_hint=_facade()._previous_response_id_from_not_found_message(error_message),
         error_message=error_message,
-        allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+        allow_unanchored_previous_response_error=is_previous_response_not_found_matching_event,
     )
 
 
@@ -2053,7 +2069,7 @@ class _WebSocketMixin:
                         )
                         error_message = error.message if error and error.message else "Upstream error"
                         error_type = error.type if error and error.type else "server_error"
-                        error_param = error.param if error else None
+                        error_param = error.param_state if error else None
                         await proxy._release_websocket_request_state_reservation(request_state)
                         await proxy._write_websocket_connect_failure(
                             account_id=None,
@@ -2190,7 +2206,7 @@ class _WebSocketMixin:
                                 error_code=error_code or "upstream_error",
                                 error_message=error_message,
                                 error_type=error.type if error and error.type else "server_error",
-                                error_param=error.param if error else None,
+                                error_param=error.param_state if error else None,
                                 downstream_activity=downstream_activity,
                             )
                             request_state = None
@@ -2344,7 +2360,7 @@ class _WebSocketMixin:
                         )
                         error_message = error.message if error and error.message else "Upstream error"
                         error_type = error.type if error and error.type else "server_error"
-                        error_param = error.param if error else None
+                        error_param = error.param_state if error else None
                         await proxy._release_websocket_request_state_reservation(response_create_request_state)
                         await proxy._write_websocket_connect_failure(
                             account_id=account.id if account else None,
@@ -2698,7 +2714,7 @@ class _WebSocketMixin:
                             error_code=error_code or "upstream_error",
                             error_message=error_message,
                             error_type=error_type,
-                            error_param=error.param if error else None,
+                            error_param=error.param_state if error else None,
                             downstream_activity=downstream_activity,
                         )
                     continue
@@ -5302,6 +5318,21 @@ class _WebSocketMixin:
             param=_websocket_event_error_param(event_type, payload),
             message=error_message,
         )
+        # Ownership matching and replay authorization are separate decisions:
+        # a canonical stale-anchor frame with malformed ``param`` still needs
+        # to claim the right pending request for masking, but must fail closed
+        # for replay.
+        is_previous_response_not_found_matching_event = (
+            is_previous_response_not_found_event
+            or _facade()._is_previous_response_not_found_public_shape(
+                code=_normalize_error_code(
+                    _websocket_event_error_code(event_type, payload),
+                    _websocket_event_error_type(event_type, payload),
+                ),
+                param=_websocket_event_error_param(event_type, payload),
+                message=error_message,
+            )
+        )
         is_missing_tool_output_event = _facade()._is_missing_tool_output_error(
             code=_normalize_error_code(
                 _websocket_event_error_code(event_type, payload),
@@ -5336,11 +5367,11 @@ class _WebSocketMixin:
             elif response_id is None:
                 request_state = _match_websocket_request_state_for_anonymous_event(
                     pending_requests,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    prefer_previous_response_not_found=is_previous_response_not_found_matching_event
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
-                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_matching_event,
                 )
                 release_create_gate = False
             else:
@@ -5418,11 +5449,11 @@ class _WebSocketMixin:
                     pending_requests,
                     response_id=response_id,
                     fallback_request_state=request_state,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    prefer_previous_response_not_found=is_previous_response_not_found_matching_event
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
-                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_matching_event,
                     allow_precreated_terminal_fallback=event_type
                     in {
                         "response.failed",
@@ -5430,14 +5461,16 @@ class _WebSocketMixin:
                         "error",
                     },
                 )
-                if request_state is None and (is_previous_response_not_found_event or is_missing_tool_output_event):
+                if request_state is None and (
+                    is_previous_response_not_found_matching_event or is_missing_tool_output_event
+                ):
                     grouped_previous_response_request_states = _pop_matching_websocket_request_states(
                         pending_requests,
                         _matching_websocket_request_states_for_previous_response_error(
                             pending_requests,
                             previous_response_id_hint=previous_response_id_hint,
                             error_message=error_message,
-                            allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+                            allow_unanchored_previous_response_error=is_previous_response_not_found_matching_event,
                         ),
                     )
                     if not grouped_previous_response_request_states and is_missing_tool_output_event:
@@ -5524,16 +5557,28 @@ class _WebSocketMixin:
             await proxy._touch_active_websocket_thread_affinity(request_state, account)
 
         if len(grouped_previous_response_request_states) > 1:
-            upstream_control.reconnect_requested = True
-            downstream_texts: list[str] = []
             grouped_error_reason = (
                 "previous_response_not_found"
                 if is_previous_response_not_found_event
+                else PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON
+                if is_previous_response_not_found_matching_event
                 else "missing_tool_output"
                 if is_missing_tool_output_event
                 else "stream_incomplete"
             )
+            if grouped_error_reason != PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON:
+                upstream_control.reconnect_requested = True
+            downstream_texts: list[str] = []
             for grouped_request_state in grouped_previous_response_request_states:
+                if grouped_error_reason == PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON:
+                    grouped_request_state.previous_response_not_found_recovery_blocked = True
+                    _record_continuity_fail_closed(
+                        surface="websocket_stream",
+                        reason=PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
+                        previous_response_id=grouped_request_state.previous_response_id,
+                        session_id=grouped_request_state.session_id,
+                        upstream_error_code=PREVIOUS_RESPONSE_NOT_FOUND_CODE,
+                    )
                 if grouped_error_reason == "previous_response_not_found":
                     _record_websocket_stale_anchor_failure(
                         grouped_request_state,
@@ -5573,10 +5618,14 @@ class _WebSocketMixin:
         _record_response_event(request_state, event_type)
 
         if request_state is None:
-            if is_previous_response_not_found_event:
-                upstream_control.reconnect_requested = True
+            if is_previous_response_not_found_matching_event:
+                malformed_param = not is_previous_response_not_found_event
+                if not malformed_param:
+                    upstream_control.reconnect_requested = True
                 fallback_error_code, fallback_error_message = _websocket_continuity_error_fields(
-                    reason="previous_response_not_found",
+                    reason=PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON
+                    if malformed_param
+                    else "previous_response_not_found",
                     expose_stale_previous_response_classifier=codex_session_affinity,
                 )
                 downstream_text = json.dumps(
@@ -5595,6 +5644,10 @@ class _WebSocketMixin:
                 return downstream_text
             if is_missing_tool_output_event:
                 upstream_control.suppress_downstream_event = True
+            if event_type in {"response.failed", "response.incomplete", "error"} and isinstance(payload, dict):
+                public_payload = _sanitize_public_websocket_event_payload(payload, event_type=event_type)
+                if public_payload is not payload:
+                    text = json.dumps(public_payload, ensure_ascii=True, separators=(",", ":"))
             return text
 
         if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -5643,6 +5696,12 @@ class _WebSocketMixin:
                 upstream_control=upstream_control,
                 original_text=text,
             )
+        if event_type in {"response.failed", "response.incomplete", "error"} and isinstance(payload, dict):
+            public_payload = _sanitize_public_websocket_event_payload(payload, event_type=event_type)
+            if public_payload is not payload:
+                # Keep raw payload/event state for settlement; only the
+                # serialized client text is sanitized.
+                downstream_text = json.dumps(public_payload, ensure_ascii=True, separators=(",", ":"))
         if retry_error_code is None:
             retry_error_code = _websocket_precreated_retry_error_code(
                 request_state,
@@ -5850,7 +5909,7 @@ class _WebSocketMixin:
                         request_state.error_code_override = _facade()._SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE
                         request_state.error_message_override = terminal_error_message
                         request_state.error_type_override = error.type if error else None
-                        request_state.error_param_override = error.param if error else None
+                        request_state.error_param_override = error.param_state if error else None
                         upstream_control.reconnect_requested = True
                         upstream_control.suppress_downstream_event = True
                         await _release_websocket_response_create_gate(request_state, response_create_gate)
@@ -6852,7 +6911,7 @@ class _WebSocketMixin:
         error_code: str,
         error_message: str,
         error_type: str = "server_error",
-        error_param: str | None = None,
+        error_param: OpenAIErrorParam | JsonValue | None = None,
         downstream_activity: _DownstreamWebSocketActivity | None = None,
     ) -> None:
         proxy = cast(_WebSocketServiceProtocol, self)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -64,9 +64,9 @@ from app.core.clients.proxy_websocket import (
     is_account_neutral_websocket_error_code,
 )
 from app.core.errors import (
-    STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES,
     PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
     PREVIOUS_RESPONSE_NOT_FOUND_CODE,
+    STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES,
     OpenAIErrorEnvelope,
     OpenAIErrorParam,
     openai_error,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -79,9 +79,13 @@ from app.core.errors import (
     HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorEnvelope,
+    OpenAIErrorParam,
     is_previous_response_not_found_error,
+    is_previous_response_not_found_public_shape,
+    normalize_public_error_param,
     openai_error,
     response_failed_event,
+    sanitize_public_error_detail,
 )
 from app.core.exceptions import (
     ProxyAuthError,
@@ -132,7 +136,7 @@ from app.core.openai.models import (
 from app.core.openai.models import (
     OpenAIErrorEnvelope as OpenAIErrorEnvelopeModel,
 )
-from app.core.openai.parsing import parse_response_payload
+from app.core.openai.parsing import classify_event_type, parse_response_payload
 from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesRequest,
@@ -238,7 +242,7 @@ from app.modules.proxy._service.support import (
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.capability_routing import required_capability_metadata_values
-from app.modules.proxy.helpers import _rate_limit_details
+from app.modules.proxy.helpers import _openai_error_param, _parse_openai_error, _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.images_observability import (
     IMAGE_ROUTE_MODEL_STATE,
@@ -7933,7 +7937,7 @@ async def _stream_response_error_events(
                 error.message if error and error.message else "Upstream error",
                 error.type if error and error.type else "server_error",
                 response_id=response_id,
-                error_param=error.param if error else None,
+                error_param=error.param_state if error else None,
             )
         )
 
@@ -7979,7 +7983,7 @@ def _stream_event_error_envelope(event_block: str) -> OpenAIErrorEnvelopeModel |
     payload = _parse_sse_payload(event_block)
     if payload is None:
         return None
-    event_type = payload.get("type")
+    event_type = classify_event_type(payload)
     if event_type == "error":
         return _parse_event_error_envelope(payload)
     if event_type != "response.failed":
@@ -7989,10 +7993,7 @@ def _stream_event_error_envelope(event_block: str) -> OpenAIErrorEnvelopeModel |
         return _default_error_envelope()
     error_value = response.get("error")
     if isinstance(error_value, dict):
-        try:
-            return OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
-        except ValidationError:
-            return _default_error_envelope()
+        return _parse_event_error_envelope({"error": error_value})
     parsed = parse_response_payload(response)
     if parsed is not None and parsed.error is not None:
         return _error_envelope_from_response(parsed.error)
@@ -8558,7 +8559,7 @@ async def _collect_responses_payload(
             continue
         if captured_turn_state_headers is not None:
             _capture_response_metadata_turn_state(payload, captured_turn_state_headers)
-        event_type = payload.get("type")
+        event_type = classify_event_type(payload)
         _collect_output_item_event(payload, output_items)
         if terminal_result is not None:
             continue
@@ -8570,12 +8571,8 @@ async def _collect_responses_payload(
             if isinstance(response, dict):
                 error_value = response.get("error")
                 if isinstance(error_value, dict):
-                    try:
-                        terminal_result = OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
-                        continue
-                    except ValidationError:
-                        terminal_result = _default_error_envelope()
-                        continue
+                    terminal_result = _parse_event_error_envelope({"error": error_value})
+                    continue
                 parsed = parse_response_payload(response)
                 if parsed is not None and parsed.error is not None:
                     terminal_result = _error_envelope_from_response(parsed.error)
@@ -8795,7 +8792,7 @@ async def _normalize_public_responses_stream(
             contract_violation_kind = contract_violation_kind or violation_kind
         if normalized_payload is None:
             continue
-        event_type = normalized_payload.get("type")
+        event_type = classify_event_type(normalized_payload)
         synthetic_created = None
         if (
             enforce_openai_sdk_contract
@@ -8810,11 +8807,12 @@ async def _normalize_public_responses_stream(
         )
         if synthetic_created is not None and synthetic_created_sequence is not None:
             synthetic_created["sequence_number"] = synthetic_created_sequence
-        if not enforce_openai_sdk_contract and (
-            event_type == "error" or is_json_mapping(normalized_payload.get("error"))
-        ):
+        if not enforce_openai_sdk_contract and event_type in {"error", "response.failed"}:
             terminal_seen = True
-            yield event_block
+            if normalized_payload is parsed_payload:
+                yield event_block
+            else:
+                yield format_sse_event(normalized_payload)
             continue
 
         if enforce_openai_sdk_contract and not created_emitted and isinstance(event_type, str):
@@ -8975,7 +8973,7 @@ def _public_response_failed_event_blocks_from_error(
             message or "Upstream error",
             error_type or "server_error",
             response_id=f"resp_{error.code or 'upstream_error'}",
-            error_param=error.param,
+            error_param=error.param_state,
         ),
     )
     failed_payload["sequence_number"] = sequence_number + int(include_created)
@@ -9183,7 +9181,7 @@ def _normalize_public_stream_payload(
     *,
     enforce_openai_sdk_contract: bool = True,
 ) -> tuple[dict[str, JsonValue] | None, str | None]:
-    event_type = payload.get("type")
+    event_type = classify_event_type(payload)
     if event_type == "response.reasoning_summary_text.done" and isinstance(payload.get("text"), str):
         normalized_payload = dict(payload)
         normalized_payload["text"] = _strip_blank_html_comment_lines(cast(str, payload["text"]))
@@ -9207,20 +9205,30 @@ def _normalize_public_stream_payload(
     # they continue to forward unchanged.
     if enforce_openai_sdk_contract and isinstance(event_type, str) and event_type.startswith("codex."):
         return None, None
-    if event_type == "error":
-        parsed_error = _parse_event_error_envelope(payload)
-        if _is_previous_response_not_found_public_error(parsed_error.error):
+    if event_type == "error" or (enforce_openai_sdk_contract and event_type == "response.failed"):
+        if event_type == "error":
+            parsed_error = _parse_event_error_envelope(payload)
+        else:
+            response = payload.get("response")
+            nested_error = response.get("error") if isinstance(response, dict) else None
+            parsed_error = _parse_event_error_envelope({"error": nested_error})
+        if enforce_openai_sdk_contract and _is_previous_response_not_found_public_error(parsed_error.error):
+            response_id = _response_id_from_event_payload(payload) if event_type == "response.failed" else None
             return (
                 cast(
                     dict[str, JsonValue],
                     response_failed_event(
                         "stream_incomplete",
                         PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+                        response_id=response_id,
                     ),
                 ),
                 None,
             )
-        return payload, None
+        if event_type == "error":
+            return _sanitize_public_stream_error_payload(payload), None
+    if event_type == "response.failed":
+        return _sanitize_public_stream_error_payload(payload), None
     if event_type in ("response.completed", "response.incomplete"):
         response = payload.get("response")
         if not is_json_mapping(response):
@@ -9265,6 +9273,47 @@ def _normalize_public_stream_payload(
             violation_kind = "invalid_output_item"
         return normalized_payload, violation_kind
     return payload, None
+
+
+def _sanitize_public_stream_error_payload(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    """Normalize or omit malformed ``error.param`` at the public boundary."""
+
+    event_type = classify_event_type(payload)
+    if event_type == "error":
+        error_value = payload.get("error")
+        if is_json_mapping(error_value):
+            sanitized_error = sanitize_public_error_detail(error_value)
+            if sanitized_error == error_value:
+                return payload
+            normalized = dict(payload)
+            normalized["error"] = sanitized_error
+            return normalized
+        if "param" not in payload:
+            return payload
+        normalized = dict(payload)
+        public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
+        if public_param is None:
+            normalized.pop("param", None)
+        else:
+            normalized["param"] = public_param
+        return normalized
+
+    if event_type != "response.failed":
+        return payload
+    response_value = payload.get("response")
+    if not is_json_mapping(response_value):
+        return payload
+    error_value = response_value.get("error")
+    if not is_json_mapping(error_value):
+        return payload
+    sanitized_error = sanitize_public_error_detail(error_value)
+    if sanitized_error == error_value:
+        return payload
+    normalized_response = dict(response_value)
+    normalized_response["error"] = sanitized_error
+    normalized = dict(payload)
+    normalized["response"] = normalized_response
+    return normalized
 
 
 def _synthetic_response_created_envelope(
@@ -9502,7 +9551,10 @@ async def _normalize_reasoning_summary_stream(stream: AsyncIterator[str]) -> Asy
         if payload is None:
             yield event_block
             continue
-        event_type = payload.get("type")
+        # Error frames can omit the discriminator and carry only ``error``;
+        # classify those as terminal so a pending reasoning candidate flushes
+        # before the frame is forwarded.
+        event_type = classify_event_type(payload)
         event_key = _reasoning_summary_delta_key(payload)
         if (
             pending
@@ -9647,12 +9699,10 @@ def _record_public_contract_violation(kind: str) -> None:
 
 def _parse_event_error_envelope(payload: dict[str, JsonValue]) -> OpenAIErrorEnvelopeModel:
     error_value = payload.get("error")
-    if isinstance(error_value, dict):
-        try:
-            return OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
-        except ValidationError:
-            return _default_error_envelope()
-    return _default_error_envelope()
+    if not isinstance(error_value, dict):
+        return _default_error_envelope()
+    parsed = _parse_openai_error({"error": error_value})
+    return _error_envelope_from_response(parsed)
 
 
 def _default_error_envelope() -> OpenAIErrorEnvelopeModel:
@@ -9670,10 +9720,11 @@ def _parse_error_envelope(payload: JsonValue | OpenAIErrorEnvelope) -> OpenAIErr
         return _default_error_envelope()
     if payload.get("type") == "error":
         return _parse_event_error_envelope(cast(dict[str, JsonValue], payload))
-    try:
-        return OpenAIErrorEnvelopeModel.model_validate(payload)
-    except ValidationError:
+    error_value = payload.get("error")
+    if not isinstance(error_value, dict):
         return _default_error_envelope()
+    parsed = _parse_openai_error({"error": error_value})
+    return _error_envelope_from_response(parsed)
 
 
 def _openai_invalid_transcription_model_error(model: str) -> OpenAIErrorEnvelope:
@@ -9696,12 +9747,43 @@ def _error_envelope_from_response(error_value: OpenAIError | None) -> OpenAIErro
     return OpenAIErrorEnvelopeModel(error=error_value)
 
 
+def _sanitize_public_error_model(error_value: OpenAIError | None) -> OpenAIError | None:
+    """Copy an error model with only a client-safe ``param`` value."""
+
+    if error_value is None or not error_value.param_state.present:
+        return error_value
+    normalized_param = normalize_public_error_param(error_value.param_state)
+    sanitized = error_value.model_copy(update={"param": normalized_param})
+    # Internal classifiers may run after a public copy has been made; retain
+    # the wire-level presence/raw value on the private state.
+    sanitized.set_param_state(error_value.param_state)
+    return sanitized
+
+
+def _sanitize_public_error_envelope(envelope: OpenAIErrorEnvelopeModel) -> OpenAIErrorEnvelopeModel:
+    error = envelope.error
+    sanitized = _sanitize_public_error_model(error)
+    if sanitized is error:
+        return envelope
+    return OpenAIErrorEnvelopeModel(error=sanitized)
+
+
 def _is_previous_response_not_found_public_error(error_value: OpenAIError | None) -> bool:
+    if error_value is None:
+        return False
+    return is_previous_response_not_found_public_shape(
+        code=error_value.code,
+        param=_openai_error_param(error_value),
+        message=error_value.message,
+    )
+
+
+def _is_previous_response_not_found_recoverable_error(error_value: OpenAIError | None) -> bool:
     if error_value is None:
         return False
     return is_previous_response_not_found_error(
         code=error_value.code,
-        param=error_value.param,
+        param=_openai_error_param(error_value),
         message=error_value.message,
     )
 
@@ -9737,17 +9819,24 @@ def _mask_previous_response_not_found_error(
     allow_client_full_history_once: bool = False,
 ) -> tuple[int, OpenAIErrorEnvelopeModel]:
     if not _is_previous_response_not_found_public_error(envelope.error):
-        return default_status if default_status is not None else _status_for_error(envelope.error), envelope
+        return (
+            default_status if default_status is not None else _status_for_error(envelope.error),
+            _sanitize_public_error_envelope(envelope),
+        )
     # In recovery-first mode, preserve the upstream-shaped 400 so Codex can
     # drop the ambiguous previous_response_id anchor and resend full local
     # history. This is intentionally opt-in because the resend is at-least-once
     # and may duplicate an upstream response that was accepted but not observed.
     if (
         allow_client_full_history_once
+        and _is_previous_response_not_found_recoverable_error(envelope.error)
         and get_settings().http_responses_session_bridge_ambiguous_continuation_recovery_mode
         == "client_full_history_once"
     ):
-        return default_status if default_status is not None else 400, envelope
+        return (
+            default_status if default_status is not None else 400,
+            _sanitize_public_error_envelope(envelope),
+        )
     return (
         502,
         OpenAIErrorEnvelopeModel(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -9280,39 +9280,46 @@ def _sanitize_public_stream_error_payload(payload: dict[str, JsonValue]) -> dict
 
     event_type = classify_event_type(payload)
     if event_type == "error":
+        normalized = payload
         error_value = payload.get("error")
         if is_json_mapping(error_value):
             sanitized_error = sanitize_public_error_detail(error_value)
-            if sanitized_error == error_value:
-                return payload
-            normalized = dict(payload)
-            normalized["error"] = sanitized_error
-            return normalized
-        if "param" not in payload:
-            return payload
-        normalized = dict(payload)
-        public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
-        if public_param is None:
-            normalized.pop("param", None)
-        else:
-            normalized["param"] = public_param
+            if sanitized_error != error_value:
+                normalized = dict(normalized)
+                normalized["error"] = sanitized_error
+        if "param" in payload:
+            sanitized = dict(normalized)
+            public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
+            if public_param is None:
+                sanitized.pop("param", None)
+            else:
+                sanitized["param"] = public_param
+            if sanitized != normalized:
+                normalized = sanitized
         return normalized
 
     if event_type != "response.failed":
         return payload
+    normalized = payload
     response_value = payload.get("response")
-    if not is_json_mapping(response_value):
-        return payload
-    error_value = response_value.get("error")
-    if not is_json_mapping(error_value):
-        return payload
-    sanitized_error = sanitize_public_error_detail(error_value)
-    if sanitized_error == error_value:
-        return payload
-    normalized_response = dict(response_value)
-    normalized_response["error"] = sanitized_error
-    normalized = dict(payload)
-    normalized["response"] = normalized_response
+    if is_json_mapping(response_value):
+        error_value = response_value.get("error")
+        if is_json_mapping(error_value):
+            sanitized_error = sanitize_public_error_detail(error_value)
+            if sanitized_error != error_value:
+                normalized_response = dict(response_value)
+                normalized_response["error"] = sanitized_error
+                normalized = dict(normalized)
+                normalized["response"] = normalized_response
+    if "param" in payload:
+        sanitized = dict(normalized)
+        public_param = normalize_public_error_param(OpenAIErrorParam(True, payload["param"]))
+        if public_param is None:
+            sanitized.pop("param", None)
+        else:
+            sanitized["param"] = public_param
+        if sanitized != normalized:
+            normalized = sanitized
     return normalized
 
 

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Mapping
+from typing import Iterable, cast
 
 from pydantic import ValidationError
 
 from app.core import usage as usage_core
 from app.core.balancer.types import ClassifiedFailure, FailureClass, FailurePhase, UpstreamError
-from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope
+from app.core.errors import OpenAIErrorDetail, OpenAIErrorParam
 from app.core.openai.models import OpenAIError
 from app.core.plan_types import normalize_rate_limit_plan_type
 from app.core.types import JsonValue
@@ -313,24 +314,30 @@ def _normalize_error_code(code: str | None, error_type: str | None) -> str:
     return value.lower()
 
 
-def _parse_openai_error(payload: OpenAIErrorEnvelope) -> OpenAIError | None:
+def _parse_openai_error(payload: Mapping[str, object]) -> OpenAIError | None:
     error = payload.get("error")
-    if not error:
+    if not isinstance(error, Mapping) or not error:
         return None
+    error_mapping = cast(Mapping[str, JsonValue], error)
+    param_state = OpenAIErrorParam.from_mapping(error_mapping)
     try:
-        return OpenAIError.model_validate(error)
+        parsed = OpenAIError.model_validate(error_mapping)
     except ValidationError:
-        if not isinstance(error, dict):
-            return None
-        return OpenAIError(
-            message=_coerce_str(error.get("message")),
-            type=_coerce_str(error.get("type")),
-            code=_coerce_str(error.get("code")),
-            param=_coerce_str(error.get("param")),
-            plan_type=_coerce_str(error.get("plan_type")),
-            resets_at=_coerce_number(error.get("resets_at")),
-            resets_in_seconds=_coerce_number(error.get("resets_in_seconds")),
+        parsed = OpenAIError(
+            message=_coerce_str(error_mapping.get("message")),
+            type=_coerce_str(error_mapping.get("type")),
+            code=_coerce_str(error_mapping.get("code")),
+            param=_coerce_str(error_mapping.get("param")),
+            plan_type=_coerce_str(error_mapping.get("plan_type")),
+            resets_at=_coerce_number(error_mapping.get("resets_at")),
+            resets_in_seconds=_coerce_number(error_mapping.get("resets_in_seconds")),
         )
+    parsed.set_param_state(param_state)
+    return parsed
+
+
+def _openai_error_param(error: OpenAIError | None) -> OpenAIErrorParam:
+    return error.param_state if error is not None else OpenAIErrorParam.absent()
 
 
 def _coerce_str(value: JsonValue) -> str | None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -63,21 +63,24 @@ from app.core.clients.proxy_websocket import (
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
-from app.core.errors import (
-    PREVIOUS_RESPONSE_NOT_FOUND_CODE as PREVIOUS_RESPONSE_NOT_FOUND_CODE,
-)
+from app.core.errors import PREVIOUS_RESPONSE_NOT_FOUND_CODE as PREVIOUS_RESPONSE_NOT_FOUND_CODE
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
 from app.core.errors import (
     OpenAIErrorEnvelope,
+    OpenAIErrorParam,
     ResponseFailedEvent,
+    coerce_error_param,
     is_previous_response_not_found_error,
     is_previous_response_not_found_message,
     openai_error,
     previous_response_id_from_not_found_message,
     previous_response_stream_incomplete_error,
     response_failed_event,
+)
+from app.core.errors import (
+    is_previous_response_not_found_public_shape as _is_previous_response_not_found_public_shape,  # noqa: F401
 )
 from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
@@ -2143,10 +2146,11 @@ def _is_missing_tool_output_message(message: str | None) -> bool:
 def _is_missing_tool_output_error(
     *,
     code: str | None,
-    param: str | None,
+    param: OpenAIErrorParam | JsonValue,
     message: str | None,
 ) -> bool:
-    if code != "invalid_request_error" or param != "input":
+    param_state = coerce_error_param(param)
+    if code != "invalid_request_error" or param_state.normalized != "input" or param_state.malformed:
         return False
     return _is_missing_tool_output_message(message)
 
@@ -2154,7 +2158,7 @@ def _is_missing_tool_output_error(
 def _is_previous_response_not_found_error(
     *,
     code: str | None,
-    param: str | None,
+    param: OpenAIErrorParam | JsonValue,
     message: str | None,
 ) -> bool:
     return is_previous_response_not_found_error(code=code, param=param, message=message)
@@ -2167,7 +2171,7 @@ def _compact_previous_response_not_found_error(exc: ProxyResponseError) -> Proxy
     code = _normalize_error_code(error.code, error.type)
     if not _is_previous_response_not_found_error(
         code=code,
-        param=error.param,
+        param=error.param_state,
         message=error.message,
     ):
         return None
@@ -2269,7 +2273,7 @@ def _partial_output_proxy_error_event_block(
         error_code=error_code,
         error_type=error.type if error else None,
         error_message=error_message,
-        error_param=error.param if error else None,
+        error_param=error.param_state if error else None,
     )
     if rewritten_error is not None:
         rewritten_code, rewritten_message, upstream_error_code = rewritten_error
@@ -2286,7 +2290,7 @@ def _partial_output_proxy_error_event_block(
         error_message or default_message,
         error_type=(error.type if error and error.type else "server_error"),
         response_id=response_id,
-        error_param=error.param if error else None,
+        error_param=error.param_state if error else None,
     )
     _apply_error_metadata(event["response"]["error"], error)
     return format_sse_event(event)
@@ -2535,7 +2539,7 @@ def _mark_request_state_previous_response_not_found(
     request_state.error_code_override = error.get("code")
     request_state.error_message_override = error.get("message")
     request_state.error_type_override = error.get("type")
-    request_state.error_param_override = error.get("param")
+    request_state.error_param_override = OpenAIErrorParam.from_mapping(cast(Mapping[str, JsonValue], error))
 
 
 def _header_value_case_insensitive(headers: Mapping[str, str], name: str) -> str | None:

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/.openspec.yaml
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/.openspec.yaml
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: spec-driven
-created: 2026-08-29
+created: 2026-08-28

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/context.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/context.md
@@ -26,6 +26,9 @@ the strict classifier, while masking code consumes the public-shape classifier.
   sanitized envelope.
 - A nested `response.failed` error may be masked without dropping the outer
   response id used by clients to correlate the terminal event.
+- The WebSocket and HTTP Responses serializers retain their native event
+  envelopes; the Chat Completions adapter deliberately emits its own
+  `{"error": ...}` wire shape and only carries over the sanitized error detail.
 
 ## Operational notes
 

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/context.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/context.md
@@ -1,0 +1,35 @@
+# Context
+
+## Scope and rationale
+
+This is the residual extraction from the broad stale-anchor hardening work. The
+canonical Codex-native classifier and the HTTP bridge recovery transaction are
+separate concerns. This change owns only the shared error-shape seam needed by
+those vehicles: parsing must remember whether `param` was absent or malformed,
+while public boundaries must never echo malformed metadata.
+
+## Decision
+
+Use a small immutable `OpenAIErrorParam` value object rather than a second model
+field. Pydantic continues to expose the normal string `param` field for valid
+payloads; the private state carries explicit presence and raw JSON only when a
+caller needs to distinguish malformed input from absence. Recovery code consumes
+the strict classifier, while masking code consumes the public-shape classifier.
+
+## Failure modes
+
+- A present `null`, number, object, array, blank string, or whitespace-only
+  string is not a proof that the upstream anchor was rejected safely. It is
+  therefore masked when appropriate but cannot trigger replay.
+- A typeless payload with an `error` object is terminal for stream settlement,
+  but must retain its original error details unless public masking requires a
+  sanitized envelope.
+- A nested `response.failed` error may be masked without dropping the outer
+  response id used by clients to correlate the terminal event.
+
+## Operational notes
+
+The change is zero-config and has no migration or runtime setting. It is safe to
+roll out independently of the later HTTP bridge recovery PR. Local proof covers
+the unit parser/classifier, Responses public normalizer, and Chat Completions
+adapter; hosted CI and maintainer review remain required before merge.

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/proposal.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/proposal.md
@@ -1,0 +1,48 @@
+# Harden stale-anchor error shapes across streaming surfaces
+
+## Why
+
+The canonical stale-anchor signal is already defined for Codex-native Responses
+streams, but the shared parsers still collapse an explicitly malformed
+`error.param` into absence. That makes a malformed upstream frame eligible for
+the same replay path as a verified `previous_response_id` error. The same
+collapse also lets invalid metadata leak through one of the WebSocket, HTTP
+Responses, or Chat Completions serializers.
+
+Typeless error frames and nested `response.failed` frames are another boundary
+case: they can be classified for settlement while still losing their error
+shape or response identifier during public normalization. This change makes
+those boundaries explicit without changing account selection or retry policy.
+
+## What changes
+
+- Preserve whether an upstream error supplied `param`, together with its raw
+  JSON value, while parsing WebSocket, HTTP bridge, Responses, and Chat
+  Completions errors.
+- Keep recovery authorization fail-closed for present non-string, null, blank,
+  or whitespace-only parameters. A malformed value may still be recognized as
+  a stale-anchor-shaped error for public masking, but it never authorizes a
+  full-history replay or account switch.
+- Sanitize malformed public `param` values by omitting them; trim valid string
+  parameters at response/event construction boundaries.
+- Classify typeless error payloads consistently and preserve a nested
+  `response.failed` response id while masking its stale-anchor error details.
+- Keep the already-defined Codex-native canonical
+  `previous_response_not_found` signal and public `/v1` `stream_incomplete`
+  masking unchanged for valid errors.
+
+## Non-goals
+
+- No new retry, account migration, durable-operation, retry-circuit,
+  quarantine, or bridge ownership behavior.
+- No changes to the existing OpenSpec canonical signal or to client code.
+- No changes to ordinary invalid-request errors whose code, parameter, and
+  message do not identify a previous-response anchor.
+
+## Capabilities
+
+### Modified capabilities
+
+- `responses-api-compat`: error parsing and public serialization preserve
+  explicit parameter presence, fail closed on malformed stale-anchor metadata,
+  and retain terminal event correlation fields.

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/proposal.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/proposal.md
@@ -25,6 +25,11 @@ those boundaries explicit without changing account selection or retry policy.
   full-history replay or account switch.
 - Sanitize malformed public `param` values by omitting them; trim valid string
   parameters at response/event construction boundaries.
+- Preserve the native event envelope on WebSocket and HTTP Responses
+  serializers. The Chat Completions adapter intentionally translates terminal
+  Responses events into the documented Chat Completions `{"error": ...}`
+  envelope; it sanitizes that nested error detail without exposing native
+  `response.failed` fields that are not part of the Chat contract.
 - Classify typeless error payloads consistently and preserve a nested
   `response.failed` response id while masking its stale-anchor error details.
 - Keep the already-defined Codex-native canonical
@@ -36,8 +41,10 @@ those boundaries explicit without changing account selection or retry policy.
 - No new retry, account migration, durable-operation, retry-circuit,
   quarantine, or bridge ownership behavior.
 - No changes to the existing OpenSpec canonical signal or to client code.
-- No changes to ordinary invalid-request errors whose code, parameter, and
-  message do not identify a previous-response anchor.
+- No changes to ordinary invalid-request classification or recovery semantics.
+  Their public envelopes remain otherwise unchanged; as required above,
+  present malformed ``param`` metadata is omitted and valid string values are
+  trimmed, while errors without ``param`` metadata are unchanged.
 
 ## Capabilities
 

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
@@ -1,0 +1,77 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Stale-anchor error parameters preserve presence and fail closed
+
+When the proxy parses an upstream Responses or Chat Completions error, it MUST
+distinguish an absent `param` from a present malformed value. A present
+non-string, null, blank, or whitespace-only `param` MUST NOT authorize
+previous-response recovery, full-history replay, account migration, or any
+other proof-gated retry. A valid string parameter MAY be normalized by trimming
+surrounding whitespace before public serialization.
+
+#### Scenario: malformed parameter cannot authorize recovery
+
+- **GIVEN** an anchored request receives a canonical stale-anchor code or
+  previous-response-not-found message with `param = null`, a non-string value,
+  or blank whitespace
+- **WHEN** the proxy evaluates replay eligibility
+- **THEN** the request fails closed and remains in the existing terminal path
+- **AND** no unanchored replay or account switch is authorized
+
+#### Scenario: absent parameter keeps the narrow parameterless classifier
+
+- **GIVEN** an anchored request receives `code = invalid_request_error`, no
+  `param`, and the exact normalized `Invalid previous_response_id.` message
+- **WHEN** the proxy evaluates continuity recovery
+- **THEN** the existing parameterless previous-response classifier may match
+- **AND** unrelated invalid-request messages remain unmatched
+
+### Requirement: Public error serializers omit malformed parameter metadata
+
+When a public WebSocket, HTTP Responses, or Chat Completions serializer emits
+an error containing a present malformed `param`, it MUST omit that field. It
+MUST preserve the rest of the error envelope and MUST NOT expose a raw stale
+`previous_response_id`. A valid string parameter MUST remain available in
+trimmed form.
+
+#### Scenario: native malformed error is sanitized without changing its shape
+
+- **GIVEN** a native terminal `error` or `response.failed` frame contains a
+  present malformed `param`
+- **WHEN** the native stream is serialized for the client
+- **THEN** the error retains its event type and other fields
+- **AND** the malformed `param` is omitted
+
+#### Scenario: public stale-anchor error remains generic
+
+- **GIVEN** a public `/v1/responses` stream receives a stale-anchor error,
+  including a typeless or nested `response.failed` shape
+- **WHEN** the API normalizes the stream
+- **THEN** it emits the existing `stream_incomplete` envelope
+- **AND** it removes the stale anchor metadata while preserving the nested
+  response id when one was supplied
+
+### Requirement: Typeless terminal errors retain settlement and correlation data
+
+The streaming normalizers MUST classify a payload with a dictionary `error`
+and no string `type` as an `error` event for terminal settlement. A nested
+`response.failed` error MUST retain its outer response identifier when its
+error details are masked or sanitized. A valid native error frame that needs no
+sanitization MUST remain byte-identical.
+
+#### Scenario: typeless error flushes pending terminal-adjacent state
+
+- **GIVEN** a stream has buffered reasoning-summary data followed by a typeless
+  error payload
+- **WHEN** the normalizer processes the error
+- **THEN** it flushes the buffered data before forwarding the terminal error
+
+#### Scenario: nested terminal masking preserves response id
+
+- **GIVEN** a `response.failed` payload has an outer `response.id` and a stale
+  previous-response error
+- **WHEN** the public normalizer masks the stale error
+- **THEN** the terminal event keeps the same `response.id`
+- **AND** the error details are the generic `stream_incomplete` shape

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
@@ -30,11 +30,17 @@ surrounding whitespace before public serialization.
 
 ### Requirement: Public error serializers omit malformed parameter metadata
 
-When a public WebSocket, HTTP Responses, or Chat Completions serializer emits
-an error containing a present malformed `param`, it MUST omit that field. It
-MUST preserve the rest of the error envelope and MUST NOT expose a raw stale
-`previous_response_id`. A valid string parameter MUST remain available in
-trimmed form.
+When a public WebSocket or HTTP Responses serializer emits an error containing
+a present malformed `param`, it MUST omit that field. It MUST preserve the
+native event envelope and MUST NOT expose a raw stale `previous_response_id`.
+A valid string parameter MUST remain available in trimmed form. This
+sanitization applies regardless of the error code or message; only an error
+that has no `param` metadata is left unchanged.
+
+The Chat Completions adapter MUST apply the same parameter sanitization to the
+nested error detail, but it MUST retain the documented Chat Completions error
+envelope rather than forwarding the native Responses event type or outer
+`response` object.
 
 #### Scenario: native malformed error is sanitized without changing its shape
 
@@ -43,6 +49,15 @@ trimmed form.
 - **WHEN** the native stream is serialized for the client
 - **THEN** the error retains its event type and other fields
 - **AND** the malformed `param` is omitted
+
+#### Scenario: Chat Completions errors keep their adapter envelope
+
+- **GIVEN** a Chat Completions stream receives a native terminal error with a
+  present malformed `param`
+- **WHEN** the Chat adapter serializes the error
+- **THEN** it emits the documented `{"error": ...}` Chat Completions shape
+- **AND** the nested malformed `param` is omitted
+- **AND** native Responses-only fields are not forwarded
 
 #### Scenario: public stale-anchor error remains generic
 

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/specs/responses-api-compat/spec.md
@@ -35,7 +35,9 @@ a present malformed `param`, it MUST omit that field. It MUST preserve the
 native event envelope and MUST NOT expose a raw stale `previous_response_id`.
 A valid string parameter MUST remain available in trimmed form. This
 sanitization applies regardless of the error code or message; only an error
-that has no `param` metadata is left unchanged.
+that has no `param` metadata is left unchanged. When stale-anchor masking
+applies, its generic terminal envelope takes precedence and may remove even a
+valid `previous_response_id` parameter.
 
 The Chat Completions adapter MUST apply the same parameter sanitization to the
 nested error detail, but it MUST retain the documented Chat Completions error

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/tasks.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/tasks.md
@@ -1,0 +1,38 @@
+# Tasks
+
+## 1. Specification
+
+- [x] 1.1 Define presence-aware parameter parsing, fail-closed replay, public
+      sanitization, and typeless/nested terminal-event requirements.
+- [x] 1.2 Record scope boundaries: no new retry, account, durable-operation,
+      circuit, quarantine, or container behavior.
+
+## 2. Implementation
+
+- [x] 2.1 Add the immutable `OpenAIErrorParam` state and preserve it through
+      strict/fallback OpenAI error parsing.
+- [x] 2.2 Split strict recovery classification from public stale-anchor shape
+      matching; malformed present parameters never authorize replay.
+- [x] 2.3 Sanitize malformed parameters and trim valid values in shared
+      WebSocket, HTTP Responses, and Chat Completions serializers.
+- [x] 2.4 Classify typeless error frames and preserve nested response ids while
+      masking terminal stale-anchor errors.
+
+## 3. Coverage
+
+- [x] 3.1 Cover absent, valid, malformed, and whitespace parameter states and
+      strict/public classifier differences.
+- [x] 3.2 Cover typeless errors, nested `response.failed` masking, native
+      malformed-parameter sanitization, and valid native byte preservation.
+- [x] 3.3 Cover Chat Completions stale-anchor masking and malformed metadata.
+
+## 4. Verification
+
+- [x] 4.1 Run focused Responses, WebSocket, Chat Completions, and proxy utility
+      unit suites.
+- [x] 4.2 Run Ruff, formatting, `ty`, and `git diff --check` on the candidate.
+- [ ] 4.3 Run strict OpenSpec validation when the CLI is available; this
+      environment currently has no `openspec` binary and network package
+      fallback is disabled.
+- [ ] 4.4 Obtain current-hosted CI, CodeRabbit, mergeability, and maintainer
+      review for the exact pushed head before calling the PR merge-ready.

--- a/openspec/changes/harden-websocket-stale-anchor-error-shapes/tasks.md
+++ b/openspec/changes/harden-websocket-stale-anchor-error-shapes/tasks.md
@@ -31,8 +31,8 @@
 - [x] 4.1 Run focused Responses, WebSocket, Chat Completions, and proxy utility
       unit suites.
 - [x] 4.2 Run Ruff, formatting, `ty`, and `git diff --check` on the candidate.
-- [ ] 4.3 Run strict OpenSpec validation when the CLI is available; this
-      environment currently has no `openspec` binary and network package
-      fallback is disabled.
+- [x] 4.3 Run strict OpenSpec validation when the CLI is available; this
+      candidate passed `pnpm --silent dlx @fission-ai/openspec@1.10.0
+      validate harden-websocket-stale-anchor-error-shapes --strict`.
 - [ ] 4.4 Obtain current-hosted CI, CodeRabbit, mergeability, and maintainer
       review for the exact pushed head before calling the PR merge-ready.

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -74,6 +74,38 @@ def test_error_event_emits_done_chunk():
     assert chunks[-1].strip() == "data: [DONE]"
 
 
+def test_typeless_previous_response_error_is_masked_in_chat_chunks():
+    raw_response_id = "resp_chat_typeless_stale"
+    lines = [
+        (
+            'data: {"error":{"type":"invalid_request_error",'
+            '"code":"previous_response_not_found",'
+            f'"message":"Previous response with id \'{raw_response_id}\' not found.",'
+            '"param":"previous_response_id"}}\n\n'
+        )
+    ]
+
+    chunks = list(iter_chat_chunks(lines, model="gpt-5.2"))
+
+    assert raw_response_id not in "".join(chunks)
+    error_payload = json.loads(chunks[-2][5:].strip())
+    assert error_payload["error"] == {
+        "message": "Upstream websocket closed before response.completed",
+        "type": "server_error",
+        "code": "stream_incomplete",
+    }
+    assert chunks[-1].strip() == "data: [DONE]"
+
+
+def test_malformed_chat_error_param_is_omitted_from_public_chunk():
+    lines = ['data: {"type":"error","error":{"code":"upstream_error","param":[]}}\n\n']
+
+    chunks = list(iter_chat_chunks(lines, model="gpt-5.2"))
+
+    error_payload = json.loads(chunks[-2][5:].strip())
+    assert "param" not in error_payload["error"]
+
+
 @pytest.mark.parametrize(
     "event_line",
     [
@@ -483,6 +515,39 @@ async def test_collect_completion_returns_error_event():
     assert isinstance(result, OpenAIErrorEnvelope)
     assert result.error is not None
     assert result.error.code == "no_accounts"
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_masks_typeless_previous_response_error():
+    raw_response_id = "resp_chat_collect_stale"
+
+    async def _stream():
+        yield (
+            'data: {"error":{"type":"invalid_request_error",'
+            '"code":"previous_response_not_found",'
+            f'"message":"Previous response with id \'{raw_response_id}\' not found.",'
+            '"param":"previous_response_id"}}\n\n'
+        )
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+
+    assert isinstance(result, OpenAIErrorEnvelope)
+    assert result.error is not None
+    assert result.error.code == "stream_incomplete"
+    assert result.error.message == "Upstream websocket closed before response.completed"
+    assert result.error.param is None
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_omits_malformed_error_param():
+    async def _stream():
+        yield 'data: {"type":"error","error":{"code":"upstream_error","param":[]}}\n\n'
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+
+    assert isinstance(result, OpenAIErrorEnvelope)
+    assert result.error is not None
+    assert result.error.param is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_openai_errors.py
+++ b/tests/unit/test_openai_errors.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from app.core.errors import (
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+    OpenAIErrorParam,
     is_previous_response_not_found_error,
+    is_previous_response_not_found_public_shape,
     previous_response_id_from_not_found_message,
     previous_response_stream_incomplete_error,
     response_failed_event,
@@ -38,7 +40,7 @@ def test_response_failed_event_preserves_reset_hint():
         resets_at=1_700_003_600,
     )
 
-    assert event["response"]["error"]["resets_at"] == 1_700_003_600
+    assert event["response"]["error"].get("resets_at") == 1_700_003_600
 
 
 def test_previous_response_not_found_classifier_covers_openai_shapes():
@@ -131,6 +133,68 @@ def test_previous_response_not_found_classifier_rejects_non_string_param():
         )
 
 
+def test_error_param_retains_presence_and_normalizes_public_strings():
+    absent = OpenAIErrorParam.absent()
+    assert not absent.present
+    assert absent.raw is None
+    assert absent.normalized is None
+    assert not absent.malformed
+
+    valid = OpenAIErrorParam(True, " previous_response_id ")
+    assert valid.present
+    assert valid.normalized == "previous_response_id"
+    assert not valid.malformed
+
+    for raw in (None, 0, False, {}, [], "", "   "):
+        malformed = OpenAIErrorParam(True, raw)
+        assert malformed.present
+        assert malformed.malformed
+
+
+def test_previous_response_not_found_classifier_fails_closed_for_malformed_present_param():
+    message = "Invalid `previous_response_id`."
+    for param in (OpenAIErrorParam(True, None), OpenAIErrorParam(True, 0), OpenAIErrorParam(True, " ")):
+        assert not is_previous_response_not_found_error(
+            code="invalid_request_error",
+            param=param,
+            message=message,
+        )
+
+
+def test_previous_response_not_found_public_shape_masks_malformed_stale_id_message():
+    assert is_previous_response_not_found_public_shape(
+        code="invalid_request_error",
+        param=OpenAIErrorParam(True, None),
+        message="Previous response with id 'resp_abc' not found.",
+    )
+    assert not is_previous_response_not_found_public_shape(
+        code="invalid_request_error",
+        param=OpenAIErrorParam(True, "input"),
+        message="Previous response with id 'resp_abc' not found.",
+    )
+    assert not is_previous_response_not_found_public_shape(
+        code="invalid_request_error",
+        param=OpenAIErrorParam.absent(),
+        message="A required tool output from the previous response was not found.",
+    )
+
+
+def test_response_failed_event_omits_malformed_param_and_trims_valid_param():
+    malformed = response_failed_event(
+        "stream_incomplete",
+        "closed",
+        error_param=OpenAIErrorParam(True, None),
+    )
+    assert "param" not in malformed["response"]["error"]
+
+    valid = response_failed_event(
+        "stream_incomplete",
+        "closed",
+        error_param=OpenAIErrorParam(True, " model "),
+    )
+    assert valid["response"]["error"].get("param") == "model"
+
+
 def test_previous_response_id_from_not_found_message_extracts_anchor():
     assert (
         previous_response_id_from_not_found_message(
@@ -143,6 +207,6 @@ def test_previous_response_id_from_not_found_message_extracts_anchor():
 def test_previous_response_stream_incomplete_error_is_public_safe():
     payload = previous_response_stream_incomplete_error()
 
-    assert payload["error"]["code"] == "stream_incomplete"
-    assert payload["error"]["type"] == "server_error"
-    assert payload["error"]["message"] == PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE
+    assert payload["error"].get("code") == "stream_incomplete"
+    assert payload["error"].get("type") == "server_error"
+    assert payload["error"].get("message") == PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -840,6 +840,58 @@ async def test_normalize_public_responses_stream_sanitizes_native_malformed_erro
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_sanitizes_top_level_and_nested_error_params() -> None:
+    source = (
+        'data: {"type":"error","param":[],"status":400,'
+        '"error":{"code":"upstream_error","message":"bad","param":" model "}}\n\n'
+    )
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(source),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert payload is not None
+    assert payload["type"] == "error"
+    assert payload["status"] == 400
+    assert "param" not in payload
+    error = payload["error"]
+    assert isinstance(error, dict)
+    assert error["param"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_sanitizes_response_failed_top_level_param() -> None:
+    source = (
+        'data: {"type":"response.failed","param":{},"response":{"id":"resp_1",'
+        '"error":{"code":"upstream_error","message":"bad","param":[]}}}\n\n'
+    )
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(source),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert payload is not None
+    assert payload["type"] == "response.failed"
+    assert "param" not in payload
+    response = payload["response"]
+    assert isinstance(response, dict)
+    assert response["id"] == "resp_1"
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert "param" not in error
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_keeps_native_valid_error_frame_byte_identical() -> None:
     source = 'data: {"type":"error","error":{"code":"upstream_error","message":"bad","param":"model"}}\n\n'
 

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -366,6 +367,31 @@ async def test_normalize_reasoning_summary_stream_cleans_complete_marker_inside_
     assert payload["delta"] == "Plan\nNext"
 
 
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_flushes_before_typeless_error() -> None:
+    pending = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "Plan\n\n<!-- -->",
+        }
+    )
+    typeless_error = "data: " + json.dumps({"error": {"code": "upstream_error"}}) + "\n\n"
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(pending, typeless_error))
+    ]
+
+    assert blocks[0] != typeless_error
+    first_payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert first_payload is not None
+    assert first_payload["delta"] == "Plan"
+    assert blocks[1] == typeless_error
+
+
 def test_normalize_reasoning_summary_part_removes_only_standalone_placeholder() -> None:
     payload, violation = proxy_api_module._normalize_public_stream_payload(
         {
@@ -707,6 +733,125 @@ async def test_normalize_public_responses_stream_masks_initial_previous_response
     assert error["code"] == "stream_incomplete"
     assert error["message"] == "Upstream websocket closed before response.completed"
     assert "param" not in error
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_masks_typeless_previous_response_not_found() -> None:
+    raw_response_id = "resp_typeless_stale"
+    source = (
+        "data: "
+        + json.dumps(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "previous_response_not_found",
+                    "message": f"Previous response with id '{raw_response_id}' not found.",
+                    "param": "previous_response_id",
+                }
+            }
+        )
+        + "\n\n"
+    )
+
+    blocks = [block async for block in proxy_api_module._normalize_public_responses_stream(_iter_blocks(source))]
+
+    joined = "".join(blocks)
+    assert "previous_response_not_found" not in joined
+    assert raw_response_id not in joined
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    payloads = [payload for payload in payloads if payload is not None]
+    assert [payload["type"] for payload in payloads] == ["response.created", "response.failed"]
+    response = payloads[1]["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "stream_incomplete"
+    assert "param" not in error
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_masks_nested_stale_error_but_keeps_response_id() -> None:
+    raw_response_id = "resp_nested_stale"
+    source = (
+        "data: "
+        + json.dumps(
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": raw_response_id,
+                    "status": "failed",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "previous_response_not_found",
+                        "message": f"Previous response with id '{raw_response_id}' not found.",
+                        "param": "previous_response_id",
+                    },
+                },
+            }
+        )
+        + "\n\n"
+    )
+
+    blocks = [block async for block in proxy_api_module._normalize_public_responses_stream(_iter_blocks(source))]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    payloads = [payload for payload in payloads if payload is not None]
+    response = payloads[-1]["response"]
+    assert isinstance(response, dict)
+    assert response["id"] == raw_response_id
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error == {
+        "message": "Upstream websocket closed before response.completed",
+        "type": "server_error",
+        "code": "stream_incomplete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_responses_payload_recognizes_typeless_error_event() -> None:
+    result = await proxy_api_module._collect_responses_payload(
+        _iter_blocks('data: {"error":{"code":"rate_limit_exceeded","type":"rate_limit_error"}}\n\n')
+    )
+
+    assert result.error is not None
+    assert result.error.code == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_sanitizes_native_malformed_error_param() -> None:
+    source = 'event: error\ndata: {"type":"error","error":{"code":"upstream_error","message":"bad","param":{}}}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(source),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks[-1] == "data: [DONE]\n\n"
+    payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert payload is not None
+    error = payload["error"]
+    assert isinstance(error, dict)
+    assert "param" not in error
+    assert payload["type"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_keeps_native_valid_error_frame_byte_identical() -> None:
+    source = 'data: {"type":"error","error":{"code":"upstream_error","message":"bad","param":"model"}}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(source),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks == [source, "data: [DONE]\n\n"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -894,6 +894,17 @@ def test_http_bridge_explicit_previous_response_rejection_normalizes_error_type(
     assert proxy_service._http_bridge_is_explicit_previous_response_rejection(ProxyResponseError(400, error)) is True
 
 
+@pytest.mark.parametrize("code", ["previous_response_not_found", "bridge_previous_response_not_found"])
+@pytest.mark.parametrize("param", [None, "", "   ", 0, False, {}, []])
+def test_http_bridge_stale_anchor_recovery_rejects_malformed_present_param(code: str, param: object) -> None:
+    error = proxy_service.openai_error(code, "Previous response with id 'resp_missing' not found.")
+    cast(Any, error["error"])["param"] = param
+    exc = ProxyResponseError(400, error)
+
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
+    assert proxy_service._http_bridge_is_explicit_previous_response_rejection(exc) is False
+
+
 @pytest.mark.parametrize("param", ["", "   "])
 def test_previous_response_recovery_preserves_present_blank_param(param: str) -> None:
     error = proxy_service.openai_error("invalid_request_error", "Invalid previous_response_id.")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -37,8 +37,8 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.config.settings import Settings
 from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE, openai_error
-from app.core.openai.requests import ResponsesRequest
 from app.core.openai.models import OpenAIError
+from app.core.openai.requests import ResponsesRequest
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
 from app.db.models import AccountStatus, Base, HttpBridgeSessionState
 from app.modules.proxy import affinity as proxy_affinity

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -38,6 +38,7 @@ from app.core.clients.proxy_websocket import (
 from app.core.config.settings import Settings
 from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE, openai_error
 from app.core.openai.requests import ResponsesRequest
+from app.core.openai.models import OpenAIError
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
 from app.db.models import AccountStatus, Base, HttpBridgeSessionState
 from app.modules.proxy import affinity as proxy_affinity
@@ -901,20 +902,20 @@ def test_previous_response_recovery_preserves_present_blank_param(param: str) ->
 
     assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
     assert proxy_service._http_bridge_is_explicit_previous_response_rejection(exc) is False
-    assert (
-        websocket_helpers_module._websocket_event_error_param(
-            "error",
-            {
-                "type": "error",
-                "status": 400,
-                "error_type": "invalid_request_error",
-                "code": "invalid_request_error",
-                "message": "Invalid previous_response_id.",
-                "param": param,
-            },
-        )
-        == ""
+    param_state = websocket_helpers_module._websocket_event_error_param(
+        "error",
+        {
+            "type": "error",
+            "status": 400,
+            "error_type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "Invalid previous_response_id.",
+            "param": param,
+        },
     )
+    assert param_state is not None
+    assert param_state.present
+    assert param_state.raw == param
 
 
 @pytest.mark.parametrize("param", [None, 0, False, {}, []])
@@ -925,21 +926,21 @@ def test_previous_response_recovery_rejects_present_non_string_param(param: obje
 
     assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
     assert proxy_service._http_bridge_is_explicit_previous_response_rejection(exc) is False
-    assert (
-        websocket_helpers_module._websocket_event_error_param(
-            "error",
-            cast(
-                dict[str, proxy_service.JsonValue],
-                {
-                    "type": "error",
-                    "code": "invalid_request_error",
-                    "message": "Invalid previous_response_id.",
-                    "param": param,
-                },
-            ),
-        )
-        == ""
+    param_state = websocket_helpers_module._websocket_event_error_param(
+        "error",
+        cast(
+            dict[str, proxy_service.JsonValue],
+            {
+                "type": "error",
+                "code": "invalid_request_error",
+                "message": "Invalid previous_response_id.",
+                "param": param,
+            },
+        ),
     )
+    assert param_state is not None
+    assert param_state.present
+    assert param_state.raw == param
 
     _event_block, normalized_payload, _event, event_type = (
         http_bridge_helpers_module._normalize_http_bridge_error_event(
@@ -962,9 +963,9 @@ def test_previous_response_recovery_rejects_present_non_string_param(param: obje
     assert normalized_payload is not None
     normalized_response = cast(dict[str, Any], normalized_payload["response"])
     normalized_error = cast(dict[str, Any], normalized_response["error"])
-    assert normalized_error["param"] == ""
+    assert "param" not in normalized_error
     normalized_envelope = proxy_support_module._openai_error_envelope_from_response_failed_payload(normalized_payload)
-    assert normalized_envelope["error"]["param"] == ""
+    assert "param" not in normalized_envelope["error"]
 
     nested_payload = cast(
         dict[str, proxy_service.JsonValue],
@@ -982,7 +983,7 @@ def test_previous_response_recovery_rejects_present_non_string_param(param: obje
     parsed_event = cast(
         Any,
         SimpleNamespace(
-            error=SimpleNamespace(
+            error=OpenAIError(
                 code="invalid_request_error",
                 type="invalid_request_error",
                 message="Invalid previous_response_id.",
@@ -1000,7 +1001,7 @@ def test_previous_response_recovery_rejects_present_non_string_param(param: obje
     assert nested_normalized is not None
     nested_response = cast(dict[str, Any], nested_normalized["response"])
     nested_error = cast(dict[str, Any], nested_response["error"])
-    assert nested_error["param"] == ""
+    assert "param" not in nested_error
 
     raw_failed_envelope = proxy_support_module._openai_error_envelope_from_response_failed_payload(
         cast(
@@ -1018,7 +1019,7 @@ def test_previous_response_recovery_rejects_present_non_string_param(param: obje
             },
         )
     )
-    assert raw_failed_envelope["error"]["param"] == ""
+    assert raw_failed_envelope["error"]["param"] == param
 
 
 def test_parse_openai_error_retains_unrelated_error_with_nullable_param() -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12809,6 +12809,29 @@ def test_public_websocket_error_sanitizes_nested_and_top_level_params() -> None:
     assert nested_error["param"] == "model"
 
 
+def test_public_websocket_response_failed_sanitizes_nested_and_top_level_params() -> None:
+    payload: dict[str, JsonValue] = {
+        "type": "response.failed",
+        "param": [],
+        "response": {
+            "id": "resp_failed_param",
+            "error": {"code": "upstream_error", "message": "bad", "param": " model "},
+        },
+    }
+
+    normalized = websocket_helpers_module._sanitize_public_websocket_event_payload(
+        payload,
+        event_type="response.failed",
+    )
+
+    assert "param" not in normalized
+    response = normalized["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["param"] == "model"
+
+
 @pytest.mark.asyncio
 async def test_service_stream_responses_records_typeless_raw_codex_error_first(monkeypatch):
     settings = _make_proxy_settings()
@@ -13238,6 +13261,89 @@ async def test_service_stream_responses_records_typeless_raw_codex_error_after_c
     assert handle_args is not None
     assert handle_args.args[0] == account
     assert handle_args.args[2] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_service_stream_responses_masks_structured_stale_anchor_error_after_created(
+    monkeypatch,
+    caplog,
+):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_stream_structured_stale_anchor")
+    previous_response_id = "resp_structured_stale_anchor"
+    request_logs.response_owner_by_id[(previous_response_id, None, "sid-stream")] = account.id
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        enforce_openai_sdk_contract=True,
+    ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, enforce_openai_sdk_contract
+        yield 'data: {"type":"response.created","response":{"id":"resp_child"}}\n\n'
+        yield (
+            'data: {"type":"error","error":{"type":"invalid_request_error",'
+            '"code":"invalid_request_error","message":"Invalid previous_response_id.",'
+            '"param":"previous_response_id"}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": previous_response_id,
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {"session_id": "sid-stream"},
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert len(chunks) == 2
+    created = parse_sse_data_json(chunks[0])
+    assert created is not None
+    assert created["type"] == "response.created"
+    failed = parse_sse_data_json(chunks[1])
+    assert failed is not None
+    assert failed["type"] == "response.failed"
+    response = failed["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in chunks[1]
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert "continuity_fail_closed surface=http_stream reason=previous_response_not_found" in caplog.text
+    handle_stream_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -28480,6 +28586,86 @@ async def test_process_upstream_websocket_text_masks_foreign_previous_response_n
     handle_stream_error.assert_not_awaited()
     assert upstream_control.reconnect_requested is False
     assert upstream_control.suppress_downstream_event is False
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_finalizes_unanchored_previous_response_error_after_created(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_unanchored_prev_nf_created")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_followup_created_unanchored_prev_nf",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        previous_response_id="resp_anchor",
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    response_create_gate = asyncio.Semaphore(1)
+
+    await service._process_upstream_websocket_text(
+        json.dumps(
+            {
+                "type": "response.created",
+                "response": {"id": "resp_ws_followup_created", "status": "in_progress"},
+            },
+            separators=(",", ":"),
+        ),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert pending_request.response_id == "resp_ws_followup_created"
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Invalid previous_response_id.",
+                    "param": "previous_response_id",
+                },
+            },
+            separators=(",", ":"),
+        ),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert '"type":"response.failed"' in downstream_text
+    assert '"id":"resp_ws_followup_created"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert upstream_control.reconnect_requested is False
+    finalize_request_state.assert_awaited_once()
+    finalize_call = finalize_request_state.await_args
+    assert finalize_call is not None
+    assert finalize_call.args[0] is pending_request
+    assert finalize_call.kwargs["event_type"] == "response.failed"
+    handle_stream_error.assert_not_awaited()
     assert list(pending_requests) == []
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12755,6 +12755,60 @@ async def test_service_stream_responses_preserves_raw_codex_error_after_created(
     assert handle_args.args[2] == "rate_limit_exceeded"
 
 
+def test_raw_error_fields_preserve_param_for_later_frame_policy() -> None:
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "code": "invalid_request_error",
+        "message": "Invalid `previous_response_id`.",
+        "param": " previous_response_id ",
+    }
+
+    error_type, error_message, error_param, error_code = streaming_helpers_module._raw_stream_error_fields(
+        "error", payload
+    )
+
+    assert error_type is None
+    assert error_message == "Invalid `previous_response_id`."
+    assert error_param is not None
+    assert error_param.present
+    assert error_param.raw == " previous_response_id "
+    assert error_code == "invalid_request_error"
+    assert proxy_service._rewrite_previous_response_stream_error(
+        previous_response_id="resp_raw_anchor",
+        preferred_account_id=None,
+        error_code=error_code,
+        error_type=error_type,
+        error_message=error_message,
+        error_param=error_param,
+    ) == (
+        "stream_incomplete",
+        "Upstream websocket closed before response.completed",
+        None,
+    )
+
+
+def test_public_websocket_error_sanitizes_nested_and_top_level_params() -> None:
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "param": [],
+        "status": 400,
+        "error": {
+            "code": "invalid_request_error",
+            "message": "Invalid request",
+            "param": " model ",
+        },
+    }
+
+    normalized = websocket_helpers_module._sanitize_public_websocket_event_payload(payload, event_type="error")
+
+    assert normalized["type"] == "error"
+    assert normalized["status"] == 400
+    assert "param" not in normalized
+    nested_error = normalized["error"]
+    assert isinstance(nested_error, dict)
+    assert nested_error["param"] == "model"
+
+
 @pytest.mark.asyncio
 async def test_service_stream_responses_records_typeless_raw_codex_error_first(monkeypatch):
     settings = _make_proxy_settings()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -49,7 +49,7 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.config.settings import Settings
 from app.core.crypto import TokenEncryptor
-from app.core.errors import openai_error
+from app.core.errors import OpenAIErrorParam, openai_error
 from app.core.exceptions import ProxyReasoningEffortNotAllowed
 from app.core.openai.models import CompactResponsePayload, OpenAIResponsePayload
 from app.core.openai.parsing import parse_sse_event
@@ -8875,7 +8875,7 @@ def test_normalize_http_bridge_error_event_prefers_selected_replacement_failure_
         error_code_override="replacement_unavailable",
         error_message_override="Selected replacement connection failed",
         error_type_override="server_error",
-        error_param_override="model",
+        error_param_override=OpenAIErrorParam(True, "model"),
         error_http_status_override=503,
     )
 
@@ -36242,7 +36242,7 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
         error_code_override="upstream_unavailable",
         error_message_override="previous replay failed",
         error_type_override="server_error",
-        error_param_override="previous_response_id",
+        error_param_override=OpenAIErrorParam(True, "previous_response_id"),
         error_http_status_override=502,
         preferred_account_id=account.id,
     )
@@ -36540,7 +36540,7 @@ def test_prepare_websocket_auth_replay_clears_stale_error_overrides():
         error_code_override="upstream_unavailable",
         error_message_override="previous auth replay failed",
         error_type_override="server_error",
-        error_param_override="previous_response_id",
+        error_param_override=OpenAIErrorParam(True, "previous_response_id"),
         error_http_status_override=502,
     )
 
@@ -37665,7 +37665,7 @@ async def test_fail_pending_websocket_requests_masks_previous_response_override_
     request_state.error_code_override = "invalid_request_error"
     request_state.error_message_override = "Previous response with id 'resp_pending_leak' not found."
     request_state.error_type_override = "invalid_request_error"
-    request_state.error_param_override = "previous_response_id"
+    request_state.error_param_override = OpenAIErrorParam(True, "previous_response_id")
 
     await service._fail_pending_websocket_requests(
         account_id_value=None,


### PR DESCRIPTION
## Problem

Shared proxy error parsing previously collapsed a present malformed `error.param` into an absent parameter. That could make malformed `previous_response_id` failures look eligible for stale-anchor recovery and could leak invalid metadata at public boundaries. Typeless terminal frames and nested `response.failed` errors also risked losing settlement or correlation data.

## Why this PR exists

This is the focused residual extraction from #1867. It isolates the shared error-shape contract across WebSocket, HTTP Responses, and Chat Completions surfaces, plus the small cancellation-helper deduplication required by review. It is intentionally partial and does not close #1867.

Refs #1867.

## How this PR solves the problem

- Preserve explicit `param` presence and raw JSON state through OpenAI error parsing.
- Fail closed for malformed, null, blank, or whitespace-only parameters before replay or account switching, while still masking stale-anchor-shaped errors publicly.
- Omit malformed public parameters and trim valid strings at serialization boundaries.
- Classify typeless terminal errors and preserve nested `response.failed` response IDs in native WebSocket and HTTP Responses paths.
- Keep the Chat Completions adapter's documented `{"error": ...}` envelope while sanitizing nested error detail.
- Share deferred-cancellation cleanup so HTTP-bridge and streaming teardown cannot drift.

OpenSpec: `openspec/changes/harden-websocket-stale-anchor-error-shapes/`.

## Scope

This PR owns the shared stale-anchor error-shape seam across WebSocket, HTTP Responses, and Chat Completions surfaces, plus the shared cleanup helper required by current review. It does not add retry, account migration, durable-operation, retry-circuit, quarantine, recovery-spool, attribution, or container behavior, and it does not close the broader #1867 work.

## Verification

Exact pushed candidate:

- Base and merge-base: `806b7442600df181e33df50138a6451b1ba1f477` (`upstream/main`, including merged #1957 and #1977)
- Head: `a6af335091925873e42a4e2ceb1628464b08025c`
- Tree: `ecf87d33c77cf13e54a4647b20482951b1ff11f4`
- Branch: `codex/pr1867-ws-stale-anchor-errors`

Proof on this exact rebased tree:

- 2,052 focused unit tests passed; 1 unrelated baseline test was deselected because its fixture fails before this change with `no such table: file_account_pins`.
- 242 focused integration tests passed across `tests/integration/test_proxy_compact.py`, `tests/integration/test_proxy_responses.py`, and `tests/integration/test_proxy_websocket_responses.py`.
- Rebased websocket shutdown coverage passed: 28 tests in `tests/unit/test_websocket_terminal_cancellation.py`.
- `uv run ruff check` and `uv run ruff format --check` passed for all changed Python files.
- `uv run ty check`, `uv run python scripts/check_proxy_architecture.py`, `uv run python .github/scripts/check_simplicity_budgets.py`, and `git diff --check` passed.
- Strict OpenSpec passed: `pnpm --silent dlx @fission-ai/openspec@1.10.0 validate harden-websocket-stale-anchor-error-shapes --strict`.
- All seven branch commits use the repository Conventional Commit format.

## Current status

The branch was semantically re-anchored once onto `upstream/main` at `806b7442600df181e33df50138a6451b1ba1f477`; no conflicts or semantic drops were found, and the exact candidate above was force-pushed with lease to the existing fork branch. Reviews and CI for prior heads are superseded. Fresh hosted CI and one substantive current-head CodeRabbit review are pending for this push; human maintainer approval and merge authority remain external gates. No merge, aggregate cutover, or deployment has occurred.