### PR TITLE
fix(accounts): probe with a valid upstream token floor

### DIFF
--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -87,6 +87,8 @@ _DETAIL_BUCKET_SECONDS = 3600  # 1h → 168 points
 DEFAULT_PROBE_MODEL = "gpt-5.5"
 PROBE_REQUEST_TIMEOUT_SECONDS = 30.0
 PROBE_CONNECT_TIMEOUT_SECONDS = 10.0
+# Codex rejects probe completions below this output-token floor (1 → 400, 16 → 200).
+PROBE_MAX_OUTPUT_TOKENS = 16
 # Network/upstream failure sentinel for ``probe_status_code`` — kept as ``0`` so
 # the value is distinguishable from any real HTTP status the upstream might
 # return.
@@ -834,7 +836,7 @@ class AccountsService:
                     "content": [{"type": "input_text", "text": "."}],
                 }
             ],
-            "max_output_tokens": 1,
+            "max_output_tokens": PROBE_MAX_OUTPUT_TOKENS,
             "stream": True,
             "store": False,
         }

--- a/openspec/changes/probe-valid-token-floor/.openspec.yaml
+++ b/openspec/changes/probe-valid-token-floor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/probe-valid-token-floor/context.md
+++ b/openspec/changes/probe-valid-token-floor/context.md
@@ -1,0 +1,45 @@
+# Probe valid token floor
+
+## Purpose
+
+Force Probe is the operator action that wakes a lazy `/wham/usage` window
+without going through load-balancer selection. It only works if upstream
+accepts the probe body.
+
+## Decision
+
+Use `max_output_tokens=16`. Issue #1895's author verified that Codex
+returns 400 for `1` and 200 for `16`. That floor is an upstream contract,
+so it is a hardcoded constant, not a `CODEX_LB_*` setting.
+
+## Non-goals
+
+- Warm-up / compact-404 (the other half of #1895)
+- Limit-warmup's separate `max_output_tokens=4` path
+- Configurable probe token budget
+
+## Failure mode
+
+If the probe still sends `1`, every Force Probe returns
+`probeStatusCode: 400`, the limiter does not re-evaluate, and 5h windows
+cannot be started from the dashboard after a reset.
+
+## Example
+
+```json
+{
+  "model": "gpt-5.5",
+  "instructions": "Respond with a single dot.",
+  "input": [{"role": "user", "content": [{"type": "input_text", "text": "."}]}],
+  "max_output_tokens": 16,
+  "stream": true,
+  "store": false
+}
+```
+
+## Related
+
+- Normative requirement: `openspec/specs/usage-refresh-policy/spec.md`
+  ("Operators can probe an account to wake the upstream limiter")
+- [#1895](https://github.com/Soju06/codex-lb/issues/1895) — this change
+  covers the probe 400 only

--- a/openspec/changes/probe-valid-token-floor/design.md
+++ b/openspec/changes/probe-valid-token-floor/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`AccountsService._send_probe_request` posts a pinned, load-balancer-bypassing
+`responses.create` so operators can wake `/wham/usage`. The body still hardcodes
+`max_output_tokens=1`, which matched the original "tiny quota" intent and the
+`usage-refresh-policy` scenario. Current Codex rejects values below 16 with
+HTTP 400, so every Force Probe lands as `probeStatusCode: 400` and never
+starts the window (#1895, author-verified: 1 → 400, 16 → 200).
+
+Limit warm-up uses `max_output_tokens=4` on a different path. That path is
+out of scope; do not share a constant or conflate the two.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Send a probe body Codex accepts (`max_output_tokens=16`).
+- Keep the probe otherwise identical: one request, `stream=true`,
+  `store=false`, pinned account, no load-balancer scoring.
+- Align the `usage-refresh-policy` probe scenario with that floor.
+
+**Non-Goals:**
+
+- Warm-up / compact-404 (#1895 other half, #1811).
+- Making the floor configurable (`CODEX_LB_*`).
+- Changing probe timeouts, model default, or response schema.
+- Changing limit-warmup's separate token value.
+
+## Decisions
+
+1. **Hardcode 16, not a setting.** The floor is an upstream contract, not an
+   operator preference. A new `CODEX_LB_*` knob would ask operators to
+   rediscover a value Codex already enforces. Why-not-a-default: it *is* the
+   default.
+
+2. **Named module constant next to the other probe knobs.** Keep
+   `PROBE_MAX_OUTPUT_TOKENS = 16` beside `DEFAULT_PROBE_MODEL` so the floor
+   is one place in code and tests can assert the public body without
+   duplicating a magic number in multiple call sites.
+
+3. **Do not reuse limit-warmup's `4`.** That path is a different request and
+   still below the verified floor. Sharing it would either leave warmup
+   broken or silently change warmup traffic in this PR.
+
+## Risks / Trade-offs
+
+- [Upstream raises the floor again] → Mitigation: one constant plus the
+  spec scenario; a later one-line bump is enough. No setting until Codex
+  actually varies this per account or model.
+- [16 spends more quota than 1] → Mitigation: still a single minimal
+  completion; issue author confirmed 16 completes. A rejected probe spends
+  nothing useful and leaves windows unstarted.
+- [Partial #1895 cover looks like a full close] → Mitigation: PR states
+  warmup/compact-404 is out of scope and uses `Related to #1895` so GitHub
+  does not auto-close the remaining half.

--- a/openspec/changes/probe-valid-token-floor/proposal.md
+++ b/openspec/changes/probe-valid-token-floor/proposal.md
@@ -1,0 +1,40 @@
+# Why
+
+Dashboard Force Probe sends `max_output_tokens=1` on the pinned
+`responses.create` used to wake the upstream limiter. Current Codex
+rejects values below 16 with HTTP 400, so every operator probe returns
+`probeStatusCode: 400` and never starts the usage window. Issue #1895
+verified that 16 is accepted.
+
+# What Changes
+
+- Raise the account-probe `max_output_tokens` from `1` to `16`, the
+  verified Codex token floor.
+- Update `usage-refresh-policy` so the probe scenario requires that
+  floor instead of `1`.
+- Keep the request otherwise unchanged (`stream=true`, `store=false`,
+  pinned account, bypass load-balancer scoring).
+
+This change does **not** include the warmup / compact-404 half of
+#1895, limit-warmup's separate `max_output_tokens=4` path, or any new
+setting.
+
+# Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: the operator probe `responses.create` MUST
+  use `max_output_tokens=16` (the current Codex token floor), not `1`.
+
+# Impact
+
+- `app/modules/accounts/service.py` (`_send_probe_request`)
+- Probe unit coverage that asserts the upstream JSON body
+- `openspec/specs/usage-refresh-policy/spec.md` and its context notes
+- Dashboard Force Probe behavior: same endpoint and response shape;
+  successful probes can now receive a 2xx upstream status instead of
+  a guaranteed 400

--- a/openspec/changes/probe-valid-token-floor/proposal.md
+++ b/openspec/changes/probe-valid-token-floor/proposal.md
@@ -16,16 +16,16 @@ verified that 16 is accepted.
   pinned account, bypass load-balancer scoring).
 
 This change does **not** include the warmup / compact-404 half of
-#1895, limit-warmup's separate `max_output_tokens=4` path, or any new
+issue #1895, limit-warmup's separate `max_output_tokens=4` path, or any new
 setting.
 
 # Capabilities
 
-### New Capabilities
+## New Capabilities
 
 - None
 
-### Modified Capabilities
+## Modified Capabilities
 
 - `usage-refresh-policy`: the operator probe `responses.create` MUST
   use `max_output_tokens=16` (the current Codex token floor), not `1`.

--- a/openspec/changes/probe-valid-token-floor/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/probe-valid-token-floor/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Operators can probe an account to wake the upstream limiter
+
+The dashboard MUST expose an admin-only endpoint that sends a single minimal `responses.create` directly to upstream pinned to one account, bypassing load-balancer scoring, then immediately refreshes that account's `/wham/usage` snapshot. The probe `responses.create` MUST set `max_output_tokens` to `16`, the current Codex token floor; values below that floor MUST NOT be used. The endpoint MUST surface the before/after usage and account status so operators can verify whether the upstream limiter re-evaluated.
+
+#### Scenario: Probe wakes the upstream limiter and refreshes usage state
+- **WHEN** an operator POSTs to `/api/accounts/{account_id}/probe`
+- **AND** the account is `active`, `rate_limited`, or `quota_exceeded`
+- **THEN** the service sends one `responses.create` request directly to `{upstream_base_url}/codex/responses` with `max_output_tokens=16`, `stream=true`, `store=false`
+- **AND** the service triggers an immediate `UsageUpdater.refresh_accounts` for that account
+- **AND** the response body carries `probe_status_code`, `primary_used_percent_before`, `primary_used_percent_after`, `secondary_used_percent_before`, `secondary_used_percent_after`, `account_status_before`, `account_status_after`
+
+#### Scenario: Probe rejects hard-blocked accounts
+- **WHEN** an operator POSTs to `/api/accounts/{account_id}/probe`
+- **AND** the account `status` is `paused` or `deactivated`
+- **THEN** the endpoint responds `409` with code `account_not_probable`
+- **AND** no upstream request is sent
+
+#### Scenario: Dashboard exposes Force probe only for probeable statuses
+
+- **WHEN** the dashboard renders account actions for an account
+- **AND** the account `status` is `active`, `rate_limited`, or `quota_exceeded`
+- **THEN** the dashboard exposes a Force probe action for that account
+- **AND** invoking the action refreshes the account list, dashboard overview, projections, and that account's trends
+- **BUT WHEN** the account `status` is `paused` or `deactivated`
+- **THEN** the Force probe action is disabled or hidden
+
+#### Scenario: Probe returns 404 for unknown account
+- **WHEN** an operator POSTs to `/api/accounts/{account_id}/probe`
+- **AND** no account with that id exists
+- **THEN** the endpoint responds `404` with code `account_not_found`

--- a/openspec/changes/probe-valid-token-floor/tasks.md
+++ b/openspec/changes/probe-valid-token-floor/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Add `PROBE_MAX_OUTPUT_TOKENS = 16` next to the other probe constants
+  in `app/modules/accounts/service.py`.
+- [x] 1.2 Send that constant from `_send_probe_request` instead of `1`.
+- [x] 1.3 Update the main `usage-refresh-policy` spec scenario and requirement
+  text to require `max_output_tokens=16`.
+- [x] 1.4 Record the floor and the #1895 partial cover in
+  `openspec/specs/usage-refresh-policy/context.md`.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert the probe JSON body uses `max_output_tokens=16` in
+  `tests/unit/test_accounts_service_probe.py`.
+
+## 3. Validation
+
+- [x] 3.1 Run the probe unit tests and `ruff` on the touched files.
+- [x] 3.2 Run `openspec validate --specs` and scoped change validation.

--- a/openspec/specs/usage-refresh-policy/context.md
+++ b/openspec/specs/usage-refresh-policy/context.md
@@ -73,12 +73,16 @@ behavior can set the threshold to `100.0`.
   rate limiter; codex-lb auto-recovers on the next refresh tick after the
   upstream payload changes.
 - The dashboard Force Probe action fires one minimal `responses.create` against
-  the selected account and immediately refreshes its usage. An accepted 2xx
-  probe also contributes to that replica's probing-health recovery streak;
-  non-2xx results do not restore routing health. Settlement reloads and
-  normalizes weekly/monthly and zero-primary-capacity usage like ordinary
-  routing and is discarded when newer replica-local runtime activity arrives
-  during that snapshot load.
+  the selected account and immediately refreshes its usage. The probe body uses
+  `max_output_tokens=16` (the current Codex token floor); `1` is rejected
+  upstream with HTTP 400 and never wakes the limiter. An accepted 2xx probe
+  also contributes to that replica's probing-health recovery streak; non-2xx
+  results do not restore routing health. Settlement reloads and normalizes
+  weekly/monthly and zero-primary-capacity usage like ordinary routing and is
+  discarded when newer replica-local runtime activity arrives during that
+  snapshot load. This floor is the probe half of
+  [#1895](https://github.com/Soju06/codex-lb/issues/1895); warmup/compact-404
+  is a separate path.
 - Do not manually flip the codex-lb account state to `ACTIVE` while
   `/wham/usage` still reports the account as fully used. That only masks the
   upstream state and can route traffic back to an account that the upstream

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -404,12 +404,12 @@ The system SHALL support an optional limit warm-up mechanism that is disabled by
 
 ### Requirement: Operators can probe an account to wake the upstream limiter
 
-The dashboard MUST expose an admin-only endpoint that sends a single minimal `responses.create` directly to upstream pinned to one account, bypassing load-balancer scoring, then immediately refreshes that account's `/wham/usage` snapshot. The endpoint MUST surface the before/after usage and account status so operators can verify whether the upstream limiter re-evaluated.
+The dashboard MUST expose an admin-only endpoint that sends a single minimal `responses.create` directly to upstream pinned to one account, bypassing load-balancer scoring, then immediately refreshes that account's `/wham/usage` snapshot. The probe `responses.create` MUST set `max_output_tokens` to `16`, the current Codex token floor; values below that floor MUST NOT be used. The endpoint MUST surface the before/after usage and account status so operators can verify whether the upstream limiter re-evaluated.
 
 #### Scenario: Probe wakes the upstream limiter and refreshes usage state
 - **WHEN** an operator POSTs to `/api/accounts/{account_id}/probe`
 - **AND** the account is `active`, `rate_limited`, or `quota_exceeded`
-- **THEN** the service sends one `responses.create` request directly to `{upstream_base_url}/codex/responses` with `max_output_tokens=1`, `stream=true`, `store=false`
+- **THEN** the service sends one `responses.create` request directly to `{upstream_base_url}/codex/responses` with `max_output_tokens=16`, `stream=true`, `store=false`
 - **AND** the service triggers an immediate `UsageUpdater.refresh_accounts` for that account
 - **AND** the response body carries `probe_status_code`, `primary_used_percent_before`, `primary_used_percent_after`, `secondary_used_percent_before`, `secondary_used_percent_after`, `account_status_before`, `account_status_after`
 

--- a/tests/unit/test_accounts_service_probe.py
+++ b/tests/unit/test_accounts_service_probe.py
@@ -13,6 +13,7 @@ from app.db.models import Account, AccountStatus
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.service import (
     DEFAULT_PROBE_MODEL,
+    PROBE_MAX_OUTPUT_TOKENS,
     AccountNotProbableError,
     AccountsService,
 )
@@ -337,6 +338,10 @@ async def test_send_probe_request_uses_shared_http_client(monkeypatch):
     assert captured["headers"]["Authorization"] == f"Bearer {_PROBE_TOKEN_PLAINTEXT}"
     assert captured["headers"]["chatgpt-account-id"] == _CHATGPT_ACCOUNT_ID
     assert captured["json"]["model"] == "gpt-5.5-test"
+    assert captured["json"]["max_output_tokens"] == PROBE_MAX_OUTPUT_TOKENS
+    assert captured["json"]["max_output_tokens"] == 16
+    assert captured["json"]["stream"] is True
+    assert captured["json"]["store"] is False
     assert captured["timeout"].total == 30.0
     assert captured["timeout"].connect is None
     assert captured["timeout"].sock_connect == 10.0


### PR DESCRIPTION
## Summary

Dashboard Force Probe hardcodes `max_output_tokens=1` on the pinned `responses.create` used to wake `/wham/usage`. Current Codex rejects values below 16 with HTTP 400, so every probe returns `probeStatusCode: 400` and never starts the window. This PR sends the author-verified floor of 16.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: **Related to #1895 (partial).** This PR only fixes the account-probe 400. The warmup / compact-404 half of #1895 is intentionally out of scope and remains open. `Fixes #1895` is not used so GitHub does not auto-close the remaining half.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/probe-valid-token-floor`

Delta updates `usage-refresh-policy`: the operator probe MUST send `max_output_tokens=16` (the current Codex token floor), not `1`.

## Changes

- `_send_probe_request` now sends `PROBE_MAX_OUTPUT_TOKENS = 16`.
- Probe unit test asserts `json["max_output_tokens"] == 16`.
- Main `usage-refresh-policy` spec + context updated to match.

Warm-up, compact-404, limit-warmup's separate `max_output_tokens=4` path, #1950, and #1924 are not included.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** (hardcoded floor; no operator setup)
- [x] No new required setup step
- New setting(s) and why each can't be a default: **none**. The floor is an upstream contract, not an operator preference.
- [x] README sections / `.env.example` / dashboard nav unchanged

## Test plan

```
uv run pytest tests/unit/test_accounts_service_probe.py tests/integration/test_accounts_api_probe.py -q
# 26 passed

uv run ruff check app/modules/accounts/service.py tests/unit/test_accounts_service_probe.py
# All checks passed

openspec validate probe-valid-token-floor --strict
# Change is valid
```

Playwright recovered on retrigger. A later current-head `integration-bridge` job timed out in `test_v1_responses_websocket_archives_multiplexed_upstream_frames_by_response_id` (unrelated websocket suite; this PR only changes account probe tokens). Job rerun is 403 (admin required on Soju06/codex-lb).

`openspec validate --specs` still reports 8 pre-existing main-spec failures, including an unrelated `usage-refresh-policy` requirement that lacks SHALL/MUST. This change's delta validates cleanly.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue as partial cover (`Related to #1895`).
- [x] Added or updated tests covering the change.
- [x] Ran the focused probe tests + ruff on the touched files.
- [x] `openspec validate probe-valid-token-floor --strict` passes.
- [x] Simplicity gates reviewed (P1–P5): no new setting, no README/nav/env growth, no dashboard layout change.
- [x] CHANGELOG is **not** edited by hand.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Force Probe requests now use the supported 16-token output limit, preventing upstream HTTP 400 rejections.
  - Successful probes can proceed and refresh account usage as expected.

- **Documentation**
  - Updated guidance and specifications to document the valid token limit and probe behavior.

- **Tests**
  - Added coverage confirming the correct output-token limit and required request options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

