### PR TITLE
fix(proxy): reallocate soft affinity after rate limit

### DIFF
--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -2364,6 +2364,7 @@ class _StreamingRetryMixin:
                                         account_id=account.id,
                                         outcome="owner_previsible_failure",
                                     )
+                                    affinity = replace(affinity, reallocate_sticky=True)
                                     break
                                 await proxy._handle_stream_error(
                                     account,

--- a/openspec/changes/fix-inline-image-rate-limit-failover/.openspec.yaml
+++ b/openspec/changes/fix-inline-image-rate-limit-failover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/fix-inline-image-rate-limit-failover/design.md
+++ b/openspec/changes/fix-inline-image-rate-limit-failover/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The direct streaming retry loop already excludes an account after a
+pre-visible upstream rate-limit or quota error. Other pre-visible failover
+paths also set `reallocate_sticky=True` before selecting the replacement.
+The generic rate-limit branch omitted that update, allowing soft prompt-cache
+affinity to keep selecting the failed account.
+
+Inline image requests intentionally use the raw HTTP streaming path rather
+than the HTTP bridge. Inline image data is self-contained and account-neutral;
+unlike an uploaded `file_id`, it creates no account-owner requirement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Permit a pre-visible, self-contained inline-image request to fail over after
+  an upstream `429`.
+- Keep soft affinity for successful requests while allowing it to move after a
+  failed account is excluded.
+- Preserve required owner and file-pin safety boundaries.
+
+**Non-Goals:**
+
+- Replaying output-visible requests.
+- Moving requests with a resolved previous-response, turn-state, or file owner.
+- Adding a configuration option or changing model eligibility.
+
+## Decision
+
+Set `reallocate_sticky=True` in the existing generic `failover_next` branch
+immediately after the failed account is excluded. This matches adjacent
+pre-visible retry branches and leaves the existing required-owner gates in
+place. No sticky row is deleted; the normal replacement selection updates it
+atomically when a new account is chosen.
+
+## Risks / Trade-offs
+
+- **Prompt-cache locality is lost for the failed attempt.** This is necessary:
+  the account is already excluded for the current request, and retaining the
+  affinity turns a recoverable limit into a client-visible failure.
+- **Required owner could cross accounts.** Existing selection guards retain
+  their required-owner checks; the regression uses an inline data URL rather
+  than an uploaded file reference.
+
+## Migration Plan
+
+No migration is required. Deploy as an application-only proxy correction;
+rollback is the previous image.

--- a/openspec/changes/fix-inline-image-rate-limit-failover/proposal.md
+++ b/openspec/changes/fix-inline-image-rate-limit-failover/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+A self-contained inline-image request can use prompt-cache affinity to select
+an account that has just reached its upstream usage limit. The streaming
+failover path excludes that account after the pre-visible `429`, but does not
+mark the soft affinity reallocatable. Selection can therefore retain the
+exhausted prompt-cache owner and surface the upstream limit despite another
+eligible account being available.
+
+## What Changes
+
+- Reallocate soft prompt-cache or sticky-thread affinity after a pre-visible
+  stream rate-limit or quota failover.
+- Preserve existing required-owner behavior for previous responses, turn state,
+  and uploaded file references.
+- Add a regression for an inline-image request that receives a `429` from its
+  prompt-cache account and succeeds on another eligible account.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require pre-visible rate-limit failover to reallocate
+  soft affinity before replacement account selection.
+
+## Impact
+
+The change is limited to the direct streaming retry loop, one integration
+regression, and the Responses compatibility contract. It adds no setting,
+endpoint, schema, migration, dashboard surface, or dependency.

--- a/openspec/changes/fix-inline-image-rate-limit-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-inline-image-rate-limit-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Pre-visible rate-limit failover reallocates soft affinity
+
+When a streaming Responses request receives a pre-visible upstream rate-limit
+or quota failure, the proxy MUST exclude the failed account from the remaining
+attempts and reallocate soft prompt-cache or sticky-thread affinity before
+selecting a replacement. This applies to self-contained inline-image input as
+well as text input. It MUST NOT relax an independently resolved required owner,
+including a `previous_response_id`, turn-state owner, or live uploaded-file
+owner.
+
+#### Scenario: Inline image retries after a prompt-cache account rate limit
+
+- **GIVEN** a self-contained inline-image streaming request has prompt-cache affinity to account A
+- **AND** account A returns a pre-visible upstream `429` usage-limit error
+- **AND** account B is eligible for the same model
+- **WHEN** the proxy retries the request
+- **THEN** account A is excluded from the remaining attempts
+- **AND** prompt-cache affinity is reallocated before selecting account B
+- **AND** the client receives account B's successful stream
+
+#### Scenario: Required file ownership remains fail closed after a rate limit
+
+- **GIVEN** a streaming request is pinned to account A by a live uploaded file owner
+- **AND** account A returns a pre-visible upstream `429` usage-limit error
+- **WHEN** the proxy evaluates retry
+- **THEN** it MUST NOT replay the request on another account

--- a/openspec/changes/fix-inline-image-rate-limit-failover/tasks.md
+++ b/openspec/changes/fix-inline-image-rate-limit-failover/tasks.md
@@ -1,0 +1,23 @@
+## 1. Contract
+
+- [x] 1.1 Add the soft-affinity reallocation requirement and required-owner
+  non-regression scenario to the Responses compatibility spec.
+
+## 2. Implementation
+
+- [x] 2.1 Mark soft affinity reallocatable after excluding an account from a
+  pre-visible stream rate-limit or quota failover.
+- [x] 2.2 Preserve existing required-owner and uploaded-file fail-closed gates.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add an inline-image, prompt-cache-affined route-level regression
+  that receives a `429` on the first account and completes on the second.
+
+## 4. Verification
+
+- [x] 4.1 Run the focused regression and adjacent stream retry coverage.
+- [x] 4.2 Run Ruff check/format, ty, architecture validation, and strict
+  change validation. Record any pre-existing aggregate-spec validation failures.
+- [x] 4.3 Inspect the final diff and worktree status for scope and unrelated
+  changes.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1302,6 +1302,33 @@ For Responses API requests, usage-based routing MUST include immediate in-proces
 
 Every account-local lease acquired for a Responses request MUST be idempotently released or settled on success, upstream error, local startup error, bridge submit failure, startup probe conversion, non-streaming collect completion, failover, downstream disconnect, cancellation, timeout, and retry. A bounded stale-lease watchdog MUST reclaim leases that survive unexpected task cancellation or exceptions, and stale reclamation MUST emit warning/metric evidence. Leases MUST NOT be persisted to the database.
 
+### Requirement: Pre-visible rate-limit failover reallocates soft affinity
+
+When a streaming Responses request receives a pre-visible upstream rate-limit
+or quota failure, the proxy MUST exclude the failed account from the remaining
+attempts and reallocate soft prompt-cache or sticky-thread affinity before
+selecting a replacement. This applies to self-contained inline-image input as
+well as text input. It MUST NOT relax an independently resolved required owner,
+including a `previous_response_id`, turn-state owner, or live uploaded-file
+owner.
+
+#### Scenario: Inline image retries after a prompt-cache account rate limit
+
+- **GIVEN** a self-contained inline-image streaming request has prompt-cache affinity to account A
+- **AND** account A returns a pre-visible upstream `429` usage-limit error
+- **AND** account B is eligible for the same model
+- **WHEN** the proxy retries the request
+- **THEN** account A is excluded from the remaining attempts
+- **AND** prompt-cache affinity is reallocated before selecting account B
+- **AND** the client receives account B's successful stream
+
+#### Scenario: Required file ownership remains fail closed after a rate limit
+
+- **GIVEN** a streaming request is pinned to account A by a live uploaded file owner
+- **AND** account A returns a pre-visible upstream `429` usage-limit error
+- **WHEN** the proxy evaluates retry
+- **THEN** it MUST NOT replay the request on another account
+
 #### Scenario: Lease releases after downstream disconnect
 
 - **WHEN** a streaming `/v1/responses` client disconnects before a terminal upstream event

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -703,8 +703,8 @@ async def test_stream_http_500_exhausts_then_failover(async_client, monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_stream_connect_phase_429_usage_limit_transparent_failover(async_client, monkeypatch):
-    """Connect-phase 429/usage_limit_reached on A should fail over to B before any downstream event."""
+async def test_stream_inline_image_429_reallocates_prompt_cache_affinity(async_client, monkeypatch):
+    """A pre-visible image 429 must not keep its soft cache affinity on the failed account."""
     await _import_account(async_client, "acc_stream_429_a", "stream429a@example.com")
     await _import_account(async_client, "acc_stream_429_b", "stream429b@example.com")
 
@@ -722,7 +722,23 @@ async def test_stream_connect_phase_429_usage_limit_transparent_failover(async_c
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
 
-    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "describe the image",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,iVBORw0KGgo=",
+                    }
+                ],
+            }
+        ],
+        "prompt_cache_key": "inline-image-rate-limit-retry",
+        "stream": True,
+    }
     async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
         assert resp.status_code == 200
         lines = [line async for line in resp.aiter_lines() if line]


