### PR TITLE
fix(proxy): pin same-owner stale-anchor replay

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3611,7 +3611,11 @@ class _HTTPBridgeStreamingMixin:
                             preferred_account_id=retry_preferred_account_id,
                             preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,
                             fallback_on_preferred_account_unavailable=not (
-                                file_required_preferred_account and retry_preferred_account_id is not None
+                                file_required_preferred_account
+                                or (
+                                    recovery_path == "local_previous_response_same_owner_fresh_replay"
+                                    and retry_preferred_account_id is not None
+                                )
                             ),
                             request_usage_budget=estimate_api_key_request_usage(retry_payload),
                             request_deadline=request_deadline,

--- a/openspec/changes/pin-same-owner-stale-anchor-replay/.openspec.yaml
+++ b/openspec/changes/pin-same-owner-stale-anchor-replay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/pin-same-owner-stale-anchor-replay/proposal.md
+++ b/openspec/changes/pin-same-owner-stale-anchor-replay/proposal.md
@@ -1,0 +1,44 @@
+# Pin same-owner stale-anchor full resend
+
+## Problem
+
+The HTTP bridge can prove that a previous-response anchor was explicitly
+rejected before upstream produced any output while the retained request still
+contains owner-bound tool history. The bridge correctly drops only that stale
+anchor and prepares an unanchored full resend, but its recovery admission
+currently allows the account selector to fall back when the preferred owner is
+unavailable. That can move retained owner-bound context to another account and
+break the continuity contract this recovery is meant to preserve.
+
+## Why this PR
+
+The original stale-anchor hardening landed in a broad change and the shared
+generation-fence portion has since landed separately. This PR carries the
+remaining same-owner pin as one reviewable concern, so maintainers can review
+the account-ownership rule without re-opening the unrelated account-neutral
+replay, quarantine, or transport-recovery work from that change.
+
+## What changes
+
+- Keep a verified owner-bound stale-anchor replacement pinned to its proven
+  preferred account whenever it has one.
+- Fail closed with the existing owner-unavailable behavior if that account
+  cannot accept the replacement; never silently select an alternate account.
+- Leave account-neutral verified replay, ordinary reconnects, delta-only
+  requests, and operation/circuit fencing unchanged.
+- Add a regression that proves the replacement omits the rejected anchor,
+  remains on the original owner, and disables preferred-owner fallback even
+  when continuity provenance is not independently available.
+
+## Modified capabilities
+
+- `responses-api-compat`: an explicitly rejected, verified owner-bound
+  previous-response anchor may be replaced only on the proven owner account.
+
+## Non-goals
+
+- No account-neutral replay policy change.
+- No retry-circuit deletion or bypass change.
+- No change to stale-anchor classification, operation fencing, or transport
+  retry behavior.
+- No live/runtime configuration or public response-schema change.

--- a/openspec/changes/pin-same-owner-stale-anchor-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/pin-same-owner-stale-anchor-replay/specs/responses-api-compat/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Verified same-owner stale-anchor replacement remains owner-bound
+
+When an HTTP-bridge continuation has a verified, prefix-safe full resend that
+is not account-neutral because its retained tool or file context is owner-bound,
+and the continuity owner explicitly rejects `previous_response_id` before
+producing any response output, the proxy MUST remove only that rejected anchor
+and attempt the bounded unanchored replacement on the proven owner account.
+If a preferred owner account is available in this recovery path, admission MUST
+set `fallback_on_preferred_account_unavailable` to false. If that owner cannot
+accept the replacement, the proxy MUST fail closed rather than selecting an
+alternate account. The replacement MUST retain the existing operation fence,
+settlement, one-shot replay, and retry-circuit rules.
+
+#### Scenario: Owner-bound replacement stays on the rejecting owner
+
+- **GIVEN** a verified full resend contains retained owner-bound tool history
+- **AND** upstream explicitly rejects its `previous_response_id` before output
+- **WHEN** the proxy prepares the one-shot unanchored replacement
+- **THEN** the replacement omits the rejected `previous_response_id`
+- **AND** it is admitted with the proven owner as `preferred_account_id`
+- **AND** preferred-owner fallback is disabled
+- **AND** the replacement does not migrate accounts
+
+#### Scenario: Unavailable owner fails closed
+
+- **GIVEN** the owner-bound replacement has a proven preferred account
+- **AND** that account is unavailable or saturated during replacement admission
+- **WHEN** the proxy selects a bridge session
+- **THEN** the request fails with the existing retryable owner-unavailable result
+- **AND** no alternate account receives the retained owner-bound context
+
+#### Scenario: Account-neutral replay remains independent
+
+- **GIVEN** an explicit stale-anchor rejection passes the existing account-neutral
+  full-resend proof
+- **WHEN** the proxy performs account-neutral recovery
+- **THEN** its existing owner-exclusion and account-neutral selection behavior
+  remains unchanged
+
+#### Scenario: Other recovery paths remain unchanged
+
+- **WHEN** a request is delta-only, prefix-unverified, transport-only, or has no
+  explicit stale-anchor rejection
+- **THEN** the proxy does not use this owner-bound replacement rule
+- **AND** its existing fail-closed or anchored recovery behavior remains in
+  force

