### PR TITLE
fix(proxy): release soft prompt-cache on pre-visible 429

### DIFF
--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -731,6 +731,21 @@ class _StreamingRetryMixin:
             )
             return True
 
+        def _release_soft_sticky_after_previsible_exclusion() -> None:
+            # Soft prompt-cache (and other non-required sticky) must not stay
+            # pinned to an excluded account. File, turn-state, and other
+            # required owners stay fail-closed; verified-replay already
+            # released affinity when it moved the body.
+            nonlocal affinity
+            if (
+                require_preferred_account
+                or file_preferred_account_id is not None
+                or turn_state_owner_account_id is not None
+                or routing_strategy == "single_account"
+            ):
+                return
+            affinity = replace(affinity, reallocate_sticky=True)
+
         async def _stream_post_refresh_with_capacity_recovery(
             account: Account,
             *,
@@ -2360,10 +2375,11 @@ class _StreamingRetryMixin:
                                     await _release_tracked_stream_lease(current_account_lease)
                                     current_account_lease = None
                                     excluded_account_ids.add(account.id)
-                                    _move_verified_fresh_replay_from_owner(
+                                    if not _move_verified_fresh_replay_from_owner(
                                         account_id=account.id,
                                         outcome="owner_previsible_failure",
-                                    )
+                                    ):
+                                        _release_soft_sticky_after_previsible_exclusion()
                                     break
                                 await proxy._handle_stream_error(
                                     account,
@@ -2964,10 +2980,11 @@ class _StreamingRetryMixin:
                                 last_transient_exc = retry_exc
                                 await _release_tracked_stream_lease(current_account_lease)
                                 current_account_lease = None
-                                _move_verified_fresh_replay_from_owner(
+                                if not _move_verified_fresh_replay_from_owner(
                                     account_id=account.id,
                                     outcome="owner_post_refresh_failure",
-                                )
+                                ):
+                                    _release_soft_sticky_after_previsible_exclusion()
                                 excluded_account_ids.add(account.id)
                                 continue
                             health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/.openspec.yaml
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/context.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/context.md
@@ -1,0 +1,54 @@
+# Soft prompt-cache release on pre-visible 429
+
+## Purpose
+
+Restore eligible-account failover for inline-image streaming requests that
+carry only soft `prompt_cache_key` affinity. A 429 on the warm-cache account
+must not fail the whole request when another image-capable account exists.
+
+See the delta and main `responses-api-compat` specs for normative rules.
+
+## Decision rationale
+
+Adjacent pre-visible paths already set `reallocate_sticky=True` after excluding
+an account (confirmed pre-dispatch connect failure, verified fresh replay).
+The `failover_next` branch excluded the account but left the sticky policy
+unreleased, so prompt-cache selection kept preferring the excluded owner.
+
+Alternatives considered:
+
+- Clear the sticky key entirely. Rejected: the balancer already knows how to
+  rebind on `reallocate_sticky=True`; inventing a second release path would
+  drift from the adjacent failover sites.
+- Reallocate every excluded account, including file pins. Rejected: file
+  ownership is hard and must fail closed.
+- Add a `CODEX_LB_*` toggle. Rejected: this is a correctness hole, not an
+  operator preference.
+
+## Constraints
+
+- File-pinned, previous-response, and turn-state owners stay required.
+- API-key reservation settlement must still happen before error-health writes.
+- Excluded accounts must remain out of the next selection loop.
+- No new settings.
+
+## Failure modes
+
+- Soft prompt-cache + inline image + pre-visible 429, two image-capable
+  accounts: must retry the second account.
+- Same request with a live `input_file.file_id` pin: must stay on the file
+  owner and fail closed if that owner is 429.
+
+## Example
+
+1. Accounts A and B both accept `gpt-5.6-sol` images.
+2. Client sends streaming `/v1/responses` with `prompt_cache_key` and an
+   inline `input_image`.
+3. Affinity selects A; A returns HTTP 429 before any visible stream bytes.
+4. Retry excludes A, sets `reallocate_sticky=True`, and completes on B.
+
+## Related
+
+- Issue #1924
+- `openspec/specs/responses-api-compat/spec.md`
+- Adjacent `reallocate_sticky=True` sites in streaming retry

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/design.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`_stream_with_retry` classifies a pre-visible HTTP 429 as `rate_limit` and
+takes `failover_next`: it records keyed health, releases the stream lease,
+excludes the account, and loops. Soft `prompt_cache_key` affinity is still
+passed into the next `_select_account_with_budget_compatible` call with
+`reallocate_sticky=False`. Prompt-cache selection then prefers the excluded
+owner and returns no eligible accounts (#1924).
+
+Inline images force HTTP upstream transport, which is how the reporter hit
+this hole. The same `failover_next` site also runs for other pre-visible
+rate-limit/quota/transient classes; the release rule is the sticky policy,
+not an image-specific branch.
+
+Confirmed hole: `app/modules/proxy/_service/streaming/retry.py` first-event
+and post-refresh `action == "failover_next"` blocks. Adjacent pre-dispatch
+connect failure already does `affinity = replace(affinity, reallocate_sticky=True)`
+after the account is excluded.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- After a pre-visible `failover_next` exclusion, release soft sticky affinity
+  so the next selection can pick another eligible account.
+- Keep file-pin, turn-state, and other required-owner requests fail-closed.
+- Prove the product path (`stream_responses` with inline image +
+  `prompt_cache_key`) and the file-pin counterpart.
+
+**Non-Goals:**
+
+- New `CODEX_LB_*` settings.
+- Changing post-visible replay, compact, or HTTP-bridge ownership rules.
+- Probe / warmup / #1950 work.
+- Rebinding hard `CODEX_SESSION` rows under budget-pressure semantics.
+
+## Decisions
+
+1. **Reuse `reallocate_sticky=True`.** Same lever as the adjacent pre-visible
+   failover sites. Do not invent a parallel "clear sticky key" path.
+
+2. **Gate on required ownership, not on "has an image".** Inline image is the
+   reporter's trigger, not a distinct ownership class. File pins, turn-state,
+   and `require_preferred_account` stay pinned. Soft prompt-cache without those
+   owners may reallocate.
+
+3. **Apply at both `failover_next` sites** (first-event and post-refresh).
+   They share the hole; fixing only one would leave the same 429 after a
+   same-account refresh replay.
+
+4. **`_move_verified_fresh_replay_from_owner` still owns the verified-replay
+   case.** That helper already sets `reallocate_sticky=True` when it succeeds.
+   The new release runs only when that move does not apply.
+
+## Risks / Trade-offs
+
+- [Soft session-header locality also reallocates on 429] → Accepted and
+  consistent with the pre-dispatch path's `not require_preferred_account`
+  gate. Hard required owners remain fail-closed.
+- [Reallocation abandons a warm cache] → Mitigation: the warm account just
+  429'd; keeping the pin fails the request. TTL still expires unused keys.
+- [Health write before reservation settle] → Existing `_handle_or_defer_keyed_stream_health`
+  + lease release order is unchanged.
+
+## Migration Plan
+
+- No schema or settings migration.
+- Deploy is a retry-policy fix; no operator action.
+
+## Open Questions
+
+- None. Ownership vs soft-cache release is already specified for adjacent
+  pre-visible paths.

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/proposal.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/proposal.md
@@ -1,0 +1,41 @@
+# Why
+
+A streaming Responses request with an inline image and a soft `prompt_cache_key`
+treats a pre-visible upstream HTTP 429 as retryable and excludes the failed
+account, but leaves prompt-cache affinity pinned to that excluded account. The
+next selection pass then reports no eligible accounts even when another
+image-capable account can serve the request (#1924).
+
+# What Changes
+
+- On a pre-visible streaming `failover_next` (including HTTP 429), release
+  soft prompt-cache affinity by setting `reallocate_sticky=True` after the
+  failed account is excluded, matching the adjacent pre-dispatch failover path.
+- Keep file-pinned, turn-state, and other required-owner requests fail-closed;
+  they MUST NOT cross accounts.
+- Add a product-path regression for inline-image + `prompt_cache_key` 429
+  failover, plus a file-pin fail-closed counterpart.
+- Document the recovery rule in `responses-api-compat`.
+
+This change does **not** add settings, mix probe/warmup work, or change
+post-visible replay rules.
+
+# Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `responses-api-compat`: a pre-visible 429 on a soft prompt-cache streaming
+  request MUST release that affinity and retry an eligible compatible account;
+  file-owned requests remain account-pinned.
+
+# Impact
+
+- `app/modules/proxy/_service/streaming/retry.py` (`failover_next` after
+  pre-visible first-event and post-refresh failures)
+- Streaming unit coverage at `ProxyService.stream_responses`
+- `openspec/specs/responses-api-compat/spec.md` and its context notes
+- No new `CODEX_LB_*` settings, API fields, or dashboard surfaces

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/proposal.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/proposal.md
@@ -22,11 +22,11 @@ post-visible replay rules.
 
 # Capabilities
 
-### New Capabilities
+## New Capabilities
 
 - None
 
-### Modified Capabilities
+## Modified Capabilities
 
 - `responses-api-compat`: a pre-visible 429 on a soft prompt-cache streaming
   request MUST release that affinity and retry an eligible compatible account;

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/specs/responses-api-compat/spec.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/specs/responses-api-compat/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Soft prompt-cache streaming failover releases affinity on pre-visible 429
+
+The proxy MUST release soft `prompt_cache_key` affinity when a streaming
+Responses request fails with a pre-visible classified `failover_next` error,
+including HTTP 429: it MUST exclude that account, set `reallocate_sticky=True`
+for the next selection, and retry an eligible compatible account. An inline
+`input_image` MUST NOT keep the request pinned to the excluded soft-cache
+account.
+
+A live `input_file.file_id` pin, turn-state owner, or other required account
+owner MUST remain fail-closed: the proxy MUST NOT dispatch that request to a
+different account after the owner returns a pre-visible 429.
+
+#### Scenario: Inline-image prompt-cache 429 fails over to another account
+
+- **GIVEN** at least two image-capable accounts are eligible
+- **AND** a streaming Responses request includes an inline `input_image` and a
+  `prompt_cache_key`
+- **AND** the request has no live file pin, turn-state owner, or
+  previous-response owner
+- **WHEN** the prompt-cache-selected account returns HTTP 429 before any
+  stream bytes are visible
+- **THEN** the proxy excludes that account
+- **AND** the next selection uses `reallocate_sticky=True`
+- **AND** the request completes on another eligible compatible account
+
+#### Scenario: File-pinned prompt-cache 429 stays fail-closed
+
+- **GIVEN** a streaming Responses request references a live
+  `input_file.file_id` pin on account A
+- **AND** the request also carries a `prompt_cache_key`
+- **WHEN** account A returns HTTP 429 before any stream bytes are visible
+- **THEN** the proxy does not dispatch the request to another account
+- **AND** the request fails closed on the file owner

--- a/openspec/changes/release-soft-prompt-cache-on-previsible-429/tasks.md
+++ b/openspec/changes/release-soft-prompt-cache-on-previsible-429/tasks.md
@@ -1,0 +1,23 @@
+## 1. Streaming retry
+
+- [x] 1.1 After a first-event `failover_next` exclusion, set
+      `reallocate_sticky=True` when the request is not file-pinned,
+      turn-state-owned, or otherwise required-owner bound, unless
+      `_move_verified_fresh_replay_from_owner` already released it
+- [x] 1.2 Apply the same release on the post-refresh `failover_next` path
+
+## 2. Tests
+
+- [x] 2.1 Add a `stream_responses` regression: inline image +
+      `prompt_cache_key` + pre-visible 429 reallocates and completes on a
+      second image-capable account
+- [x] 2.2 Add a file-pin counterpart that stays fail-closed on the owner
+      after the same 429
+
+## 3. Specs
+
+- [x] 3.1 Sync the delta requirement into
+      `openspec/specs/responses-api-compat/spec.md`
+- [x] 3.2 Record the hole and example in
+      `openspec/specs/responses-api-compat/context.md`
+- [x] 3.3 Validate the scoped OpenSpec change

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -225,6 +225,14 @@ is positively classified as pre-dispatch therefore leaves the body unowned and
 eligible for its first real dispatch on another account. Ambiguous failures
 remain owner-bound.
 
+Soft `prompt_cache_key` affinity is locality, not ownership. A pre-visible
+HTTP 429 on the warm-cache account (including inline-image HTTP streams) must
+set `reallocate_sticky=True` after excluding that account so another eligible
+account can finish the request. File pins, turn-state, and other required
+owners stay fail-closed and must not ride that release. Example: accounts A
+and B both accept images; A is selected via `prompt_cache_key` and returns 429
+before visible bytes; B completes the same request.
+
 ## Known Client Integrations (Reference)
 
 Third-party agents that consume the `/v1` Responses surface documented by this

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1892,6 +1892,41 @@ the existing pre-visible forced-refresh and eligible-account failover behavior.
 - **THEN** the failed owner's stream lease is released before replacement
   selection so the owner does not retain stale local pressure
 
+### Requirement: Soft prompt-cache streaming failover releases affinity on pre-visible 429
+
+The proxy MUST release soft `prompt_cache_key` affinity when a streaming
+Responses request fails with a pre-visible classified `failover_next` error,
+including HTTP 429: it MUST exclude that account, set `reallocate_sticky=True`
+for the next selection, and retry an eligible compatible account. An inline
+`input_image` MUST NOT keep the request pinned to the excluded soft-cache
+account.
+
+A live `input_file.file_id` pin, turn-state owner, or other required account
+owner MUST remain fail-closed: the proxy MUST NOT dispatch that request to a
+different account after the owner returns a pre-visible 429.
+
+#### Scenario: Inline-image prompt-cache 429 fails over to another account
+
+- **GIVEN** at least two image-capable accounts are eligible
+- **AND** a streaming Responses request includes an inline `input_image` and a
+  `prompt_cache_key`
+- **AND** the request has no live file pin, turn-state owner, or
+  previous-response owner
+- **WHEN** the prompt-cache-selected account returns HTTP 429 before any
+  stream bytes are visible
+- **THEN** the proxy excludes that account
+- **AND** the next selection uses `reallocate_sticky=True`
+- **AND** the request completes on another eligible compatible account
+
+#### Scenario: File-pinned prompt-cache 429 stays fail-closed
+
+- **GIVEN** a streaming Responses request references a live
+  `input_file.file_id` pin on account A
+- **AND** the request also carries a `prompt_cache_key`
+- **WHEN** account A returns HTTP 429 before any stream bytes are visible
+- **THEN** the proxy does not dispatch the request to another account
+- **AND** the request fails closed on the file owner
+
 ### Requirement: Stale HTTP bridge previous-response aliases fail closed
 
 The HTTP bridge MUST NOT treat a stale previous-response alias as a model

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -38710,6 +38710,7 @@ async def test_stream_file_pinned_prompt_cache_429_stays_fail_closed(monkeypatch
     async def fake_select_account(**kwargs):
         selection_calls.append(dict(kwargs))
         assert kwargs.get("reallocate_sticky") is not True
+        assert kwargs.get("required_account_id") == file_owner.id
         excluded = set(cast(set[str], kwargs.get("exclude_account_ids") or set()))
         if file_owner.id in excluded:
             return AccountSelection(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -38628,6 +38628,143 @@ async def test_stream_verified_fresh_replay_moves_off_owner_after_previsible_quo
 
 
 @pytest.mark.asyncio
+async def test_stream_inline_image_prompt_cache_429_reallocates_soft_sticky(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_prompt_cache_image_429_a")
+    account_b = _make_account("acc_prompt_cache_image_429_b")
+    selection_calls: list[dict[str, object]] = []
+    streamed_account_ids: list[str | None] = []
+
+    async def fake_select_account(**kwargs):
+        selection_calls.append(dict(kwargs))
+        excluded = set(cast(set[str], kwargs.get("exclude_account_ids") or set()))
+        if account_a.id in excluded:
+            assert kwargs.get("reallocate_sticky") is True
+            assert kwargs.get("required_account_id") is None
+            return AccountSelection(account=account_b, error_message=None)
+        return AccountSelection(account=account_a, error_message=None)
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, base_url, raise_for_status, kwargs
+        streamed_account_ids.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_service.ProxyResponseError(
+                429,
+                openai_error("rate_limit_exceeded", "upstream quota reached"),
+            )
+        assert account_id == account_b.chatgpt_account_id
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_image_failover_ok",'
+            '"status":"completed","usage":{"input_tokens":1,"output_tokens":1,'
+            '"total_tokens":2}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", AsyncMock(side_effect=fake_select_account))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(return_value={"failure_class": "rate_limit"}))
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "describe the image",
+            "input": [{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}],
+            "prompt_cache_key": "cache_inline_image_429",
+            "stream": True,
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {},
+            openai_cache_affinity=True,
+        )
+    ]
+
+    assert json.loads(chunks[-1].split("data: ", 1)[1])["type"] == "response.completed"
+    assert streamed_account_ids == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    assert len(selection_calls) >= 2
+    assert selection_calls[1]["reallocate_sticky"] is True
+    assert selection_calls[1]["exclude_account_ids"] == {account_a.id}
+
+
+@pytest.mark.asyncio
+async def test_stream_file_pinned_prompt_cache_429_stays_fail_closed(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    file_owner = _make_account("acc_file_pin_image_429_owner")
+    other_account = _make_account("acc_file_pin_image_429_other")
+    selection_calls: list[dict[str, object]] = []
+    streamed_account_ids: list[str | None] = []
+
+    async def fake_select_account(**kwargs):
+        selection_calls.append(dict(kwargs))
+        assert kwargs.get("reallocate_sticky") is not True
+        excluded = set(cast(set[str], kwargs.get("exclude_account_ids") or set()))
+        if file_owner.id in excluded:
+            return AccountSelection(
+                account=None,
+                error_message="Previous response owner account is unavailable; retry later.",
+                error_code="previous_response_owner_unavailable",
+            )
+        return AccountSelection(account=file_owner, error_message=None)
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, base_url, raise_for_status, kwargs
+        streamed_account_ids.append(account_id)
+        raise proxy_service.ProxyResponseError(
+            429,
+            openai_error("rate_limit_exceeded", "upstream quota reached"),
+        )
+        yield ""
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", AsyncMock(side_effect=fake_select_account))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(return_value={"failure_class": "rate_limit"}))
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=file_owner.id))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "read the file",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+            "prompt_cache_key": "cache_file_pin_429",
+            "stream": True,
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {},
+            openai_cache_affinity=True,
+        )
+    ]
+
+    assert other_account.id not in {call.get("preferred_account_id") for call in selection_calls}
+    assert streamed_account_ids == [file_owner.chatgpt_account_id]
+    assert all(call.get("reallocate_sticky") is not True for call in selection_calls)
+    event = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert event["type"] == "response.failed"
+
+
+@pytest.mark.asyncio
 async def test_stream_verified_fresh_replay_moves_off_owner_after_refresh_connect_failure(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary

A streaming Responses request with an inline image and a soft `prompt_cache_key` treated a pre-visible upstream HTTP 429 as retryable and excluded the failed account, but left prompt-cache affinity pinned to that account. The next selection then reported no eligible accounts even when another image-capable account could serve the request. This PR releases soft sticky affinity on that `failover_next` path.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: **Fixes #1924**

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/release-soft-prompt-cache-on-previsible-429`

Delta updates `responses-api-compat`: a pre-visible 429 on a soft prompt-cache streaming request MUST set `reallocate_sticky=True` and retry an eligible account. File-owned requests remain fail-closed.

## Changes

- First-event and post-refresh `failover_next` paths now set `reallocate_sticky=True` after excluding a non-required-owner account (unless verified fresh replay already released it).
- File-pin, turn-state, required-owner, and `single_account` requests stay pinned.
- Product-path unit coverage: inline image + `prompt_cache_key` + 429 completes on a second account; file-pin + `prompt_cache_key` + 429 fails closed.

Probe, warmup, and #1950 are not included.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** (retry-policy fix; no operator setup)
- [x] No new required setup step
- New setting(s) and why each can't be a default: **none**. This is a correctness hole, not an operator preference.
- [x] README sections / `.env.example` / dashboard nav unchanged

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py::test_stream_inline_image_prompt_cache_429_reallocates_soft_sticky tests/unit/test_proxy_utils.py::test_stream_file_pinned_prompt_cache_429_stays_fail_closed tests/unit/test_proxy_utils.py::test_stream_verified_fresh_replay_moves_off_owner_after_previsible_quota tests/unit/test_proxy_utils.py::test_stream_verified_fresh_replay_moves_off_owner_after_refresh_connect_failure tests/unit/test_proxy_utils.py::test_stream_previous_response_owner_usage_limit_fails_closed tests/unit/test_proxy_utils.py::test_stream_responses_confirmed_proxy_connect_failure_fails_over_after_lease_release -q
# 6 passed

uv run ruff check app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
# All checks passed

openspec validate release-soft-prompt-cache-on-previsible-429 --strict
# Change is valid
```

`openspec validate --specs` still reports pre-existing main-spec SHALL/MUST failures, including on `responses-api-compat`. This change's delta validates cleanly. I did not run full local CI; GitHub required CI is the integration gate.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue (`Fixes #1924`).
- [x] Added or updated tests covering the change at `stream_responses`.
- [x] Ran the focused stream failover tests + ruff on the touched files.
- [x] `openspec validate release-soft-prompt-cache-on-previsible-429 --strict` passes.
- [x] Simplicity gates reviewed (P1–P5): no new setting, no README/nav/env growth, no dashboard layout change.
- [x] CHANGELOG is **not** edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming requests with soft prompt-cache affinity now fail over to another eligible account after a pre-visible 429.
  * Inline-image requests can recover when the initially selected account is excluded.
  * Requests with required file or turn ownership remain safely fail-closed.

* **Tests**
  * Added coverage for successful inline-image failover and required-owner failure behavior.

* **Documentation**
  * Updated compatibility guidance and specifications for soft-affinity failover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->