### PR TITLE
fix(proxy): stop defer-cancellation shield waits from starving the event loop

### DIFF
--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from app.core.errors import ResponseFailedEvent
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_dict
+from app.core.utils.shared_future import wait_on_shared_future
 
 type JsonPayload = Mapping[str, JsonValue] | ResponseFailedEvent
 
@@ -76,8 +77,12 @@ async def inject_sse_keepalives(
                 if pending is None:
                     pending = asyncio.create_task(_next_chunk(iterator))
                 try:
-                    chunk = await asyncio.wait_for(
-                        asyncio.shield(pending),
+                    # Not ``wait_for(shield(pending))``: Python 3.14's shield
+                    # leaks a done-callback onto ``pending`` at every keepalive
+                    # timeout, so a quiet upstream accumulates callbacks (and
+                    # O(n) remove scans) until the next chunk arrives.
+                    chunk = await wait_on_shared_future(
+                        pending,
                         timeout=interval_seconds,
                     )
                 except asyncio.TimeoutError:

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -389,15 +389,24 @@ async def _shielded_bounded(awaitable: Awaitable[object], timeout: float) -> asy
     anything the aiosqlite worker thread holds (issue #1682).
     """
     task = asyncio.ensure_future(awaitable)
-    waiter = asyncio.ensure_future(asyncio.wait({task}, timeout=timeout))
-    while not waiter.done():
-        try:
-            await asyncio.shield(waiter)
-        except asyncio.CancelledError:
-            # Teardown runs in ``finally`` blocks: the bound, not the caller's
-            # cancellation, decides abandonment. ``asyncio.wait`` cannot
-            # outlive its timeout, so this drain stays bounded.
-            continue
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    # The anyio shield keeps a level-cancelled scope from re-raising into
+    # every ``await`` (busy-spin); ``asyncio.wait`` removes its callback in a
+    # ``finally`` and never cancels ``task``, unlike 3.14's ``asyncio.shield``
+    # which leaks a done-callback per cancelled wait. The deadline (not a
+    # restarted timeout) keeps the bound exact under repeated edge cancels.
+    with anyio.CancelScope(shield=True):
+        while not task.done():
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                await asyncio.wait({task}, timeout=remaining)
+            except asyncio.CancelledError:
+                # Teardown runs in ``finally`` blocks: the bound, not the
+                # caller's cancellation, decides abandonment.
+                continue
     if task.done():
         task.result()
         return None

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -10,6 +10,7 @@ from typing import Any, NoReturn, Protocol, TypeVar, cast
 
 import aiohttp
 import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 from pydantic import ValidationError
 
 from app.core.auth.refresh import RefreshError, is_transient_refresh_contention, refresh_contention_kind
@@ -1034,7 +1035,7 @@ class _CompactMixin:
                 # promises to re-raise after the flush. Probe without
                 # suspending so a disconnected compact request still cancels.
                 try:
-                    await anyio.lowlevel.checkpoint_if_cancelled()
+                    await checkpoint_if_cancelled()
                 except asyncio.CancelledError:
                     cancellation_pending = True
             try:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -1029,6 +1029,14 @@ class _CompactMixin:
                         cancellation_pending = True
                     except Exception:
                         break
+            if not cancellation_pending:
+                # The shield also blocks the level cancellation this block
+                # promises to re-raise after the flush. Probe without
+                # suspending so a disconnected compact request still cancels.
+                try:
+                    await anyio.lowlevel.checkpoint_if_cancelled()
+                except asyncio.CancelledError:
+                    cancellation_pending = True
             try:
                 flush_task.result()
             except Exception:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, NoReturn, Protocol, TypeVar, cast
 
 import aiohttp
+import anyio
 from pydantic import ValidationError
 
 from app.core.auth.refresh import RefreshError, is_transient_refresh_contention, refresh_contention_kind
@@ -32,6 +33,7 @@ from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id, get_request_id
 from app.core.utils.retry import backoff_seconds
+from app.core.utils.shared_future import wait_on_shared_future
 from app.db.models import Account, AccountStatus, DashboardSettings, StickySessionKind
 from app.modules.api_keys.service import (
     ApiKeyData,
@@ -1015,13 +1017,18 @@ class _CompactMixin:
                 name=f"compact-deferred-health-{request_id}",
             )
             cancellation_pending = False
-            while not flush_task.done():
-                try:
-                    await asyncio.shield(flush_task)
-                except asyncio.CancelledError:
-                    cancellation_pending = True
-                except Exception:
-                    break
+            # The anyio shield keeps a level-cancelled Starlette scope from
+            # re-raising into every ``await`` (busy-spin), and
+            # ``wait_on_shared_future`` keeps waits off the task's
+            # done-callback list (3.14 shield leaks one per cancelled wait).
+            with anyio.CancelScope(shield=True):
+                while not flush_task.done():
+                    try:
+                        await wait_on_shared_future(flush_task)
+                    except asyncio.CancelledError:
+                        cancellation_pending = True
+                    except Exception:
+                        break
             try:
                 flush_task.result()
             except Exception:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -245,12 +245,21 @@ async def _await_task_deferring_cancellation(
     with anyio.CancelScope(shield=True):
         while True:
             try:
-                return await wait_on_shared_future(task), cancellation
+                result = await wait_on_shared_future(task)
+                break
             except asyncio.CancelledError as exc:
                 if task.cancelled():
                     raise
                 cancellation = cancellation or exc
-    raise RuntimeError("unreachable shielded cancellation-deferral state")
+    if cancellation is None:
+        # The shield also blocks the level cancellation this helper promises
+        # to surface. Probe for it without suspending so callers still get
+        # their cancellation marker after the owned task finished.
+        try:
+            await anyio.lowlevel.checkpoint_if_cancelled()
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+    return result, cancellation
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, Mapping, TypeVar, cast
 from urllib.parse import urlparse
 
 import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 
 from app.core import shutdown as shutdown_state
 from app.core.balancer.rendezvous_hash import select_node
@@ -256,7 +257,7 @@ async def _await_task_deferring_cancellation(
         # to surface. Probe for it without suspending so callers still get
         # their cancellation marker after the owned task finished.
         try:
-            await anyio.lowlevel.checkpoint_if_cancelled()
+            await checkpoint_if_cancelled()
         except asyncio.CancelledError as exc:
             cancellation = exc
     return result, cancellation

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -12,6 +12,8 @@ from ipaddress import ip_address
 from typing import Any, Literal, Mapping, TypeVar, cast
 from urllib.parse import urlparse
 
+import anyio
+
 from app.core import shutdown as shutdown_state
 from app.core.balancer.rendezvous_hash import select_node
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
@@ -64,6 +66,7 @@ from app.core.openai.requests import (
 from app.core.resilience.overload import local_overload_error
 from app.core.types import JsonValue
 from app.core.utils.request_id import get_request_id
+from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
@@ -232,13 +235,22 @@ async def _await_task_deferring_cancellation(
     """Finish critical cleanup while preserving the caller's cancellation."""
 
     cancellation: asyncio.CancelledError | None = None
-    while True:
-        try:
-            return await asyncio.shield(task), cancellation
-        except asyncio.CancelledError as exc:
-            if task.cancelled():
-                raise
-            cancellation = cancellation or exc
+    # The anyio shield keeps a level-cancelled Starlette scope from re-raising
+    # into every ``await``, which would otherwise busy-spin this loop until the
+    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
+    # off the task's done-callback list: Python 3.14's ``asyncio.shield``
+    # leaks a callback per cancelled wait, so re-shielding a task wedged on a
+    # lock grew 100k+ callbacks and O(n^2) remove scans in the 2026-08-30
+    # production event-loop livelock.
+    with anyio.CancelScope(shield=True):
+        while True:
+            try:
+                return await wait_on_shared_future(task), cancellation
+            except asyncio.CancelledError as exc:
+                if task.cancelled():
+                    raise
+                cancellation = cancellation or exc
+    raise RuntimeError("unreachable shielded cancellation-deferral state")
 
 
 @dataclass(frozen=True, slots=True)
@@ -1157,8 +1169,11 @@ async def _close_http_bridge_session_bounded(
         close_task.add_done_callback(close_done)
 
     try:
-        await asyncio.wait_for(
-            asyncio.shield(close_task),
+        # Not ``wait_for(shield(...))``: ``close_task`` is the shared
+        # per-session resource owner, and 3.14's shield leaks a done-callback
+        # onto it for every waiter that times out or is cancelled.
+        await wait_on_shared_future(
+            close_task,
             timeout=_HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
         )
     except TimeoutError:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -106,12 +106,21 @@ async def _await_task_deferring_cancellation(
     with anyio.CancelScope(shield=True):
         while True:
             try:
-                return await wait_on_shared_future(task), cancellation
+                result = await wait_on_shared_future(task)
+                break
             except asyncio.CancelledError as exc:
                 if task.cancelled():
                     raise
                 cancellation = cancellation or exc
-    raise RuntimeError("unreachable shielded cancellation-deferral state")
+    if cancellation is None:
+        # The shield also blocks the level cancellation this helper promises
+        # to surface. Probe for it without suspending so callers still get
+        # their cancellation marker after the owned task finished.
+        try:
+            await anyio.lowlevel.checkpoint_if_cancelled()
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+    return result, cancellation
 
 
 def _facade() -> Any:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -30,6 +30,7 @@ from app.core.resilience.network_recovery import (
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id
 from app.core.utils.retry import backoff_seconds
+from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.sse import format_sse_event
 from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
@@ -99,11 +100,13 @@ async def _await_task_deferring_cancellation(
     cancellation: asyncio.CancelledError | None = None
     # The anyio shield keeps a level-cancelled Starlette scope from re-raising
     # into every ``await``, which would otherwise busy-spin this loop until the
-    # owned task completes.
+    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
+    # off the task's done-callback list: Python 3.14's ``asyncio.shield``
+    # leaks a callback per cancelled wait (2026-08-30 event-loop livelock).
     with anyio.CancelScope(shield=True):
         while True:
             try:
-                return await asyncio.shield(task), cancellation
+                return await wait_on_shared_future(task), cancellation
             except asyncio.CancelledError as exc:
                 if task.cancelled():
                     raise

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncGenerator, AsyncIterator, Mapping, TypeVar, cast
 
 import aiohttp
 import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 
 from app.core.auth.refresh import RefreshError, is_transient_refresh_contention, refresh_contention_kind
 from app.core.balancer import failover_decision
@@ -117,7 +118,7 @@ async def _await_task_deferring_cancellation(
         # to surface. Probe for it without suspending so callers still get
         # their cancellation marker after the owned task finished.
         try:
-            await anyio.lowlevel.checkpoint_if_cancelled()
+            await checkpoint_if_cancelled()
         except asyncio.CancelledError as exc:
             cancellation = exc
     return result, cancellation

--- a/openspec/changes/fix-defer-cancellation-shield-leak/.openspec.yaml
+++ b/openspec/changes/fix-defer-cancellation-shield-leak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fix-defer-cancellation-shield-leak/proposal.md
+++ b/openspec/changes/fix-defer-cancellation-shield-leak/proposal.md
@@ -1,0 +1,60 @@
+# Fix defer-cancellation shield leak (2026-08-30 event-loop livelock)
+
+## Why
+
+Production starved its event loop again on 2026-08-30 (~4 days of uptime on
+1.24.0): a live-process autopsy found 26 futures carrying 500+ leaked
+`asyncio.shield` callbacks — the worst a wedged
+`_cleanup_http_bridge_submit_interruption` task with 100,986 — and ~50% of
+main-thread GIL samples inside `Future.remove_done_callback` O(n) scans.
+
+The http-bridge copy of `_await_task_deferring_cancellation` was the one
+defer-cancellation loop that never received the anyio `CancelScope(shield=True)`
+guard its `streaming/retry.py` sibling got in #1645. Under a level-cancelled
+Starlette scope (client disconnect), anyio re-delivers cancellation at every
+`await`, so the bare `while True: await asyncio.shield(task)` loop busy-spun
+at event-loop speed, and Python 3.14's `shield` leaks a done-callback onto the
+still-pending inner task for every cancelled wait (~10-20k callbacks/second
+measured). Two more unguarded copies (`compact.py` flush loop,
+`db/session.py::_shielded_bounded`) and two repeat-shield tick loops
+(SSE keepalive injector, timed waits on the shared per-session
+`resource_close_task`) share the same failure class.
+
+## What Changes
+
+- Guard the http-bridge `_await_task_deferring_cancellation` with
+  `anyio.CancelScope(shield=True)` (stops the level-cancel busy-spin) and wait
+  through `wait_on_shared_future` (keeps the owned task's callback list
+  bounded under edge cancels), matching and hardening the retry-module copy.
+- Apply the same guard+wait conversion to the compact deferred-health flush
+  loop and to `db/session.py::_shielded_bounded` (deadline-preserving
+  `asyncio.wait` drain).
+- Convert the two repeat-shield tick waits — the SSE keepalive injector's
+  per-tick wait on the pending chunk task and the timed wait on the shared
+  http-bridge `resource_close_task` — to `wait_on_shared_future`.
+- Add regression coverage proving callback counts stay bounded under a
+  level-cancelled anyio scope, repeated edge cancels, and quiet-upstream
+  keepalive ticks, while defer-cancellation semantics are preserved.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: extend the established shared-future wait
+  contract to defer-cancellation waits on owned cleanup tasks and repeated
+  timed waits (keepalive ticks, bounded teardown drains).
+
+## Impact
+
+- A client-disconnect storm or a slow/wedged cleanup task can no longer grow
+  task callback lists without bound or busy-spin the event loop; loop-lag
+  under those conditions returns to baseline.
+- Cleanup ownership semantics are unchanged: owned tasks are never cancelled
+  by their waiters, the caller's cancellation is still deferred until the
+  owned task finishes and then re-raised, and owned-task cancellation and
+  exceptions propagate exactly as before.
+- API response shapes do not change. No new settings.

--- a/openspec/changes/fix-defer-cancellation-shield-leak/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/fix-defer-cancellation-shield-leak/specs/proxy-admission-control/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: Admission waits on shared futures scale O(1) per waiter
+
+When multiple requests wait on one shared future (an inflight bridge session creation, a capacity slot, a token-refresh singleflight, or a usage-refresh singleflight), the system MUST use the established shared-future fan-out wait mechanism so attaching a waiter, a waiter timing out, and a waiter being cancelled each perform O(1) work on the shared future. The shared future MUST carry a constant number of done callbacks regardless of waiter count, and the wait mechanism itself MUST NOT cancel or otherwise mutate the shared future or the work it represents when a waiter times out or is cancelled. Admission handlers MAY still settle the shared future explicitly after a waiter's timeout (the http-bridge timeout handler fails and unregisters the inflight future so piled-up waiters converge on one overload outcome); that settlement is an admission-contract decision, not a side effect of waiting. The shared future's result, exception, or cancellation MUST propagate to every waiter with the same semantics as `asyncio.wait_for(asyncio.shield(shared), timeout)`.
+
+The same bounded-callback contract applies to waits that re-attach to one owned task repeatedly: defer-cancellation waits on owned cleanup tasks, repeated timed waits such as SSE keepalive ticks on a pending chunk task, and bounded teardown drains. A defer-cancellation wait MUST shield itself from level-cancelled scopes so re-delivered cancellation cannot busy-spin the wait loop, MUST keep the owned task's done-callback count bounded by a constant regardless of how many times the waiter is cancelled or times out, MUST NOT cancel the owned task, MUST defer the caller's cancellation until the owned task finishes and then surface it, and MUST propagate the owned task's cancellation and exceptions unchanged.
+
+#### Scenario: Waiter pile-up keeps the shared future's callback list constant
+
+- **WHEN** many requests wait on the same inflight bridge-session future
+- **THEN** the shared future carries a constant number of done callbacks
+- **AND** the callback count does not grow with the number of waiters
+
+#### Scenario: Mass timeout does not degrade the event loop
+
+- **GIVEN** waiters piled onto a shared future that has not resolved within
+  the admission wait timeout
+- **WHEN** the waiters time out together
+- **THEN** each timeout detaches in O(1) without scanning the shared future's
+  callback list
+- **AND** the surviving admission contract (local-overload `429` with the
+  capacity error code) is unchanged
+
+#### Scenario: Client-disconnect storm leaves the owner's creation running
+
+- **WHEN** every waiter on an inflight session future is cancelled by client
+  disconnects
+- **THEN** the shared future stays pending and the owner's session creation
+  continues
+- **AND** no per-waiter callbacks remain attached to the shared future
+
+#### Scenario: Cancelled usage-refresh waiters leave shared refresh running
+
+- **GIVEN** many callers are waiting on one in-flight usage refresh
+- **WHEN** all but one caller are cancelled
+- **THEN** the cancelled callers detach without adding or removing per-waiter
+  callbacks on the shared refresh task
+- **AND** the shared refresh continues to completion for the remaining caller
+
+#### Scenario: Non-joining usage refresh starts after its predecessor
+
+- **GIVEN** a usage refresh is already in flight for an account
+- **WHEN** another caller requests a non-joining refresh for that account
+- **THEN** it waits without cancelling or mutating the in-flight refresh
+- **AND** it starts a successor refresh only after the in-flight refresh has
+  finished
+
+#### Scenario: Level-cancelled scope cannot spin a defer-cancellation wait
+
+- **GIVEN** a cleanup task owned by a defer-cancellation wait is still running
+- **WHEN** the waiter's scope is level-cancelled (client disconnect) while the
+  cleanup task remains pending
+- **THEN** the wait loop does not busy-spin on re-delivered cancellation
+- **AND** the cleanup task's done-callback count stays bounded by a constant
+- **AND** the cleanup task runs to completion before the caller's cancellation
+  is surfaced
+
+#### Scenario: Keepalive ticks leave the pending chunk task's callbacks bounded
+
+- **GIVEN** an SSE stream whose upstream produces no chunk for many keepalive
+  intervals
+- **WHEN** each keepalive tick's timed wait on the pending chunk task times out
+- **THEN** keepalive frames are emitted and the pending chunk task is not
+  cancelled
+- **AND** the pending chunk task's done-callback count does not grow with the
+  number of elapsed ticks

--- a/openspec/changes/fix-defer-cancellation-shield-leak/tasks.md
+++ b/openspec/changes/fix-defer-cancellation-shield-leak/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## 1. Defer-Cancellation Wait Conversion
+
+- [x] 1.1 Guard the http-bridge `_await_task_deferring_cancellation` with `anyio.CancelScope(shield=True)` and route its wait through `wait_on_shared_future`, covering all ~18 call sites including the shared per-session `resource_close_task` waiters.
+- [x] 1.2 Apply the same guard+wait conversion to the retry-module copy (already shield-guarded; wait converted), the compact deferred-health flush loop, and `db/session.py::_shielded_bounded` (deadline-preserving `asyncio.wait` drain).
+- [x] 1.3 Convert the SSE keepalive injector's per-tick wait and the timed wait on the shared http-bridge `resource_close_task` to `wait_on_shared_future`.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Test that a level-cancelled anyio scope neither busy-spins the defer-cancellation wait nor grows the owned task's callback list, and that the owned task finishes before cancellation is surfaced.
+- [x] 2.2 Test that repeated edge `task.cancel()` deliveries keep the owned task's callback count bounded while deferring and then surfacing the cancellation.
+- [x] 2.3 Test that owned-task cancellation and exceptions propagate unchanged.
+- [x] 2.4 Test that quiet-upstream keepalive ticks keep the pending chunk task's callback count bounded while keepalive frames are emitted and the next chunk still arrives.
+- [x] 2.5 Test that `_shielded_bounded` honors its deadline under repeated cancels, keeps callbacks bounded, and still reports wedged vs finished teardown.
+- [x] 2.6 Sabotage-verify: restore the unguarded helper and record the level-cancel regression test failing.
+
+## 3. Verification
+
+- [x] 3.1 Run the new regression file plus the shared-future, SSE, db-session, and defer/cleanup/compact-related proxy unit tests.
+- [x] 3.2 Run ruff on all touched files and strict OpenSpec validation.

--- a/openspec/changes/fix-defer-cancellation-shield-leak/tasks.md
+++ b/openspec/changes/fix-defer-cancellation-shield-leak/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.1 Guard the http-bridge `_await_task_deferring_cancellation` with `anyio.CancelScope(shield=True)` and route its wait through `wait_on_shared_future`, covering all ~18 call sites including the shared per-session `resource_close_task` waiters.
 - [x] 1.2 Apply the same guard+wait conversion to the retry-module copy (already shield-guarded; wait converted), the compact deferred-health flush loop, and `db/session.py::_shielded_bounded` (deadline-preserving `asyncio.wait` drain).
 - [x] 1.3 Convert the SSE keepalive injector's per-tick wait and the timed wait on the shared http-bridge `resource_close_task` to `wait_on_shared_future`.
+- [x] 1.4 Probe for the shield-blocked level cancellation (`anyio.lowlevel.checkpoint_if_cancelled()`) after each guarded wait so the defer-cancellation marker (`cancellation` / `cancellation_pending`) still surfaces to callers.
 
 ## 2. Regression Coverage
 
@@ -13,7 +14,8 @@
 - [x] 2.3 Test that owned-task cancellation and exceptions propagate unchanged.
 - [x] 2.4 Test that quiet-upstream keepalive ticks keep the pending chunk task's callback count bounded while keepalive frames are emitted and the next chunk still arrives.
 - [x] 2.5 Test that `_shielded_bounded` honors its deadline under repeated cancels, keeps callbacks bounded, and still reports wedged vs finished teardown.
-- [x] 2.6 Sabotage-verify: restore the unguarded helper and record the level-cancel regression test failing.
+- [x] 2.6 Sabotage-verify: restore the unguarded helper and record the level-cancel regression test failing; separately remove the cancellation probe and record the marker assertion failing.
+- [x] 2.7 Product-path regression (`test_http_bridge_idle_leases.py`): a level-cancelled scope during `_submit_http_bridge_request` keeps the interruption-cleanup task's callbacks bounded, completes cleanup (lease released, waiter count zero), and surfaces the cancellation afterwards.
 
 ## 3. Verification
 

--- a/tests/unit/test_defer_cancellation_shield_leak.py
+++ b/tests/unit/test_defer_cancellation_shield_leak.py
@@ -1,0 +1,187 @@
+"""Regression tests for the 2026-08-30 shield-callback event-loop livelock.
+
+Python 3.14's ``asyncio.shield`` leaves callbacks behind on a still-pending
+inner task whenever the outer await is cancelled (``_clear_awaited_by_callback``
+is never detached), and every later detach pays an O(n) scan of the inner
+task's callback list. The http-bridge copy of
+``_await_task_deferring_cancellation`` re-shielded its task in a bare
+``while True`` loop, so a level-cancelled Starlette scope (client disconnect)
+busy-spun the loop against any slow cleanup task — production autopsy found
+cleanup tasks carrying 100k+ leaked callbacks and the event loop starved at
+~50% of GIL samples inside ``Future.remove_done_callback``.
+
+The structural invariant under test: no matter how often a waiter is
+cancelled — edge ``task.cancel()`` or a level-cancelled anyio scope — the
+awaited task's callback list stays bounded, while the defer-cancellation
+semantics (finish the owned task, then surface the caller's cancellation)
+are preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+
+from app.core.utils.sse import inject_sse_keepalives
+from app.db.session import _shielded_bounded
+from app.modules.proxy._service.http_bridge.helpers import (
+    _await_task_deferring_cancellation,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _callback_count(future: asyncio.Future) -> int:
+    return len(getattr(future, "_callbacks", None) or [])
+
+
+async def test_level_cancelled_scope_does_not_grow_task_callbacks():
+    """A cancelled anyio scope must not spin-leak callbacks onto the task."""
+
+    release = asyncio.Event()
+
+    async def cleanup() -> str:
+        await release.wait()
+        return "settled"
+
+    task = asyncio.create_task(cleanup())
+    await asyncio.sleep(0)
+
+    async def waiter() -> tuple[str, asyncio.CancelledError | None]:
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            return await _await_task_deferring_cancellation(task)
+
+    waiter_task = asyncio.create_task(waiter())
+    # Give the old busy-spin ample iterations to manifest: the unshielded
+    # loop leaked >900 callbacks in 50ms of wall clock.
+    await asyncio.sleep(0.05)
+    assert _callback_count(task) <= 3
+    assert not task.done()
+
+    release.set()
+    result, _cancellation = await asyncio.wait_for(waiter_task, timeout=1)
+    assert result == "settled"
+
+
+async def test_repeated_edge_cancellation_keeps_callbacks_bounded_and_defers():
+    release = asyncio.Event()
+
+    async def cleanup() -> str:
+        await release.wait()
+        return "settled"
+
+    task = asyncio.create_task(cleanup())
+    waiter_task = asyncio.create_task(_await_task_deferring_cancellation(task))
+    await asyncio.sleep(0)
+
+    for _ in range(50):
+        waiter_task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert _callback_count(task) <= 3
+    assert not waiter_task.done()
+
+    release.set()
+    result, cancellation = await asyncio.wait_for(waiter_task, timeout=1)
+    assert result == "settled"
+    assert cancellation is not None
+
+
+async def test_owned_task_cancellation_still_propagates():
+    async def cleanup() -> str:
+        await asyncio.Event().wait()
+        return "unreachable"
+
+    task = asyncio.create_task(cleanup())
+    waiter_task = asyncio.create_task(_await_task_deferring_cancellation(task))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(waiter_task, timeout=1)
+
+
+async def test_owned_task_exception_propagates():
+    async def cleanup() -> str:
+        raise RuntimeError("cleanup failed")
+
+    task = asyncio.create_task(cleanup())
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await _await_task_deferring_cancellation(task)
+
+
+async def test_sse_keepalive_ticks_do_not_grow_pending_chunk_callbacks():
+    """Every keepalive timeout used to leave a shield callback on ``pending``."""
+
+    release = asyncio.Event()
+
+    async def quiet_then_one_chunk():
+        await release.wait()
+        yield "data: chunk\n\n"
+
+    stream = inject_sse_keepalives(
+        quiet_then_one_chunk(),
+        interval_seconds=0.01,
+        keepalive_frame=": keepalive\n\n",
+        on_keepalive=None,
+    )
+
+    frames: list[str] = []
+
+    async def consume() -> None:
+        async for frame in stream:
+            frames.append(frame)
+            if frame == "data: chunk\n\n":
+                break
+
+    consumer = asyncio.create_task(consume())
+    # Let ~20 keepalive intervals elapse against a quiet upstream.
+    await asyncio.sleep(0.25)
+
+    pending_tasks = [
+        t
+        for t in asyncio.all_tasks()
+        if t not in {consumer, asyncio.current_task()} and "_next_chunk" in repr(t.get_coro())
+    ]
+    assert pending_tasks, "keepalive injector should have a pending chunk task"
+    assert all(_callback_count(t) <= 3 for t in pending_tasks)
+
+    release.set()
+    await asyncio.wait_for(consumer, timeout=1)
+    assert ": keepalive\n\n" in frames
+    assert frames[-1] == "data: chunk\n\n"
+
+
+async def test_shielded_bounded_honors_deadline_under_repeated_cancels():
+    wedged = asyncio.Event()
+
+    async def wedged_teardown() -> None:
+        await wedged.wait()
+
+    async def caller() -> asyncio.Task[object] | None:
+        return await _shielded_bounded(wedged_teardown(), timeout=0.1)
+
+    caller_task = asyncio.create_task(caller())
+    await asyncio.sleep(0)
+    for _ in range(10):
+        caller_task.cancel()
+        await asyncio.sleep(0)
+
+    leftover = await asyncio.wait_for(caller_task, timeout=1)
+    assert leftover is not None, "deadline must abandon the wedged teardown"
+    assert not leftover.done()
+    assert _callback_count(leftover) <= 2
+
+    wedged.set()
+    await asyncio.wait_for(leftover, timeout=1)
+
+
+async def test_shielded_bounded_returns_none_when_teardown_finishes():
+    async def quick_teardown() -> None:
+        await asyncio.sleep(0)
+
+    assert await _shielded_bounded(quick_teardown(), timeout=1) is None

--- a/tests/unit/test_defer_cancellation_shield_leak.py
+++ b/tests/unit/test_defer_cancellation_shield_leak.py
@@ -62,8 +62,11 @@ async def test_level_cancelled_scope_does_not_grow_task_callbacks():
     assert not task.done()
 
     release.set()
-    result, _cancellation = await asyncio.wait_for(waiter_task, timeout=1)
+    result, cancellation = await asyncio.wait_for(waiter_task, timeout=1)
     assert result == "settled"
+    # The level cancellation blocked by the shield must still surface as the
+    # deferred-cancellation marker callers re-raise after cleanup.
+    assert cancellation is not None
 
 
 async def test_repeated_edge_cancellation_keeps_callbacks_bounded_and_defers():

--- a/tests/unit/test_defer_cancellation_shield_leak.py
+++ b/tests/unit/test_defer_cancellation_shield_leak.py
@@ -53,6 +53,7 @@ async def test_level_cancelled_scope_does_not_grow_task_callbacks():
         with anyio.CancelScope() as scope:
             scope.cancel()
             return await _await_task_deferring_cancellation(task)
+        raise AssertionError("cancelled scope must not suppress the helper's return")
 
     waiter_task = asyncio.create_task(waiter())
     # Give the old busy-spin ample iterations to manifest: the unshielded

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -629,6 +629,117 @@ async def test_prewarm_failure_retires_closed_session_after_last_waiter(
 
 
 @pytest.mark.asyncio
+async def test_level_cancelled_submit_finishes_cleanup_without_leaking_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-08-30 livelock regression at the product path: a client disconnect
+    (level-cancelled scope) during submit must neither busy-spin the
+    defer-cancellation wait nor grow the cleanup task's callback list, and the
+    interruption cleanup must still run to completion before the cancellation
+    surfaces."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    lease = _make_lease("l-level-cancel")
+    acquire_account_lease = AsyncMock(return_value=lease)
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "acquire_account_lease", acquire_account_lease)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+
+    prewarm_started = asyncio.Event()
+    hold_prewarm = asyncio.Event()
+
+    async def wait_in_prewarm(*_args: object, **_kwargs: object) -> None:
+        prewarm_started.set()
+        await hold_prewarm.wait()
+
+    monkeypatch.setattr(service, "_maybe_prewarm_http_bridge_session", AsyncMock(side_effect=wait_in_prewarm))
+
+    cleanup_started = asyncio.Event()
+    finish_cleanup = asyncio.Event()
+    cleanup_task_holder: dict[str, asyncio.Task[None] | None] = {"task": None}
+    original_cleanup = service._cleanup_http_bridge_submit_interruption
+
+    async def delayed_cleanup(
+        cleanup_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        gate_acquired: bool,
+        request_enqueued: bool,
+        counted_in_queue: bool,
+        admission_waiter_registered: bool = False,
+    ) -> None:
+        cleanup_task_holder["task"] = cast("asyncio.Task[None] | None", asyncio.current_task())
+        cleanup_started.set()
+        await finish_cleanup.wait()
+        await original_cleanup(
+            cleanup_session,
+            request_state=request_state,
+            gate_acquired=gate_acquired,
+            request_enqueued=request_enqueued,
+            counted_in_queue=counted_in_queue,
+            admission_waiter_registered=admission_waiter_registered,
+        )
+
+    monkeypatch.setattr(service, "_cleanup_http_bridge_submit_interruption", delayed_cleanup)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-level-cancel",
+        model="gpt-5.2",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.2","input":"hi"}',
+        transport="http",
+        skip_request_log=True,
+    )
+
+    scope_holder: dict[str, anyio.CancelScope] = {}
+    submit_cancelled = False
+
+    async def run_submit() -> None:
+        nonlocal submit_cancelled
+        with anyio.CancelScope() as scope:
+            scope_holder["scope"] = scope
+            try:
+                await service._submit_http_bridge_request(
+                    session,
+                    request_state=request_state,
+                    text_data=request_state.request_text or "{}",
+                    queue_limit=8,
+                )
+            except asyncio.CancelledError:
+                submit_cancelled = True
+                raise
+
+    submit_task = asyncio.create_task(run_submit())
+    await asyncio.wait_for(prewarm_started.wait(), timeout=1)
+    scope_holder["scope"].cancel()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+
+    # The level cancellation stays pending while cleanup is held. The old
+    # unguarded loop busy-spun here, leaking >900 shield callbacks onto the
+    # cleanup task within 50ms.
+    await asyncio.sleep(0.05)
+    cleanup_task = cleanup_task_holder["task"]
+    assert cleanup_task is not None
+    assert len(getattr(cleanup_task, "_callbacks", None) or []) <= 3
+    assert not cleanup_task.done()
+
+    finish_cleanup.set()
+    await asyncio.wait_for(submit_task, timeout=1)
+
+    # Cleanup ran to completion and the cancellation surfaced afterwards.
+    assert submit_cancelled
+    assert scope_holder["scope"].cancelled_caught
+    release_account_lease.assert_awaited_once_with(lease)
+    assert session.admission_waiter_count == 0
+    assert session.account_lease is None
+
+
+@pytest.mark.asyncio
 async def test_prewarm_cancellation_cannot_interrupt_waiter_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #1968

## Why

2026-08-30 production event-loop livelock (third recurrence of the 3.14 shield callback-leak class after #1842/#1897). Live-process autopsy: wedged `_cleanup_http_bridge_submit_interruption` tasks carrying up to **100,986 leaked shield callbacks**, ~47% of main-thread GIL samples inside `Future.remove_done_callback` O(n) scans (`asyncio/tasks.py:996/998`), `/health` p50 1.7s, burn persisting at ~0 sessions. Full evidence in #1968.

## What

- **`http_bridge/helpers.py::_await_task_deferring_cancellation`** — the one defer-cancellation copy that never received the `anyio.CancelScope(shield=True)` guard (#1645 added it to the retry-module sibling): add the guard (kills the level-cancel busy-spin measured at ~10-20k leaked callbacks/s) and wait via `wait_on_shared_future` (bounds the owned task's callback list under the remaining edge cancels). Covers all ~18 call sites, including the racing waiters on the shared per-session `resource_close_task`.
- **`compact.py` deferred-health flush loop** and **`db/session.py::_shielded_bounded`** — same class, same treatment; `_shielded_bounded` drains via deadline-preserving `asyncio.wait` (removes its callback in a `finally`, never cancels the teardown task, keeps the abandonment bound exact under repeated cancels).
- **Repeat-shield tick waits** — SSE keepalive injector (`sse.py`, re-shielded the same pending chunk task every tick against a quiet upstream) and the 5s timed wait on the shared `resource_close_task` (`helpers.py`) → `wait_on_shared_future`.
- **`streaming/retry.py`** — already spin-guarded; wait converted for the same bounded-callback invariant.

Semantics preserved at every site: owned tasks are never cancelled by waiters; the caller's cancellation is deferred until the owned task finishes and then surfaced; owned-task cancellation and exceptions propagate unchanged (existing `test_streaming_retry_cleanup_helper_finishes_task_before_reporting_cancellation` and the compact/db suites stay green).

## Regression coverage

`tests/unit/test_defer_cancellation_shield_leak.py`:
- level-cancelled anyio scope: no busy-spin, owned-task callbacks ≤3, task finishes before cancellation surfaces — **sabotage-verified** (fails in 0.24s against the unguarded helper: the old loop leaks >900 callbacks in 50ms);
- 50 edge `task.cancel()` deliveries: callbacks bounded, cancellation deferred then returned;
- owned-task cancellation and exception propagation;
- 20+ quiet-upstream keepalive ticks: pending chunk task callbacks bounded, keepalives emitted, chunk still delivered;
- `_shielded_bounded`: deadline honored under repeated cancels, wedged-vs-finished contract intact.

## Verification

- `uv run pytest tests/unit/test_defer_cancellation_shield_leak.py tests/unit/test_shared_future_waiters.py tests/unit/test_sse.py` — 43 passed
- `uv run pytest tests/unit/test_proxy_utils.py -k "cleanup or defer or shield or keepalive"` — 41 passed; `-k compact` — 100 passed
- `uv run pytest tests/unit/test_db_session*.py` — 59 passed
- `uv run ruff check` on all touched files — clean
- `openspec validate fix-defer-cancellation-shield-leak --strict` — valid

## Out of scope (follow-up)

The underlying wedge — cleanup tasks blocked on `session.pending_lock` for days — is a separate defect tracked in #1971; this PR removes the livelock amplification (unbounded callbacks + O(n²) scans + busy-spin) regardless of what wedges a cleanup task. Consolidating the six hand-rolled defer-cancellation copies into one shared utility is also deferred to keep this PR one concern wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling across streaming, proxy, database, and connection cleanup workflows.
  * Prevented callback and resource growth during repeated timeouts or cancellations.
  * Preserved task completion, exception propagation, keepalive behavior, and teardown deadlines.

* **Tests**
  * Added regression coverage for cancellation storms, callback growth, keepalive cleanup, task failures, and bounded teardown waits.

* **Documentation**
  * Added technical specifications and tracking documentation for the cancellation-handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
