### PR TITLE
fix(proxy): preserve recovery spool fence during local rebind

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3095,6 +3095,12 @@ class _HTTPBridgeStreamingMixin:
                             exc_info=True,
                         )
                         return
+                    logger.warning(
+                        "Required HTTP bridge recovery spool reset failed request_id=%s operation_id=%s",
+                        recovery_request_state.request_id,
+                        recovery_request_state.operation_id,
+                        exc_info=True,
+                    )
                     raise spool_reset_failure() from reset_exc
                 if not reset_ok:
                     if not required:
@@ -3104,6 +3110,11 @@ class _HTTPBridgeStreamingMixin:
                             recovery_request_state.operation_id,
                         )
                         return
+                    logger.warning(
+                        "Required HTTP bridge recovery spool reset declined request_id=%s operation_id=%s",
+                        recovery_request_state.request_id,
+                        recovery_request_state.operation_id,
+                    )
                     raise spool_reset_failure()
 
             async def capture_verified_stale_anchor_circuit_generation(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3055,6 +3055,16 @@ class _HTTPBridgeStreamingMixin:
                             "HTTP response recovery operation fence is unavailable; retry the request.",
                         ),
                     )
+
+                def spool_reset_failure() -> ProxyResponseError:
+                    return ProxyResponseError(
+                        502,
+                        openai_error(
+                            "bridge_continuity_persistence_failed",
+                            "HTTP response recovery spool could not be reset; retry the request.",
+                        ),
+                    )
+
                 reset_operation_event_spool = getattr(self._durable_bridge, "reset_operation_event_spool", None)
                 if not callable(reset_operation_event_spool):
                     if not required:
@@ -3069,20 +3079,27 @@ class _HTTPBridgeStreamingMixin:
                 assert recovery_request_state.operation_id is not None
                 assert recovery_session.durable_session_id is not None
                 assert recovery_session.durable_owner_epoch is not None
