### PR TITLE
fix(images): release API-key reservation when cancelled before first SSE frame

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3055,15 +3055,15 @@ async def _prime_upstream_stream(
     Returns ``(primed_iterator, None)`` on success, where the returned
     iterator yields the captured first chunk followed by the rest of
     ``upstream``. A pre-yield ``ProxyResponseError`` returns a structured
-    response. Cancellation or generator termination closes ``upstream``, runs
-    ``on_error`` when provided, and then propagates the original terminal.
+    response. Cancellation closes ``upstream``, runs ``on_error`` when
+    provided, and then propagates the original ``CancelledError``.
     """
     iterator = upstream.__aiter__()
     try:
         first_chunk = await iterator.__anext__()
     except StopAsyncIteration:
         first_chunk = None
-    except (asyncio.CancelledError, GeneratorExit):
+    except asyncio.CancelledError:
         try:
             await _await_cleanup_deferring_cancellation(_aclose_stream(iterator))
         except BaseException as exc:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3054,15 +3054,32 @@ async def _prime_upstream_stream(
 
     Returns ``(primed_iterator, None)`` on success, where the returned
     iterator yields the captured first chunk followed by the rest of
-    ``upstream``. Returns ``(None, error_response)`` when the upstream
-    raised before yielding anything; in that case ``on_error`` is called
-    so the caller can release reservations.
+    ``upstream``. A pre-yield ``ProxyResponseError`` returns a structured
+    response. Cancellation or generator termination closes ``upstream``, runs
+    ``on_error`` when provided, and then propagates the original terminal.
     """
     iterator = upstream.__aiter__()
     try:
         first_chunk = await iterator.__anext__()
     except StopAsyncIteration:
         first_chunk = None
+    except (asyncio.CancelledError, GeneratorExit):
+        try:
+            await _await_cleanup_deferring_cancellation(_aclose_stream(iterator))
+        except BaseException as exc:
+            logger.warning(
+                "Failed to close Images upstream stream after first-frame termination",
+                exc_info=exc,
+            )
+        if on_error is not None:
+            try:
+                await _await_cleanup_deferring_cancellation(on_error())
+            except BaseException as exc:
+                logger.warning(
+                    "Failed to run Images first-frame termination cleanup",
+                    exc_info=exc,
+                )
+        raise
     except ProxyResponseError as exc:
         if on_error is not None:
             await on_error()

--- a/openspec/changes/fix-images-cancel-reservation/.openspec.yaml
+++ b/openspec/changes/fix-images-cancel-reservation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fix-images-cancel-reservation/design.md
+++ b/openspec/changes/fix-images-cancel-reservation/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Both Images adapters commit a limited API-key reservation before constructing an
+internal Responses stream. They intentionally pass
+`api_key_reservation=None` into `stream_responses`, because captured
+`tool_usage.image_gen` tokens make the Images route the sole settlement owner.
+Before returning either an SSE or JSON response, `_prime_upstream_stream` awaits
+the first upstream event. Its existing `ProxyResponseError` branch invokes the
+route-provided `on_error` release callback, but `asyncio.CancelledError` is a
+`BaseException` and bypasses that branch. A cancellation before the first event
+therefore ends request ownership while quota remains reserved until the
+six-hour stale sweep.
+
+PR #1822 established tracked settlement after image usage is captured and
+explicitly excluded broader pre-terminal cancellation cleanup. The proxy
+already provides `_await_cleanup_deferring_cancellation` and
+`_release_reservation_deferring_cancellation` for request-owned cleanup that
+must finish despite active cancellation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Close the upstream iterator when cancellation or generator termination
+  interrupts its first `__anext__` call.
+- Invoke the route-owned error callback exactly once in a cancellation-safe
+  cleanup window, then propagate the original terminal unchanged.
+- Restore limited-key quota immediately when release persistence succeeds.
+- Cover generation and edit through their actual HTTP route surface.
+
+**Non-Goals:**
+
+- Changing the existing `ProxyResponseError` conversion or callback behavior.
+- Changing post-first-event streaming cancellation, captured-token
+  finalization, billing, settlement retry policy, or stale-reclamation timing.
+- Passing the reservation into the internal Responses settlement path or
+  adding another reservation owner.
+- Changing public Images request, response, or SSE formats.
+
+## Decisions
+
+1. **Handle the terminal at the first-frame ownership seam.** Catch
+   `asyncio.CancelledError` and `GeneratorExit` only around
+   `iterator.__anext__()`. At that point the caller has committed the Images
+   reservation, no image usage has been captured, and the supplied `on_error`
+   callback remains its sole cleanup owner. Broader route `finally` blocks were
+   rejected because they would overlap successful captured-token settlement.
+2. **Close and release as separate cancellation-deferring operations.** First
+   close the iterator, then run `on_error`, using the existing cleanup deferral
+   primitive for each operation. Attempting them independently ensures a close
+   failure cannot skip reservation release. A raw await was rejected because
+   repeated task cancellation could interrupt cleanup before persistence
+   completes.
+3. **Preserve the original terminal.** Record close or callback failures with
+   cancellation-neutral warnings and use bare `raise`. Cleanup diagnostics must
+   never replace the client's `CancelledError` or a delivered `GeneratorExit`.
+4. **Prove both Images owners at the route surface.** A parameterized
+   integration regression creates a real limited key, starts generation or
+   edit, waits until the fake upstream is blocked before its first yield,
+   cancels the client request, and verifies cancellation propagation, iterator
+   closure, one release call, persisted `released` state, and restored quota.
+
+## Risks / Trade-offs
+
+- **Cleanup delays cancellation propagation.** The handler deliberately waits
+  for the existing bounded persistence operation because returning earlier
+  would recreate the reservation leak.
+- **Release persistence can still fail.** The handler logs the failure,
+  preserves the original terminal, and leaves the reservation eligible for the
+  existing stale-reclamation backstop. This exceptional fallback does not
+  weaken normal request-owned cleanup.
+- **`GeneratorExit` may not be delivered by current ASGI cancellation paths.**
+  Handling it at the same ownership seam is safe and prevents an equivalent
+  leak if an async-generator consumer closes priming directly.
+- **Post-first-event cancellation is distinct.** Existing translated-stream
+  finalization owns that lifecycle and remains unchanged by keeping this catch
+  limited to the initial `__anext__` call.

--- a/openspec/changes/fix-images-cancel-reservation/design.md
+++ b/openspec/changes/fix-images-cancel-reservation/design.md
@@ -21,8 +21,8 @@ must finish despite active cancellation.
 
 **Goals:**
 
-- Close the upstream iterator when cancellation or generator termination
-  interrupts its first `__anext__` call.
+- Close the upstream iterator when cancellation interrupts its first
+  `__anext__` call.
 - Invoke the route-owned error callback exactly once in a cancellation-safe
   cleanup window, then propagate the original terminal unchanged.
 - Restore limited-key quota immediately when release persistence succeeds.
@@ -39,21 +39,25 @@ must finish despite active cancellation.
 
 ## Decisions
 
-1. **Handle the terminal at the first-frame ownership seam.** Catch
-   `asyncio.CancelledError` and `GeneratorExit` only around
-   `iterator.__anext__()`. At that point the caller has committed the Images
-   reservation, no image usage has been captured, and the supplied `on_error`
-   callback remains its sole cleanup owner. Broader route `finally` blocks were
-   rejected because they would overlap successful captured-token settlement.
+1. **Handle cancellation at the first-frame ownership seam.** Catch
+   `asyncio.CancelledError` only around `iterator.__anext__()`. At that point
+   the caller has committed the Images reservation, no image usage has been
+   captured, and the supplied `on_error` callback remains its sole cleanup
+   owner. Broader route `finally` blocks were rejected because they would
+   overlap successful captured-token settlement. Catching `GeneratorExit` was
+   also rejected: `_prime_upstream_stream` is a normal coroutine, so synchronous
+   coroutine close forbids suspension and cannot await iterator or reservation
+   cleanup. FastAPI request disconnects cancel the owning task with
+   `CancelledError`, which is the confirmed route terminal.
 2. **Close and release as separate cancellation-deferring operations.** First
    close the iterator, then run `on_error`, using the existing cleanup deferral
    primitive for each operation. Attempting them independently ensures a close
    failure cannot skip reservation release. A raw await was rejected because
    repeated task cancellation could interrupt cleanup before persistence
    completes.
-3. **Preserve the original terminal.** Record close or callback failures with
-   cancellation-neutral warnings and use bare `raise`. Cleanup diagnostics must
-   never replace the client's `CancelledError` or a delivered `GeneratorExit`.
+3. **Preserve the original cancellation.** Record close or callback failures
+   with cancellation-neutral warnings and use bare `raise`. Cleanup diagnostics
+   must never replace the client's `CancelledError`.
 4. **Prove both Images owners at the route surface.** A parameterized
    integration regression creates a real limited key, starts generation or
    edit, waits until the fake upstream is blocked before its first yield,
@@ -69,9 +73,11 @@ must finish despite active cancellation.
   preserves the original terminal, and leaves the reservation eligible for the
   existing stale-reclamation backstop. This exceptional fallback does not
   weaken normal request-owned cleanup.
-- **`GeneratorExit` may not be delivered by current ASGI cancellation paths.**
-  Handling it at the same ownership seam is safe and prevents an equivalent
-  leak if an async-generator consumer closes priming directly.
+- **Synchronous coroutine close cannot await cleanup.** Calling `.close()` on
+  the suspended priming coroutine injects `GeneratorExit` and rejects any
+  attempted suspension. The handler therefore leaves `GeneratorExit` to normal
+  coroutine unwinding instead of pretending asynchronous cleanup can complete;
+  the Images HTTP routes use task cancellation and deliver `CancelledError`.
 - **Post-first-event cancellation is distinct.** Existing translated-stream
   finalization owns that lifecycle and remains unchanged by keeping this catch
   limited to the initial `__anext__` call.

--- a/openspec/changes/fix-images-cancel-reservation/proposal.md
+++ b/openspec/changes/fix-images-cancel-reservation/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Limited-API-key image generation and edit requests can be cancelled while the
+Images adapter is awaiting the first upstream SSE frame. That cancellation
+currently bypasses the adapter's error callback, leaving its route-owned usage
+reservation charged until stale reclamation instead of releasing it during the
+request lifecycle.
+
+## What Changes
+
+- Release the Images route-owned API-key reservation when cancellation or
+  generator termination interrupts first-frame priming.
+- Close the upstream iterator and complete reservation cleanup despite active
+  cancellation, then propagate the original terminal unchanged.
+- Keep cleanup failures diagnostic-only so they cannot replace the original
+  cancellation or generator termination.
+- Add route-level regression coverage for both `/v1/images/generations` and
+  `/v1/images/edits`, proving exactly-once release before the first upstream
+  frame while preserving existing post-first-frame image settlement.
+- Keep the existing `ProxyResponseError` branch, captured-token finalization,
+  billing, stale-reclamation policy, and external response shapes unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Require immediate, exactly-once cleanup of an Images route-owned
+  limited-key reservation when cancellation interrupts upstream stream priming.
+
+## Impact
+
+The change is limited to first-frame priming in `app/modules/proxy/api.py`, the
+Images integration regression surface, and the API-key reservation lifecycle
+contract. It completes the pre-terminal cancellation path that was explicitly
+outside the scope of PR #1822. It adds no API, setting, dependency, migration,
+dashboard change, or alternate settlement owner.

--- a/openspec/changes/fix-images-cancel-reservation/proposal.md
+++ b/openspec/changes/fix-images-cancel-reservation/proposal.md
@@ -8,12 +8,12 @@ request lifecycle.
 
 ## What Changes
 
-- Release the Images route-owned API-key reservation when cancellation or
-  generator termination interrupts first-frame priming.
+- Release the Images route-owned API-key reservation when cancellation
+  interrupts first-frame priming.
 - Close the upstream iterator and complete reservation cleanup despite active
   cancellation, then propagate the original terminal unchanged.
 - Keep cleanup failures diagnostic-only so they cannot replace the original
-  cancellation or generator termination.
+  cancellation.
 - Add route-level regression coverage for both `/v1/images/generations` and
   `/v1/images/edits`, proving exactly-once release before the first upstream
   frame while preserving existing post-first-frame image settlement.

--- a/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
@@ -45,12 +45,24 @@ for normal request-owned cleanup.
 - **AND** the original `CancelledError` propagates after cleanup completes
 - **AND** stale-reservation reclamation is not required for that request
 
-#### Scenario: Failed pre-first-frame cleanup preserves the original terminal
+#### Scenario: Failed upstream close does not prevent reservation release
 
 - **GIVEN** cancellation interrupts Images stream priming before the first
   upstream SSE event
-- **WHEN** closing the upstream iterator or releasing the route-owned
-  reservation fails
-- **THEN** the proxy logs the cleanup failure
+- **WHEN** closing the upstream iterator fails but the route-owned reservation
+  release succeeds
+- **THEN** the proxy logs the close failure
+- **AND** the Images route releases its reservation exactly once
+- **AND** the reservation reaches `released` state and its reserved quota is
+  restored
 - **AND** the original `CancelledError` propagates unchanged
-- **AND** a still-reserved reservation remains eligible for stale reclamation
+- **AND** stale-reservation reclamation is not required for that request
+
+#### Scenario: Failed reservation release preserves the original cancellation
+
+- **GIVEN** cancellation interrupts Images stream priming before the first
+  upstream SSE event
+- **WHEN** releasing the route-owned reservation fails
+- **THEN** the proxy logs the release failure
+- **AND** the original `CancelledError` propagates unchanged
+- **AND** the still-reserved reservation remains eligible for stale reclamation

--- a/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
@@ -4,13 +4,13 @@
 
 Usage reservation의 최종 정산(finalize 또는 release)은 요청 단위에서 정확히 1회 수행되어야 한다. 재시도 가능한 중간 attempt에서는 정산을 defer하고, 요청 종료 시점에서 단일 지점이 정산 책임을 갖는다. 시스템은 이 동작을 SHALL 보장해야 한다.
 
-When an Images route owns a limited API-key reservation and cancellation or
-generator termination interrupts the first upstream SSE read, the system MUST
-close the upstream iterator, MUST finish the route-owned release attempt despite
-active cancellation, and MUST then propagate the original terminal unchanged.
-A failed close or release MUST be logged and MUST NOT replace the original
-terminal. Stale reclamation MUST remain an exceptional backstop and MUST NOT
-substitute for normal request-owned cleanup.
+When an Images route owns a limited API-key reservation and cancellation
+interrupts the first upstream SSE read, the system MUST close the upstream
+iterator, MUST finish the route-owned release attempt despite active
+cancellation, and MUST then propagate the original `CancelledError`. A failed
+close or release MUST be logged and MUST NOT replace the original cancellation.
+Stale reclamation MUST remain an exceptional backstop and MUST NOT substitute
+for normal request-owned cleanup.
 
 #### Scenario: 스트림 401 → refresh retry 성공 시 finalize 1회
 
@@ -47,11 +47,10 @@ substitute for normal request-owned cleanup.
 
 #### Scenario: Failed pre-first-frame cleanup preserves the original terminal
 
-- **GIVEN** cancellation or generator termination interrupts Images stream
-  priming before the first upstream SSE event
+- **GIVEN** cancellation interrupts Images stream priming before the first
+  upstream SSE event
 - **WHEN** closing the upstream iterator or releasing the route-owned
   reservation fails
 - **THEN** the proxy logs the cleanup failure
-- **AND** the original cancellation or generator termination propagates
-  unchanged
+- **AND** the original `CancelledError` propagates unchanged
 - **AND** a still-reserved reservation remains eligible for stale reclamation

--- a/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-images-cancel-reservation/specs/api-keys/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Reservation 정산 exactly-once 보장
+
+Usage reservation의 최종 정산(finalize 또는 release)은 요청 단위에서 정확히 1회 수행되어야 한다. 재시도 가능한 중간 attempt에서는 정산을 defer하고, 요청 종료 시점에서 단일 지점이 정산 책임을 갖는다. 시스템은 이 동작을 SHALL 보장해야 한다.
+
+When an Images route owns a limited API-key reservation and cancellation or
+generator termination interrupts the first upstream SSE read, the system MUST
+close the upstream iterator, MUST finish the route-owned release attempt despite
+active cancellation, and MUST then propagate the original terminal unchanged.
+A failed close or release MUST be logged and MUST NOT replace the original
+terminal. Stale reclamation MUST remain an exceptional backstop and MUST NOT
+substitute for normal request-owned cleanup.
+
+#### Scenario: 스트림 401 → refresh retry 성공 시 finalize 1회
+
+- **WHEN** 첫 `_stream_once()` attempt에서 401을 수신하고 계정 refresh 후 재시도가 성공하면
+- **THEN** 첫 attempt에서는 reservation 정산이 수행되지 않아야 한다 (SHALL)
+- **AND** 최종 성공 시점에서 `finalize_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+- **AND** 실제 token 사용량이 quota에 반영되어야 한다 (SHALL)
+
+#### Scenario: 스트림 401 → retry 소진 실패 시 release 1회
+
+- **WHEN** 401 후 재시도를 모두 소진하여 요청이 최종 실패하면
+- **THEN** `release_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+- **AND** 예약된 quota가 원복되어야 한다 (SHALL)
+
+#### Scenario: 스트림 성공 시 finalize 1회
+
+- **WHEN** `_stream_once()`가 retry 없이 첫 attempt에서 성공하면
+- **THEN** `finalize_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+
+#### Scenario: Cancelled Images priming releases its route-owned reservation
+
+- **GIVEN** a limited API key has created an Images route-owned reservation for
+  `/v1/images/generations` or `/v1/images/edits`
+- **AND** the internal Responses stream has no API-key reservation owner
+- **WHEN** request cancellation interrupts the first upstream SSE read before
+  any event is yielded
+- **THEN** the upstream iterator is closed
+- **AND** the Images route finishes releasing its reservation exactly once
+  despite active cancellation
+- **AND** the reservation reaches `released` state and its reserved quota is
+  restored
+- **AND** the original `CancelledError` propagates after cleanup completes
+- **AND** stale-reservation reclamation is not required for that request
+
+#### Scenario: Failed pre-first-frame cleanup preserves the original terminal
+
+- **GIVEN** cancellation or generator termination interrupts Images stream
+  priming before the first upstream SSE event
+- **WHEN** closing the upstream iterator or releasing the route-owned
+  reservation fails
+- **THEN** the proxy logs the cleanup failure
+- **AND** the original cancellation or generator termination propagates
+  unchanged
+- **AND** a still-reserved reservation remains eligible for stale reclamation

--- a/openspec/changes/fix-images-cancel-reservation/tasks.md
+++ b/openspec/changes/fix-images-cancel-reservation/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add deterministic route-level coverage for limited-key image generation and edit requests cancelled while the first upstream SSE read is blocked.
+- [x] 1.2 Confirm the regression fails on baseline because cancellation propagates but the route-owned reservation is not released exactly once.
+- [x] 1.3 Add focused priming coverage for cleanup ordering, repeated cancellation, explicit iterator close, and cleanup-failure terminal preservation.
+
+## 2. First-Frame Cancellation Cleanup
+
+- [x] 2.1 Close the upstream iterator and invoke the Images-owned error callback through cancellation-deferring cleanup when `CancelledError` or `GeneratorExit` interrupts first-frame priming.
+- [x] 2.2 Preserve the original terminal when cleanup fails, retain existing `ProxyResponseError` behavior, and leave post-first-frame image billing and captured-token finalization unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Run the new generation/edit cancellation regression and the complete Images integration test file.
+- [x] 3.2 Run Ruff check on every changed Python file.
+- [x] 3.3 Run scoped and repository-spec OpenSpec validation and verify the change artifacts are coherent.
+- [x] 3.4 Inspect the final diff and worktree status for scope, simplicity, and unrelated changes.

--- a/openspec/changes/fix-images-cancel-reservation/tasks.md
+++ b/openspec/changes/fix-images-cancel-reservation/tasks.md
@@ -6,8 +6,9 @@
 
 ## 2. First-Frame Cancellation Cleanup
 
-- [x] 2.1 Close the upstream iterator and invoke the Images-owned error callback through cancellation-deferring cleanup when `CancelledError` or `GeneratorExit` interrupts first-frame priming.
+- [x] 2.1 Close the upstream iterator and invoke the Images-owned error callback through cancellation-deferring cleanup when `CancelledError` interrupts first-frame priming.
 - [x] 2.2 Preserve the original terminal when cleanup fails, retain existing `ProxyResponseError` behavior, and leave post-first-frame image billing and captured-token finalization unchanged.
+- [x] 2.3 Reproduce synchronous coroutine-close `GeneratorExit`, document why it cannot await cleanup, and keep request-owned asynchronous cleanup limited to `CancelledError`.
 
 ## 3. Verification
 

--- a/openspec/changes/fix-images-cancel-reservation/tasks.md
+++ b/openspec/changes/fix-images-cancel-reservation/tasks.md
@@ -16,3 +16,4 @@
 - [x] 3.2 Run Ruff check on every changed Python file.
 - [x] 3.3 Run scoped and repository-spec OpenSpec validation and verify the change artifacts are coherent.
 - [x] 3.4 Inspect the final diff and worktree status for scope, simplicity, and unrelated changes.
+- [x] 3.5 Distinguish iterator-close and reservation-release failure outcomes so stale reclamation remains conditional on release failure.

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -20,6 +20,7 @@ import pytest
 from httpx import AsyncByteStream
 from sqlalchemy import select
 from starlette.datastructures import UploadFile
+from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 import app.modules.proxy.api as proxy_api_module
@@ -1402,6 +1403,211 @@ async def test_images_generations_propagates_upstream_error_before_first_chunk(a
     assert response.status_code == 503
     body = response.json()
     assert body["error"]["code"] == "upstream_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["generations", "edits"])
+async def test_image_routes_cancel_before_first_upstream_frame_release_reservation(
+    async_client,
+    monkeypatch,
+    route,
+):
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": f"images-{route}-cancel-before-first-frame",
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "weekly",
+                    "maxValue": 1_000_000,
+                },
+            ],
+        },
+    )
+    assert created.status_code == 200, created.text
+    key_payload = created.json()
+    api_key = key_payload["key"]
+    api_key_id = key_payload["id"]
+
+    await _import_account(
+        async_client,
+        f"acc_images_{route}_cancel_prime",
+        f"img-{route}-cancel-prime@example.com",
+    )
+
+    upstream_entered = asyncio.Event()
+    upstream_closed = asyncio.Event()
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        **kwargs,
+    ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        upstream_entered.set()
+        try:
+            if False:  # pragma: no cover - generator marker only
+                yield ""
+            await asyncio.Event().wait()
+        finally:
+            upstream_closed.set()
+
+    async def fake_ensure_fresh(self, account, **kwargs):
+        del self, kwargs
+        return account
+
+    from app.modules.api_keys.service import ApiKeysService
+
+    release_calls: list[str] = []
+    release_started = asyncio.Event()
+    release_allowed = asyncio.Event()
+    release_completed = asyncio.Event()
+    original_release = ApiKeysService.release_usage_reservation
+
+    async def tracked_release(self, reservation_id):
+        release_calls.append(reservation_id)
+        release_started.set()
+        await release_allowed.wait()
+        await original_release(self, reservation_id)
+        release_completed.set()
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+    monkeypatch.setattr(ApiKeysService, "release_usage_reservation", tracked_release)
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if route == "generations":
+        request = async_client.post(
+            "/v1/images/generations",
+            headers=headers,
+            json={
+                "model": "gpt-image-2",
+                "prompt": "cancel before first frame",
+                "size": "1024x1024",
+                "quality": "low",
+            },
+        )
+    else:
+        request = async_client.post(
+            "/v1/images/edits",
+            headers=headers,
+            data={
+                "model": "gpt-image-2",
+                "prompt": "cancel before first frame",
+                "size": "1024x1024",
+                "quality": "low",
+            },
+            files={
+                "image": (
+                    "source.png",
+                    b"\x89PNG\r\n\x1a\n" + b"\x00" * 16,
+                    "image/png",
+                ),
+            },
+        )
+
+    request_task = asyncio.create_task(request)
+    await asyncio.wait_for(upstream_entered.wait(), timeout=1.0)
+    request_task.cancel()
+
+    await asyncio.wait_for(release_started.wait(), timeout=1.0)
+    assert upstream_closed.is_set()
+    assert not request_task.done()
+
+    request_task.cancel()
+    await asyncio.sleep(0)
+    assert not request_task.done()
+
+    release_allowed.set()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+    assert release_completed.is_set()
+
+    async with SessionLocal() as session:
+        reservations = (
+            (
+                await session.execute(
+                    select(ApiKeyUsageReservation).where(ApiKeyUsageReservation.api_key_id == api_key_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(reservations) == 1
+        reservation = reservations[0]
+        assert release_calls == [reservation.id]
+        assert reservation.status == "released"
+
+        limits = await ApiKeysRepository(session).get_limits_by_key(api_key_id)
+        assert len(limits) == 1
+        assert limits[0].current_value == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected_log"),
+    [
+        ("close", "Failed to close Images upstream stream after first-frame termination"),
+        ("release", "Failed to run Images first-frame termination cleanup"),
+    ],
+)
+async def test_prime_upstream_stream_cleanup_failure_preserves_original_cancellation(
+    caplog,
+    failure,
+    expected_log,
+):
+    cancellation = asyncio.CancelledError("upstream cancelled")
+    close_calls = 0
+    release_calls = 0
+
+    class _CancelledIterator:
+        def __aiter__(self) -> _CancelledIterator:
+            return self
+
+        async def __anext__(self) -> str:
+            raise cancellation
+
+        async def aclose(self) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            if failure == "close":
+                raise RuntimeError("simulated close failure")
+
+    async def on_error() -> None:
+        nonlocal release_calls
+        release_calls += 1
+        if failure == "release":
+            raise RuntimeError("simulated release failure")
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/images/generations",
+            "headers": [],
+        }
+    )
+    iterator = _CancelledIterator()
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await proxy_api_module._prime_upstream_stream(
+                request,
+                iterator,
+                {},
+                on_error=on_error,
+            )
+
+    assert exc_info.value is cancellation
+    assert close_calls == 1
+    assert release_calls == 1
+    assert expected_log in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Release route-owned limited-API-key reservations when image generation or edit requests are cancelled before the first upstream SSE frame. Without this cleanup, reserved quota remains charged until stale reclamation.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: No covering issue exists, so this PR intentionally has no `Fixes #N` / `Closes #N` footer.

## Root cause

Both Images routes intentionally pass `api_key_reservation=None` into the internal Responses stream and retain sole settlement ownership. `_prime_upstream_stream` invoked their `on_error` release callback for `ProxyResponseError`, but `asyncio.CancelledError` from the first `__anext__()` bypassed that branch. No remaining owner released the reservation.

## Fix

- catch `CancelledError` only around first-frame priming
- close the upstream iterator and run the existing Images-owned `on_error` callback through cancellation-deferring cleanup
- attempt release even when iterator close fails, log cleanup failures, and propagate the original cancellation
- leave `GeneratorExit` to normal coroutine unwinding: `_prime_upstream_stream` is a normal coroutine, synchronous `.close()` cannot suspend for async cleanup, and FastAPI request disconnects cancel the owning task with `CancelledError`
- preserve the existing `ProxyResponseError` branch, internal reservation-free stream, post-first-frame billing, and captured-token finalization
- cover both `/v1/images/generations` and `/v1/images/edits` with limited-key route regressions that prove ordered, exactly-once release under repeated cancellation

This is the residual pre-terminal path that PR #1822 explicitly excluded while fixing post-completion image settlement ownership.

Refs #1822

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful image path and preserves its request/response/SSE wire behavior

Change directory: `openspec/changes/fix-images-cancel-reservation/`

Validation:

- `uv run openspec validate fix-images-cancel-reservation --strict` — valid
- `uv run openspec validate api-keys --strict` — valid
- `uv run openspec validate --specs` — 50 passed, with the same 8 pre-existing main-spec failures; affected `api-keys` and `images-api-compat` specs pass

## Test evidence

RED on baseline:

- generation and edit cancellation cases both propagated `CancelledError` but timed out waiting for reservation release

GREEN:

```text
uv run pytest -q tests/integration/test_proxy_images.py::test_image_routes_cancel_before_first_upstream_frame_release_reservation tests/integration/test_proxy_images.py::test_prime_upstream_stream_cleanup_failure_preserves_original_cancellation
4 passed

uv run pytest -q tests/integration/test_proxy_images.py
63 passed

uv run pytest -q tests/unit/test_proxy_utils.py::test_external_stream_startup_waits_for_single_account_response_create_capacity
4 passed

uv run ruff check app/modules/proxy/api.py tests/integration/test_proxy_images.py
All checks passed!
```

The review-found `GeneratorExit` reproduction changed from `RuntimeError: coroutine ignored GeneratorExit` with a skipped release callback to clean, non-suspending coroutine close; the confirmed HTTP disconnect path remains covered through `CancelledError`. Full local CI was not run; required GitHub CI remains the integration gate.

## Simplicity

No setting, dependency, migration, README section, dashboard navigation item, setup step, or default changes.

## Screenshots / output

Not applicable; this changes cancellation-time reservation cleanup without changing public Images output.

## Checklist

- [x] Conventional Commit title
- [x] Regression coverage at the failing generation/edit route surface
- [x] Focused tests and Ruff passed
- [x] Scoped OpenSpec validation passed
- [x] Simplicity gates reviewed
- [x] `CHANGELOG.md` was not edited


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed image generation and editing requests so cancelled connections promptly release reserved API-key capacity.
  - Ensured upstream streams are closed during cancellation before the first image response.
  - Preserved the original cancellation error even if cleanup encounters an issue.

- **Tests**
  - Added coverage for cancellation during initial image response handling and cleanup failures across generation and editing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->