### PR TITLE
fix(metrics): bound request metric path and method label cardinality

### DIFF
--- a/app/core/metrics/middleware.py
+++ b/app/core/metrics/middleware.py
@@ -11,6 +11,8 @@ from app.core.metrics.prometheus import (
     requests_total,
 )
 
+_SUPPORTED_METHODS = frozenset(("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"))
+
 
 def _normalize_path(path: str) -> str:
     if path.startswith("/v1/"):
@@ -19,9 +21,13 @@ def _normalize_path(path: str) -> str:
         return "/api/..."
     if path.startswith("/health/"):
         return "/health/..."
-    if len(path) > 50:
-        return path[:50]
-    return path or "/"
+    if path == "/health":
+        return path
+    return "/other"
+
+
+def _normalize_method(method: str) -> str:
+    return method if method in _SUPPORTED_METHODS else "OTHER"
 
 
 class MetricsMiddleware:
@@ -40,7 +46,7 @@ class MetricsMiddleware:
 
         start = time.monotonic()
         status_code = 500
-        method = scope.get("method", "GET")
+        method = _normalize_method(scope.get("method", "GET"))
         path = _normalize_path(scope.get("path", "/"))
 
         active_connections.inc()

--- a/app/core/metrics/middleware.py
+++ b/app/core/metrics/middleware.py
@@ -23,6 +23,10 @@ def _normalize_path(path: str) -> str:
         return "/health/..."
     if path == "/health":
         return path
+    if path.startswith("/backend-api/"):
+        return "/backend-api/..."
+    if path.startswith("/internal/"):
+        return "/internal/..."
     return "/other"
 
 

