### PR TITLE
fix(proxy): enforce prohibited priority service tier

### DIFF
--- a/app/modules/proxy/_service/warmup.py
+++ b/app/modules/proxy/_service/warmup.py
@@ -29,7 +29,11 @@ from app.db.models import Account, AccountStatus
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy._service.support import _call_with_supported_optional_kwargs, _request_log_client_fields
 from app.modules.proxy.helpers import _header_account_id, _normalize_error_code, _parse_openai_error
-from app.modules.proxy.request_policy import normalize_upstream_model_alias, validate_model_access
+from app.modules.proxy.request_policy import (
+    apply_prohibit_fast_mode,
+    normalize_upstream_model_alias,
+    validate_model_access,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -340,7 +344,12 @@ class _WarmupMixin:
                 input="warmup",
                 store=False,
             )
-            normalize_upstream_model_alias(payload, prohibit_fast_mode=prohibit_fast_mode)
+            normalize_upstream_model_alias(payload)
+            apply_prohibit_fast_mode(
+                payload,
+                prohibit_fast_mode=prohibit_fast_mode,
+                request_id=request_id,
+            )
             response = await _call_with_supported_optional_kwargs(
                 _service_core_compact_responses(),
                 payload,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -249,6 +249,7 @@ from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     apply_api_key_enforcement_to_chat_payload,
     apply_enforced_service_tier_model_fallback,
+    apply_prohibit_fast_mode,
     enforce_strict_function_tools_format,
     enforce_strict_text_format,
     model_alias_requests_fast_mode,
@@ -4305,6 +4306,7 @@ async def v1_chat_completions(
             ),
             reservation=reservation,
             rate_limit_headers=rate_limit_headers,
+            prohibit_fast_mode=prohibit_fast_mode,
         )
     responses_payload.stream = True
     stream = context.service.stream_responses(
@@ -5150,6 +5152,7 @@ async def _source_chat_completion_response(
     allowed_reasoning_effort: str | None = None,
     reservation: ApiKeyUsageReservationData | None,
     rate_limit_headers: Mapping[str, str],
+    prohibit_fast_mode: bool = False,
 ) -> Response:
     source_payload = payload.model_dump(mode="json", exclude_none=True)
     source_payload["model"] = model
@@ -5160,6 +5163,7 @@ async def _source_chat_completion_response(
         allowed_reasoning_effort=allowed_reasoning_effort,
         materialize_allowed_reasoning_effort=allowed_reasoning_effort is not None,
     )
+    apply_prohibit_fast_mode(source_payload, prohibit_fast_mode=prohibit_fast_mode)
     sanitize_source_chat_payload(
         source_payload,
         allow_reasoning=source_model_supports_reasoning(source, model),
@@ -5837,7 +5841,9 @@ async def _stream_responses(
         service_tier_was_enforced = apply_api_key_enforcement(
             payload,
             api_key,
-            prohibit_fast_mode=prohibit_fast_mode,
+            # A forwarded payload carries the origin's signed effective tier.
+            # Restore that tier below, then apply the global policy once.
+            prohibit_fast_mode=prohibit_fast_mode and not forwarded_request,
         ).service_tier_was_enforced
     if forwarded_request:
         payload.service_tier = forwarded_effective_service_tier
@@ -5846,6 +5852,7 @@ async def _stream_responses(
             payload,
             service_tier_was_enforced=service_tier_was_enforced,
         )
+    apply_prohibit_fast_mode(payload, prohibit_fast_mode=prohibit_fast_mode)
     validate_model_access(api_key, payload.model)
     compact_payload: ResponsesCompactRequest | None = None
     if codex_session_affinity:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.exceptions import ProxyModelNotAllowed, ProxyReasoningEffortNotAllowed
 from app.core.openai.exceptions import ClientPayloadError
-from app.core.openai.model_registry import ModelRegistry, get_model_registry
+from app.core.openai.model_registry import ModelRegistry, canonical_service_tier_value, get_model_registry
 from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesReasoning,
@@ -281,11 +281,12 @@ def apply_api_key_enforcement(
     client_reasoning_effort = payload._codex_lb_client_reasoning_effort or _client_reasoning_effort(payload)
     payload._codex_lb_client_reasoning_effort = client_reasoning_effort
     provider_reasoning_effort = _client_reasoning_effort_from_provider_aliases(payload)
-    normalize_upstream_model_alias(payload, prohibit_fast_mode=prohibit_fast_mode)
+    normalize_upstream_model_alias(payload)
 
     if api_key is None:
         _materialize_provider_reasoning_effort(payload, provider_reasoning_effort)
         pre_normalization_effort = normalize_unsupported_reasoning_effort(payload, registry=registry)
+        apply_prohibit_fast_mode(payload, prohibit_fast_mode=prohibit_fast_mode)
         return ApiKeyEnforcementResult(False, pre_normalization_effort)
 
     if api_key.enforced_model:
@@ -303,7 +304,7 @@ def apply_api_key_enforcement(
         if enforced_model_reasoning_effort is not None:
             client_reasoning_effort = enforced_model_reasoning_effort
             payload._codex_lb_client_reasoning_effort = client_reasoning_effort
-        normalize_upstream_model_alias(payload, prohibit_fast_mode=prohibit_fast_mode)
+        normalize_upstream_model_alias(payload)
         if (
             responses_input_uses_lite_tools(payload.input)
             and _model_responses_lite_capability(
@@ -371,7 +372,32 @@ def apply_api_key_enforcement(
                 api_key.enforced_service_tier,
                 effective_service_tier,
             )
+    apply_prohibit_fast_mode(payload, prohibit_fast_mode=prohibit_fast_mode)
     return ApiKeyEnforcementResult(service_tier_was_enforced, pre_normalization_effort)
+
+
+def apply_prohibit_fast_mode(
+    payload: ResponsesRequest | ResponsesCompactRequest | dict[str, JsonValue],
+    *,
+    prohibit_fast_mode: bool,
+    request_id: str | None = None,
+) -> bool:
+    """Remove a resolved priority tier when the global policy prohibits it."""
+    raw_service_tier = payload.get("service_tier") if isinstance(payload, dict) else payload.service_tier
+    service_tier = raw_service_tier if isinstance(raw_service_tier, str) else None
+    if not prohibit_fast_mode or service_tier is None or canonical_service_tier_value(service_tier) != "priority":
+        return False
+
+    logger.info(
+        "fast_mode_service_tier_prohibited request_id=%s stripped_service_tier=%s",
+        request_id or get_request_id(),
+        service_tier,
+    )
+    if isinstance(payload, dict):
+        payload.pop("service_tier", None)
+    else:
+        payload.service_tier = None
+    return True
 
 
 def apply_enforced_service_tier_model_fallback(
@@ -551,17 +577,13 @@ def model_alias_requests_fast_mode(model: str | None) -> bool:
     return alias is not None and alias[3]
 
 
-def normalize_upstream_model_alias(
-    payload: ResponsesRequest | ResponsesCompactRequest,
-    *,
-    prohibit_fast_mode: bool = False,
-) -> None:
+def normalize_upstream_model_alias(payload: ResponsesRequest | ResponsesCompactRequest) -> None:
     requested_model = payload.model
     alias = _resolve_model_alias_parts(requested_model)
     if alias is None:
         return
 
-    canonical_model, alias_effort, alias_service_tier, alias_requests_fast_mode = alias
+    canonical_model, alias_effort, alias_service_tier, _alias_requests_fast_mode = alias
     if payload.model != canonical_model:
         logger.info(
             "model_alias_normalized request_id=%s requested_model=%s normalized_model=%s",
@@ -589,14 +611,6 @@ def normalize_upstream_model_alias(
             )
 
     if alias_service_tier is not None and getattr(payload, "service_tier", None) is None:
-        if prohibit_fast_mode and alias_requests_fast_mode:
-            logger.info(
-                "model_alias_fast_mode_prohibited request_id=%s requested_model=%s normalized_model=%s",
-                get_request_id(),
-                requested_model,
-                canonical_model,
-            )
-            return
         setattr(payload, "service_tier", alias_service_tier)
         logger.info(
             "model_alias_service_tier_normalized request_id=%s requested_model=%s "

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/design.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`prohibitFastMode` is currently evaluated inside model-alias normalization. That location can only decline to derive `service_tier: "priority"` from a `fast` alias; it cannot remove a tier supplied directly by a client, introduced by API-key enforcement, or already present on a forwarded payload. The policy therefore disagrees across HTTP, compact, WebSocket, warmup, and owner-forwarding paths.
+
+Outbound Responses payloads are mutable typed request models. Request preparation already converges on `apply_api_key_enforcement` for ordinary HTTP, compact, chat-conversion, and WebSocket traffic, while warmup and owner-forward replay have narrow preparation paths of their own. Routing and quota reservation inspect `payload.service_tier` before serialization, so wire-only filtering would leave internal selection and accounting inconsistent with what is sent.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enforce one canonical definition of prohibited priority service tiers across every outbound Responses path.
+- Remove the tier before model-source selection, quota reservation, request logging, and upstream serialization.
+- Preserve API-key enforcement provenance and all non-priority wire behavior.
+- Make every removal observable through a low-cardinality info log.
+
+**Non-Goals:**
+
+- Changing priority-tier pricing, response-tier accounting, or upstream response interpretation.
+- Changing model alias, reasoning-effort, WebSocket continuity, or source-routing behavior beyond the tier prohibition.
+- Adding a Prometheus series solely for this bug fix; the removal log gives direct evidence without expanding the metrics contract, while existing service-tier metrics continue to describe effective requests.
+
+## Decisions
+
+### Decision: Centralize the policy in one typed request-policy helper
+
+Add one helper in `request_policy.py` that inspects a `ResponsesRequest` or `ResponsesCompactRequest`, canonicalizes its current tier with `canonical_service_tier_value`, and sets only canonical priority values to `None` when prohibition is enabled. It logs the request ID and original stripped value.
+
+The helper runs after the last tier writer in each preparation flow. `apply_api_key_enforcement` invokes it after alias normalization and API-key tier enforcement; warmup invokes it after alias normalization; owner-forward preparation invokes it after restoring the signed effective tier. This keeps routing, reservations, logs, and serialization aligned while retaining one implementation of the rule.
+
+Alternatives considered:
+
+- Filtering only in `to_payload()` was rejected because model-source selection and quota reservation happen before serialization and would still observe priority.
+- Adding independent string checks at every route was rejected because it duplicates policy and risks drift.
+- Retaining the alias-specific prohibition plus adding explicit-tier filtering was rejected because it leaves two enforcement mechanisms with different precedence and observability.
+
+### Decision: Global prohibition overrides API-key enforced priority
+
+An administrator-enabled global prohibition wins over a key's `enforced_service_tier`. API-key enforcement still runs and returns its existing provenance, but the shared prohibition helper removes a resulting canonical priority tier before downstream decisions.
+
+This precedence matches an operator-wide safety control: a narrower credential policy must not bypass it. When the global setting is disabled, API-key behavior is unchanged.
+
+### Decision: Omit prohibited priority tiers
+
+Set the typed field to `None`, producing no `service_tier` key upstream. Do not substitute literal `"default"`: existing code documents that the subscription backend rejects some literal default-tier values, and absence is already the established wire representation for the upstream default. Non-priority values and an already absent field remain untouched.
+
+### Decision: Preserve connection-snapshot semantics for WebSockets
+
+The WebSocket path continues using the `prohibitFastMode` value captured when the connection begins. Each `response.create` frame is normalized with that snapshot, including explicit priority fields. Changing the dashboard setting still requires reconnecting an existing WebSocket to observe the new policy.
+
+## Risks / Trade-offs
+
+- [A forwarded request could restore a prohibited signed tier after ordinary enforcement] → Invoke the shared helper after the forwarded tier restoration, immediately before downstream routing and serialization.
+- [Refactoring alias normalization could change disabled-policy behavior] → Add red-first tests for enabled and disabled alias, explicit, and API-key cases; priority remains derived normally when prohibition is off.
+- [Clearing the tier could leave quota/accounting metadata stale] → Enforce before reservation and request-state capture, and assert effective outbound/request-state tiers in path-level tests.
+- [Lower-frequency request paths may bypass ordinary API-key enforcement] → Enumerate every assignment, mapping normalization, and outbound serialization path, and cover warmup plus forwarded preparation explicitly.
+
+## Migration Plan
+
+No data migration or configuration change is required. Deploying the code makes an already-enabled setting effective for all new HTTP requests and newly connected WebSockets. Rollback restores the prior alias-only behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/notes.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/notes.md
@@ -1,0 +1,90 @@
+## Outbound `service_tier` write audit
+
+The application-wide audit separates request-payload writers from response,
+pricing, persistence, and observability fields that happen to share the same
+name.
+
+### Outbound request writers and normalizers
+
+- `app/core/openai/requests.py`: `ResponsesRequest` field validation and the
+  compact/OpenAI-compatible mapping normalizers canonicalize inbound `fast` to
+  `priority`. Covered: every resulting typed Responses payload reaches the
+  shared prohibition after validation and before routing/serialization.
+- `app/core/openai/v1_requests.py` and `app/core/openai/chat_requests.py`:
+  typed `service_tier` fields are transferred into `ResponsesRequest` during
+  `/v1` and chat conversion. Covered by the shared typed policy and route-level
+  tests.
+- `app/modules/proxy/request_policy.py::normalize_upstream_model_alias`:
+  derives `priority` from qualified Fast Mode aliases. Covered: ordinary paths
+  call the shared prohibition at the end of `apply_api_key_enforcement`, and
+  warmup calls it immediately after alias normalization.
+- `app/modules/proxy/request_policy.py::apply_api_key_enforcement`: writes an
+  API key's enforced tier (or `None` for omit-equivalent `auto`/`default`).
+  Covered: the shared prohibition runs after the write while preserving the
+  function's pre-write provenance result.
+- `app/modules/proxy/request_policy.py::apply_api_key_enforcement_to_chat_payload`:
+  writes or removes an API-key enforced tier on source-routed chat dictionaries.
+  Covered: `_source_chat_completion_response` applies the same shared helper
+  after chat enforcement and before forwarding.
+- `app/modules/proxy/api.py::_stream_responses`: restores the origin-signed
+  effective tier on owner-forwarded payloads. Covered: the shared prohibition
+  runs immediately after restoration, before account selection and upstream
+  serialization.
+- `app/modules/proxy/request_policy.py::apply_enforced_service_tier_model_fallback`:
+  can only remove an enforced tier when the selected subscription model lacks
+  it. Deliberately retained as an independent compatibility fallback; it never
+  introduces priority, and the global prohibition runs after it at boundaries
+  that can restore or rewrite a tier.
+- `app/modules/proxy/request_policy.py::apply_prohibit_fast_mode`: the sole
+  prohibition implementation. It removes canonical priority from typed
+  Responses payloads and source-chat dictionaries and never writes a
+  non-priority value.
+
+### Same-name writes that are not outbound request writers
+
+- Model/request field declarations in `app/core/openai/*.py` define typed
+  schema surfaces; their actual transfers are covered above.
+- `app/modules/proxy/_service/streaming/*`, `_service/websocket/*`,
+  `_service/http_bridge/upstream_events.py`, and `_service/api_key_usage.py`
+  assign observed upstream response tiers into request state, settlement, and
+  logs after dispatch. They do not mutate a request that will be serialized
+  upstream.
+- `app/modules/automations/service.py` reads an upstream compact response tier
+  for request logging only.
+- `app/modules/api_keys/*`, `app/db/*`, `app/modules/request_logs/*`, pricing,
+  metrics, dashboards, and rollups persist policy configuration or report
+  observed tiers; they do not build upstream request payloads.
+
+## OpenSpec validation evidence
+
+The change and its primary owning capability pass strict validation:
+
+- `npx --yes @fission-ai/openspec@1.3.0 validate prohibit-priority-service-tier --type change --strict`
+- `npx --yes @fission-ai/openspec@1.3.0 validate fast-mode-policy --type spec --strict`
+
+The aggregate command
+`npx --yes @fission-ai/openspec@1.3.0 validate --specs --strict` reports
+`50 passed, 8 failed (58 items)`. The failing capabilities are the pre-existing
+`database-backends`, `frontend-architecture`, `model-catalog-compat`,
+`model-source-routing`, `query-caching`, `responses-api-compat`,
+`usage-error-metrics`, and `usage-refresh-policy` specs. The new
+`responses-api-compat` requirement itself contains the required normative
+keyword and scenarios; this change does not broaden into repairing the older
+unrelated requirements in that capability.
+
+## CodeRabbit review triage
+
+The final light review completed against all 18 changed files with zero
+findings. A prior completed pass identified one minor observability issue:
+warmup strip logs used the ambient request ID rather than the per-submission
+upstream ID. The helper now accepts the submission ID and the warmup regression
+test proves that the strip log matches `x-request-id`.
+
+Two interrupted earlier streams suggested changing omission assertions to
+literal `service_tier: "default"`, and another suggested making that the
+normative wire behavior. Those suggestions were deliberately not applied:
+the existing API-key contract and issue #546 document that the ChatGPT/Codex
+backend rejects literal `auto`/`default`, while omission is its established
+default-tier representation. One valid minor from an interrupted stream asked
+for auditable aggregate OpenSpec evidence; the command and baseline failures
+are recorded above.

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/proposal.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The operator-wide `prohibitFastMode` setting currently blocks only priority tiers derived from Fast Mode model aliases. Explicit client `service_tier: "priority"` values, including Codex WebSocket `response.create` frames, still reach OpenAI and bypass the configured policy.
+
+## What Changes
+
+- Treat `prohibitFastMode` as a global prohibition of any service tier that canonicalizes to OpenAI's `priority` tier.
+- Apply the prohibition after client input, model-alias normalization, defaults, and API-key enforcement have resolved the outbound tier, before upstream serialization on every Responses request path.
+- Give the administrator's global prohibition precedence over an API key's `enforced_service_tier`; prohibited priority tiers are omitted from the upstream payload while non-priority and absent values retain their existing wire behavior.
+- Emit an info-level diagnostic containing the request ID and stripped tier whenever the policy removes a priority tier.
+- Add regression coverage for HTTP Responses, OpenAI-compatible `/v1` Responses, compact Responses, WebSocket `response.create`, warmup, model aliases, and API-key enforced priority tiers.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `fast-mode-policy`: Expand the operator policy from alias-derived Fast Mode tiers to all outbound priority-tier requests and define precedence over API-key enforcement.
+- `responses-api-compat`: Require consistent priority-tier prohibition across native HTTP, OpenAI-compatible `/v1`, compact, WebSocket, chat-conversion, and warmup request paths.
+
+## Impact
+
+- Affected policy logic: `app/modules/proxy/request_policy.py` and outbound Responses request preparation/serialization.
+- Affected entry points: native and `/v1` Responses, compact Responses, chat-to-Responses conversion, WebSocket `response.create`, and dashboard warmup.
+- Existing API-key enforced priority behavior changes only when the administrator has enabled `prohibitFastMode`; all behavior remains unchanged while the setting is disabled.
+- No schema, migration, dependency, or changelog changes are required.

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/fast-mode-policy/spec.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/fast-mode-policy/spec.md
@@ -1,11 +1,4 @@
-# Fast Mode Policy Specification
-
-## Purpose
-
-Define the operator policy that prevents outbound requests from selecting
-OpenAI's priority service tier.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Operators can prohibit priority service tiers
 

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/fast-mode-policy/spec.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/fast-mode-policy/spec.md
@@ -11,10 +11,11 @@ owner-forwarded payload. The administrator prohibition MUST take precedence
 over API-key service-tier enforcement. A prohibited tier MUST be represented
 on the upstream wire by omitting `service_tier`; absent and non-priority values
 MUST retain their existing behavior. The setting MUST take effect before
-model-source selection, quota reservation, request logging, and upstream
-OpenAI forwarding for HTTP requests; a Codex WebSocket connection MUST use the
-policy resolved when that connection began. Each stripped tier MUST emit an
-info-level diagnostic containing the request ID and stripped value.
+model-source selection, quota reservation, request-state capture, request
+logging, serialization, and upstream OpenAI forwarding for HTTP requests; a
+Codex WebSocket connection MUST use the policy resolved when that connection
+began. Each stripped tier MUST emit an info-level diagnostic containing the
+request ID and stripped value.
 
 #### Scenario: Operator disables Fast Mode for a harness alias
 
@@ -64,6 +65,7 @@ info-level diagnostic containing the request ID and stripped value.
 - **GIVEN** a Codex WebSocket connection began while `prohibitFastMode` was enabled
 - **WHEN** a `response.create` frame carries `service_tier: "priority"`
 - **THEN** its upstream payload omits `service_tier`
+- **AND** its effective request state omits `service_tier`
 
 #### Scenario: Policy changes are audited
 

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/responses-api-compat/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Responses transports apply the global priority-tier prohibition consistently
+
+The service MUST apply the same canonical priority-tier prohibition before
+forwarding an upstream payload from native `/responses`, OpenAI-compatible
+`/v1/responses`, native and `/v1` compact Responses, chat-to-Responses
+conversion, WebSocket `response.create`, dashboard warmup, and internal
+owner-forwarding paths whenever `prohibitFastMode` is enabled.
+
+#### Scenario: Native and OpenAI-compatible HTTP requests omit explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** `/responses` or `/v1/responses` receives an explicit priority service tier
+- **THEN** the effective upstream payload omits `service_tier`
+
+#### Scenario: Compact requests omit explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** `/responses/compact` or `/v1/responses/compact` receives an explicit priority service tier
+- **THEN** the effective upstream payload omits `service_tier`
+
+#### Scenario: Chat conversion omits explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** a compatible chat-completions request carries an explicit priority service tier and is converted to Responses
+- **THEN** the effective upstream Responses payload omits `service_tier`
+
+#### Scenario: Owner forwarding cannot restore priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** an internal owner-forwarded payload carries a priority service tier
+- **THEN** the receiving preparation boundary omits `service_tier` before upstream forwarding

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/specs/responses-api-compat/spec.md
@@ -6,7 +6,9 @@ The service MUST apply the same canonical priority-tier prohibition before
 forwarding an upstream payload from native `/responses`, OpenAI-compatible
 `/v1/responses`, native and `/v1` compact Responses, chat-to-Responses
 conversion, WebSocket `response.create`, dashboard warmup, and internal
-owner-forwarding paths whenever `prohibitFastMode` is enabled.
+owner-forwarding paths whenever `prohibitFastMode` is enabled. WebSocket
+`response.create` frames MUST use the `prohibitFastMode` policy snapshot
+captured when the connection began.
 
 #### Scenario: Native and OpenAI-compatible HTTP requests omit explicit priority
 

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/tasks.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/tasks.md
@@ -1,0 +1,21 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add shared policy tests for explicit `priority`/`fast`, non-priority preservation, disabled policy, alias-derived priority, API-key enforced priority precedence, and strip logging; run them against the current implementation and record the expected failures.
+- [x] 1.2 Add native `/responses`, `/v1/responses`, native compact, `/v1` compact, and chat-conversion path tests proving explicit priority is absent from the effective upstream payload; run them red before implementation.
+- [x] 1.3 Add a WebSocket `response.create` regression test proving explicit priority is absent from the upstream payload and effective request state; run it red before implementation.
+- [x] 1.4 Add warmup and owner-forward preparation regression tests for the shared prohibition boundary; run each red before implementation.
+
+## 2. Policy Implementation
+
+- [x] 2.1 Add the shared canonical priority-tier prohibition helper with request-ID/stripped-value info logging.
+- [x] 2.2 Refactor alias normalization and API-key enforcement so all tier writers resolve before the shared prohibition, preserving enforcement provenance and disabled-policy behavior.
+- [x] 2.3 Apply the shared helper after warmup alias normalization and after owner-forward tier restoration, before routing, reservation, request-state capture, or serialization.
+- [x] 2.4 Enumerate every application write/normalization site for `service_tier` and confirm it is covered or document why it is not an outbound request writer.
+
+## 3. Verification and Documentation
+
+- [x] 3.1 Run the focused proxy, WebSocket, compact, chat, and warmup tests plus lint/type checks for changed files.
+- [x] 3.2 Sync the delta requirements and stable rationale/example into the owning main OpenSpec capability documents, then run strict OpenSpec validation. The change and `fast-mode-policy` capability validate strictly; repository-wide spec validation remains blocked by pre-existing failures recorded in `notes.md`.
+- [x] 3.3 Run the repository's proportionate final local gate and integration targets that exercise changed proxy paths.
+- [x] 3.4 Run CodeRabbit review, read every finding, resolve all critical/major findings and any impactful lower-severity findings, and document deliberate deferrals.
+- [x] 3.5 Verify the OpenSpec change against implementation and tests, then archive it only after verification is clean.

--- a/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/tasks.md
+++ b/openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add shared policy tests for explicit `priority`/`fast`, non-priority preservation, disabled policy, alias-derived priority, API-key enforced priority precedence, and strip logging; run them against the current implementation and record the expected failures.
 - [x] 1.2 Add native `/responses`, `/v1/responses`, native compact, `/v1` compact, and chat-conversion path tests proving explicit priority is absent from the effective upstream payload; run them red before implementation.
 - [x] 1.3 Add a WebSocket `response.create` regression test proving explicit priority is absent from the upstream payload and effective request state; run it red before implementation.
-- [x] 1.4 Add warmup and owner-forward preparation regression tests for the shared prohibition boundary; run each red before implementation.
+- [x] 1.4 Add warmup characterization and owner-forward preparation regression coverage for the shared prohibition boundary. The owner-forward case ran red; warmup remained green because its input surface only derives priority from a Fast alias, which the previous alias guard already handled.
 
 ## 2. Policy Implementation
 

--- a/openspec/specs/fast-mode-policy/context.md
+++ b/openspec/specs/fast-mode-policy/context.md
@@ -2,35 +2,40 @@
 
 ## Purpose and Scope
 
-`prohibitFastMode` is an operator-wide routing preference for Codex harness
-model labels that end in the known `fast` suffix. It keeps the request on the
-same canonical OpenAI model and preserves the selected reasoning effort while
-preventing the alias from opting into the priority tier.
+`prohibitFastMode` is an operator-wide control for preventing OpenAI priority
+service-tier requests across the proxy. It covers explicit client fields,
+Fast Mode model aliases, API-key enforcement, forwarded requests, and other
+resolved defaults while preserving the selected model and reasoning effort.
 
 ## Decision Rationale
 
-The setting lives with dashboard routing controls because operators normally
-use it to control account consumption across the entire proxy, not one API
-key. It acts during alias normalization, before source selection and quota
-reservation, so downstream routing observes the normal-tier request rather
-than only changing an already-built wire payload.
+The setting lives with dashboard routing controls because operators use it to
+control account consumption across the entire proxy. An administrator-enabled
+global prohibition therefore takes precedence over a narrower API-key policy:
+an enforced priority tier cannot bypass the operator control.
 
-The policy is intentionally narrower than disabling all `priority` traffic.
-Explicit `service_tier` values and API-key service-tier enforcement are
-separate caller and operator contracts and remain intact.
+Policy resolution happens after request-tier writers have run but before
+source selection, quota reservation, request logging, and serialization. This
+keeps internal routing and accounting aligned with the payload sent upstream.
+The shared policy removes priority by setting the typed field to `None` (or
+removing it from a source-chat dictionary), because wire-level absence is the
+existing representation of the upstream default. It does not substitute the
+literal `"default"` value.
 
 ## Constraints and Failure Modes
 
-- It applies only to supported qualified GPT-5 aliases containing the `fast`
-  token. It does not reinterpret unrelated slugs such as Codex Spark.
+- Both `fast` and `priority` canonicalize to the prohibited priority identity;
+  unrelated service tiers remain unchanged.
 - Existing requests remain unchanged until an operator enables the setting;
   this preserves rollout compatibility.
-- HTTP requests observe a refreshed dashboard setting through the normal
-  settings-cache invalidation path. A connected Codex WebSocket uses the
-  policy snapshot taken when it connected, so reconnect it after changing the
-  setting when immediate WebSocket behavior is required.
+- API-key enforcement provenance remains intact even when its resulting
+  priority tier is later removed by the global policy.
+- HTTP requests observe a refreshed dashboard setting through normal cache
+  invalidation. A connected Codex WebSocket uses the policy snapshot taken
+  when it connected, so reconnect it after changing the setting when immediate
+  WebSocket behavior is required.
 
-## Example
+## Examples
 
 With the switch enabled, this harness request:
 
@@ -38,13 +43,22 @@ With the switch enabled, this harness request:
 {"model":"gpt-5.6-sol-xhigh-fast","input":"review this change"}
 ```
 
-is forwarded as the `gpt-5.6-sol` model with `reasoning.effort: "high"` and
-without a `service_tier`. With the switch disabled, the same alias derives the
-usual `service_tier: "priority"` request.
+is forwarded as `gpt-5.6-sol` with `reasoning.effort: "high"` and without a
+`service_tier`.
+
+The same omission applies to an explicit request:
+
+```json
+{"model":"gpt-5.6-sol","input":"review this change","service_tier":"priority"}
+```
+
+and to an API key that enforces priority. With the switch disabled, these
+requests retain the existing priority-tier behavior.
 
 ## Operational Notes
 
 Enable the setting from Settings → Routing when normal-tier requests are
-required for Codex harness Fast Mode labels. Check the request log's requested
-service tier after a new HTTP request; it will be absent for a prohibited Fast
-Mode alias unless another explicit policy set it.
+required. New HTTP requests use the updated policy immediately; reconnect
+long-lived Codex WebSockets. The info log
+`fast_mode_service_tier_prohibited` records each removal with the request ID
+and stripped value.

--- a/openspec/specs/fast-mode-policy/spec.md
+++ b/openspec/specs/fast-mode-policy/spec.md
@@ -18,10 +18,11 @@ owner-forwarded payload. The administrator prohibition MUST take precedence
 over API-key service-tier enforcement. A prohibited tier MUST be represented
 on the upstream wire by omitting `service_tier`; absent and non-priority values
 MUST retain their existing behavior. The setting MUST take effect before
-model-source selection, quota reservation, request logging, and upstream
-OpenAI forwarding for HTTP requests; a Codex WebSocket connection MUST use the
-policy resolved when that connection began. Each stripped tier MUST emit an
-info-level diagnostic containing the request ID and stripped value.
+model-source selection, quota reservation, request-state capture, request
+logging, serialization, and upstream OpenAI forwarding for HTTP requests; a
+Codex WebSocket connection MUST use the policy resolved when that connection
+began. Each stripped tier MUST emit an info-level diagnostic containing the
+request ID and stripped value.
 
 #### Scenario: Operator disables Fast Mode for a harness alias
 
@@ -71,6 +72,7 @@ info-level diagnostic containing the request ID and stripped value.
 - **GIVEN** a Codex WebSocket connection began while `prohibitFastMode` was enabled
 - **WHEN** a `response.create` frame carries `service_tier: "priority"`
 - **THEN** its upstream payload omits `service_tier`
+- **AND** its effective request state omits `service_tier`
 
 #### Scenario: Policy changes are audited
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5509,7 +5509,9 @@ The service MUST apply the same canonical priority-tier prohibition before
 forwarding an upstream payload from native `/responses`, OpenAI-compatible
 `/v1/responses`, native and `/v1` compact Responses, chat-to-Responses
 conversion, WebSocket `response.create`, dashboard warmup, and internal
-owner-forwarding paths whenever `prohibitFastMode` is enabled.
+owner-forwarding paths whenever `prohibitFastMode` is enabled. WebSocket
+`response.create` frames MUST use the `prohibitFastMode` policy snapshot
+captured when the connection began.
 
 #### Scenario: Native and OpenAI-compatible HTTP requests omit explicit priority
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5502,3 +5502,35 @@ When the compact Responses upstream terminates with a top-level SSE `type=error`
 
 - **WHEN** compact upstream terminates with a nested OpenAI-style error envelope
 - **THEN** the proxy preserves the nested type and all other mapped fields using the existing parser
+
+### Requirement: Responses transports apply the global priority-tier prohibition consistently
+
+The service MUST apply the same canonical priority-tier prohibition before
+forwarding an upstream payload from native `/responses`, OpenAI-compatible
+`/v1/responses`, native and `/v1` compact Responses, chat-to-Responses
+conversion, WebSocket `response.create`, dashboard warmup, and internal
+owner-forwarding paths whenever `prohibitFastMode` is enabled.
+
+#### Scenario: Native and OpenAI-compatible HTTP requests omit explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** `/responses` or `/v1/responses` receives an explicit priority service tier
+- **THEN** the effective upstream payload omits `service_tier`
+
+#### Scenario: Compact requests omit explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** `/responses/compact` or `/v1/responses/compact` receives an explicit priority service tier
+- **THEN** the effective upstream payload omits `service_tier`
+
+#### Scenario: Chat conversion omits explicit priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** a compatible chat-completions request carries an explicit priority service tier and is converted to Responses
+- **THEN** the effective upstream Responses payload omits `service_tier`
+
+#### Scenario: Owner forwarding cannot restore priority
+
+- **GIVEN** `prohibitFastMode` is enabled
+- **WHEN** an internal owner-forwarded payload carries a priority service tier
+- **THEN** the receiving preparation boundary omits `service_tier` before upstream forwarding

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -1354,6 +1354,81 @@ async def test_cancelled_buffered_stream_logs_disconnect(async_client, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_source_chat_completion_prohibits_explicit_priority_service_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from starlette.requests import Request
+
+    import app.modules.proxy.api as proxy_api
+    from app.core.openai.chat_requests import ChatCompletionsRequest
+    from app.db.models import ModelSource
+    from app.modules.model_sources.forwarding import SourceChatCompletion
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_forward(_source: ModelSource, source_payload: dict[str, object]) -> SourceChatCompletion:
+        seen_payload.update(source_payload)
+        return SourceChatCompletion(
+            payload={"id": "chatcmpl_prohibit_priority", "object": "chat.completion", "choices": []},
+            usage=None,
+            timings=None,
+            upstream_status_code=200,
+        )
+
+    async def settle(*_args: object, **_kwargs: object) -> bool:
+        return True
+
+    async def record_log(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(proxy_api, "forward_chat_completion", fake_forward)
+    monkeypatch.setattr(proxy_api, "_settle_source_reservation", settle)
+    monkeypatch.setattr(proxy_api, "_log_source_chat_completion", record_log)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "query_string": b"",
+        }
+    )
+    source = ModelSource(
+        id="src_prohibit_priority",
+        name="prohibit-priority",
+        kind="openai_compatible",
+        base_url="http://127.0.0.1:9/v1",
+        is_enabled=True,
+        supports_chat_completions=True,
+        supports_responses=False,
+    )
+    payload = ChatCompletionsRequest.model_validate(
+        {
+            "model": "source-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "service_tier": "priority",
+            "stream": False,
+        }
+    )
+
+    response = await proxy_api._source_chat_completion_response(
+        request,
+        payload,
+        source=source,
+        model="source-model",
+        api_key=None,
+        reservation=None,
+        rate_limit_headers={},
+        prohibit_fast_mode=True,
+    )
+
+    assert response.status_code == 200
+    assert "service_tier" not in seen_payload
+
+
+@pytest.mark.asyncio
 async def test_source_completion_success_log_finishes_after_cancellation(async_client, monkeypatch):
     from starlette.requests import Request
 

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -213,6 +213,136 @@ async def test_backend_responses_prohibits_fast_model_alias_priority_tier(async_
     assert "service_tier" not in seen_payload
 
 
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.asyncio
+async def test_responses_prohibit_explicit_priority_service_tier(async_client, monkeypatch, path: str):
+    raw_account_id = f"acc_prohibit_explicit_{path.rsplit('/', 2)[-2]}"
+    auth_json = _make_auth_json(raw_account_id, f"{raw_account_id}@example.com")
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+    response = await async_client.put("/api/settings", json={"prohibitFastMode": True})
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, account_id, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_prohibit_explicit",'
+            '"object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    async with async_client.stream(
+        "POST",
+        path,
+        json={
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "stream": True,
+            "service_tier": "priority",
+        },
+    ) as response:
+        assert response.status_code == 200
+        _ = [line async for line in response.aiter_lines() if line]
+
+    assert "service_tier" not in seen_payload
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/backend-api/codex/responses/compact", "/v1/responses/compact"],
+)
+@pytest.mark.asyncio
+async def test_compact_responses_prohibits_explicit_priority_service_tier(async_client, monkeypatch, path: str):
+    raw_account_id = f"acc_prohibit_compact_{path.rsplit('/', 3)[-3]}"
+    auth_json = _make_auth_json(raw_account_id, f"{raw_account_id}@example.com")
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+    response = await async_client.put("/api/settings", json={"prohibitFastMode": True})
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_compact(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, account_id, kwargs
+        seen_payload.update(payload.to_payload())
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "id": "cmp_prohibit_priority",
+                    "encrypted_content": "summary",
+                },
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        path,
+        json={
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "service_tier": "priority",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "service_tier" not in seen_payload
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_conversion_prohibits_explicit_priority_service_tier(async_client, monkeypatch):
+    raw_account_id = "acc_prohibit_chat_priority"
+    auth_json = _make_auth_json(raw_account_id, "prohibit-chat-priority@example.com")
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+    response = await async_client.put("/api/settings", json={"prohibitFastMode": True})
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, account_id, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_prohibit_chat",'
+            '"object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    async with async_client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+            "service_tier": "priority",
+        },
+    ) as response:
+        assert response.status_code == 200
+        _ = [line async for line in response.aiter_lines() if line]
+
+    assert "service_tier" not in seen_payload
+
+
 @pytest.mark.parametrize(("path", "stream"), [("/backend-api/codex/responses", True), ("/v1/responses", False)])
 @pytest.mark.asyncio
 async def test_responses_prohibits_enforced_fast_model_alias_priority_tier(

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -538,6 +538,84 @@ async def test_stream_responses_preserves_forwarded_effective_service_tier(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_prohibits_forwarded_priority_service_tier_once(monkeypatch):
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/internal/bridge/responses",
+            "headers": [],
+            "client": ("10.0.0.12", 12345),
+        }
+    )
+    payload = ResponsesRequest(
+        model="gpt-5.6-sol",
+        instructions="hi",
+        input="hi",
+        service_tier="priority",
+    )
+    observed: dict[str, object] = {}
+    enforcement_prohibit_values: list[bool] = []
+
+    original_apply_api_key_enforcement = proxy_api_module.apply_api_key_enforcement
+
+    def capture_apply_api_key_enforcement(*args, prohibit_fast_mode=False, **kwargs):
+        enforcement_prohibit_values.append(prohibit_fast_mode)
+        return original_apply_api_key_enforcement(
+            *args,
+            prohibit_fast_mode=prohibit_fast_mode,
+            **kwargs,
+        )
+
+    async def fake_rate_limit_headers():
+        return {}
+
+    def fake_stream_http_responses(forwarded_payload, _headers, **_kwargs):
+        observed.update(forwarded_payload.to_payload())
+
+        async def body():
+            yield (
+                'data: {"type":"response.completed","response":'
+                '{"id":"resp_1","object":"response","status":"completed","output":[]}}\n\n'
+            )
+
+        return body()
+
+    monkeypatch.setattr(
+        proxy_api_module.proxy_service_module,
+        "get_settings",
+        lambda: SimpleNamespace(http_responses_session_bridge_enabled=True),
+    )
+    monkeypatch.setattr(proxy_api_module, "apply_api_key_enforcement", capture_apply_api_key_enforcement)
+    context = cast(
+        proxy_api_module.ProxyContext,
+        SimpleNamespace(
+            service=SimpleNamespace(
+                rate_limit_headers=fake_rate_limit_headers,
+                stream_http_responses=fake_stream_http_responses,
+            )
+        ),
+    )
+
+    response = await proxy_api_module._stream_responses(
+        request,
+        payload,
+        context,
+        None,
+        prefer_http_bridge=True,
+        skip_limit_enforcement=True,
+        include_rate_limit_headers=False,
+        forwarded_request=True,
+        prohibit_fast_mode=True,
+    )
+
+    assert response.status_code == 200
+    assert "service_tier" not in observed
+    assert payload.service_tier is None
+    assert enforcement_prohibit_values == [False]
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_does_not_release_forwarded_reservation_on_internal_bridge_error(monkeypatch):
     request = Request(
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1910,6 +1910,43 @@ async def test_warmup_persists_conversation_id_in_request_log(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_warmup_prohibit_fast_mode_omits_alias_priority_tier(monkeypatch, caplog):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_warmup_prohibit_fast")
+    snapshot = proxy_warmup_service._snapshot_warmup_account(account)
+    upstream = AsyncMock(return_value=SimpleNamespace(id="warmup-prohibit-fast", usage=None))
+
+    monkeypatch.setattr(service._encryptor, "decrypt", lambda _token: "access-token")
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+    monkeypatch.setattr(proxy_service, "core_compact_responses", upstream)
+    caplog.set_level("INFO", logger="app.modules.proxy.request_policy")
+
+    result = await service._submit_warmup_request(
+        account=snapshot,
+        api_key=None,
+        headers={},
+        warmup_model="gpt-5.6-sol-xhigh-fast",
+        prohibit_fast_mode=True,
+    )
+
+    assert result.success is True
+    upstream.assert_awaited_once()
+    upstream_call = upstream.await_args
+    assert upstream_call is not None
+    forwarded_payload = upstream_call.args[0]
+    assert forwarded_payload.model == "gpt-5.6-sol"
+    assert forwarded_payload.reasoning is not None
+    assert forwarded_payload.reasoning.effort == "high"
+    assert forwarded_payload.service_tier is None
+    upstream_request_id = upstream_call.args[1]["x-request-id"]
+    assert f"request_id={upstream_request_id}" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_model_source_persists_conversation_id_without_changing_useragent_group(monkeypatch):
     calls: list[dict[str, object]] = []
 
@@ -23593,6 +23630,39 @@ async def test_prepare_websocket_response_create_request_normalizes_payload_and_
     assert normalized_payload["model"] == "gpt-5.2"
     assert normalized_payload["reasoning"] == {"effort": "high"}
     assert normalized_payload["service_tier"] == "priority"
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_prohibits_explicit_priority(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=None))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        {
+            "type": "response.create",
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": "hello",
+            "service_tier": "priority",
+        },
+        headers={},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=None,
+        prohibit_fast_mode=True,
+    )
+
+    reserve_usage.assert_awaited_once()
+    reserve_call = reserve_usage.await_args
+    assert reserve_call is not None
+    assert reserve_call.kwargs["request_service_tier"] is None
+    assert prepared.request_state.service_tier is None
+    assert "service_tier" not in json.loads(prepared.text_data)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_request_policy.py
+++ b/tests/unit/test_request_policy.py
@@ -97,6 +97,71 @@ def test_fast_mode_prohibition_keeps_explicit_service_tier() -> None:
     assert request.service_tier == "flex"
 
 
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+@pytest.mark.parametrize("service_tier", ["priority", "fast"])
+def test_fast_mode_prohibition_strips_explicit_priority_service_tier(
+    request_type: type[ResponsesRequest] | type[ResponsesCompactRequest],
+    service_tier: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request = request_type.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "service_tier": service_tier,
+        }
+    )
+    caplog.set_level("INFO", logger="app.modules.proxy.request_policy")
+
+    apply_api_key_enforcement(request, None, prohibit_fast_mode=True)
+
+    assert request.service_tier is None
+    assert "fast_mode_service_tier_prohibited" in caplog.text
+    assert "stripped_service_tier=priority" in caplog.text
+
+
+def test_fast_mode_prohibition_overrides_api_key_enforced_priority() -> None:
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "service_tier": "flex",
+        }
+    )
+    api_key = cast(
+        ApiKeyData,
+        SimpleNamespace(
+            id="key-enforced-priority",
+            enforced_model=None,
+            enforced_reasoning_effort=None,
+            enforced_service_tier="priority",
+            allowed_reasoning_efforts=None,
+        ),
+    )
+
+    result = apply_api_key_enforcement(request, api_key, prohibit_fast_mode=True)
+
+    assert result.service_tier_was_enforced is False
+    assert request.service_tier is None
+
+
+def test_disabled_fast_mode_prohibition_preserves_explicit_priority() -> None:
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "service_tier": "priority",
+        }
+    )
+
+    apply_api_key_enforcement(request, None, prohibit_fast_mode=False)
+
+    assert request.service_tier == "priority"
+
+
 def test_minimal_reasoning_alias_uses_upstream_safe_fallback() -> None:
     request = ResponsesRequest.model_validate(
         {


### PR DESCRIPTION
## Summary

Prohibit Fast Mode now removes any outbound `service_tier` that canonicalizes to `priority`, including explicit Codex client input. The policy runs after tier writers and before routing, reservation, request-state capture, or serialization across Responses transports.

## Type of change

- [x] `fix:` - bug fix (no behavior change beyond the bug)
- [ ] `feat:` - new user-facing feature or capability
- [ ] `refactor:` - internal refactor (no behavior change, no API change)
- [ ] `docs:` - documentation only
- [ ] `chore:` / `ci:` / `build:` - tooling, CI, packaging
- [ ] `test:` - test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1960

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable - bug fix that matches the existing spec
- [ ] Not applicable - docs / CI / chore only
- [x] This PR touches a codex-faithful request path and preserves the established upstream wire behavior

Change directory: `openspec/changes/archive/2026-08-29-prohibit-priority-service-tier/`

The administrator-wide setting takes precedence over an API key's `enforced_service_tier`. Prohibited priority tiers are omitted, not rewritten to literal `default`; the existing API-key contract documents that the ChatGPT/Codex backend rejects literal `auto` and `default` values.

## Changes

- Add one canonical priority prohibition helper in `request_policy.py`, with request ID and stripped-value logging.
- Apply it after alias/API-key resolution, source-chat conversion, warmup normalization, and owner-forward tier restoration. The normal HTTP, `/v1`, compact, and WebSocket paths converge through the same policy helper.
- Add red-first regressions for explicit `priority`/`fast`, API-key precedence, native and `/v1` HTTP, both compact routes, chat conversion, WebSocket `response.create`, warmup, source routing, and owner forwarding.

No Prometheus series was added. The info log is enough to audit policy removals without adding a new metrics contract.

## Simplicity

This changes the behavior of an existing opt-in setting. It adds no setting, setup step, README section, `.env.example` entry, dashboard navigation item, or default change.

## Test plan

The path regressions failed on the original implementation before the policy change. The WebSocket regression observed `request_service_tier="priority"`; five shared-policy cases failed while the non-priority controls passed.

```text
make lint typecheck
# proxy architecture checks passed
# ruff check and format check passed
# ty check passed

make test-unit
# 6646 passed, 3 skipped

make test-integration-core
# 2070 passed, 34 skipped

make test-integration-bridge
# 279 passed

.venv/bin/python -m pytest -q tests/unit/test_proxy_utils.py -k warmup_prohibit_fast_mode_omits_alias_priority_tier
# 1 passed, 1151 deselected

npx --yes @fission-ai/openspec@1.3.0 validate prohibit-priority-service-tier --type change --strict
# Change 'prohibit-priority-service-tier' is valid (run before archive)

npx --yes @fission-ai/openspec@1.3.0 validate fast-mode-policy --type spec --strict
# Specification 'fast-mode-policy' is valid

coderabbit review --agent --light
# review completed, 0 findings across all 18 changed files
```

Repository-wide `npx --yes @fission-ai/openspec@1.3.0 validate --specs --strict` remains at the existing baseline of 50 passing and 8 failing capabilities. The failures are in `database-backends`, `frontend-architecture`, `model-catalog-compat`, `model-source-routing`, `query-caching`, `responses-api-compat`, `usage-error-metrics`, and `usage-refresh-policy`. The new requirement validates as part of the strict change; this PR does not rewrite unrelated old requirements to clear the repository baseline.

## Screenshots / output

Input with Prohibit Fast Mode enabled:

```json
{"type":"response.create","model":"gpt-5.6-sol","input":"hello","service_tier":"priority"}
```

Effective outbound shape:

```json
{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}
```

The strip emits `fast_mode_service_tier_prohibited` with the request ID and original tier.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added tests covering the externally failing paths.
- [x] Ran the relevant local gate and proxy integration targets.
- [ ] Repository-wide `openspec validate --specs` passes. It has the documented pre-existing 50/8 baseline above; the strict change and owning capability validations pass, and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed; this adds no surface or setup.
- [x] `CHANGELOG.md` was not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global setting to prohibit priority service tiers across supported request types and forwarding paths.
  * Priority tiers are removed before upstream requests are sent, including Responses, compact, chat conversion, warmup, forwarded, and WebSocket requests.
  * The prohibition overrides API-key service-tier enforcement while preserving non-priority tiers.
  * Added informational diagnostics when a priority tier is removed.

* **Tests**
  * Added coverage for HTTP, streaming, compact, chat, warmup, forwarded, and WebSocket scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->