--- a/openspec/changes/pin-same-owner-stale-anchor-replay/tasks.md
+++ b/openspec/changes/pin-same-owner-stale-anchor-replay/tasks.md
@@ -1,0 +1,29 @@
+## 1. Specification
+
+- [x] 1.1 Record the owner-bound stale-anchor replacement problem, rationale,
+  scope, and non-goals.
+- [x] 1.2 Require owner-pinned admission and fail-closed behavior when the
+  proven owner is unavailable.
+
+## 2. Implementation
+
+- [x] 2.1 Disable preferred-owner fallback for the verified same-owner stale-
+  anchor replacement path while leaving account-neutral replay unchanged.
+
+## 3. Coverage
+
+- [x] 3.1 Add a regression proving the replacement drops only the stale anchor,
+  remains on the same account, and disables preferred-owner fallback.
+- [x] 3.2 Cover the owner-unavailable fail-closed outcome without exercising an
+  alternate account through the existing required-owner selection regression.
+
+## 4. Verification
+
+- [x] 4.1 Run focused bridge tests and affected unit/integration checks.
+- [x] 4.2 Run Ruff, formatting, changed-file type checks, proxy architecture,
+  simplicity, diff, and strict OpenSpec validation where available.
+  Strict OpenSpec CLI is unavailable in this environment (`openspec` is not
+  installed); record that as a hosted/environment gate rather than claiming a
+  local strict validation result.
+- [ ] 4.3 Review the immutable candidate and post exact-head evidence before
+  requesting maintainer merge.

--- a/openspec/changes/pin-same-owner-stale-anchor-replay/tasks.md
+++ b/openspec/changes/pin-same-owner-stale-anchor-replay/tasks.md
@@ -22,8 +22,9 @@
 - [x] 4.1 Run focused bridge tests and affected unit/integration checks.
 - [x] 4.2 Run Ruff, formatting, changed-file type checks, proxy architecture,
   simplicity, diff, and strict OpenSpec validation where available.
