### PR TITLE
fix(transcribe): make subscription transcription reservation release cancellation-safe

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6783,6 +6783,26 @@ async def _transcribe_request(
     )
     rate_limit_headers = await _rate_limit_headers_with_reservation_cleanup(context, api_key, reservation)
     cancellation_handled = False
+
+    async def release_reservation() -> bool:
+        async def attempt_release() -> BaseException | None:
+            try:
+                await _release_reservation(reservation)
+            except BaseException as exc:
+                return exc
+            return None
+
+        release_exc, cancellation_deferred = await _await_result_deferring_cancellation(attempt_release())
+        if release_exc is not None:
+            if not cancellation_deferred:
+                raise release_exc
+            logger.warning(
+                "Failed to release subscription transcription reservation after request cancellation model=%s",
+                _TRANSCRIPTION_MODEL,
+                exc_info=release_exc,
+            )
+        return cancellation_deferred
+
     try:
         result = await context.service.transcribe(
             audio_bytes=multipart.audio_bytes,
@@ -6816,8 +6836,8 @@ async def _transcribe_request(
             headers=rate_limit_headers,
         )
     finally:
-        if not cancellation_handled:
-            await _release_reservation(reservation)
+        if not cancellation_handled and await release_reservation():
+            raise asyncio.CancelledError
     return JSONResponse(content=result, headers=rate_limit_headers)
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6782,6 +6782,7 @@ async def _transcribe_request(
         request_service_tier=None,
     )
     rate_limit_headers = await _rate_limit_headers_with_reservation_cleanup(context, api_key, reservation)
+    cancellation_handled = False
     try:
         result = await context.service.transcribe(
             audio_bytes=multipart.audio_bytes,
@@ -6791,6 +6792,21 @@ async def _transcribe_request(
             headers=request.headers,
             api_key=api_key,
         )
+    except asyncio.CancelledError:
+        cancellation_handled = True
+        release_exc: BaseException | None = None
+        if reservation is not None:
+            try:
+                await _release_reservation_deferring_cancellation(reservation)
+            except BaseException as exc:
+                release_exc = exc
+        if release_exc is not None:
+            logger.warning(
+                "Failed to release subscription transcription reservation after request cancellation model=%s",
+                _TRANSCRIPTION_MODEL,
+                exc_info=release_exc,
+            )
+        raise
     except ProxyResponseError as exc:
         error = _parse_error_envelope(exc.payload)
         return _logged_error_json_response(
@@ -6800,7 +6816,8 @@ async def _transcribe_request(
             headers=rate_limit_headers,
         )
     finally:
-        await _release_reservation(reservation)
+        if not cancellation_handled:
+            await _release_reservation(reservation)
     return JSONResponse(content=result, headers=rate_limit_headers)
 
 

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/.openspec.yaml
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/proposal.md
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/proposal.md
@@ -13,11 +13,11 @@ A cancelled subscription-backed transcription request can leave its committed AP
 
 ### New Capabilities
 
-None.
+- `api-keys`: Require immediate, exactly-once release of an owned subscription-backed transcription reservation when request cancellation interrupts upstream forwarding.
 
 ### Modified Capabilities
 
-- `api-keys`: Require immediate, exactly-once release of an owned subscription-backed transcription reservation when request cancellation interrupts upstream forwarding.
+None.
 
 ## Impact
 

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/proposal.md
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+A cancelled subscription-backed transcription request can leave its committed API-key usage reservation in `reserved` state until stale reclamation, consuming quota after request ownership has ended. Cancellation must release that reservation immediately through the established cancellation-safe cleanup mechanism.
+
+## What Changes
+
+- Release the owned subscription-backed transcription usage reservation when upstream forwarding is cancelled.
+- Preserve the original cancellation after cleanup and keep existing success, forwarding-error, and response behavior unchanged.
+- Add deterministic route-level regression coverage that cancels only after transcription forwarding begins and verifies the release completes exactly once and the reservation quota is restored.
+- Cover both `/backend-api/transcribe` and `/v1/audio/transcriptions` through their shared request helper without changing response shape or billing behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Require immediate, exactly-once release of an owned subscription-backed transcription reservation when request cancellation interrupts upstream forwarding.
+
+## Impact
+
+The change is limited to the shared subscription-backed transcription helper in `app/modules/proxy/api.py`, its focused route-level integration coverage, and the API-key reservation contract. It adds no public API, setting, dependency, migration, or dashboard change.

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/specs/api-keys/spec.md
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/specs/api-keys/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Subscription-backed transcription reservations survive cancellation safely
+
+The system MUST reserve API-key usage before forwarding an authenticated subscription-backed transcription request, and MUST release that owned reservation exactly once when cancellation interrupts upstream forwarding. The cancellation-deferring release MUST finish despite active AnyIO cancellation. If release persistence succeeds, the reservation MUST reach `released` state and its reserved quota MUST be restored before the original cancellation propagates. If release persistence fails after the existing bounded persistence retries, the system MUST emit cancellation-neutral cleanup diagnostics, MUST propagate the original cancellation, and MUST leave the reservation eligible for stale-reservation reclamation.
+
+#### Scenario: Cancelled subscription transcription releases its reservation
+
+- **GIVEN** a limited API key has created an owned reservation for a subscription-backed transcription request
+- **WHEN** cancellation interrupts the request while upstream transcription forwarding is in flight
+- **THEN** the request owner finishes releasing the reservation exactly once despite active cancellation
+- **AND** the reservation reaches `released` state and its reserved quota is restored
+- **AND** the original cancellation propagates after cleanup completes
+- **AND** stale-reservation reclamation is not required for that request
+
+#### Scenario: Failed cancellation release remains recoverable
+
+- **GIVEN** cancellation interrupts a limited subscription-backed transcription request after its reservation is created
+- **AND** the immediate release attempt exhausts the existing bounded persistence retries
+- **WHEN** release persistence reports failure
+- **THEN** the proxy emits cancellation-neutral cleanup diagnostics
+- **AND** the original cancellation propagates
+- **AND** stale-reservation reclamation remains eligible to release the reservation and restore its reserved quota

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/specs/api-keys/spec.md
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/specs/api-keys/spec.md
@@ -1,4 +1,4 @@
-## MODIFIED Requirements
+## ADDED Requirements
 
 ### Requirement: Subscription-backed transcription reservations survive cancellation safely
 

--- a/openspec/changes/fix-transcribe-cancel-reservation-release/tasks.md
+++ b/openspec/changes/fix-transcribe-cancel-reservation-release/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression
+
+- [x] 1.1 Add a deterministic subscription-backed transcription route cancellation test that waits for upstream forwarding to begin, uses a release spy with an await checkpoint, and verifies cancellation propagation plus exactly-once persisted release and quota restoration.
+- [x] 1.2 Confirm the focused regression fails on baseline because the release is interrupted and the reservation remains `reserved`.
+
+## 2. Implementation
+
+- [x] 2.1 Release the owned transcription reservation through the established cancellation-deferring cleanup helper, logging cleanup failures without replacing the original cancellation.
+- [x] 2.2 Preserve exactly-once cleanup and existing success, `ProxyResponseError`, billing, and response behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused transcription and source-audio integration test files.
+- [x] 3.2 Run Ruff check on the changed Python files.
+- [x] 3.3 Run strict OpenSpec validation for the scoped change and affected `api-keys` spec.
+- [x] 3.4 Inspect the final diff and worktree status for scope and unrelated changes.

--- a/tests/integration/test_proxy_transcriptions.py
+++ b/tests/integration/test_proxy_transcriptions.py
@@ -471,9 +471,11 @@ async def test_v1_audio_transcriptions_forwards_prompt(async_client, monkeypatch
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_phase", ["forward", "release"])
 async def test_subscription_transcription_cancellation_releases_reservation(
     async_client,
     monkeypatch: pytest.MonkeyPatch,
+    cancel_phase: str,
 ) -> None:
     await _enable_api_key_auth(async_client)
     await _import_account(async_client, "acc_transcribe_cancel", "cancel-transcribe@example.com")
@@ -492,6 +494,7 @@ async def test_subscription_transcription_cancellation_releases_reservation(
 
     forward_started = asyncio.Event()
     allow_upstream_finish = asyncio.Event()
+    allow_release_finish = asyncio.Event()
 
     async def transcribe(
         self,
@@ -503,9 +506,9 @@ async def test_subscription_transcription_cancellation_releases_reservation(
         headers,
         api_key=None,
     ):
-        del self, audio_bytes, filename, content_type, prompt, headers, api_key
         forward_started.set()
-        await allow_upstream_finish.wait()
+        if cancel_phase == "forward":
+            await allow_upstream_finish.wait()
         return {"text": "cancelled transcription"}
 
     monkeypatch.setattr(proxy_module.ProxyService, "transcribe", transcribe)
@@ -519,7 +522,10 @@ async def test_subscription_transcription_cancellation_releases_reservation(
         nonlocal release_calls
         release_calls += 1
         release_started.set()
-        await asyncio.sleep(0)
+        if cancel_phase == "release":
+            await allow_release_finish.wait()
+        else:
+            await asyncio.sleep(0)
         await original_release(reservation)
         release_finished.set()
 
@@ -533,15 +539,19 @@ async def test_subscription_transcription_cancellation_releases_reservation(
             files={"file": ("sample.wav", b"\x01\x02", "audio/wav")},
         )
     )
-    await asyncio.wait_for(forward_started.wait(), timeout=1)
+    if cancel_phase == "forward":
+        await asyncio.wait_for(forward_started.wait(), timeout=1)
+    else:
+        await asyncio.wait_for(release_started.wait(), timeout=1)
 
     request_task.cancel()
+    allow_release_finish.set()
     try:
         with pytest.raises(asyncio.CancelledError):
             await request_task
     finally:
         allow_upstream_finish.set()
-
+        allow_release_finish.set()
     assert release_started.is_set()
     assert release_finished.is_set()
     assert release_calls == 1

--- a/tests/integration/test_proxy_transcriptions.py
+++ b/tests/integration/test_proxy_transcriptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from collections.abc import AsyncIterator
@@ -8,7 +9,7 @@ from tempfile import SpooledTemporaryFile
 import pytest
 import starlette.formparsers as starlette_formparsers
 from httpx import AsyncByteStream
-from sqlalchemy import update
+from sqlalchemy import select, update
 
 import app.modules.proxy.api as proxy_api
 import app.modules.proxy.service as proxy_module
@@ -16,8 +17,9 @@ from app.core.auth.refresh import RefreshError
 from app.core.errors import openai_error
 from app.core.multipart import TRANSCRIPTION_MULTIPART_POLICY
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
-from app.db.models import ApiKeyLimit
+from app.db.models import ApiKeyLimit, ApiKeyUsageReservation
 from app.db.session import SessionLocal
+from app.modules.api_keys.repository import ApiKeysRepository
 
 pytestmark = pytest.mark.integration
 
@@ -466,6 +468,95 @@ async def test_v1_audio_transcriptions_forwards_prompt(async_client, monkeypatch
     assert captured["audio_bytes"] == b"\x0a\x0b"
     assert captured["prompt"] == "domain context"
     assert captured["account_id"] == "acc_transcribe_v1"
+
+
+@pytest.mark.asyncio
+async def test_subscription_transcription_cancellation_releases_reservation(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _enable_api_key_auth(async_client)
+    await _import_account(async_client, "acc_transcribe_cancel", "cancel-transcribe@example.com")
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "cancelled-transcription-key",
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 100_000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key = created.json()["key"]
+    key_id = created.json()["id"]
+
+    forward_started = asyncio.Event()
+    allow_upstream_finish = asyncio.Event()
+
+    async def transcribe(
+        self,
+        *,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        prompt: str | None,
+        headers,
+        api_key=None,
+    ):
+        del self, audio_bytes, filename, content_type, prompt, headers, api_key
+        forward_started.set()
+        await allow_upstream_finish.wait()
+        return {"text": "cancelled transcription"}
+
+    monkeypatch.setattr(proxy_module.ProxyService, "transcribe", transcribe)
+
+    release_started = asyncio.Event()
+    release_finished = asyncio.Event()
+    release_calls = 0
+    original_release = proxy_api._release_reservation
+
+    async def tracked_release(reservation):
+        nonlocal release_calls
+        release_calls += 1
+        release_started.set()
+        await asyncio.sleep(0)
+        await original_release(reservation)
+        release_finished.set()
+
+    monkeypatch.setattr(proxy_api, "_release_reservation", tracked_release)
+
+    request_task = asyncio.create_task(
+        async_client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": f"Bearer {key}"},
+            data={"model": "gpt-4o-transcribe"},
+            files={"file": ("sample.wav", b"\x01\x02", "audio/wav")},
+        )
+    )
+    await asyncio.wait_for(forward_started.wait(), timeout=1)
+
+    request_task.cancel()
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+    finally:
+        allow_upstream_finish.set()
+
+    assert release_started.is_set()
+    assert release_finished.is_set()
+    assert release_calls == 1
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(ApiKeyUsageReservation).where(
+                ApiKeyUsageReservation.api_key_id == key_id,
+                ApiKeyUsageReservation.model == "gpt-4o-transcribe",
+            )
+        )
+        reservation = result.scalar_one()
+        limits = await ApiKeysRepository(session).get_limits_by_key(key_id)
+        assert len(limits) == 1
+        assert (reservation.status, limits[0].current_value) == ("released", 0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Cancelling a subscription-backed transcription request can leave its API-key usage reservation in `reserved` state until stale reclamation, keeping quota charged for hours.

## Root cause

`_transcribe_request` released its reservation with a plain await in `finally`. Under AnyIO level cancellation, that first await was cancelled before persistence completed.

## Fix

Handle `asyncio.CancelledError` at the reservation-ownership seam, release through the existing cancellation-deferring helper, log cleanup failures without replacing the original cancellation, and skip the ordinary finally release after cancellation so the reservation is released exactly once. The final release also defers cancellation and re-propagates it after cleanup, covering cancellation that arrives after forwarding returns or while handling a `ProxyResponseError`. Success and `ProxyResponseError` behavior, billing, and response shape are unchanged. Both transcription route aliases use this helper.

PR #1936 fixed this behavior only for the model-source audio transcription path; this PR covers the subscription-backed path. No covering issue exists, so this PR intentionally does not include a `Fixes #N` reference.

## Test evidence

- Baseline regression: 1 failed; release spy did not finish and reservation remained reserved.
- `uv run pytest -q tests/integration/test_proxy_transcriptions.py`: 31 passed
- `uv run pytest -q tests/integration/test_model_source_routing.py`: 94 passed
- `uv run ruff check app/modules/proxy/api.py tests/integration/test_proxy_transcriptions.py`: passed
- `uv run ruff format --check app/modules/proxy/api.py tests/integration/test_proxy_transcriptions.py`: passed
- `openspec validate fix-transcribe-cancel-reservation-release --type change --strict`: valid
- `openspec validate api-keys --type spec --strict`: valid

## OpenSpec

Added `openspec/changes/fix-transcribe-cancel-reservation-release/` with proposal, tasks, and the `api-keys` delta spec.

Intentionally not run locally: project-wide tests, full local CI, package builds, and the repository-wide OpenSpec validation because unrelated pre-existing spec failures are present outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cancelled transcription requests so reserved API-key usage is released correctly.
  - Ensured quota is restored after cancellation while preserving the original cancellation behavior.

- **Tests**
  - Added coverage for reservation release and quota restoration across cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->