### PR DESCRIPTION
## Summary

Release soft prompt-cache affinity after a retryable pre-visible upstream rate limit. This prevents an inline-image Responses stream from returning a local usage-limit error when the affinity-selected account returns HTTP 429 but another compatible account is available.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

## Related issue

Fixes #1924 — inline-image HTTP 429 can leave prompt-cache affinity pinned to an excluded account and prevent compatible-account failover.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] This PR touches a codex-faithful request/response path and preserves upstream-equivalent wire behavior

Change directory: `openspec/changes/fix-inline-image-rate-limit-failover/`

## Changes

- Mark soft affinity for reallocation when a selected account returns a retryable pre-visible 429.
- Preserve account-pinned file ownership: those requests remain fail-closed and are not reallocated.
- Add an integration regression for an inline-image request with a `prompt_cache_key`, where the affinity-selected account returns 429 and a compatible account succeeds.
- Specify the reallocation and file-ownership invariants in OpenSpec.

## Test plan

```text
npx -y @fission-ai/openspec validate fix-inline-image-rate-limit-failover --strict
# valid

uv run pytest -q tests/integration/test_proxy_transient_retry.py
# 33 passed

make lint typecheck
# architecture, Ruff, format, and type checking passed
```

Frontend checks were not run locally because this PR changes no frontend code. Cloud CI remains authoritative.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran relevant focused backend checks.
- [x] Strict OpenSpec change validation passes.
- [x] CHANGELOG is not edited by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming request failover after upstream rate-limit or quota errors.
  - Inline-image requests can now retry on an eligible account while preserving prompt-cache affinity behavior.
  - Required ownership for previous responses, conversation state, and uploaded files remains protected and fails closed when necessary.

- **Tests**
  - Added regression coverage for inline-image rate-limit retries and affinity reallocation.

- **Documentation**
  - Updated compatibility requirements and design documentation for the revised failover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->