-  Strict OpenSpec CLI is unavailable in this environment (`openspec` is not
-  installed); record that as a hosted/environment gate rather than claiming a
-  local strict validation result.
-- [ ] 4.3 Review the immutable candidate and post exact-head evidence before
+  Exact candidate validation: `pnpm --silent dlx
+  @fission-ai/openspec@1.10.0 validate
+  pin-same-owner-stale-anchor-replay --strict` passes. Full strict specs remain
+  57/58 with the unrelated pre-existing `model-source-routing` failure.
+- [x] 4.3 Review the immutable candidate and post exact-head evidence before
   requesting maintainer merge.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -30918,6 +30918,213 @@ async def test_stream_via_http_bridge_recovers_terse_previous_response_rejection
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_same_owner_fresh_replay_pins_owner_without_continuity_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session-injected anchor must not let the fresh replay switch accounts."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    prefix = {"role": "user", "content": [{"type": "input_text", "text": "first"}]}
+    full_input = [
+        prefix,
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "call_id": "call-owner-bound",
+            "name": "spawn_agent",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-owner-bound",
+            "output": "completed",
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "first answer"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "second"}]},
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": full_input,
+        }
+    )
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="soft-owner-replay",
+        canonical_kind="prompt_cache",
+        canonical_key="soft-owner-replay",
+        api_key_scope="__anonymous__",
+        account_id="acc-owner",
+        owner_instance_id="instance-a",
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-stale-anchor",
+        latest_input_item_count=1,
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(cast(Any, [prefix])),
+    )
+    soft_key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "soft-owner-replay", None)
+    session = _make_bridge_session(key=soft_key, key_value="soft-owner-replay")
+    session.codex_session = True
+    session.durable_session_id = lookup.session_id
+    session.durable_owner_epoch = lookup.owner_epoch
+    session.account = cast(Any, SimpleNamespace(id="acc-owner", status=AccountStatus.ACTIVE, plan_type="plus"))
+    session.last_completed_response_id = lookup.latest_response_id
+    session.last_completed_response_account_id = lookup.account_id
+    session.last_completed_input_count = lookup.latest_input_item_count or 0
+    session.last_completed_input_prefix_fingerprint = lookup.latest_input_full_fingerprint
+    recovery_session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("internal_request_parallel", "same-owner-replay", None),
+        key_value="same-owner-replay",
+    )
+    recovery_session.durable_session_id = lookup.session_id
+    recovery_session.durable_owner_epoch = lookup.owner_epoch
+    recovery_session.account = cast(
+        Any,
+        SimpleNamespace(id="acc-owner", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    alternate_session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("internal_request_parallel", "alternate-replay", None),
+        key_value="alternate-replay",
+    )
+    alternate_session.account = cast(
+        Any,
+        SimpleNamespace(id="acc-alternate", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    get_or_create_calls: list[dict[str, object]] = []
+
+    async def fake_get_or_create(*_args: object, **kwargs: object) -> proxy_service._HTTPBridgeSession:
+        get_or_create_calls.append(kwargs)
+        if len(get_or_create_calls) == 1:
+            return session
+        if kwargs["fallback_on_preferred_account_unavailable"]:
+            return alternate_session
+        return recovery_session
+
+    get_or_create = AsyncMock(side_effect=fake_get_or_create)
+    stale_rejection = ProxyResponseError(
+        400,
+        {
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Invalid `previous_response_id`.",
+            }
+        },
+    )
+    stream_attempts: list[tuple[str | None, str | None, str]] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: Mapping[str, str],
+        **_kwargs: object,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        text_data = json.dumps(prepared_payload.to_payload())
+        request_state = proxy_service._WebSocketRequestState(
+            request_id="req-soft-owner-replay",
+            model=prepared_payload.model,
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=1.0,
+            previous_response_id=prepared_payload.previous_response_id,
+            request_text=text_data,
+            operation_id="op-soft-owner-replay",
+            operation_registered=True,
+            operation_fingerprint="fingerprint-soft-owner-replay",
+            transport="http",
+        )
+        return request_state, text_data
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+        request_deadline: float | None = None,
+    ):
+        del text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
+        stream_attempts.append(
+            (request_state.previous_response_id, request_state.preferred_account_id, _session.account.id)
+        )
+        if len(stream_attempts) == 1:
+            assert request_state.previous_response_id == "resp-stale-anchor", stream_attempts
+            raise stale_rejection
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=lookup))
+    monkeypatch.setattr(service._durable_bridge, "reset_operation_event_spool", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+    monkeypatch.setattr(service, "_reset_http_bridge_session_after_local_terminal_error", AsyncMock())
+    monkeypatch.setattr(service, "_http_bridge_retry_circuit_generation", AsyncMock(return_value=(True, None)))
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_verified_stale_anchor_replay_is_operation_fenced",
+        lambda _session, _request_state: True,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert stream_attempts == [
+        ("resp-stale-anchor", "acc-owner", "acc-owner"),
+        (None, "acc-owner", "acc-owner"),
+    ]
+    assert get_or_create.await_count == 2
+    recovery_call = get_or_create.await_args_list[1]
+    assert recovery_call.kwargs["preferred_account_id"] == "acc-owner"
+    assert recovery_call.kwargs["preferred_account_has_continuity_provenance"] is False
+    assert recovery_call.kwargs["fallback_on_preferred_account_unavailable"] is False
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_retire_stale_pending_clean_close_never_poisons_anchor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

After an upstream `previous_response_id` rejection, a verified full-resend replacement still carried the original durable operation. When retained context was not file-pinned, admission could fall back to another account. That breaks owner-bound continuity and can send tool history to the wrong account.

## Why this PR exists

This is the focused V5b residual from #1867. The original stale-anchor implementation mixed same-owner replay with generation fencing, quarantine, error-shape, recovery-spool, and transport work. The maintainer asked for those concerns to be split so each vehicle can be reviewed and merged independently. This PR owns only the same-owner fallback rule.

## How this PR solves the problem

For `local_previous_response_same_owner_fresh_replay`, a proven non-null owner now forces `fallback_on_preferred_account_unavailable=False`. The selector therefore keeps the replacement on that owner or fails closed with the owner-unavailable result; it cannot silently switch accounts. The replacement still drops the rejected anchor and preserves the existing operation, settlement, one-shot, retry-circuit, and cancellation fences. Account-neutral replay and unrelated recovery paths remain unchanged.

## Scope

- One production guard in `app/modules/proxy/_service/http_bridge/streaming.py`.
- Route-level regression coverage for stale-anchor removal, same-owner selection, and disabled fallback without continuity provenance.
- OpenSpec change: `openspec/changes/pin-same-owner-stale-anchor-replay/`.
- No attribution files, settings, migrations, public schema, or runtime/live-container changes.
- `Refs #1867`; this is a focused successor and does not close the old source PR.

## Verification

Exact candidate:

- Head: `e8ed1d7af583fbf24919dde2a67c64a450e31941`.
- Tree: `f59d2f116d4471cad5b659b6123c6f2701970e47`.
- Base and merge-base: `upstream/main` `54fca65b72d267a2dfa377fe26cb1c62da29a88f` (includes #1978).
- Branch: `codex/pr1867-v5b-same-owner-current-main`.

Exact-tree proof:

- New same-owner route regression: 1 passed.
- Stale-anchor/same-owner unit selection: 6 passed.
- Stale-owner/full-resend integration selection: 17 passed.
- Full `tests/unit/test_proxy_http_bridge.py`: 743 passed; one unrelated existing `file_account_pins` missing-table fixture fails (`no such table: file_account_pins`).
- Ruff check and format, `ty`, proxy architecture, `git diff --check`, and strict targeted OpenSpec validation: passed.
- Both branch commits use Conventional Commit subjects.

## Current status

The branch is clean and force-with-lease pushed at the exact head above, rebased directly onto current `upstream/main`. Hosted checks are refreshing for this new head (labeler queued, Simplicity budgets and GitGuardian in progress; CI and exact-head CodeRabbit pending). Human maintainer review and merge authority remain external gates. This is not a merge-ready claim until those current-head gates finish. No self-merge or live-container mutation has occurred.
