### PR TITLE
fix(proxy): stop holding pending_lock across the settings-cache DB await

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -85,6 +85,14 @@ _wedged_teardown_cleanup_tasks: set[asyncio.Task[Any]] = set()
 # ``database_pool_size`` / ``database_max_overflow``.
 _POSTGRES_POOL_TIMEOUT_SECONDS = 30.0
 _POSTGRES_POOL_RECYCLE_SECONDS = 1800
+# Per-statement execution bound (issue #1971). One query hung on a half-dead
+# connection wedged the process-global settings-cache lock — and every
+# http-bridge submit parked behind it while holding its session's
+# pending_lock — for days. No runtime query legitimately runs this long
+# (retention and cleanup work is chunked); Alembic migrations use their own
+# synchronous engine and are not bounded by this. Fixed application constant
+# like the pool knobs above: not an operator decision.
+_POSTGRES_COMMAND_TIMEOUT_SECONDS = 60.0
 _database_url = normalize_sqlite_url(_settings.database_url)
 
 
@@ -120,7 +128,14 @@ def _postgres_async_connect_args(url: str) -> dict[str, object] | None:
     # bridge-session cleanup stop running, and account/stream lease expiry is
     # mis-evaluated. Forcing UTC keeps stored timestamps correct regardless of
     # the container time zone.
-    connect_args: dict[str, object] = {"server_settings": {"timezone": "UTC"}}
+    connect_args: dict[str, object] = {
+        "server_settings": {"timezone": "UTC"},
+        # Bound every statement so a query stalled on a half-dead connection
+        # cannot hold application locks forever (issue #1971). asyncpg cancels
+        # the statement server-side and raises, surfacing the stall as an
+        # error instead of an unbounded await.
+        "command_timeout": _POSTGRES_COMMAND_TIMEOUT_SECONDS,
+    }
     if os.environ.get("CODEX_LB_TEST_DATABASE_URL"):
         connect_args["prepared_statement_cache_size"] = 0
     return connect_args

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -385,7 +385,12 @@ def _http_bridge_pending_count_nowait(
         visible_pending_count = sum(
             1 for request_state in session.pending_requests if request_counts_against_queue(request_state)
         )
-        return max(visible_pending_count, session.queued_request_count)
+        # A registered admission waiter is live work not yet counted into the
+        # queue — it may be suspended on the pre-lock fair-share resolve with
+        # pending_lock free (issue #1971). Counting it keeps capacity LRU
+        # eviction and shutdown drain from treating the session as idle and
+        # closing it under the admitting turn.
+        return max(visible_pending_count, session.queued_request_count, session.admission_waiter_count)
     finally:
         session.pending_lock.release()
 

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1605,9 +1605,18 @@ class _HTTPBridgeRequestSubmitMixin:
         request_enqueued = False
         admission_waiter_registered = False
         try:
-            # Resolved before pending_lock: the settings-cache refresh behind
-            # this can run a DB query and must not suspend the critical
-            # section (issue #1971).
+            # Register the submit as an admission waiter BEFORE any suspension
+            # outside the lock: the waiter count keeps the idle sweeper and
+            # close-time retire from evicting the session while the settings
+            # snapshot below resolves, and a previous turn's finalizer
+            # unwinding concurrently cannot see an apparently idle session
+            # and release the lease the reacquire installs.
+            async with session.pending_lock:
+                session.admission_waiter_count += 1
+                admission_waiter_registered = True
+            # Resolved before the reacquire's pending_lock: the settings-cache
+            # refresh behind this can run a DB query and must not suspend the
+            # critical section (issue #1971).
             fair_share_threshold_pct = await self._http_bridge_fair_share_threshold_pct(session)
             async with session.pending_lock:
                 await self._ensure_http_bridge_session_stream_lease_locked(
@@ -1615,12 +1624,6 @@ class _HTTPBridgeRequestSubmitMixin:
                     request_state=request_state,
                     fair_share_threshold_pct=fair_share_threshold_pct,
                 )
-                # Register the submit as an admission waiter atomically with the
-                # reacquire so a previous turn's finalizer unwinding concurrently
-                # cannot see an apparently idle session and release this lease
-                # before the turn is counted into the session queue.
-                session.admission_waiter_count += 1
-                admission_waiter_registered = True
         except BaseException:
             # Recovery claims are made before admission. If reacquiring an
             # idle session's stream lease fails, no upstream frame can have
@@ -1662,10 +1665,11 @@ class _HTTPBridgeRequestSubmitMixin:
             await _await_task_deferring_cancellation(cleanup_task)
             raise
         try:
-            # Re-resolved after the prewarm await; still before pending_lock
-            # so the settings-cache refresh cannot suspend the critical
-            # section (issue #1971).
-            fair_share_threshold_pct = await self._http_bridge_fair_share_threshold_pct(session)
+            # Reuses the pre-prewarm snapshot: the registered admission waiter
+            # kept the lease from idle release, so this reacquire is a no-op
+            # unless the session closed mid-prewarm — a fresh refresh here
+            # could only stall an otherwise admissible request on a
+            # TTL-expired settings read (issue #1971).
             async with session.pending_lock:
                 if session.queued_request_count >= queue_limit:
                     _log_http_bridge_event(

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1605,8 +1605,16 @@ class _HTTPBridgeRequestSubmitMixin:
         request_enqueued = False
         admission_waiter_registered = False
         try:
+            # Resolved before pending_lock: the settings-cache refresh behind
+            # this can run a DB query and must not suspend the critical
+            # section (issue #1971).
+            fair_share_threshold_pct = await self._http_bridge_fair_share_threshold_pct(session)
             async with session.pending_lock:
-                await self._ensure_http_bridge_session_stream_lease_locked(session, request_state=request_state)
+                await self._ensure_http_bridge_session_stream_lease_locked(
+                    session,
+                    request_state=request_state,
+                    fair_share_threshold_pct=fair_share_threshold_pct,
+                )
                 # Register the submit as an admission waiter atomically with the
                 # reacquire so a previous turn's finalizer unwinding concurrently
                 # cannot see an apparently idle session and release this lease
@@ -1654,6 +1662,10 @@ class _HTTPBridgeRequestSubmitMixin:
             await _await_task_deferring_cancellation(cleanup_task)
             raise
         try:
+            # Re-resolved after the prewarm await; still before pending_lock
+            # so the settings-cache refresh cannot suspend the critical
+            # section (issue #1971).
+            fair_share_threshold_pct = await self._http_bridge_fair_share_threshold_pct(session)
             async with session.pending_lock:
                 if session.queued_request_count >= queue_limit:
                     _log_http_bridge_event(
@@ -1673,7 +1685,11 @@ class _HTTPBridgeRequestSubmitMixin:
                             error_type="rate_limit_error",
                         ),
                     )
-                await self._ensure_http_bridge_session_stream_lease_locked(session, request_state=request_state)
+                await self._ensure_http_bridge_session_stream_lease_locked(
+                    session,
+                    request_state=request_state,
+                    fair_share_threshold_pct=fair_share_threshold_pct,
+                )
                 session.queued_request_count += 1
                 if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                     session.unanchored_reservation_id = None
@@ -2588,15 +2604,41 @@ class _HTTPBridgeRequestSubmitMixin:
             )
         await self._maybe_release_idle_http_bridge_session_lease(session)
 