-                reset_ok = await reset_operation_event_spool(
-                    operation_id=recovery_request_state.operation_id,
-                    session_id=recovery_session.durable_session_id,
-                    instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
-                    owner_epoch=recovery_session.durable_owner_epoch,
-                )
-                if not reset_ok:
-                    raise ProxyResponseError(
-                        502,
-                        openai_error(
-                            "bridge_continuity_persistence_failed",
-                            "HTTP response recovery spool could not be reset; retry the request.",
-                        ),
+                try:
+                    reset_ok = await reset_operation_event_spool(
+                        operation_id=recovery_request_state.operation_id,
+                        session_id=recovery_session.durable_session_id,
+                        instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
+                        owner_epoch=recovery_session.durable_owner_epoch,
                     )
+                except Exception as reset_exc:
+                    if not required:
+                        logger.warning(
+                            "Best-effort HTTP bridge recovery spool reset failed request_id=%s operation_id=%s",
+                            recovery_request_state.request_id,
+                            recovery_request_state.operation_id,
+                            exc_info=True,
+                        )
+                        return
+                    raise spool_reset_failure() from reset_exc
+                if not reset_ok:
+                    if not required:
+                        return
+                    raise spool_reset_failure()
 
             async def capture_verified_stale_anchor_circuit_generation(
                 recovery_session: "_HTTPBridgeSession",
@@ -3548,6 +3565,11 @@ class _HTTPBridgeStreamingMixin:
             else:
                 if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
                     bridge_durable_recover_total.labels(path="local_previous_response_error").inc()
+                await reset_previous_response_recovery_operation_spool(
+                    session,
+                    request_state,
+                    required=False,
+                )
                 _log_http_bridge_event(
                     "previous_response_recover_local",
                     bridge_session_key,
@@ -3686,12 +3708,6 @@ class _HTTPBridgeStreamingMixin:
                     "local_previous_response_fresh_replay",
                     "local_previous_response_same_owner_fresh_replay",
                 }
-                if recovery_path == "local_previous_response_error":
-                    await reset_previous_response_recovery_operation_spool(
-                        session,
-                        request_state,
-                        required=False,
-                    )
                 # A recovery request is the one bounded server-side replay;
                 # prevent a second cooldown bypass if this fresh socket also
                 # fails before response.created.

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3098,6 +3098,11 @@ class _HTTPBridgeStreamingMixin:
                     raise spool_reset_failure() from reset_exc
                 if not reset_ok:
                     if not required:
+                        logger.warning(
+                            "Best-effort HTTP bridge recovery spool reset declined request_id=%s operation_id=%s",
+                            recovery_request_state.request_id,
+                            recovery_request_state.operation_id,
+                        )
                         return
                     raise spool_reset_failure()
 

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/context.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/context.md
@@ -1,0 +1,40 @@
+## Purpose and scope
+
+The HTTP bridge stores response events in a durable operation spool. During an
+anchored local recovery, a failed operation must remain the single durable
+identity while the in-memory bridge session is retired and a replacement is
+created. The optional reset is cleanup of the failed attempt; the subsequent
+`record_operation` call is the authoritative fenced rebind.
+
+## Decision rationale
+
+The reset is ordered before session retirement because the repository checks
+the caller's durable session ID and owner epoch. Moving it later would either
+silently miss the row or require an unfenced write. The ordinary local-error
+branch already has a safe fallback: `record_operation` atomically clears stale
+spool material when it moves a failed operation back to `submitted`. Therefore
+an optional reset refusal or transient exception is logged/ignored, while the
+explicitly required stale-anchor replay path remains fail-closed.
+
+## Failure modes
+
+- If the original owner fence is gone, the optional reset is a no-op and the
+  normal operation rebind decides whether the request can proceed.
+- If the required reset is unavailable or refused, recovery stops with the
+  typed continuity-persistence error before any unanchored response is sent.
+- A reset exception in the optional branch must not mask the original upstream
+  error; the operation ledger remains the final fence.
+
+## Example
+
+1. An anchored operation on durable session `origin` receives a transport
+   failure and enters local recovery.
+2. The optional reset is called with `session_id=origin` and may return
+   `False`.
+3. The old session is retired, a replacement is created, and
+   `record_operation` rebinds the same operation ID under the replacement
+   owner. No duplicate operation is dispatched and no continuity-persistence
+   error is manufactured solely by the optional cleanup refusal.
+
+Related normative behavior lives in `openspec/specs/responses-api-compat/` and
+the existing durable operation ledger contract.

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/proposal.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/proposal.md
@@ -1,0 +1,54 @@
+# Preserve the HTTP bridge recovery operation fence during local rebind
+
+## Summary
+
+An anchored HTTP Responses bridge request can fail before any replacement
+session is dispatched. The local recovery path keeps the durable operation
+ledger as the idempotency fence, but current main invokes its best-effort
+transcript-spool reset after rebinding the in-memory session. The repository
+write is scoped to the original durable session, so it returns `False` for the
+replacement and the helper raises even though this call was explicitly
+best-effort. A normal anchored recovery therefore becomes a
+`bridge_continuity_persistence_failed` response instead of proceeding through
+the existing operation rebind.
+
+## Why
+
+The operation row is owned by the failed durable session until
+`record_operation` performs the guarded rebind. Resetting its transcript before
+that handoff removes stale terminal events while the original owner fence is
+still valid. Resetting after `_get_or_create_http_bridge_session` cannot match
+the row, and treating a best-effort refusal as fatal makes a recoverable local
+transport failure depend on an implementation detail of the replacement
+session.
+
+## What changes
+
+- Run the optional operation-spool reset for the ordinary anchored local-error
+  recovery branch while the failed session still owns the durable operation,
+  before retiring or replacing that session.
+- Keep the required stale-anchor replay reset fail-closed: an unavailable or
+  refused reset still returns the typed `bridge_continuity_persistence_failed`
+  error before an unanchored replay can be sent.
+- Make the existing `required=False` reset contract real for both a missing
+  reset capability and a reset refusal (and a reset exception), so the
+  ordinary local rebind can continue to the fenced operation transition.
+- Add a regression at the HTTP Responses bridge surface proving that the
+  best-effort reset receives the original durable session identity and that a
+  refused reset does not abort the anchored recovery path.
+
+## Capabilities
+
+### Modified capabilities
+
+- `responses-api-compat`: an anchored local HTTP bridge recovery preserves its
+  durable operation fence and does not turn an optional transcript cleanup
+  refusal into a continuity failure.
+
+## Non-goals
+
+- No change to operation IDs, durable schema, upstream retry policy, account
+  selection, or stale-anchor full-resend replay admission.
+- No weakening of the required reset used before account-neutral or owner-bound
+  unanchored replay.
+- No automatic merge, deployment, or live-container mutation.

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
@@ -1,4 +1,6 @@
-## Requirement: Optional recovery-spool cleanup MUST remain optional
+## ADDED Requirements
+
+### Requirement: Optional recovery-spool cleanup MUST remain optional
 
 For an anchored local HTTP bridge recovery that has not dispatched its
 replacement request, the implementation MUST attempt the operation-spool
@@ -9,7 +11,7 @@ cleanup MUST NOT replace the original recovery path with a
 rebind remains responsible for clearing stale attempt material before the
 replacement dispatch.
 
-### Scenario: Optional reset refusal does not abort local recovery
+#### Scenario: Optional reset refusal does not abort local recovery
 
 - **GIVEN** an anchored operation belongs to the failed durable session
 - **AND** local recovery has not dispatched a replacement request
@@ -18,7 +20,7 @@ replacement dispatch.
 - **AND** the replacement is allowed to reach the normal fenced operation
   rebind path.
 
-### Scenario: Optional reset exception does not mask the upstream failure
+#### Scenario: Optional reset exception does not mask the upstream failure
 
 - **GIVEN** the same anchored local recovery path
 - **WHEN** the optional spool reset raises
@@ -26,7 +28,7 @@ replacement dispatch.
 - **AND** recovery does not emit a new continuity-persistence error solely for
   that cleanup failure.
 
-## Requirement: Required replay-spool cleanup MUST fail closed
+### Requirement: Required replay-spool cleanup MUST fail closed
 
 Before an account-neutral or owner-bound unanchored stale-anchor replay, the
 implementation MUST keep the operation fence and required spool reset strict.
@@ -34,7 +36,7 @@ An unavailable, refused, or raising required reset MUST return the typed
 `bridge_continuity_persistence_failed` error and MUST NOT dispatch the
 unanchored replacement request.
 
-### Scenario: Required reset refusal blocks unanchored replay
+#### Scenario: Required reset refusal blocks unanchored replay
 
 - **GIVEN** a verified stale-anchor full-resend replay
 - **WHEN** the required operation-spool reset is unavailable or returns

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
@@ -32,9 +32,9 @@ replacement dispatch.
 
 Before an account-neutral or owner-bound unanchored stale-anchor replay, the
 implementation MUST keep the operation fence and required spool reset strict.
-An unavailable, refused, or raising required reset MUST return the typed
-`bridge_continuity_persistence_failed` error and MUST NOT dispatch the
-unanchored replacement request.
+An unavailable or refused required reset, or a required reset operation that
+raises an exception, MUST return the typed `bridge_continuity_persistence_failed`
+error and MUST NOT dispatch the unanchored replacement request.
 
 #### Scenario: Required reset refusal blocks unanchored replay
 

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
@@ -1,0 +1,43 @@
+## Requirement: Optional recovery-spool cleanup MUST remain optional
+
+For an anchored local HTTP bridge recovery that has not dispatched its
+replacement request, the implementation MUST attempt the operation-spool
+cleanup while the failed durable session still holds the operation owner fence.
+If that cleanup is unavailable, refuses the owner, or raises, the optional
+cleanup MUST NOT replace the original recovery path with a
+`bridge_continuity_persistence_failed` response. The existing durable operation
+rebind remains responsible for clearing stale attempt material before the
+replacement dispatch.
+
+#### Scenario: Optional reset refusal does not abort local recovery
+
+- **GIVEN** an anchored operation belongs to the failed durable session
+- **AND** local recovery has not dispatched a replacement request
+- **WHEN** the optional spool reset returns `False`
+- **THEN** recovery continues with the same operation identity
+- **AND** the replacement is allowed to reach the normal fenced operation
+  rebind path.
+
+#### Scenario: Optional reset exception does not mask the upstream failure
+
+- **GIVEN** the same anchored local recovery path
+- **WHEN** the optional spool reset raises
+- **THEN** the exception is handled as optional cleanup failure
+- **AND** recovery does not emit a new continuity-persistence error solely for
+  that cleanup failure.
+
+## Requirement: Required replay-spool cleanup MUST fail closed
+
+Before an account-neutral or owner-bound unanchored stale-anchor replay, the
+implementation MUST keep the operation fence and required spool reset strict.
+An unavailable, refused, or raising required reset MUST return the typed
+`bridge_continuity_persistence_failed` error and MUST NOT dispatch the
+unanchored replacement request.
+
+#### Scenario: Required reset refusal blocks unanchored replay
+
+- **GIVEN** a verified stale-anchor full-resend replay
+- **WHEN** the required operation-spool reset is unavailable or returns
+  `False`
+- **THEN** the request fails with `bridge_continuity_persistence_failed`
+- **AND** no unanchored replacement request is sent.

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/specs/responses-api-compat/spec.md
@@ -9,7 +9,7 @@ cleanup MUST NOT replace the original recovery path with a
 rebind remains responsible for clearing stale attempt material before the
 replacement dispatch.
 
-#### Scenario: Optional reset refusal does not abort local recovery
+### Scenario: Optional reset refusal does not abort local recovery
 
 - **GIVEN** an anchored operation belongs to the failed durable session
 - **AND** local recovery has not dispatched a replacement request
@@ -18,7 +18,7 @@ replacement dispatch.
 - **AND** the replacement is allowed to reach the normal fenced operation
   rebind path.
 
-#### Scenario: Optional reset exception does not mask the upstream failure
+### Scenario: Optional reset exception does not mask the upstream failure
 
 - **GIVEN** the same anchored local recovery path
 - **WHEN** the optional spool reset raises
@@ -34,7 +34,7 @@ An unavailable, refused, or raising required reset MUST return the typed
 `bridge_continuity_persistence_failed` error and MUST NOT dispatch the
 unanchored replacement request.
 
-#### Scenario: Required reset refusal blocks unanchored replay
+### Scenario: Required reset refusal blocks unanchored replay
 
 - **GIVEN** a verified stale-anchor full-resend replay
 - **WHEN** the required operation-spool reset is unavailable or returns

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
@@ -22,5 +22,4 @@
       checking, proxy architecture checks, and `git diff --check`.
 - [x] 4.2 Run strict OpenSpec validation when the CLI is available; validation
       passed with `pnpm --silent dlx @fission-ai/openspec@1.10.0 validate
-      preserve-http-bridge-recovery-operation-spool --type change --strict
-      --no-interactive`.
+      preserve-http-bridge-recovery-operation-spool --strict --no-interactive`.

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
@@ -20,6 +20,7 @@
 
 - [x] 4.1 Run focused HTTP bridge unit/integration tests, Ruff, formatting, type
       checking, proxy architecture checks, and `git diff --check`.
-- [x] 4.2 Run strict OpenSpec validation when the CLI is available; otherwise
-      record the environment blocker in the delivery evidence (the `openspec`
-      CLI is unavailable in this environment).
+- [x] 4.2 Run strict OpenSpec validation when the CLI is available; validation
+      passed with `pnpm --silent dlx @fission-ai/openspec@1.10.0 validate
+      preserve-http-bridge-recovery-operation-spool --type change --strict
+      --no-interactive`.

--- a/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
+++ b/openspec/changes/preserve-http-bridge-recovery-operation-spool/tasks.md
@@ -1,0 +1,25 @@
+## 1. Specification
+
+- [x] 1.1 Define the optional-versus-required operation-spool reset contract.
+- [x] 1.2 Document the owner-fence ordering and non-goals in `context.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Make `required=False` ignore reset refusal and exceptions while
+      preserving strict required behavior.
+- [x] 2.2 Move the ordinary anchored local-recovery reset before durable-session
+      retirement/replacement.
+
+## 3. Coverage
+
+- [x] 3.1 Add HTTP Responses bridge regression coverage for original-session
+      reset ordering and optional refusal/exception behavior.
+- [x] 3.2 Preserve the existing required stale-anchor reset regression.
+
+## 4. Verification
+
+- [x] 4.1 Run focused HTTP bridge unit/integration tests, Ruff, formatting, type
+      checking, proxy architecture checks, and `git diff --check`.
+- [x] 4.2 Run strict OpenSpec validation when the CLI is available; otherwise
+      record the environment blocker in the delivery evidence (the `openspec`
+      CLI is unavailable in this environment).

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -13877,6 +13877,10 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_previous_response
         "transport-only",
         "operation-fence-unavailable",
         "spool-reset-unavailable",
+        "spool-reset-raises",
+        "spool-reset-falsy",
+        "local-rebind-spool-reset-raises",
+        "local-rebind-spool-reset-falsy",
         "prior-replay-ambiguous",
         "inactive-unknown-journal",
         "pending-tool-manifest",
@@ -13901,10 +13905,26 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
         "forwarded-account-neutral",
         "pending-tool-manifest",
         "account-neutral-newer-circuit-before-submit",
+        "spool-reset-raises",
+        "spool-reset-falsy",
     }
     forwarded_receiver = replay_case.startswith("forwarded-")
     operation_fence_unavailable = replay_case == "operation-fence-unavailable"
     spool_reset_unavailable = replay_case == "spool-reset-unavailable"
+    # Required stale-anchor replay must fail closed when the durable reset
+    # raises or returns false; ordinary anchored local rebind keeps this
+    # cleanup best effort because it does not remove the anchor.
+    spool_reset_raises = replay_case in {"spool-reset-raises", "local-rebind-spool-reset-raises"}
+    spool_reset_falsy = replay_case in {"spool-reset-falsy", "local-rebind-spool-reset-falsy"}
+    local_rebind_spool_reset_raises = replay_case == "local-rebind-spool-reset-raises"
+    local_rebind_spool_reset_falsy = replay_case == "local-rebind-spool-reset-falsy"
+    spool_reset_fail_closed = (spool_reset_raises or spool_reset_falsy) and not (
+        local_rebind_spool_reset_raises or local_rebind_spool_reset_falsy
+    )
+    raising_reset_operation_event_spool = AsyncMock(
+        side_effect=RuntimeError("durable operation spool reset is unavailable")
+    )
+    falsy_reset_operation_event_spool = AsyncMock(return_value=False)
     prior_replay_ambiguous = replay_case == "prior-replay-ambiguous"
     prior_replay_ambiguous_after_event = replay_case == "prior-replay-ambiguous-after-event"
     stale_rejection_after_event_first_attempt = replay_case == "stale-rejection-after-event-first-attempt"
@@ -14012,6 +14032,10 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
     service = get_proxy_service_for_app(app_instance)
     async with service._http_bridge_lock:
         session = next(iter(service._http_bridge_sessions.values()))
+        original_durable_session_id = session.durable_session_id
+        original_durable_owner_epoch = session.durable_owner_epoch
+        assert original_durable_session_id is not None
+        assert original_durable_owner_epoch is not None
         if owner_bound_replay or newer_circuit_before_submit or circuit_advances_during_admission:
             cast(Any, service)._http_bridge_retry_circuits[session.key] = (
                 http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
@@ -14033,6 +14057,18 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
             )
         if spool_reset_unavailable:
             monkeypatch.setattr(service._durable_bridge, "reset_operation_event_spool", None)
+        if spool_reset_raises:
+            monkeypatch.setattr(
+                service._durable_bridge,
+                "reset_operation_event_spool",
+                raising_reset_operation_event_spool,
+            )
+        if spool_reset_falsy:
+            monkeypatch.setattr(
+                service._durable_bridge,
+                "reset_operation_event_spool",
+                falsy_reset_operation_event_spool,
+            )
         if prior_replay_ambiguous or prior_replay_ambiguous_after_event:
             original_prepare_http_bridge_request = service._prepare_http_bridge_request
 
@@ -14148,7 +14184,13 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
         ),
         *(
             []
-            if replay_case in {"missing-prior-output", "pending-tool-manifest"}
+            if replay_case
+            in {
+                "missing-prior-output",
+                "pending-tool-manifest",
+                "local-rebind-spool-reset-raises",
+                "local-rebind-spool-reset-falsy",
+            }
             else [
                 {
                     "type": "message",
@@ -14224,7 +14266,7 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
         assert len(owner_upstream.sent_text) == 1
         assert alternate_upstream.sent_text == []
         return
-    if operation_fence_unavailable or spool_reset_unavailable or prior_replay_ambiguous:
+    if operation_fence_unavailable or spool_reset_unavailable or prior_replay_ambiguous or spool_reset_fail_closed:
         failed_response = await async_client.post(
             "/backend-api/codex/responses",
             json=second_payload,
@@ -14235,6 +14277,18 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
         assert connected_account_ids == [owner_chatgpt_account_id]
         assert len(owner_upstream.sent_text) == 1
         assert alternate_upstream.sent_text == []
+        if spool_reset_raises:
+            raising_reset_operation_event_spool.assert_awaited()
+        if spool_reset_falsy:
+            falsy_reset_operation_event_spool.assert_awaited()
+        if spool_reset_raises or spool_reset_falsy:
+            reset_operation_event_spool = (
+                raising_reset_operation_event_spool if spool_reset_raises else falsy_reset_operation_event_spool
+            )
+            reset_call = reset_operation_event_spool.await_args
+            assert reset_call is not None
+            assert reset_call.kwargs["session_id"] == original_durable_session_id
+            assert reset_call.kwargs["owner_epoch"] == original_durable_owner_epoch
         return
     if prior_replay_ambiguous_after_event or stale_rejection_after_event_first_attempt:
         failed_events = await _collect_sse_events(
@@ -14332,6 +14386,24 @@ async def test_backend_responses_http_bridge_replays_verified_full_resend_after_
             key.lower(): value for key, value in connect_headers_by_account[owner_chatgpt_account_id].items()
         }
         assert replay_payload["previous_response_id"] == first_response_id
+        if local_rebind_spool_reset_raises:
+            # The anchored rebind keeps its anchor, so best-effort spool
+            # cleanup must not turn a recoverable local error into a 502.
+            raising_reset_operation_event_spool.assert_awaited()
+        if local_rebind_spool_reset_falsy:
+            # A refused best-effort reset must not remove the anchor or abort
+            # the fenced local rebind.
+            falsy_reset_operation_event_spool.assert_awaited()
+        if local_rebind_spool_reset_raises or local_rebind_spool_reset_falsy:
+            reset_operation_event_spool = (
+                raising_reset_operation_event_spool
+                if local_rebind_spool_reset_raises
+                else falsy_reset_operation_event_spool
+            )
+            reset_call = reset_operation_event_spool.await_args
+            assert reset_call is not None
+            assert reset_call.kwargs["session_id"] == original_durable_session_id
+            assert reset_call.kwargs["owner_epoch"] == original_durable_owner_epoch
     if account_neutral:
         assert "previous_response_id" not in replay_payload
         assert replay_payload["input"] == expected_replay_input

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -30818,7 +30818,9 @@ async def test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reset_outcome", [False, RuntimeError("durable spool reset failed")])
 async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection(
+    reset_outcome: bool | RuntimeError,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Issue #1830 product path: an anchored bridge request fails with the terse
@@ -30835,6 +30837,37 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
         }
     )
     session = _make_bridge_session(key_value="sid-terse-recovery")
+    session.durable_session_id = "durable-terse-recovery"
+    session.durable_owner_epoch = 7
+    request_states: list[proxy_service._WebSocketRequestState] = []
+
+    def fake_prepare(
+        request_payload: proxy_service.ResponsesRequest,
+        _headers: Mapping[str, str],
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+        **_kwargs: Any,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip
+        request_state = proxy_service._WebSocketRequestState(
+            request_id="req-terse-recovery",
+            model=request_payload.model,
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=time.monotonic(),
+            event_queue=asyncio.Queue(),
+            transport="http",
+            previous_response_id=request_payload.previous_response_id,
+            operation_registered=True,
+            operation_id="op-terse-recovery",
+        )
+        request_states.append(request_state)
+        return request_state, '{"type":"response.create"}'
+
     terse_rejection = ProxyResponseError(
         400,
         {
@@ -30883,6 +30916,13 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
     )
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    reset_operation_event_spool = (
+        AsyncMock(side_effect=reset_outcome)
+        if isinstance(reset_outcome, RuntimeError)
+        else AsyncMock(return_value=reset_outcome)
+    )
+    monkeypatch.setattr(service._durable_bridge, "reset_operation_event_spool", reset_operation_event_spool)
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
     monkeypatch.setattr(service, "_http_bridge_local_owner_account_id", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-owner"))
     monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
@@ -30915,6 +30955,13 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
     assert recovery_call.kwargs["allow_previous_response_recovery_rebind"] is True
     assert recovery_call.kwargs["request_stage"] == "reattach"
     assert stream_attempts == ["resp_stale_anchor", "resp_stale_anchor"]
+    assert request_states
+    reset_operation_event_spool.assert_awaited_once_with(
+        operation_id="op-terse-recovery",
+        session_id="durable-terse-recovery",
+        instance_id=proxy_service.get_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=7,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -30840,6 +30840,7 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
     session.durable_session_id = "durable-terse-recovery"
     session.durable_owner_epoch = 7
     request_states: list[proxy_service._WebSocketRequestState] = []
+    ordered_events: list[str] = []
 
     def fake_prepare(
         request_payload: proxy_service.ResponsesRequest,
@@ -30916,18 +30917,29 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
     )
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
-    reset_operation_event_spool = (
-        AsyncMock(side_effect=reset_outcome)
-        if isinstance(reset_outcome, RuntimeError)
-        else AsyncMock(return_value=reset_outcome)
-    )
+
+    async def reset_spool(**_kwargs: Any) -> bool:
+        ordered_events.append("reset")
+        if isinstance(reset_outcome, RuntimeError):
+            raise reset_outcome
+        return reset_outcome
+
+    reset_operation_event_spool = AsyncMock(side_effect=reset_spool)
+
+    async def retire_session(*_args: Any, **_kwargs: Any) -> None:
+        ordered_events.append("retire")
+
     monkeypatch.setattr(service._durable_bridge, "reset_operation_event_spool", reset_operation_event_spool)
     monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
     monkeypatch.setattr(service, "_http_bridge_local_owner_account_id", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-owner"))
     monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
     monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
-    monkeypatch.setattr(service, "_reset_http_bridge_session_after_local_terminal_error", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_reset_http_bridge_session_after_local_terminal_error",
+        AsyncMock(side_effect=retire_session),
+    )
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
     monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
 
@@ -30956,6 +30968,7 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
     assert recovery_call.kwargs["request_stage"] == "reattach"
     assert stream_attempts == ["resp_stale_anchor", "resp_stale_anchor"]
     assert request_states
+    assert ordered_events == ["reset", "retire"]
     reset_operation_event_spool.assert_awaited_once_with(
         operation_id="op-terse-recovery",
         session_id="durable-terse-recovery",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -30821,6 +30821,7 @@ async def test_http_bridge_retire_stale_pending_reattempts_failed_poison_clear(
 @pytest.mark.parametrize("reset_outcome", [False, RuntimeError("durable spool reset failed")])
 async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection(
     reset_outcome: bool | RuntimeError,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Issue #1830 product path: an anchored bridge request fails with the terse
@@ -30975,6 +30976,8 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
         instance_id=proxy_service.get_settings().http_responses_session_bridge_instance_id,
         owner_epoch=7,
     )
+    if reset_outcome is False:
+        assert "Best-effort HTTP bridge recovery spool reset declined" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

An anchored HTTP Responses bridge request can fail before its replacement is dispatched. The durable operation still belongs to the failed session, but the optional recovery-spool reset was attempted after local session replacement. That loses the original owner fence and can turn a recoverable local transport failure into `bridge_continuity_persistence_failed`.

## Why this PR exists

The broad stale-anchor recovery work in #1867 bundled recovery-spool ordering with retry, quarantine, error-shape, and replay changes. This PR extracts only the recovery-spool fence and optional-reset semantics for focused review.

Refs #1867 (extraction; this PR does not close the parent issue).

## How this PR solves the problem

- Attempt optional spool cleanup while the failed durable session still owns the operation, before retiring or replacing that session.
- Keep missing, refused, and raising optional cleanup best effort so it cannot mask the original recovery path; declined and raising resets emit warnings for operator visibility.
- Keep the required stale-anchor replay reset fail-closed with `bridge_continuity_persistence_failed` and no unanchored dispatch.
- Add OpenSpec requirements plus unit and HTTP Responses integration coverage for owner identity, refusal/exception behavior, reset-before-retirement ordering, and refusal observability.

OpenSpec: `openspec/changes/preserve-http-bridge-recovery-operation-spool/` (strict targeted validation passes).

## Scope

This PR owns HTTP bridge recovery-spool ordering and optional-versus-required reset handling only. It does not change operation IDs, durable schema, upstream retry policy, account selection, stale-anchor replay admission, attribution, or container state.

## Verification

Exact candidate:

- Head: `c6ba2751ee1f7cc145cf2e0ab52f5f3f4ee3429d`.
- Tree: `ba3c860a615aa5e86b0106f6b001dfd34a6204df`.
- Base and merge-base: `upstream/main` `806b7442600df181e33df50138a6451b1ba1f477` (includes merged #1977 and #1957).
- Branch: `codex/pr1867-v3-operation`.

Exact-tree proof:

- HTTP Responses stale-owner recovery matrix: 21 passed.
- Targeted terse previous-response recovery unit variants: 2 passed.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run python scripts/check_proxy_architecture.py`, `uv run python .github/scripts/check_simplicity_budgets.py`, and `git diff --check` passed.
- Strict targeted OpenSpec validation passed: `pnpm --silent dlx @fission-ai/openspec@1.10.0 validate preserve-http-bridge-recovery-operation-spool --type change --strict --no-interactive`.
- The seven PR-only commits retain Conventional Commit subjects and the diff remains limited to the intended seven paths.

## Current status

The branch is force-with-lease pushed at the exact head above after one semantic rebase from the verified remote lease `679ada72f4ffdbfa17c75efe32feb355222e8b5c` onto current `upstream/main` `806b7442600df181e33df50138a6451b1ba1f477`. The rebase includes merged #1977 and #1957 without duplicating their changes.

Fresh hosted CI, security/attribution checks, and an exact-head CodeRabbit review are pending after this push; GitHub mergeability must settle to `CLEAN`. Human maintainer approval and merge authority remain external gates. No merge, self-merge, deployment, or live-container mutation was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP bridge recovery when response cleanup succeeds, is declined, or encounters an error.
  - Recovery now preserves operation continuity when optional cleanup cannot be completed.
  - Required cleanup failures now fail safely with a consistent continuity error instead of triggering an invalid replacement request.
  - Prevented denied proxy-provided anchors from being reused in later requests.
  - Improved cleanup ordering and diagnostics for more reliable follow-up responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->