--- a/app/core/metrics/middleware.py
+++ b/app/core/metrics/middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+from starlette._utils import get_route_path
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.metrics.prometheus import (
@@ -51,7 +52,7 @@ class MetricsMiddleware:
         start = time.monotonic()
         status_code = 500
         method = _normalize_method(scope.get("method", "GET"))
-        path = _normalize_path(scope.get("path", "/"))
+        path = _normalize_path(get_route_path(scope))
 
         active_connections.inc()
 

--- a/openspec/changes/bound-request-metric-label-cardinality/proposal.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The request metrics middleware currently emits arbitrary unmatched URL paths and raw HTTP methods as Prometheus labels. Because the SPA serves arbitrary unauthenticated GET paths, path churn creates a never-evicted metric child for every distinct path and can drive memory and scrape growth toward OOM.
+
+## What Changes
+
+- Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse values exactly.
+- Collapse every other request path to the single `/other` metric path value.
+- Normalize request method labels to the finite `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` vocabulary; map all other methods to `OTHER`.
+- Add regression coverage for unmatched-path cardinality, method normalization, and the existing `/v1/` collapse.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`
+
+## Impact
+
+- **Code:** Prometheus request counter and duration label normalization only.
+- **Compatibility:** Existing `/v1/...`, `/api/...`, `/health/...`, and bare `/health` values remain unchanged; only unmatched path and unsupported method label values change.
+- **Operations:** No new settings, dependencies, or runtime behavior outside metric label values.

--- a/openspec/changes/bound-request-metric-label-cardinality/proposal.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/proposal.md
@@ -5,9 +5,10 @@ The request metrics middleware currently emits arbitrary unmatched URL paths and
 ## What Changes
 
 - Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse values exactly.
+- Collapse `/backend-api/` and `/internal/` paths to their own bounded metric path values.
 - Collapse every other request path to the single `/other` metric path value.
 - Normalize request method labels to the finite `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` vocabulary; map all other methods to `OTHER`.
-- Add regression coverage for unmatched-path cardinality, method normalization, and the existing `/v1/` collapse.
+- Add regression coverage for unmatched-path cardinality, primary proxy path buckets, method normalization, and the existing `/v1/` collapse.
 
 ## Capabilities
 
@@ -22,5 +23,5 @@ None.
 ## Impact
 
 - **Code:** Prometheus request counter and duration label normalization only.
-- **Compatibility:** Existing `/v1/...`, `/api/...`, `/health/...`, and bare `/health` values remain unchanged; only unmatched path and unsupported method label values change.
+- **Compatibility:** Existing `/v1/...`, `/api/...`, `/health/...`, and bare `/health` values remain unchanged; `/backend-api/...` and `/internal/...` replace raw primary proxy path labels; other unmatched paths and unsupported method label values change.
 - **Operations:** No new settings, dependencies, or runtime behavior outside metric label values.

--- a/openspec/changes/bound-request-metric-label-cardinality/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/specs/proxy-runtime-observability/spec.md
@@ -6,18 +6,27 @@ The service MUST expose request counter and duration metrics with finite-vocabul
 `method` and `path` labels. The `method` label MUST be one of `GET`, `POST`, `PUT`,
 `PATCH`, `DELETE`, `HEAD`, `OPTIONS`, or `OTHER`; any other HTTP method MUST map to
 `OTHER`. The `path` label MUST preserve the existing `/v1/...`, `/api/...`, and
-`/health/...` collapse values and the existing bare `/health` value, while every
-other path MUST map to the single `/other` sentinel. Metric labels MUST NOT contain
-raw or truncated unmatched paths.
+`/health/...` collapse values and the existing bare `/health` value. Paths under
+`/backend-api/` MUST map to `/backend-api/...`, and paths under `/internal/` MUST map
+to `/internal/...`; every other path MUST map to the single `/other` sentinel. Metric
+labels MUST NOT contain raw or truncated unmatched paths.
 
 #### Scenario: Unmatched paths share one metric label
 
-- **WHEN** requests use distinct paths outside the `/v1/`, `/api/`, and `/health/`
-  prefixes, including SPA-looking paths
+- **WHEN** requests use distinct paths outside the `/v1/`, `/api/`, `/health/`,
+  `/backend-api/`, and `/internal/` prefixes, including SPA-looking paths
 - **THEN** request counter and duration metrics use `path="/other"` for every
   such request
 - **AND** no raw unmatched path or truncated unmatched path becomes a metric
   label value
+
+#### Scenario: Primary proxy paths use bounded labels
+
+- **WHEN** requests use `/backend-api/codex/responses`, dynamic
+  `/backend-api/files/{file_id}/uploaded`, or `/internal/bridge/...` paths
+- **THEN** request counter and duration metrics use `/backend-api/...` for every
+  `/backend-api/` path and `/internal/...` for every `/internal/` path
+- **AND** no dynamic file ID or other raw suffix becomes a metric label value
 
 #### Scenario: Unsupported methods share the OTHER label
 

--- a/openspec/changes/bound-request-metric-label-cardinality/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Request metric labels have bounded cardinality
+
+The service MUST expose request counter and duration metrics with finite-vocabulary
+`method` and `path` labels. The `method` label MUST be one of `GET`, `POST`, `PUT`,
+`PATCH`, `DELETE`, `HEAD`, `OPTIONS`, or `OTHER`; any other HTTP method MUST map to
+`OTHER`. The `path` label MUST preserve the existing `/v1/...`, `/api/...`, and
+`/health/...` collapse values and the existing bare `/health` value, while every
+other path MUST map to the single `/other` sentinel. Metric labels MUST NOT contain
+raw or truncated unmatched paths.
+
+#### Scenario: Unmatched paths share one metric label
+
+- **WHEN** requests use distinct paths outside the `/v1/`, `/api/`, and `/health/`
+  prefixes, including SPA-looking paths
+- **THEN** request counter and duration metrics use `path="/other"` for every
+  such request
+- **AND** no raw unmatched path or truncated unmatched path becomes a metric
+  label value
+
+#### Scenario: Unsupported methods share the OTHER label
+
+- **WHEN** a request uses an HTTP method outside the supported method vocabulary
+- **THEN** request counter and duration metrics use `method="OTHER"`
+
+#### Scenario: Existing collapsed paths remain stable
+
+- **WHEN** a request uses a path under `/v1/`, `/api/`, or `/health/`, or uses bare `/health`
+- **THEN** the metric path label retains its existing value

--- a/openspec/changes/bound-request-metric-label-cardinality/tasks.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/tasks.md
@@ -1,0 +1,18 @@
+# Bound Request Metric Label Cardinality
+
+## 1. Normalize request metric labels
+
+- [ ] 1.1 Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse behavior, including bare `/health` behavior.
+- [ ] 1.2 Map all other paths to `/other` and normalize methods to the finite supported-method vocabulary, with unsupported methods mapped to `OTHER`.
+
+## 2. Regression coverage
+
+- [ ] 2.1 Verify many distinct unmatched paths, including an SPA-looking path, create exactly one path label value.
+- [ ] 2.2 Verify unsupported methods use the `OTHER` label.
+- [ ] 2.3 Verify the existing `/v1/` collapse remains unchanged.
+
+## 3. Validation
+
+- [ ] 3.1 Run `uv run pytest tests/unit/test_metrics.py`.
+- [ ] 3.2 Run `uv run ruff check app/core/metrics/middleware.py tests/unit/test_metrics.py`.
+- [ ] 3.3 Run `openspec validate --specs`.

--- a/openspec/changes/bound-request-metric-label-cardinality/tasks.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/tasks.md
@@ -2,17 +2,17 @@
 
 ## 1. Normalize request metric labels
 
-- [ ] 1.1 Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse behavior, including bare `/health` behavior.
-- [ ] 1.2 Map all other paths to `/other` and normalize methods to the finite supported-method vocabulary, with unsupported methods mapped to `OTHER`.
+- [x] 1.1 Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse behavior, including bare `/health` behavior.
+- [x] 1.2 Map all other paths to `/other` and normalize methods to the finite supported-method vocabulary, with unsupported methods mapped to `OTHER`.
 
 ## 2. Regression coverage
 
-- [ ] 2.1 Verify many distinct unmatched paths, including an SPA-looking path, create exactly one path label value.
-- [ ] 2.2 Verify unsupported methods use the `OTHER` label.
-- [ ] 2.3 Verify the existing `/v1/` collapse remains unchanged.
+- [x] 2.1 Verify many distinct unmatched paths, including an SPA-looking path, create exactly one path label value.
+- [x] 2.2 Verify unsupported methods use the `OTHER` label.
+- [x] 2.3 Verify the existing `/v1/` collapse remains unchanged.
 
 ## 3. Validation
 
-- [ ] 3.1 Run `uv run pytest tests/unit/test_metrics.py`.
-- [ ] 3.2 Run `uv run ruff check app/core/metrics/middleware.py tests/unit/test_metrics.py`.
-- [ ] 3.3 Run `openspec validate --specs`.
+- [x] 3.1 Run `uv run pytest tests/unit/test_metrics.py`.
+- [x] 3.2 Run `uv run ruff check app/core/metrics/middleware.py tests/unit/test_metrics.py`.
+- [x] 3.3 Run `openspec validate --specs`.

--- a/openspec/changes/bound-request-metric-label-cardinality/tasks.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/tasks.md
@@ -16,4 +16,4 @@
 
 - [x] 3.1 Run `uv run pytest tests/unit/test_metrics.py`.
 - [x] 3.2 Run `uv run ruff check app/core/metrics/middleware.py tests/unit/test_metrics.py`.
-- [x] 3.3 Run `openspec validate --specs`.
+- [x] 3.3 Run `openspec validate bound-request-metric-label-cardinality --strict`.

--- a/openspec/changes/bound-request-metric-label-cardinality/tasks.md
+++ b/openspec/changes/bound-request-metric-label-cardinality/tasks.md
@@ -3,13 +3,14 @@
 ## 1. Normalize request metric labels
 
 - [x] 1.1 Preserve the existing `/v1/`, `/api/`, and `/health/` path collapse behavior, including bare `/health` behavior.
-- [x] 1.2 Map all other paths to `/other` and normalize methods to the finite supported-method vocabulary, with unsupported methods mapped to `OTHER`.
+- [x] 1.2 Collapse `/backend-api/` and `/internal/` paths to bounded buckets, map all other paths to `/other`, and normalize methods to the finite supported-method vocabulary, with unsupported methods mapped to `OTHER`.
 
 ## 2. Regression coverage
 
 - [x] 2.1 Verify many distinct unmatched paths, including an SPA-looking path, create exactly one path label value.
-- [x] 2.2 Verify unsupported methods use the `OTHER` label.
-- [x] 2.3 Verify the existing `/v1/` collapse remains unchanged.
+- [x] 2.2 Verify `/backend-api/` and `/internal/` paths use bounded buckets, including dynamic file-upload paths.
+- [x] 2.3 Verify unsupported methods use the `OTHER` label.
+- [x] 2.4 Verify the existing `/v1/` collapse remains unchanged.
 
 ## 3. Validation
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -240,6 +240,35 @@ async def test_metrics_middleware_bounds_unmatched_path_labels(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
+async def test_metrics_middleware_bounds_primary_proxy_path_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    prometheus_module, middleware_module = _load_metrics_modules(
+        monkeypatch,
+        prometheus_client_module=_fake_prometheus_client_module(),
+    )
+
+    app = FastAPI()
+    app.add_middleware(middleware_module.MetricsMiddleware, enabled=True)
+
+    paths = (
+        "/backend-api/codex/responses",
+        "/backend-api/files/file_abc/uploaded",
+        "/backend-api/files/file_xyz/uploaded",
+        "/internal/bridge/instance-123",
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for path in paths:
+            response = await client.get(path)
+            assert response.status_code == 404
+
+    expected_path_values = {"/backend-api/...", "/internal/..."}
+    request_path_values = {dict(labels)["path"] for labels in prometheus_module.requests_total.samples}
+    duration_path_values = {dict(labels)["path"] for labels in prometheus_module.request_duration_seconds.samples}
+    assert request_path_values == expected_path_values
+    assert duration_path_values == expected_path_values
+
+
+@pytest.mark.asyncio
 async def test_metrics_middleware_normalizes_unknown_method(monkeypatch: pytest.MonkeyPatch) -> None:
     prometheus_module, middleware_module = _load_metrics_modules(
         monkeypatch,

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -218,6 +218,50 @@ async def test_metrics_middleware_records_request_metrics(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_metrics_middleware_bounds_unmatched_path_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    prometheus_module, middleware_module = _load_metrics_modules(
+        monkeypatch,
+        prometheus_client_module=_fake_prometheus_client_module(),
+    )
+
+    app = FastAPI()
+    app.add_middleware(middleware_module.MetricsMiddleware, enabled=True)
+
+    paths = [f"/probe-{index}" for index in range(50)]
+    paths.append("/dashboard/settings/profile")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for path in paths:
+            response = await client.get(path)
+            assert response.status_code == 404
+
+    path_values = {dict(labels)["path"] for labels in prometheus_module.requests_total.samples}
+    assert path_values == {"/other"}
+
+
+@pytest.mark.asyncio
+async def test_metrics_middleware_normalizes_unknown_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    prometheus_module, middleware_module = _load_metrics_modules(
+        monkeypatch,
+        prometheus_client_module=_fake_prometheus_client_module(),
+    )
+
+    app = FastAPI()
+    app.add_middleware(middleware_module.MetricsMiddleware, enabled=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.request("BREW", "/unmatched")
+
+    assert response.status_code == 404
+    request_sample = prometheus_module.requests_total.samples[
+        (("method", "OTHER"), ("path", "/other"), ("status", "404"))
+    ]
+    duration_sample = prometheus_module.request_duration_seconds.samples[(("method", "OTHER"), ("path", "/other"))]
+    assert request_sample.value == 1.0
+    assert len(duration_sample.observations) == 1
+
+
+@pytest.mark.asyncio
 async def test_metrics_middleware_noops_without_prometheus_client(monkeypatch: pytest.MonkeyPatch) -> None:
     prometheus_module, middleware_module = _load_metrics_modules(monkeypatch, prometheus_client_module=None)
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -269,6 +269,34 @@ async def test_metrics_middleware_bounds_primary_proxy_path_labels(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_metrics_middleware_classifies_mounted_proxy_path_application_relative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prometheus_module, middleware_module = _load_metrics_modules(
+        monkeypatch,
+        prometheus_client_module=_fake_prometheus_client_module(),
+    )
+
+    app = FastAPI()
+    middleware = middleware_module.MetricsMiddleware(app, enabled=True)
+    cases = (
+        ("", "/backend-api/codex/responses"),
+        ("/prefix", "/prefix/backend-api/codex/responses"),
+    )
+    for root_path, path in cases:
+        transport = ASGITransport(app=middleware, root_path=root_path)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get(path)
+        assert response.status_code == 404
+
+    expected_path_values = {"/backend-api/..."}
+    request_path_values = {dict(labels)["path"] for labels in prometheus_module.requests_total.samples}
+    duration_path_values = {dict(labels)["path"] for labels in prometheus_module.request_duration_seconds.samples}
+    assert request_path_values == expected_path_values
+    assert duration_path_values == expected_path_values
+
+
+@pytest.mark.asyncio
 async def test_metrics_middleware_normalizes_unknown_method(monkeypatch: pytest.MonkeyPatch) -> None:
     prometheus_module, middleware_module = _load_metrics_modules(
         monkeypatch,


### PR DESCRIPTION
## Problem

The metrics middleware used verbatim unmatched request paths as Prometheus `Counter` and `Histogram` labels. The unauthenticated SPA catch-all serves arbitrary GET paths with 200 responses, so path churn creates unbounded metric children that are never evicted; 10,000 unique paths produce 10,000 labels and can drive memory and scrape growth toward OOM.

## Fix

- Preserve the existing `/v1/...`, `/api/...`, `/health/...`, and bare `/health` path values.
- Collapse every other path to the bounded `/other` sentinel.
- Normalize methods to `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`, or `OTHER`.
- Add regression coverage for many unmatched paths, SPA-looking paths, unknown methods, both metric families, and the existing `/v1` collapse.

### Root-path follow-up

Metric path classification now passes `get_route_path(scope)` into `_normalize_path`, matching the sibling middleware pattern and stripping the ASGI `root_path` before applying the bounded buckets. A mounted request with `root_path="/prefix"` and `path="/prefix/backend-api/codex/responses"` and the equivalent unmounted request both record `/backend-api/...`; `test_metrics_middleware_classifies_mounted_proxy_path_application_relative` covers both through the real middleware. `get_route_path` returns `""` when `path == root_path`, which `_normalize_path` maps to `/other`.

## Verification

- RED on pristine `upstream/main` (test file copied into a detached baseline checkout): `tests/unit/test_metrics.py::test_metrics_middleware_classifies_mounted_proxy_path_application_relative` — `1 failed, 10 deselected in 0.13s`
- `set -o pipefail; .venv/bin/python -m pytest tests/unit/test_metrics.py -k "test_metrics_middleware_classifies_mounted_proxy_path_application_relative" -q -p no:cacheprovider` — `1 passed, 10 deselected in 0.07s`
- `set -o pipefail; .venv/bin/python -m pytest tests/unit/test_metrics.py -q -p no:cacheprovider` — `11 passed in 0.10s`
- `set -o pipefail; .venv/bin/ruff check app/core/metrics/middleware.py tests/unit/test_metrics.py` — `All checks passed!`
- `set -o pipefail; .venv/bin/ruff format --check app/core/metrics/middleware.py tests/unit/test_metrics.py` — `2 files already formatted`
- `set -o pipefail; .venv/bin/ty check app/core/metrics/middleware.py tests/unit/test_metrics.py` — `All checks passed!`
- `set -o pipefail; npx -y @fission-ai/openspec@1.11.0 validate bound-request-metric-label-cardinality --strict` — `Change 'bound-request-metric-label-cardinality' is valid`
- `set -o pipefail; npx -y @fission-ai/openspec@1.8.0 validate bound-request-metric-label-cardinality --strict` — `Change 'bound-request-metric-label-cardinality' is valid`

No project-wide test suite was run locally; required CI covers the rest.

OpenSpec change: `openspec/changes/bound-request-metric-label-cardinality/`.

No covering upstream issue exists, so there is no `Fixes #N` reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized unsupported HTTP methods to `OTHER` in request metrics.
  * Grouped unrecognized request paths under `/other`.
  * Added bounded categories for `/backend-api/...` and `/internal/...` paths.
  * Preserved existing categories for versioned, API, and health-check paths.
  * Improved consistency and predictability of request metric labels.

* **Tests**
  * Added coverage for unmatched paths, proxy paths, mounted applications, and unsupported HTTP methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->