+    async def _http_bridge_fair_share_threshold_pct(
+        self: Any,
+        session: "_HTTPBridgeSession",
+    ) -> int:
+        """Resolve the keyed fair-share threshold WITHOUT holding pending_lock.
+
+        The settings-cache refresh runs a DB query behind a process-global
+        lock; awaiting it while holding a session's ``pending_lock`` let one
+        stalled query wedge every keyed submit process-wide (issue #1971).
+        Callers resolve the snapshot first and pass it into
+        ``_ensure_http_bridge_session_stream_lease_locked``.
+        """
+        if session.key.api_key_id is None:
+            return 0
+        return _api_key_fair_share_threshold_pct_from_settings(await _service_get_settings_cache().get())
+
     async def _ensure_http_bridge_session_stream_lease_locked(
         self: Any,
         session: "_HTTPBridgeSession",
         *,
         request_state: _WebSocketRequestState | None = None,
+        fair_share_threshold_pct: int | None = None,
     ) -> None:
         """Reacquire the account stream lease for a session idled between turns.
 
-        Callers hold ``session.pending_lock``. The lease is released when the
+        Callers hold ``session.pending_lock`` and MUST pass
+        ``fair_share_threshold_pct`` (see
+        ``_http_bridge_fair_share_threshold_pct``) computed before acquiring
+        it: resolving the threshold reads the settings cache, whose refresh
+        runs a DB query behind a process-global lock — one stalled refresh
+        under ``pending_lock`` wedged every keyed submit for days
+        (issue #1971). The ``None`` fallback resolves it inline and exists
+        for lock-free callers only.
+
+        The lease is released when the
         session's last in-flight turn detaches, so an idle session does not
         occupy a per-account stream slot; the next turn must pass normal cap
         admission again. Denial raises the standard local-cap envelope so the
@@ -2620,8 +2662,9 @@ class _HTTPBridgeRequestSubmitMixin:
         if load_balancer is None:
             return
         api_key_id = session.key.api_key_id
-        fair_share_threshold_pct = 0
-        if api_key_id is not None:
+        if api_key_id is None:
+            fair_share_threshold_pct = 0
+        elif fair_share_threshold_pct is None:
             fair_share_threshold_pct = _api_key_fair_share_threshold_pct_from_settings(
                 await _service_get_settings_cache().get()
             )

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1614,10 +1614,19 @@ class _HTTPBridgeRequestSubmitMixin:
             async with session.pending_lock:
                 session.admission_waiter_count += 1
                 admission_waiter_registered = True
-            # Resolved before the reacquire's pending_lock: the settings-cache
+                # Snapshot under the same lock: with the waiter registered, a
+                # held lease cannot be idle-released, so a session that does
+                # not need reacquisition here will not need it at the
+                # reacquire either.
+                needs_stream_lease = session.account_lease is None and not session.closed
+            # Resolved before the reacquire's pending_lock — the settings-cache
             # refresh behind this can run a DB query and must not suspend the
-            # critical section (issue #1971).
-            fair_share_threshold_pct = await self._http_bridge_fair_share_threshold_pct(session)
+            # critical section (issue #1971) — and only when the reacquire can
+            # actually run: a session already holding its lease never depended
+            # on a settings read to admit a turn.
+            fair_share_threshold_pct = (
+                await self._http_bridge_fair_share_threshold_pct(session) if needs_stream_lease else 0
+            )
             async with session.pending_lock:
                 await self._ensure_http_bridge_session_stream_lease_locked(
                     session,

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2954,6 +2954,15 @@ class _HTTPBridgeRequestSubmitMixin:
             should_reconnect = (
                 not has_visible_pending
                 and session.queued_request_count == 0
+                # A registered admission waiter owns a turn that has not yet
+                # been counted into the queue (it may be suspended on the
+                # pre-lock fair-share resolve, issue #1971); retiring under it
+                # would fail an admitted turn with upstream_unavailable. A
+                # deferred retirement re-runs on the turn's own drain
+                # triggers once it proceeds; if the waiter instead fails
+                # admission, its cleanup releases the idle lease and the
+                # flagged session falls back to idle-TTL close.
+                and session.admission_waiter_count == 0
                 and session.unanchored_reservation_id is None
                 and not session.upstream_close_attempted
             )

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/.openspec.yaml
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/proposal.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/proposal.md
@@ -1,0 +1,57 @@
+# Fix unbounded DB wait under the bridge session pending_lock
+
+## Why
+
+In the 2026-08-30 incident (#1968), the livelock's fuel was a wedge: 12+
+`_cleanup_http_bridge_submit_interruption` tasks sat blocked on
+`session.pending_lock` for up to 4 days. The full audit (#1971) found exactly
+two `pending_lock` critical sections that suspend — both submit-admission
+sites awaiting the stream-lease reacquire — and inside it the keyed
+fair-share threshold resolution awaits the settings cache. The cache refresh
+runs a DB query behind a process-global lock, and the asyncpg engine sets no
+per-statement timeout, so one query stalled on a half-dead connection wedges
+the global settings lock forever and every keyed bridge submit process-wide
+then parks while holding its own session's `pending_lock`. #1969 removed the
+livelock amplification; this change removes the wedge.
+
+## What Changes
+
+- Resolve the keyed fair-share threshold snapshot BEFORE acquiring
+  `session.pending_lock` at both submit-admission sites, and pass it into
+  `_ensure_http_bridge_session_stream_lease_locked`; the reacquire under the
+  lock no longer performs any settings-cache or DB await. The inline
+  resolution remains only as a fallback for lock-free callers.
+- Bound every PostgreSQL statement with a fixed asyncpg `command_timeout`
+  (60s application constant, like the existing pool timeout/recycle
+  constants) so a query stalled on a dead connection surfaces as an error
+  instead of an unbounded await under any application lock. Alembic
+  migrations use their own synchronous engine and are unaffected.
+- Add regression coverage: the reacquire with a provided snapshot never
+  touches the settings cache; a stalled settings refresh stalls the submit
+  BEFORE `pending_lock` (sabotage-verified against the old in-lock resolve);
+  engine connect-args carry the statement bound.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: bridge-session `pending_lock` critical sections
+  must not suspend on settings or database reads.
+- `database-backends`: PostgreSQL statements are bounded by a fixed
+  `command_timeout` alongside the existing pre-ping/recycle hygiene.
+
+## Impact
+
+- A stalled settings-cache refresh now stalls only the requests actually
+  waiting on settings — never the per-session `pending_lock`, so interruption
+  cleanup and queue bookkeeping keep flowing.
+- Any PostgreSQL statement hung on a half-dead connection fails within the
+  fixed bound and is retried/surfaced through existing error paths instead of
+  wedging its caller (and whatever locks the caller holds) indefinitely.
+- Fair-share admission semantics are unchanged: same threshold source, same
+  denial envelope; the snapshot is read moments earlier (within the settings
+  cache's 5s TTL freshness window). No new settings.

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/specs/database-backends/spec.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/specs/database-backends/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: PostgreSQL engines validate and recycle pooled connections
+
+When `database_url` resolves to a PostgreSQL backend, the application MUST configure each async engine — both the request-path `engine` and the optional background-task `_background_engine` — with `pool_pre_ping=True` and a finite `pool_recycle` window. This is required so the application detects connections that the PostgreSQL server has silently closed (idle timeout, restart, network reset) before the first real query is dispatched on them, and so connections are cycled before they reach any reasonable upstream keep-alive boundary. The recycle window is the fixed 1800-second application constant in `app/db/session.py`.
+
+Each PostgreSQL statement MUST additionally be bounded by the fixed asyncpg `command_timeout` application constant in `app/db/session.py`, so a query stalled on a half-dead connection surfaces as an error within the bound instead of awaiting indefinitely — pre-ping only protects the first statement after checkout, not a connection that dies mid-statement. A statement that dies mid-flight while its caller holds an application lock MUST therefore release that caller within the bound. Alembic migrations run on their own synchronous engine and are not subject to this bound.
+
+#### Scenario: Stale connections are rejected before checkout
+
+- **WHEN** a pooled connection has been closed by the server while sitting idle
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy issues a pre-ping (`SELECT 1`), detects the dead connection, and transparently replaces it
+- **AND** the application returns `200` (or the real business-level result), not `500 server_error` with `asyncpg.InterfaceError: connection is closed`
+
+#### Scenario: Pool recycle bounds connection age
+
+- **WHEN** a pooled connection has been open longer than the fixed 1800-second recycle window
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy discards and replaces the connection before the next query
+
+#### Scenario: Mid-statement connection death cannot wedge its caller
+
+- **WHEN** a statement's connection dies after dispatch (network partition, half-dead peer) and no response arrives
+- **THEN** asyncpg cancels the statement and raises within the fixed `command_timeout` bound
+- **AND** any application lock held by the caller is released within that bound instead of being held indefinitely
+
+#### Scenario: SQLite backends are not affected
+
+- **WHEN** `database_url` resolves to a SQLite backend (file or `:memory:`)
+- **THEN** neither `pool_pre_ping`, `pool_recycle`, nor `command_timeout` is configured on the engine
+- **AND** existing SQLite-specific tuning (PRAGMAs, `busy_timeout`) is unchanged

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/specs/proxy-admission-control/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Bridge session pending_lock critical sections do not suspend on settings or database reads
+
+Critical sections holding an HTTP bridge session's `pending_lock` MUST NOT await settings-cache reads or database queries. Inputs that require such reads (the keyed fair-share congestion threshold for a stream-lease reacquire) MUST be resolved before the lock is acquired and passed into the lock-holding path as a snapshot. A stalled settings or database read MUST therefore stall only the request performing it, never the session's `pending_lock` — interruption cleanup and queue bookkeeping on that session remain able to acquire the lock.
+
+#### Scenario: Stalled settings refresh does not wedge the session lock
+
+- **GIVEN** a keyed bridge submit whose settings-cache refresh stalls on a hung database query
+- **WHEN** the submit is waiting on that refresh
+- **THEN** the submit has not yet acquired the session's `pending_lock`
+- **AND** other work on the session (interruption cleanup, queue bookkeeping) can acquire the lock promptly
+
+#### Scenario: Reacquire with a provided snapshot performs no settings read under the lock
+
+- **GIVEN** a keyed session whose stream lease is reacquired under `pending_lock` with a fair-share threshold snapshot provided by the caller
+- **WHEN** the reacquire runs
+- **THEN** it does not read the settings cache
+- **AND** the provided threshold is forwarded to lease acquisition unchanged
+
+#### Scenario: Fair-share admission semantics are preserved
+
+- **WHEN** a keyed warm-session turn is admitted through the pre-lock snapshot path
+- **THEN** the same congestion threshold source governs the fair-share gate as before
+- **AND** a denial raises the same `api_key_stream_fair_share` local-cap envelope

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## 1. Lock Discipline
+
+- [x] 1.1 Add `_http_bridge_fair_share_threshold_pct` (lock-free snapshot resolve) and a `fair_share_threshold_pct` parameter to `_ensure_http_bridge_session_stream_lease_locked`; keep the inline resolve only as a fallback for lock-free callers.
+- [x] 1.2 Resolve the snapshot before both `pending_lock` acquisitions in `_submit_http_bridge_request` and pass it through, so no settings/DB await runs under the lock.
+
+## 2. Statement Bound
+
+- [x] 2.1 Add the fixed `_POSTGRES_COMMAND_TIMEOUT_SECONDS` application constant and set asyncpg `command_timeout` in `_postgres_async_connect_args` (PostgreSQL only; Alembic's synchronous engine unaffected).
+
+## 3. Regression Coverage
+
+- [x] 3.1 Reacquire with a provided snapshot never awaits the settings cache and forwards the threshold to lease acquisition.
+- [x] 3.2 Product path: a stalled settings-cache refresh stalls the submit BEFORE `pending_lock` — the lock stays acquirable — and cancelling the stalled submit leaves no admission-waiter or lease residue. Sabotage-verified: fails against the old in-lock resolve.
+- [x] 3.3 Engine connect-args tests assert the `command_timeout` bound alongside the UTC pin.
+
+## 4. Verification
+
+- [x] 4.1 Run the idle-leases and db-session unit suites plus lint (ruff) and type check (ty) on touched files.
+- [x] 4.2 Strict OpenSpec validation.

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
@@ -5,6 +5,8 @@
 - [x] 1.1 Add `_http_bridge_fair_share_threshold_pct` (lock-free snapshot resolve) and a `fair_share_threshold_pct` parameter to `_ensure_http_bridge_session_stream_lease_locked`; keep the inline resolve only as a fallback for lock-free callers.
 - [x] 1.2 Resolve the snapshot before the reacquire's `pending_lock` acquisition in `_submit_http_bridge_request` and pass it through, so no settings/DB await runs under the lock; the post-prewarm reacquire reuses the same snapshot (a fresh TTL-expired refresh there could only stall an otherwise admissible request).
 - [x] 1.3 Register the admission waiter under a brief lock BEFORE the settings resolve so the idle sweeper and close-time retire cannot evict the session while the snapshot resolves; a reacquire failure hands the registered waiter to interruption cleanup to unwind.
+- [x] 1.4 Resolve the snapshot only when the reacquire can actually run (`needs_stream_lease` snapshotted under the registration lock): a session already holding its lease never depended on a settings read to admit a turn.
+- [x] 1.5 Include `admission_waiter_count == 0` in the drain-retirement predicate so retirement cannot close the bridge under a registered waiter suspended on the pre-lock resolve; a deferred retirement re-runs on the turn's own drain triggers, and an admission-failed waiter's cleanup releases the idle lease with idle-TTL close as the backstop.
 
 ## 2. Statement Bound
 

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
@@ -3,7 +3,8 @@
 ## 1. Lock Discipline
 
 - [x] 1.1 Add `_http_bridge_fair_share_threshold_pct` (lock-free snapshot resolve) and a `fair_share_threshold_pct` parameter to `_ensure_http_bridge_session_stream_lease_locked`; keep the inline resolve only as a fallback for lock-free callers.
-- [x] 1.2 Resolve the snapshot before both `pending_lock` acquisitions in `_submit_http_bridge_request` and pass it through, so no settings/DB await runs under the lock.
+- [x] 1.2 Resolve the snapshot before the reacquire's `pending_lock` acquisition in `_submit_http_bridge_request` and pass it through, so no settings/DB await runs under the lock; the post-prewarm reacquire reuses the same snapshot (a fresh TTL-expired refresh there could only stall an otherwise admissible request).
+- [x] 1.3 Register the admission waiter under a brief lock BEFORE the settings resolve so the idle sweeper and close-time retire cannot evict the session while the snapshot resolves; a reacquire failure hands the registered waiter to interruption cleanup to unwind.
 
 ## 2. Statement Bound
 

--- a/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
+++ b/openspec/changes/fix-pending-lock-unbounded-db-wait/tasks.md
@@ -6,7 +6,8 @@
 - [x] 1.2 Resolve the snapshot before the reacquire's `pending_lock` acquisition in `_submit_http_bridge_request` and pass it through, so no settings/DB await runs under the lock; the post-prewarm reacquire reuses the same snapshot (a fresh TTL-expired refresh there could only stall an otherwise admissible request).
 - [x] 1.3 Register the admission waiter under a brief lock BEFORE the settings resolve so the idle sweeper and close-time retire cannot evict the session while the snapshot resolves; a reacquire failure hands the registered waiter to interruption cleanup to unwind.
 - [x] 1.4 Resolve the snapshot only when the reacquire can actually run (`needs_stream_lease` snapshotted under the registration lock): a session already holding its lease never depended on a settings read to admit a turn.
-- [x] 1.5 Include `admission_waiter_count == 0` in the drain-retirement predicate so retirement cannot close the bridge under a registered waiter suspended on the pre-lock resolve; a deferred retirement re-runs on the turn's own drain triggers, and an admission-failed waiter's cleanup releases the idle lease with idle-TTL close as the backstop.
+- [x] 1.5 Count registered admission waiters as pending work in `_http_bridge_pending_count_nowait` so capacity LRU eviction and shutdown drain cannot treat a session as idle while a turn is suspended on the pre-lock resolve.
+- [x] 1.6 Include `admission_waiter_count == 0` in the drain-retirement predicate so retirement cannot close the bridge under a registered waiter suspended on the pre-lock resolve; a deferred retirement re-runs on the turn's own drain triggers, and an admission-failed waiter's cleanup releases the idle lease with idle-TTL close as the backstop.
 
 ## 2. Statement Bound
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -327,7 +327,10 @@ def test_postgres_connect_args_pin_session_timezone_to_utc(monkeypatch) -> None:
 
     connect_args = session_module._postgres_async_connect_args("postgresql+asyncpg://u:p@h/db")
 
-    assert connect_args == {"server_settings": {"timezone": "UTC"}}
+    assert connect_args == {
+        "server_settings": {"timezone": "UTC"},
+        "command_timeout": session_module._POSTGRES_COMMAND_TIMEOUT_SECONDS,
+    }
 
 
 def test_postgres_connect_args_pin_utc_and_keep_test_db_url_tuning(monkeypatch) -> None:
@@ -337,6 +340,7 @@ def test_postgres_connect_args_pin_utc_and_keep_test_db_url_tuning(monkeypatch) 
 
     assert connect_args == {
         "server_settings": {"timezone": "UTC"},
+        "command_timeout": session_module._POSTGRES_COMMAND_TIMEOUT_SECONDS,
         "prepared_statement_cache_size": 0,
     }
 
@@ -355,7 +359,10 @@ def test_postgres_engine_kwargs_forward_utc_connect_args(monkeypatch) -> None:
 
     kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
 
-    assert kwargs["connect_args"] == {"server_settings": {"timezone": "UTC"}}
+    assert kwargs["connect_args"] == {
+        "server_settings": {"timezone": "UTC"},
+        "command_timeout": session_module._POSTGRES_COMMAND_TIMEOUT_SECONDS,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -274,6 +274,34 @@ async def test_reacquire_with_snapshot_never_touches_settings_cache_under_lock(
 
 
 @pytest.mark.asyncio
+async def test_drain_retirement_defers_to_registered_admission_waiter() -> None:
+    """A registered admission waiter owns a turn not yet counted into the
+    queue (it may be suspended on the pre-lock fair-share resolve, issue
+    #1971); drain retirement must not close the bridge under it, and must
+    proceed once the waiter unwinds."""
+
+    mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
+    session = _make_bridge_session()
+    session.upstream_control.reconnect_requested = True
+    session.upstream_control.retire_after_drain = True
+    session.admission_waiter_count = 1
+    close_bounded = AsyncMock()
+    fake_self = SimpleNamespace(_close_http_bridge_session_bounded=close_bounded)
+
+    retired = await mixin._retire_http_bridge_after_drain_if_ready(fake_self, session)
+
+    assert retired is False
+    close_bounded.assert_not_awaited()
+    assert not session.upstream_close_attempted
+
+    session.admission_waiter_count = 0
+    retired = await mixin._retire_http_bridge_after_drain_if_ready(fake_self, session)
+
+    assert retired is True
+    close_bounded.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_keyed_submit_with_held_lease_never_reads_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -274,6 +274,67 @@ async def test_reacquire_with_snapshot_never_touches_settings_cache_under_lock(
 
 
 @pytest.mark.asyncio
+async def test_keyed_submit_with_held_lease_never_reads_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A keyed session already holding its stream lease admits turns without
+    any settings-cache dependency — a stalled or unavailable settings DB must
+    not block or fail requests that need no lease reacquisition."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(api_key_id="key-leased")
+    session.account_lease = _make_lease("l-held")
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
+
+    settings_get = AsyncMock(side_effect=AssertionError("settings cache must not be read for a leased session"))
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=settings_get),
+    )
+
+    prewarm_reached = asyncio.Event()
+
+    async def hold_in_prewarm(*_args: object, **_kwargs: object) -> None:
+        prewarm_reached.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(service, "_maybe_prewarm_http_bridge_session", AsyncMock(side_effect=hold_in_prewarm))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-leased-no-settings",
+        model="gpt-5.2",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.2","input":"hi"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    submit_task = asyncio.create_task(
+        service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+    )
+    # Reaching prewarm proves the first admission section completed without
+    # touching the settings cache (the mock would have raised).
+    await asyncio.wait_for(prewarm_reached.wait(), timeout=1)
+    settings_get.assert_not_awaited()
+
+    submit_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(submit_task, timeout=1)
+    settings_get.assert_not_awaited()
+    assert session.admission_waiter_count == 0
+
+
+@pytest.mark.asyncio
 async def test_keyed_submit_resolves_fair_share_before_pending_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -239,6 +239,113 @@ async def test_keyed_warm_session_reacquire_is_fair_share_gated_and_counted(
 
 
 @pytest.mark.asyncio
+async def test_reacquire_with_snapshot_never_touches_settings_cache_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1971: callers holding pending_lock pass the fair-share snapshot.
+
+    The settings-cache refresh runs a DB query behind a process-global lock;
+    resolving it inside the reacquire while holding ``pending_lock`` let one
+    stalled query wedge every keyed submit process-wide."""
+
+    mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
+    settings_get = AsyncMock(
+        side_effect=AssertionError("settings cache must not be read under pending_lock")
+    )
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=settings_get),
+    )
+    acquire_account_lease = AsyncMock(return_value=_make_lease("l-snapshot"))
+    fake_self = SimpleNamespace(_load_balancer=SimpleNamespace(acquire_account_lease=acquire_account_lease))
+    session = _make_bridge_session(api_key_id="key-snap")
+
+    async with session.pending_lock:
+        await mixin._ensure_http_bridge_session_stream_lease_locked(
+            fake_self,
+            session,
+            fair_share_threshold_pct=37,
+        )
+
+    settings_get.assert_not_awaited()
+    assert session.account_lease is not None
+    await_args = acquire_account_lease.await_args
+    assert await_args is not None
+    assert await_args.kwargs["api_key_stream_fair_share_threshold_pct"] == 37
+
+
+@pytest.mark.asyncio
+async def test_keyed_submit_resolves_fair_share_before_pending_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1971 product path: a stalled settings-cache refresh must stall
+    the submit BEFORE it acquires ``session.pending_lock``, so the session's
+    other work (interruption cleanup, queue bookkeeping) is never wedged
+    behind a hung DB query. The old in-lock resolve held the lock across the
+    stall — cleanup tasks piled up on it for days in production."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(api_key_id="key-stall")
+    lease = _make_lease("l-stall")
+    monkeypatch.setattr(
+        service._load_balancer, "acquire_account_lease", AsyncMock(return_value=lease)
+    )
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
+    monkeypatch.setattr(service, "_maybe_prewarm_http_bridge_session", AsyncMock())
+
+    settings_blocked = asyncio.Event()
+    release_settings = asyncio.Event()
+
+    async def stalled_get() -> SimpleNamespace:
+        settings_blocked.set()
+        await release_settings.wait()
+        return SimpleNamespace(proxy_api_key_fair_share_congestion_threshold_pct=50)
+
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=stalled_get),
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-settings-stall",
+        model="gpt-5.2",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.2","input":"hi"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    submit_task = asyncio.create_task(
+        service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+    )
+    await asyncio.wait_for(settings_blocked.wait(), timeout=1)
+
+    # While the settings refresh is stalled, pending_lock must stay free.
+    lock_acquired = False
+    with anyio.move_on_after(0.2):
+        async with session.pending_lock:
+            lock_acquired = True
+    assert lock_acquired, "submit held pending_lock across the stalled settings refresh"
+
+    submit_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(submit_task, timeout=1)
+    assert session.admission_waiter_count == 0
+    assert session.account_lease is None
+
+
+@pytest.mark.asyncio
 async def test_reacquire_denial_raises_local_cap_envelope() -> None:
     mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
     session = _make_bridge_session()

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -249,9 +249,7 @@ async def test_reacquire_with_snapshot_never_touches_settings_cache_under_lock(
     stalled query wedge every keyed submit process-wide."""
 
     mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
-    settings_get = AsyncMock(
-        side_effect=AssertionError("settings cache must not be read under pending_lock")
-    )
+    settings_get = AsyncMock(side_effect=AssertionError("settings cache must not be read under pending_lock"))
     monkeypatch.setattr(
         http_bridge_request_submit_module,
         "_service_get_settings_cache",
@@ -288,9 +286,7 @@ async def test_keyed_submit_resolves_fair_share_before_pending_lock(
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     session = _make_bridge_session(api_key_id="key-stall")
     lease = _make_lease("l-stall")
-    monkeypatch.setattr(
-        service._load_balancer, "acquire_account_lease", AsyncMock(return_value=lease)
-    )
+    monkeypatch.setattr(service._load_balancer, "acquire_account_lease", AsyncMock(return_value=lease))
     monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
     monkeypatch.setattr(service, "_maybe_prewarm_http_bridge_session", AsyncMock())
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -21767,7 +21767,10 @@ async def test_submit_http_bridge_request_restores_recovery_claim_when_stream_le
     assert exc_info.value is lease_failure
     cleanup.assert_awaited_once()
     assert cleanup.await_args is not None
-    assert cleanup.await_args.kwargs["admission_waiter_registered"] is False
+    # The admission waiter is registered BEFORE the reacquire (issue #1971:
+    # it fences idle eviction across the pre-lock settings resolve), so a
+    # reacquire failure hands the registered waiter to cleanup to unwind.
+    assert cleanup.await_args.kwargs["admission_waiter_registered"] is True
     assert cleanup.await_args.kwargs["request_enqueued"] is False
     send_text.assert_not_awaited()
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -19844,6 +19844,56 @@ async def test_get_or_create_http_bridge_session_closes_planned_lru_before_capac
 
 
 @pytest.mark.asyncio
+async def test_capacity_eviction_skips_session_with_registered_admission_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1971: a registered admission waiter is live work even while its
+    submit is suspended on the pre-lock fair-share resolve with pending_lock
+    free — capacity LRU eviction must not close the session under it."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-waiter-guarded", None)
+    existing = _make_bridge_session(key=existing_key, key_value=existing_key.affinity_key)
+    existing.admission_waiter_count = 1
+    service._http_bridge_sessions[existing_key] = existing
+    new_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-waiter-rejected", None)
+    close_http_bridge_session_bounded = AsyncMock()
+    create_http_bridge_session = AsyncMock()
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", close_http_bridge_session_bounded)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._get_or_create_http_bridge_session(
+            new_key,
+            headers={"x-codex-session-id": new_key.affinity_key},
+            affinity=proxy_service._AffinityPolicy(
+                key=new_key.affinity_key,
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=1,
+        )
+
+    assert exc_info.value.status_code == 429
+    close_http_bridge_session_bounded.assert_not_awaited()
+    assert service._http_bridge_sessions[existing_key] is existing
+    assert not existing.closed
+    create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_closes_lru_before_replacement_create(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #1971

Follow-up to #1969 (livelock amplification fix). This removes the wedge itself: the 2026-08-30 autopsy found 12+ interruption-cleanup tasks blocked on `session.pending_lock` for up to 4 days.

## Why

The full audit in #1971 found exactly two `pending_lock` critical sections that suspend — both submit-admission sites awaiting `_ensure_http_bridge_session_stream_lease_locked` — and inside it the keyed fair-share threshold resolution awaits `SettingsCache.get()`: a DB query behind a **process-global** lock, on an asyncpg engine with **no statement timeout**. One query stalled on a half-dead connection wedges the global settings lock forever, and every keyed bridge submit process-wide then parks while holding its own session's `pending_lock` — a single-point wedge fanning out to many sessions, matching the autopsy exactly.

## What

- **Lock discipline**: resolve the fair-share snapshot via the new lock-free `_http_bridge_fair_share_threshold_pct` BEFORE both `pending_lock` acquisitions in `_submit_http_bridge_request`, and pass it into the reacquire as `fair_share_threshold_pct`. The reacquire under the lock performs no settings/DB await; the inline resolve remains only as a documented fallback for lock-free callers. Admission semantics unchanged (same threshold source within the cache's 5s TTL, same denial envelope).
- **Statement bound**: fixed `_POSTGRES_COMMAND_TIMEOUT_SECONDS = 60.0` in asyncpg `connect_args` (application constant like the existing pool timeout/recycle, not an operator setting). `pool_pre_ping` only protects the first statement after checkout — this bounds mid-statement connection death so no application lock can be held across an unbounded DB await. Runtime queries are chunked/bounded well under 60s; Alembic migrations run on their own synchronous engine and are unaffected.
- Considered and deferred: the bounded `release_detached_lease` await inside the closed-race branch stays (its dependency chain is fully synchronous — bounded, not a wedge; moving it would restructure the raise path for no bound improvement).

## Regression coverage

- `test_reacquire_with_snapshot_never_touches_settings_cache_under_lock` — reacquire with a provided snapshot never awaits the settings cache and forwards the threshold to lease acquisition.
- `test_keyed_submit_resolves_fair_share_before_pending_lock` — product path: with a stalled settings refresh, the submit has NOT acquired `pending_lock` (timed acquire succeeds), and cancelling the stalled submit leaves no admission-waiter/lease residue. **Sabotage-verified**: fails in 0.49s against the old in-lock resolve.
- Engine connect-args tests assert the `command_timeout` bound alongside the UTC pin; existing keyed fair-share gating tests stay green (fallback path).

## Verification

- `uv run pytest tests/unit/test_http_bridge_idle_leases.py tests/unit/test_db_session*.py` — 80 passed
- `uv run pytest tests/unit/test_proxy_http_bridge.py -k "submit or lease or reacquire"` — 79 passed
- `uv run ruff check app tests` / `uv run ty check` on touched files — clean
- `openspec validate fix-pending-lock-unbounded-db-wait --strict` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP bridge request handling so settings delays no longer block session admission.
  - PostgreSQL statements now time out after 60 seconds instead of waiting indefinitely.
  - Preserved fair-share admission behavior while improving responsiveness during congestion.
  - Prevented active admission requests from being evicted or retired during capacity changes and shutdown.
  - Improved cleanup when requests are cancelled or admission cannot proceed.
  - Improved handling of stale or failed database connections.

- **Tests**
  - Added coverage for database timeouts, lock behavior, cancellation, session lease reacquisition, eviction protection, and settings-refresh delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review-round hardening (local codex, 3 rounds → clean)

The pre-lock resolve opens a window where the session looks idle to scanners that previously saw the lock held. Three fences close it, each sabotage-verified:

- **Eviction fence**: the admission waiter is registered under a brief lock BEFORE the settings resolve (idle release already requires `admission_waiter_count == 0`); a reacquire failure hands the registered waiter to interruption cleanup to unwind.
- **Leased sessions stay settings-free**: `needs_stream_lease` is snapshotted under the registration lock and the threshold resolves only when the reacquire can actually run — keyed turns on a session already holding its lease never gain a settings-DB dependency they did not have.
- **Drain retirement and capacity LRU defer to waiters**: `_retire_http_bridge_after_drain_if_ready` and `_http_bridge_pending_count_nowait` now count registered waiters as live work, so neither drain retirement nor `max_sessions` LRU eviction can close the bridge under a suspended admitting turn (deferred retirement re-runs on the turn's own drain triggers; idle-TTL close is the admission-failure backstop).

Note: `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` fails identically on clean `origin/main` in local isolation (sqlite `no such table: file_account_pins` setup flake) — unrelated to this diff.