### PR TITLE
fix(proxy): name the pre-response eventless timeout honestly and derive its budget from settings

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -302,6 +302,10 @@ class Settings(BaseSettings):
     http_responses_session_bridge_codex_prewarm_enabled: bool = False
     http_responses_session_bridge_stuck_gate_retire_after_seconds: float = Field(default=300.0, gt=0)
     http_responses_session_bridge_anchor_poison_failure_threshold: int = Field(default=7, ge=1, le=100)
+    # Cap on server-owned recovery attempts while the client stream is held
+    # open after an eligible eventless terminal (`server_indefinite_recovery`
+    # mode). Once exhausted, the bridge emits one terminal `response.failed`.
+    http_responses_session_bridge_server_recovery_max_attempts: int = Field(default=6, ge=1, le=100)
     http_responses_session_bridge_max_sessions: int = Field(default=256, gt=0)
     http_responses_session_bridge_queue_limit: int = Field(default=8, gt=0)
     http_responses_session_bridge_clean_close_retry_jitter_max_seconds: float = Field(

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -43,6 +43,24 @@ class ResponseFailedEvent(TypedDict):
 
 
 PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE = "Upstream websocket closed before response.completed"
+# Local bridge recovery (fresh replay, context-overflow rollover, previous
+# response rebind) tears down our own upstream session. It is not an upstream
+# close and must not be reported as one.
+HTTP_BRIDGE_LOCAL_RESET_MESSAGE = "HTTP responses session bridge reset this session locally before response.completed"
+# ``stream_incomplete`` raised against a continuation anchor is ambiguous: the
+# turn may already exist upstream. Neither of these messages proves the account
+# misbehaved, so neither may drive an account-health penalty.
+STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES = frozenset(
+    {
+        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+        HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
+    }
+)
+# Pre-response-start bridge silence. Distinct from ``stream_idle_timeout``,
+# whose budget (``stream_idle_timeout_seconds``) only governs gaps *after*
+# ``response.created``. Nothing was created upstream, so a retry forks no
+# context and the client may safely repeat the request.
+HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE = "bridge_eventless_timeout"
 PREVIOUS_RESPONSE_NOT_FOUND_CODE = "previous_response_not_found"
 PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE = "Previous response was not found; retry without previous_response_id."
 

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -58,8 +58,10 @@ STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES = frozenset(
 )
 # Pre-response-start bridge silence. Distinct from ``stream_idle_timeout``,
 # whose budget (``stream_idle_timeout_seconds``) only governs gaps *after*
-# ``response.created``. Nothing was created upstream, so a retry forks no
-# context and the client may safely repeat the request.
+# ``response.created``. When the bridge saw no unmatched upstream liveness,
+# nothing was created upstream and a retry forks no context. If liveness was
+# observed but not matched to a response, callers must treat retry as
+# at-least-once.
 HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE = "bridge_eventless_timeout"
 PREVIOUS_RESPONSE_NOT_FOUND_CODE = "previous_response_not_found"
 PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE = "Previous response was not found; retry without previous_response_id."

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -96,6 +96,11 @@ _HARD_STICKY_UNAVAILABLE_STATUSES = frozenset(
 _HARD_STICKY_OUTAGE_GRACE_SEEDED_SENTINEL = "hard_sticky_outage_grace_seeded"
 
 
+def _is_missing_hard_sticky_seed_table(exc: OperationalError) -> bool:
+    message = str(exc).lower()
+    return "no such table: runtime_sentinels" in message or "no such table: accounts" in message
+
+
 @dataclass(frozen=True, slots=True)
 class AccountRequestUsageSummary:
     request_count: int
@@ -883,20 +888,26 @@ class AccountsRepository:
             .on_conflict_do_nothing(index_elements=[RuntimeSentinel.name])
             .returning(RuntimeSentinel.name)
         )
-        async with sqlite_writer_section():
-            stamp_result = await self._session.execute(stamp_stmt)
-            stamped_by_this_boot = stamp_result.scalar_one_or_none() is not None
-            if not stamped_by_this_boot:
+        try:
+            async with sqlite_writer_section():
+                stamp_result = await self._session.execute(stamp_stmt)
+                stamped_by_this_boot = stamp_result.scalar_one_or_none() is not None
+                if not stamped_by_this_boot:
+                    await self._session.commit()
+                    return 0
+                account_ids = (
+                    await self._session.scalars(
+                        select(Account.id).where(Account.status.in_(_HARD_STICKY_UNAVAILABLE_STATUSES))
+                    )
+                ).all()
+                for account_id in account_ids:
+                    await self._refresh_hard_sticky_outage_grace(account_id)
                 await self._session.commit()
-                return 0
-            account_ids = (
-                await self._session.scalars(
-                    select(Account.id).where(Account.status.in_(_HARD_STICKY_UNAVAILABLE_STATUSES))
-                )
-            ).all()
-            for account_id in account_ids:
-                await self._refresh_hard_sticky_outage_grace(account_id)
-            await self._session.commit()
+        except OperationalError as exc:
+            if not _is_missing_hard_sticky_seed_table(exc):
+                raise
+            await self._session.rollback()
+            return 0
         return len(account_ids)
 
     async def _close_http_bridge_sessions_for_account(self, account_id: str) -> None:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -97,6 +97,19 @@ _HARD_STICKY_OUTAGE_GRACE_SEEDED_SENTINEL = "hard_sticky_outage_grace_seeded"
 
 
 def _is_missing_hard_sticky_seed_table(exc: OperationalError) -> bool:
+    """Return True when startup grace seeding hit a not-yet-migrated database.
+
+    ``seed_hard_sticky_outage_grace_on_startup`` runs unguarded in the app
+    lifespan. With ``database_migrate_on_startup=false`` (operator-managed
+    migrations) the process can boot against a legacy database that does not
+    have ``runtime_sentinels`` (or, on a brand-new file, ``accounts``) yet;
+    before this guard that boot crashed with an unhandled sqlite
+    ``OperationalError``. The seeding is a best-effort one-time backfill: on a
+    missing table it rolls back and returns 0 without stamping the sentinel,
+    so the first boot after migrations run still performs the backfill. Only
+    the sqlite "no such table" shape is matched — this deployment mode boots
+    sqlite before migration; every other OperationalError still propagates.
+    """
     message = str(exc).lower()
     return "no such table: runtime_sentinels" in message or "no such table: accounts" in message
 

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -674,7 +674,6 @@ def _http_bridge_denied_anchor_fence_advanced(
     )
 
 
-
 # Silence before ``response.created`` is a different failure class than a
 # stream that started and then went quiet. When no unmatched upstream liveness
 # was observed, nothing exists upstream yet, so the request is safe to retry and

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -676,14 +676,18 @@ def _http_bridge_denied_anchor_fence_advanced(
 
 
 # Silence before ``response.created`` is a different failure class than a
-# stream that started and then went quiet. Nothing exists upstream yet, so the
-# request is safe to retry and the upstream is not proven at fault. Keep it out
-# of ``stream_idle_timeout``, whose budget is the post-start
-# ``stream_idle_timeout_seconds``.
+# stream that started and then went quiet. When no unmatched upstream liveness
+# was observed, nothing exists upstream yet, so the request is safe to retry and
+# the upstream is not proven at fault. Keep it out of ``stream_idle_timeout``,
+# whose budget is the post-start ``stream_idle_timeout_seconds``.
 _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL = HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
 _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE = (
     "HTTP responses session bridge saw no response events before its pre-response budget expired; "
     "no response was created upstream, so the request is safe to retry"
+)
+_HTTP_BRIDGE_EVENTLESS_TIMEOUT_UNMATCHED_LIVENESS_MESSAGE = (
+    "HTTP responses session bridge saw upstream liveness before its pre-response budget expired, "
+    "but no response events were matched; retry may duplicate upstream work"
 )
 _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE = (
     "HTTP responses session bridge is cooling down after repeated upstream timeouts; retry shortly."
@@ -710,6 +714,12 @@ _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR = "http_bridge_prepared_continuity_anchor"
 _HTTP_BRIDGE_COOLDOWN_SUPPRESSION_ATTR = "http_bridge_cooldown_suppression"
 _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
 _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
+
+
+def _http_bridge_eventless_timeout_message(unmatched_upstream_liveness_count: int) -> str:
+    if unmatched_upstream_liveness_count > 0:
+        return _HTTP_BRIDGE_EVENTLESS_TIMEOUT_UNMATCHED_LIVENESS_MESSAGE
+    return _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
 
 
 async def _await_task_deferring_cancellation(

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import json
 import logging
+import math
 import sys
 import time
 from collections.abc import Callable, Coroutine, Sequence
@@ -43,6 +44,8 @@ from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # 
 from app.core.config.settings import Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import (
+    HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
+    HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
     openai_error,
@@ -671,6 +674,23 @@ def _http_bridge_denied_anchor_fence_advanced(
     )
 
 
+
+# Silence before ``response.created`` is a different failure class than a
+# stream that started and then went quiet. Nothing exists upstream yet, so the
+# request is safe to retry and the upstream is not proven at fault. Keep it out
+# of ``stream_idle_timeout``, whose budget is the post-start
+# ``stream_idle_timeout_seconds``.
+_HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL = HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
+_HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE = (
+    "HTTP responses session bridge saw no response events before its pre-response budget expired; "
+    "no response was created upstream, so the request is safe to retry"
+)
+_HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE = (
+    "HTTP responses session bridge is cooling down after repeated upstream timeouts; retry shortly."
+)
+# Local bridge recovery closes and rebuilds our own upstream session. Reserve
+# upstream-close wording for frames the upstream actually sent.
+_HTTP_BRIDGE_LOCAL_RESET_MESSAGE = HTTP_BRIDGE_LOCAL_RESET_MESSAGE
 T = TypeVar("T")
 
 _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
@@ -3531,6 +3551,61 @@ def _http_bridge_request_budget_seconds(settings: object) -> float:
     )
 
 
+def _http_bridge_eventless_budget_seconds(settings: object, *, fallback_seconds: float) -> float:
+    """Named pre-response-start silence budget for the downstream bridge stream.
+
+    Before ``response.created`` the downstream event queue is silent by design,
+    so ``stream_idle_timeout_seconds`` (a *post-start* inter-event budget) does
+    not describe this phase at all. The honest bound is the owner-side stuck
+    gate: once ``http_responses_session_bridge_stuck_gate_retire_after_seconds``
+    retires the pending handoff there is nothing left for the client to wait
+    for. Clamp to the stream-idle and bridge-request budgets so the pre-response
+    watchdog can never outlive the request it guards.
+
+    ``fallback_seconds`` is used when a caller's settings object does not carry
+    ``stream_idle_timeout_seconds`` at all.
+    """
+
+    stuck_gate_seconds = float(
+        getattr(settings, "http_responses_session_bridge_stuck_gate_retire_after_seconds", 300.0)
+    )
+    stream_idle_timeout_seconds = float(getattr(settings, "stream_idle_timeout_seconds", fallback_seconds))
+    return max(
+        0.001,
+        min(
+            stuck_gate_seconds,
+            stream_idle_timeout_seconds,
+            _http_bridge_request_budget_seconds(settings),
+        ),
+    )
+
+
+def _http_bridge_eventless_max_keepalive_count(
+    settings: object,
+    *,
+    keepalive_interval_seconds: float,
+    floor_count: int,
+) -> int:
+    """Keepalive ticks the downstream stream waits before ``response.created``.
+
+    Derived from :func:`_http_bridge_eventless_budget_seconds` instead of the
+    implicit ``_STREAM_KEEPALIVE_MAX_COUNT * sse_keepalive_interval_seconds``
+    product, which silently encoded a ~60s pre-response deadline that had no
+    relationship to any configured timeout.
+    """
+
+    interval_seconds = max(0.001, keepalive_interval_seconds)
+    minimum_count = max(1, floor_count)
+    budget_seconds = _http_bridge_eventless_budget_seconds(
+        settings,
+        fallback_seconds=interval_seconds * minimum_count,
+    )
+    derived_count = max(1, math.ceil(budget_seconds / interval_seconds))
+    if minimum_count * interval_seconds <= budget_seconds:
+        return max(minimum_count, derived_count)
+    return derived_count
+
+
 def _http_bridge_admission_timeout_seconds(
     request_state: _WebSocketRequestState,
     admission_timeout_seconds: float,
@@ -3559,6 +3634,32 @@ def _http_bridge_owner_check_required(
 
 def _http_bridge_key_strength(key: _HTTPBridgeSessionKey) -> str:
     return key.strength or "soft"
+
+
+# Frames the bridge injects into its own downstream streams. They prove the
+# proxy is alive, never that the upstream is.
+_HTTP_BRIDGE_LOCALLY_INJECTED_EVENT_TYPES = frozenset({"codex.keepalive"})
+
+
+def _http_bridge_event_proves_upstream_liveness(event_type: str | None) -> bool:
+    """Return whether an event type is upstream traffic rather than our own."""
+
+    if not event_type:
+        return False
+    return event_type not in _HTTP_BRIDGE_LOCALLY_INJECTED_EVENT_TYPES
+
+
+def _record_http_bridge_unmatched_upstream_liveness(
+    session: "_HTTPBridgeSession",
+    *,
+    event_type: str | None,
+) -> int:
+    """Count an upstream frame that proved liveness but matched no request."""
+
+    if not _http_bridge_event_proves_upstream_liveness(event_type):
+        return session.unmatched_upstream_liveness_count
+    session.unmatched_upstream_liveness_count += 1
+    return session.unmatched_upstream_liveness_count
 
 
 def _log_http_bridge_event(

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import anyio
 
+from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, http_bridge_retry_circuit_total
 from app.modules.proxy._service.observability import _hash_identifier
 from app.modules.proxy._service.support import (
@@ -31,11 +32,16 @@ _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_DETAILS = frozenset(
         "stream_incomplete",
         "clean_close",
         "stream_idle_timeout",
+        # Pre-response-start bridge silence. Deliberately *not* aliased onto
+        # stream_idle_timeout: the whole point is that a circuit opened before
+        # any response existed must be distinguishable from one opened by a
+        # started stream going quiet.
+        HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
     }
 )
 _HTTP_BRIDGE_RETRY_CIRCUIT_DETAIL_ALIASES = {
     # These diagnostics describe the same ambiguous idle/incomplete
-    # transport class. Keep the durable contract to the three documented
+    # transport class. Keep the durable contract to the documented
     # failure classes while retaining the more specific event in logs.
     "upstream_keepalive_timeout": "stream_idle_timeout",
     "missing_response_created_timeout": "stream_idle_timeout",

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -582,6 +582,14 @@ class _HTTPBridgeSessionRegistryMixin:
                 )
                 if lookup.owner_instance_id == current_instance:
                     break
+                if lookup.owner_instance_id is None and claim_attempt == 0:
+                    # The lookup used to decide ``allow_takeover`` can race a
+                    # concurrent close/release. If the first claim lands after
+                    # ownership has already been cleared, retry once with the
+                    # forced epoch-advance path instead of treating an ownerless
+                    # row as a foreign replica.
+                    await asyncio.sleep(0)
+                    continue
                 if not allow_takeover or claim_attempt > 0:
                     break
                 if not _http_bridge_allow_durable_takeover(lookup):

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -77,7 +77,6 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _HTTP_BRIDGE_COOLDOWN_SUPPRESSION_ATTR,
     _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
     _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
     _HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
     _HTTP_BRIDGE_PRE_SUBMIT_FAILURE_ATTR,
     _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR,
@@ -88,6 +87,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_durable_lookup_allows_turn_state_takeover,
     _http_bridge_eventless_budget_seconds,
     _http_bridge_eventless_max_keepalive_count,
+    _http_bridge_eventless_timeout_message,
     _http_bridge_is_context_overflow_error,
     _http_bridge_is_explicit_previous_response_rejection,
     _http_bridge_is_previous_response_owner_unavailable,
@@ -3942,6 +3942,7 @@ class _HTTPBridgeStreamingMixin:
                 )
                 mark_bridge_eventless_failure()
                 await record_bridge_eventless_timeout_failure()
+                eventless_message = _http_bridge_eventless_timeout_message(session.unmatched_upstream_liveness_count)
                 if getattr(
                     _service_get_settings(),
                     "http_responses_session_bridge_ambiguous_continuation_recovery_mode",
@@ -3951,7 +3952,7 @@ class _HTTPBridgeStreamingMixin:
                         503,
                         openai_error(
                             _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-                            _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+                            eventless_message,
                             error_type="server_error",
                         ),
                     ) from exc
@@ -3962,7 +3963,7 @@ class _HTTPBridgeStreamingMixin:
                             Mapping[str, JsonValue],
                             response_failed_event(
                                 _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-                                _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+                                eventless_message,
                                 response_id=downstream_response_id,
                             ),
                         )
@@ -4095,12 +4096,13 @@ class _HTTPBridgeStreamingMixin:
             await self._release_websocket_request_state_reservation(request_state)
             request_state.api_key_reservation = None
             mark_bridge_eventless_failure()
+            eventless_message = _http_bridge_eventless_timeout_message(session.unmatched_upstream_liveness_count)
             if propagate_http_errors:
                 raise ProxyResponseError(
                     503,
                     openai_error(
                         _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+                        eventless_message,
                         error_type="server_error",
                     ),
                 )
@@ -4109,7 +4111,7 @@ class _HTTPBridgeStreamingMixin:
                     Mapping[str, JsonValue],
                     response_failed_event(
                         _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+                        eventless_message,
                         response_id=_websocket_downstream_response_id(request_state),
                     ),
                 )
@@ -4777,12 +4779,15 @@ class _HTTPBridgeStreamingMixin:
                                             eventless_budget_seconds,
                                             session.unmatched_upstream_liveness_count,
                                         )
+                                        eventless_message = _http_bridge_eventless_timeout_message(
+                                            session.unmatched_upstream_liveness_count
+                                        )
                                         yield format_sse_event(
                                             cast(
                                                 Mapping[str, JsonValue],
                                                 response_failed_event(
                                                     _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
-                                                    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+                                                    eventless_message,
                                                     response_id=downstream_response_id,
                                                 ),
                                             )

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -37,6 +37,7 @@ from app.core.clients.proxy import compact_responses as core_compact_responses  
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
 from app.core.clients.proxy_websocket import UpstreamWebSocketTransportError
 from app.core.errors import (
+    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorEnvelope,
     openai_error,
     response_failed_event,
@@ -74,6 +75,10 @@ from app.modules.proxy._service.compact import (
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _HTTP_BRIDGE_COOLDOWN_SUPPRESSION_ATTR,
+    _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
+    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
+    _HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
     _HTTP_BRIDGE_PRE_SUBMIT_FAILURE_ATTR,
     _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR,
     _bind_http_bridge_proxy_injected_anchor,
@@ -81,6 +86,8 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _effective_http_bridge_idle_ttl_seconds,
     _http_bridge_durable_lease_ttl_seconds,
     _http_bridge_durable_lookup_allows_turn_state_takeover,
+    _http_bridge_eventless_budget_seconds,
+    _http_bridge_eventless_max_keepalive_count,
     _http_bridge_is_context_overflow_error,
     _http_bridge_is_explicit_previous_response_rejection,
     _http_bridge_is_previous_response_owner_unavailable,
@@ -149,6 +156,9 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _websocket_event_error_param,
     _websocket_event_error_type,
 )
+from app.modules.proxy._service.http_bridge.upstream_events import (
+    _abandon_durable_http_bridge_continuity,
+)
 from app.modules.proxy._service.observability import (
     _hash_identifier as _hash_identifier,
 )
@@ -174,6 +184,7 @@ from app.modules.proxy._service.support import (
     _DeferredAccountBackoffTracker,
     _event_type_from_payload,
     _HTTPBridgeOwnerForward,
+    _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _is_local_account_cap_code,
@@ -508,7 +519,7 @@ def _http_bridge_dead_owner_previous_response_not_found_terminal(
             cast(str, error["message"]),
             error_type=cast(str, error["type"]),
             response_id=response_id,
-            error_param=cast(str, error["param"]),
+            error_param=cast(str | None, error["param"]),
         ),
     )
 
@@ -575,6 +586,10 @@ _HTTP_BRIDGE_AMBIGUOUS_RECOVERY_ERROR_CODES = frozenset(
         "stream_incomplete",
         "stream_idle_timeout",
         "upstream_request_timeout",
+        # Pre-response bridge timeouts replaced the upstream_request_timeout
+        # code that startup cooldown fail-closed used to raise; they leave
+        # upstream acceptance exactly as unknown as it was before.
+        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
     }
 )
 
@@ -1459,7 +1474,8 @@ class _HTTPBridgeStreamingMixin:
             current_instance = _service_get_settings().http_responses_session_bridge_instance_id
             current_process_epoch = http_bridge_owner_process_epoch()
             dead_owner_process_epoch_mismatch = (
-                durable_lookup.owner_process_epoch is not None
+                durable_lookup.owner_instance_id == current_instance
+                and durable_lookup.owner_process_epoch is not None
                 and durable_lookup.owner_process_epoch != current_process_epoch
             )
             dead_owner_anchor = _http_bridge_durable_owner_is_dead(
@@ -3442,7 +3458,7 @@ class _HTTPBridgeStreamingMixin:
                 await self._reset_http_bridge_session_after_local_terminal_error(
                     session,
                     error_code="stream_incomplete",
-                    error_message="Upstream websocket closed before response.completed",
+                    error_message=_HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
                 )
                 recovery_path = "context_overflow_fresh_turn"
                 retry_payload = _http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)
@@ -3464,7 +3480,7 @@ class _HTTPBridgeStreamingMixin:
                 await self._reset_http_bridge_session_after_local_terminal_error(
                     session,
                     error_code="stream_incomplete",
-                    error_message="Upstream websocket closed before response.completed",
+                    error_message=_HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
                 )
                 raise
             elif previous_response_rejected_full_resend:
@@ -3474,7 +3490,7 @@ class _HTTPBridgeStreamingMixin:
                 await self._reset_http_bridge_session_after_local_terminal_error(
                     session,
                     error_code="stream_incomplete",
-                    error_message="Upstream websocket closed before response.completed",
+                    error_message=_HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
                 )
                 switch_to_account_neutral_replay(
                     event="previous_response_recover_fresh_resend",
@@ -3523,7 +3539,7 @@ class _HTTPBridgeStreamingMixin:
                 await self._reset_http_bridge_session_after_local_terminal_error(
                     session,
                     error_code="stream_incomplete",
-                    error_message="Upstream websocket closed before response.completed",
+                    error_message=_HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
                 )
                 recovery_path = "local_previous_response_same_owner_fresh_replay"
                 retry_previous_response_id = None
@@ -3545,7 +3561,7 @@ class _HTTPBridgeStreamingMixin:
                 await self._reset_http_bridge_session_after_local_terminal_error(
                     session,
                     error_code="stream_incomplete",
-                    error_message="Upstream websocket closed before response.completed",
+                    error_message=_HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
                 )
                 recovery_path = "local_previous_response_error"
                 retry_payload = effective_payload
@@ -3854,6 +3870,7 @@ class _HTTPBridgeStreamingMixin:
             error_message=error_message,
             api_key=None,
             response_create_gate=session.response_create_gate,
+            penalize_account=False,
         )
         await self._close_http_bridge_session(session, release_durable_session=not preserve_durable_lease)
 
@@ -3895,8 +3912,9 @@ class _HTTPBridgeStreamingMixin:
                                 cast(
                                     Mapping[str, JsonValue],
                                     response_failed_event(
-                                        "stream_idle_timeout",
-                                        "Clean-close recovery exceeded the request budget",
+                                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                                        "HTTP responses session bridge clean-close recovery "
+                                        "exceeded the request budget",
                                         response_id=downstream_response_id,
                                     ),
                                 )
@@ -3915,27 +3933,25 @@ class _HTTPBridgeStreamingMixin:
                 )
             except UpstreamWebSocketTransportError as exc:
                 if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                    stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                    stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
                 logger.info(
-                    "HTTP bridge stream idle recovery retry%s failed with transport error request_id=%s error_code=%s",
+                    "HTTP bridge eventless recovery retry%s failed with transport error request_id=%s error_code=%s",
                     " after circuit cooldown" if after_circuit_cooldown else "",
                     request_state.request_id,
                     exc.error_code,
                 )
+                mark_bridge_eventless_failure()
+                await record_bridge_eventless_timeout_failure()
                 if getattr(
                     _service_get_settings(),
                     "http_responses_session_bridge_ambiguous_continuation_recovery_mode",
                     "fail_closed",
                 ) == "server_indefinite_recovery" and _http_bridge_server_anchored_replay_enabled(request_state):
-                    # Let the outer server-owned recovery loop classify this
-                    # eventless transport failure as retryable. Returning a
-                    # synthetic response.failed event would make the loop
-                    # believe the attempt completed successfully after one try.
                     raise ProxyResponseError(
-                        502,
+                        503,
                         openai_error(
-                            "stream_idle_timeout",
-                            str(exc),
+                            _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                            _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
                             error_type="server_error",
                         ),
                     ) from exc
@@ -3945,8 +3961,8 @@ class _HTTPBridgeStreamingMixin:
                         cast(
                             Mapping[str, JsonValue],
                             response_failed_event(
-                                exc.error_code,
-                                str(exc),
+                                _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                                _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
                                 response_id=downstream_response_id,
                             ),
                         )
@@ -4098,6 +4114,57 @@ class _HTTPBridgeStreamingMixin:
                 )
             )
 
+        def mark_bridge_eventless_failure() -> None:
+            """Record the pre-response-start classification on the request log.
+
+            ``stream_idle_timeout`` describes a stream that started and then
+            went quiet for ``stream_idle_timeout_seconds``. Nothing about this
+            phase matches that, and stamping request logs with it hid every
+            eventless bridge handoff wedge behind an upstream-shaped label.
+            """
+
+            if request_state.failure_phase_override is None:
+                request_state.failure_phase_override = "bridge"
+            if request_state.failure_detail_override is None:
+                request_state.failure_detail_override = _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL
+
+        async def record_bridge_eventless_timeout_failure(
+            selection: _HTTPBridgeRetryCircuitAttemptSelection | None = None,
+        ) -> None:
+            if selection is None:
+                consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
+                    session,
+                    detail=_HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                )
+            else:
+                consecutive_failures = await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+                    session,
+                    detail=_HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                    selection=selection,
+                )
+            observed_response_events = max(
+                request_state.response_event_count,
+                int(
+                    request_state.response_id is not None
+                    or request_state.latency_response_created_ms is not None
+                    or request_state.downstream_visible
+                ),
+            )
+            if (
+                observed_response_events > 0
+                or consecutive_failures is None
+                or consecutive_failures
+                < _service_get_settings().http_responses_session_bridge_anchor_poison_failure_threshold
+            ):
+                return
+            if await _abandon_durable_http_bridge_continuity(self, session):
+                await self._retire_stale_pending_http_bridge_session(
+                    session,
+                    detail="repeated_zero_event_idle_timeout",
+                    response_events_seen=0,
+                    retired_request_count=0,
+                )
+
         async def startup_continuity_cooldown_terminal_event() -> str | None:
             if (
                 session.key.strength != "hard"
@@ -4111,15 +4178,16 @@ class _HTTPBridgeStreamingMixin:
             if retry_cooldown_seconds <= 0:
                 return None
             if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
             _record_continuity_fail_closed(
                 surface="http_bridge",
                 reason="retry_circuit_cooldown_continuity_bound",
                 previous_response_id=request_state.previous_response_id,
                 session_id=downstream_turn_state or request_state.session_id,
             )
+            mark_bridge_eventless_failure()
             logger.info(
-                "HTTP bridge stream idle timeout fail-closed before submit without safe replay "
+                "HTTP bridge eventless timeout fail-closed before submit without safe replay "
                 "request_id=%s retry_after_seconds=%.1f",
                 request_state.request_id,
                 retry_cooldown_seconds,
@@ -4143,9 +4211,8 @@ class _HTTPBridgeStreamingMixin:
                 raise ProxyResponseError(
                     503,
                     openai_error(
-                        "upstream_request_timeout",
-                        "HTTP responses session bridge is cooling down after repeated upstream "
-                        "timeouts; retry shortly.",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
                         error_type="server_error",
                     ),
                     retry_after_seconds=max(1, math.ceil(retry_cooldown_seconds)),
@@ -4159,8 +4226,8 @@ class _HTTPBridgeStreamingMixin:
                     )
                     if request_state.durable_owner_dead
                     else response_failed_event(
-                        "stream_idle_timeout",
-                        "Upstream did not respond within the keepalive window",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
                         response_id=_websocket_downstream_response_id(request_state),
                     ),
                 )
@@ -4275,15 +4342,16 @@ class _HTTPBridgeStreamingMixin:
             and event_queue.empty()
         ):
             if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
             _record_continuity_fail_closed(
                 surface="http_bridge",
                 reason="retry_circuit_cooldown_continuity_bound",
                 previous_response_id=request_state.previous_response_id,
                 session_id=downstream_turn_state or request_state.session_id,
             )
+            mark_bridge_eventless_failure()
             logger.info(
-                "HTTP bridge stream idle timeout fail-closed at startup without safe replay "
+                "HTTP bridge eventless timeout fail-closed at startup without safe replay "
                 "request_id=%s retry_after_seconds=%.1f",
                 request_state.request_id,
                 initial_retry_cooldown_seconds,
@@ -4297,8 +4365,8 @@ class _HTTPBridgeStreamingMixin:
                     )
                     if request_state.durable_owner_dead
                     else response_failed_event(
-                        "stream_idle_timeout",
-                        "Upstream did not respond within the keepalive window",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
                         response_id=_websocket_downstream_response_id(request_state),
                     ),
                 )
@@ -4321,9 +4389,8 @@ class _HTTPBridgeStreamingMixin:
                 raise ProxyResponseError(
                     503,
                     openai_error(
-                        "upstream_request_timeout",
-                        "HTTP responses session bridge is cooling down after repeated upstream "
-                        "timeouts; retry shortly.",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
                         error_type="server_error",
                     ),
                     retry_after_seconds=max(1, math.ceil(initial_retry_cooldown_seconds)),
@@ -4419,13 +4486,27 @@ class _HTTPBridgeStreamingMixin:
                         or request_state.response_event_count > 0
                         or request_state.latency_response_created_ms is not None
                     )
+                    # Before response.created the downstream queue is silent by
+                    # design, so stream_idle_timeout_seconds does not describe
+                    # this phase. Use the named settings-derived pre-response
+                    # budget (aligned with the owner-side stuck gate) instead of
+                    # the implicit _STREAM_KEEPALIVE_MAX_COUNT * interval
+                    # product that used to expire at ~60s under any settings.
+                    eventless_budget_seconds = _http_bridge_eventless_budget_seconds(
+                        settings,
+                        fallback_seconds=keepalive_interval * stream_keepalive_max_count,
+                    )
                     max_keepalive_count = (
                         max(
                             stream_keepalive_max_count,
                             math.ceil(max(0.001, stream_idle_timeout_seconds) / keepalive_interval),
                         )
                         if response_started
-                        else stream_keepalive_max_count
+                        else _http_bridge_eventless_max_keepalive_count(
+                            settings,
+                            keepalive_interval_seconds=keepalive_interval,
+                            floor_count=stream_keepalive_max_count,
+                        )
                     )
                     wait_timeout = keepalive_interval
                     if circuit_keepalive_waiting:
@@ -4536,7 +4617,7 @@ class _HTTPBridgeStreamingMixin:
                                             yield keepalive_event
                                         continue
                                     if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                                        stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                                        stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
                                     _record_continuity_fail_closed(
                                         surface="http_bridge",
                                         reason=(
@@ -4547,8 +4628,9 @@ class _HTTPBridgeStreamingMixin:
                                         previous_response_id=request_state.previous_response_id,
                                         session_id=downstream_turn_state or request_state.session_id,
                                     )
+                                    mark_bridge_eventless_failure()
                                     logger.info(
-                                        "HTTP bridge stream idle timeout fail-closed without safe replay "
+                                        "HTTP bridge eventless timeout fail-closed without safe replay "
                                         "request_id=%s retry_after_seconds=%.1f continuity_bound=%s",
                                         request_state.request_id,
                                         retry_cooldown_seconds,
@@ -4572,8 +4654,8 @@ class _HTTPBridgeStreamingMixin:
                                             )
                                             if request_state.durable_owner_dead
                                             else response_failed_event(
-                                                "stream_idle_timeout",
-                                                "Upstream did not respond within the keepalive window",
+                                                _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                                                _HTTP_BRIDGE_EVENTLESS_COOLDOWN_MESSAGE,
                                                 response_id=downstream_response_id,
                                             ),
                                         )
@@ -4596,9 +4678,10 @@ class _HTTPBridgeStreamingMixin:
                                                 yield keepalive_event
                                             continue
                                         if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                                            stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                                            stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
+                                        mark_bridge_eventless_failure()
                                         logger.info(
-                                            "HTTP bridge stream idle timeout during retry circuit cooldown "
+                                            "HTTP bridge eventless timeout during retry circuit cooldown "
                                             "request_id=%s retry_after_seconds=%.1f remaining_budget_seconds=%.1f",
                                             request_state.request_id,
                                             retry_cooldown_seconds,
@@ -4615,8 +4698,9 @@ class _HTTPBridgeStreamingMixin:
                                             cast(
                                                 Mapping[str, JsonValue],
                                                 response_failed_event(
-                                                    "stream_idle_timeout",
-                                                    "Upstream retry circuit cooldown exceeds the request budget",
+                                                    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                                                    "HTTP responses session bridge retry cooldown "
+                                                    "exceeds the request budget",
                                                     response_id=downstream_response_id,
                                                 ),
                                             )
@@ -4676,26 +4760,28 @@ class _HTTPBridgeStreamingMixin:
                                             if keepalive_event is not None:
                                                 yield keepalive_event
                                             continue
-                                        await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
-                                            session,
-                                            detail="stream_idle_timeout",
-                                            selection=timed_out_retry_circuit_attempt_selection,
+                                        await record_bridge_eventless_timeout_failure(
+                                            timed_out_retry_circuit_attempt_selection
                                         )
                                         if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
-                                            stream_idle_timeout_total.labels(surface="http_bridge").inc()
+                                            stream_idle_timeout_total.labels(surface="http_bridge_eventless").inc()
+                                        mark_bridge_eventless_failure()
                                         logger.info(
-                                            "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s "
-                                            "max_keepalive_count=%s",
+                                            "HTTP bridge eventless timeout request_id=%s keepalive_count=%s "
+                                            "max_keepalive_count=%s eventless_budget_seconds=%.1f "
+                                            "unmatched_upstream_liveness=%s",
                                             request_state.request_id,
                                             keepalive_count,
                                             max_keepalive_count,
+                                            eventless_budget_seconds,
+                                            session.unmatched_upstream_liveness_count,
                                         )
                                         yield format_sse_event(
                                             cast(
                                                 Mapping[str, JsonValue],
                                                 response_failed_event(
-                                                    "stream_idle_timeout",
-                                                    "Upstream did not respond within the keepalive window",
+                                                    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                                                    _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
                                                     response_id=downstream_response_id,
                                                 ),
                                             )
@@ -4776,7 +4862,10 @@ class _HTTPBridgeStreamingMixin:
                     ) = _build_rewritten_stream_response_failed_event(
                         response_id=_websocket_downstream_response_id(request_state),
                         error_code="stream_incomplete",
-                        error_message="Upstream websocket closed before response.completed",
+                        # Canonical public masking for an upstream
+                        # previous_response_not_found rejection (see
+                        # app.modules.proxy.api._mask_previous_response_not_found_error).
+                        error_message=PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
                     )
                 if (
                     not yielded_any
@@ -4790,7 +4879,7 @@ class _HTTPBridgeStreamingMixin:
                             request_state.error_http_status_override,
                             openai_error(
                                 "bridge_previous_response_not_found",
-                                "Upstream websocket closed before response.completed",
+                                PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
                             ),
                         )
                     raise ProxyResponseError(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -4094,12 +4094,13 @@ class _HTTPBridgeStreamingMixin:
                 return None
             await self._release_websocket_request_state_reservation(request_state)
             request_state.api_key_reservation = None
+            mark_bridge_eventless_failure()
             if propagate_http_errors:
                 raise ProxyResponseError(
                     503,
                     openai_error(
-                        "upstream_request_timeout",
-                        "HTTP responses session bridge recovery exceeded the request budget.",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
                         error_type="server_error",
                     ),
                 )
@@ -4107,8 +4108,8 @@ class _HTTPBridgeStreamingMixin:
                 cast(
                     Mapping[str, JsonValue],
                     response_failed_event(
-                        "stream_idle_timeout",
-                        "HTTP responses session bridge recovery exceeded the request budget",
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_DETAIL,
+                        _HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE,
                         response_id=_websocket_downstream_response_id(request_state),
                     ),
                 )

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -67,6 +67,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_denied_anchor_fence_current_map,
     _http_bridge_denied_anchor_fence_entry,
     _http_bridge_durable_lease_ttl_seconds,
+    _http_bridge_event_proves_upstream_liveness,
     _http_bridge_eventless_precreated_deadline,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
@@ -75,6 +76,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _normalize_http_bridge_error_event,
     _record_http_bridge_denied_anchor_fence,
     _record_http_bridge_stuck_retire,
+    _record_http_bridge_unmatched_upstream_liveness,
     _schedule_http_bridge_background_cleanup,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
@@ -2722,15 +2724,39 @@ class _HTTPBridgeUpstreamEventsMixin:
             # whatever was waiting for it waits until a timeout fires, so the
             # drop needs to be visible rather than inferred from a missing
             # downstream response.
+            #
+            # The frame still proves the upstream transport is alive. Nothing
+            # resets the downstream pre-response silence clock from here (that
+            # clock only sees matched queue items), so record the liveness as an
+            # explicit marker: a later bridge_eventless_timeout with a non-zero
+            # count is a local matching wedge, not a silent upstream.
+            unmatched_liveness_count = _record_http_bridge_unmatched_upstream_liveness(
+                session,
+                event_type=event_type,
+            )
             logger.warning(
                 "HTTP bridge upstream event matched no pending request account_id=%s bridge_kind=%s "
-                "event_type=%s has_response_id=%s pending_count=%d",
+                "event_type=%s has_response_id=%s pending_count=%d unmatched_upstream_liveness=%d",
                 session.account.id,
                 session.key.affinity_kind,
                 event_type or "unknown",
                 response_id is not None,
                 pending_request_count,
+                unmatched_liveness_count,
             )
+            if _http_bridge_event_proves_upstream_liveness(event_type):
+                _log_http_bridge_event(
+                    "unmatched_upstream_liveness",
+                    session.key,
+                    account_id=session.account.id,
+                    model=session.request_model,
+                    pending_count=pending_request_count,
+                    detail=(
+                        f"event_type={event_type or 'unknown'} unmatched_upstream_liveness={unmatched_liveness_count}"
+                    ),
+                    cache_key_family=session.key.affinity_kind,
+                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                )
 
         if status_request_state is not None and event_type not in {
             "response.completed",

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1324,6 +1324,11 @@ class _HTTPBridgeSession:
     upstream_proxy_endpoint_id: str | None = None
     upstream_proxy_fallback_used: bool | None = None
     upstream_proxy_fail_closed_reason: str | None = None
+    # Upstream frames that proved transport liveness but matched no pending
+    # request. They are dropped from the downstream queues, so without this
+    # counter a pre-response bridge timeout cannot tell "upstream said nothing"
+    # apart from "upstream spoke and our matching lost the frame".
+    unmatched_upstream_liveness_count: int = 0
 
     def claim_liveness_settlement(self) -> bool:
         """Claim whole-deque settlement for a liveness-failed submitter.

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -64,6 +64,7 @@ from app.core.clients.proxy_websocket import (
     is_account_neutral_websocket_error_code,
 )
 from app.core.errors import (
+    STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES,
     OpenAIErrorEnvelope,
     openai_error,
     response_failed_event,
@@ -6160,7 +6161,7 @@ class _WebSocketMixin:
         if (
             error_code == "stream_incomplete"
             and request_state.previous_response_id is not None
-            and error_message == "Upstream websocket closed before response.completed"
+            and error_message in STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES
         ):
             settlement.account_health_error = False
         proxy._cancel_request_state_api_key_reservation_heartbeat(request_state)
@@ -6588,11 +6589,18 @@ class _WebSocketMixin:
         if penalize_account:
             for request_state in remaining:
                 request_error_code = request_state.error_code_override or error_code
+                request_error_message = request_state.error_message_override or error_message
+                if (
+                    request_error_code == "stream_incomplete"
+                    and request_state.previous_response_id is not None
+                    and request_error_message in STREAM_INCOMPLETE_ANCHOR_NEUTRAL_MESSAGES
+                ):
+                    continue
                 if request_error_code in _facade()._TRANSIENT_RETRY_CODES or _facade()._should_penalize_stream_error(
                     request_error_code
                 ):
                     penalty_code = request_error_code
-                    penalty_message = request_state.error_message_override or error_message
+                    penalty_message = request_error_message
                     break
 
         reservation_release_succeeded = True

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -421,7 +421,6 @@ internal_router = APIRouter(
 )
 
 _TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
-_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS = 6
 _OPENAPI_VALIDATION_ERROR_RESPONSE: Final[dict[str, Any]] = {
     "description": "Validation Error",
     "content": {
@@ -7701,7 +7700,8 @@ async def _stream_response_error_events(
             # fingerprint; each new upstream attempt is still at-least-once.
             retry_delay = max(1.0, min(30.0, float(exc.retry_after_seconds or 5.0)))
             recovery_attempts = 0
-            while recovery_attempts < _HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS:
+            server_recovery_max_attempts = settings.http_responses_session_bridge_server_recovery_max_attempts
+            while recovery_attempts < server_recovery_max_attempts:
                 yield ": codex-lb recovery in progress\n\n"
                 await asyncio.sleep(retry_delay)
                 recovery_attempts += 1
@@ -7771,7 +7771,7 @@ async def _stream_response_error_events(
             else:
                 logger.warning(
                     "HTTP bridge server recovery exhausted before downstream event after %s attempts",
-                    _HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS,
+                    server_recovery_max_attempts,
                 )
         await release_owned_reservation()
         response_id = None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -76,6 +76,7 @@ from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
+    HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorEnvelope,
     is_previous_response_not_found_error,
@@ -420,6 +421,7 @@ internal_router = APIRouter(
 )
 
 _TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS = 6
 _OPENAPI_VALIDATION_ERROR_RESPONSE: Final[dict[str, Any]] = {
     "description": "Validation Error",
     "content": {
@@ -7670,9 +7672,9 @@ async def _stream_response_error_events(
             yield line
     except ProxyResponseError as exc:
         error_code = exc.payload.get("error", {}).get("code") if isinstance(exc.payload, dict) else None
+        settings = get_settings()
         indefinite_recovery = (
-            get_settings().http_responses_session_bridge_ambiguous_continuation_recovery_mode
-            == "server_indefinite_recovery"
+            settings.http_responses_session_bridge_ambiguous_continuation_recovery_mode == "server_indefinite_recovery"
         )
         if (
             recovery_stream_factory is not None
@@ -7686,9 +7688,11 @@ async def _stream_response_error_events(
             # The operation remains serialized by the durable operation
             # fingerprint; each new upstream attempt is still at-least-once.
             retry_delay = max(1.0, min(30.0, float(exc.retry_after_seconds or 5.0)))
-            while True:
+            recovery_attempts = 0
+            while recovery_attempts < _HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS:
                 yield ": codex-lb recovery in progress\n\n"
                 await asyncio.sleep(retry_delay)
+                recovery_attempts += 1
                 try:
                     retry_stream = recovery_stream_factory()
                     retry_saw_downstream_event = False
@@ -7699,6 +7703,7 @@ async def _stream_response_error_events(
                         yield line
                     return
                 except ProxyResponseError as retry_exc:
+                    exc = retry_exc
                     retry_code = (
                         retry_exc.payload.get("error", {}).get("code") if isinstance(retry_exc.payload, dict) else None
                     )
@@ -7716,7 +7721,6 @@ async def _stream_response_error_events(
                             and not getattr(retry_exc, "http_bridge_durable_recovery_eligible", False)
                         )
                     ):
-                        exc = retry_exc
                         break
                     retry_delay = max(1.0, min(30.0, float(retry_exc.retry_after_seconds or retry_delay)))
                 except (ProxyRateLimitError, ProxyAuthError) as retry_limit_exc:
@@ -7751,7 +7755,17 @@ async def _stream_response_error_events(
                         retry_after_seconds=5,
                     )
                     break
+            else:
+                logger.warning(
+                    "HTTP bridge server recovery exhausted before downstream event after %s attempts",
+                    _HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS,
+                )
         await release_owned_reservation()
+        response_id = None
+        if isinstance(exc.payload, dict):
+            response_id = _response_id_from_event_payload(cast(dict[str, JsonValue], exc.payload))
+        if response_id is None:
+            response_id = f"resp_{uuid4().hex}"
         envelope = _parse_error_envelope(exc.payload)
         _, envelope = _mask_previous_response_not_found_error(
             envelope,
@@ -7774,6 +7788,7 @@ async def _stream_response_error_events(
                 error.code if error and error.code else "upstream_error",
                 error.message if error and error.message else "Upstream error",
                 error.type if error and error.type else "server_error",
+                response_id=response_id,
                 error_param=error.param if error else None,
             )
         )
@@ -9604,6 +9619,11 @@ def _mask_previous_response_not_found_error(
 def _status_for_error(error_value: OpenAIError | None) -> int:
     if error_value and error_value.code == "previous_response_not_found":
         return 502
+    if error_value and error_value.code == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE:
+        # The bridge never got a response created upstream, so this is our
+        # availability problem and the request is safe to repeat: 503, not a
+        # 502 that claims the upstream returned a bad response.
+        return 503
     if error_value and error_value.code in _UNAVAILABLE_SELECTION_ERROR_CODES:
         return 503
     if error_value and error_value.code in {"rate_limit_exceeded", "usage_limit_reached", "insufficient_quota"}:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6186,7 +6186,13 @@ async def _stream_responses(
             == "server_indefinite_recovery"
             and getattr(startup_error, "http_bridge_durable_recovery_eligible", False)
             and startup_error_code
-            in {"stream_incomplete", "stream_idle_timeout", "upstream_request_timeout", "upstream_unavailable"}
+            in {
+                HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
+                "stream_incomplete",
+                "stream_idle_timeout",
+                "upstream_request_timeout",
+                "upstream_unavailable",
+            }
             and _responses_origin_may_release_reservation(
                 service_cleanup_ready_event=responses_service_cleanup_ready_event,
                 owner_forward_dispatched_event=responses_owner_forward_dispatched_event,
@@ -7682,7 +7688,13 @@ async def _stream_response_error_events(
             and (not require_durable_recovery_fence or getattr(exc, "http_bridge_durable_recovery_eligible", False))
             and not saw_downstream_event
             and error_code
-            in {"stream_incomplete", "stream_idle_timeout", "upstream_request_timeout", "upstream_unavailable"}
+            in {
+                HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
+                "stream_incomplete",
+                "stream_idle_timeout",
+                "upstream_request_timeout",
+                "upstream_unavailable",
+            }
         ):
             # Keep the client stream alive while the server owns recovery.
             # The operation remains serialized by the durable operation
@@ -7710,6 +7722,7 @@ async def _stream_response_error_events(
                     if (
                         retry_code
                         not in {
+                            HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
                             "stream_incomplete",
                             "stream_idle_timeout",
                             "upstream_request_timeout",

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -9633,9 +9633,10 @@ def _status_for_error(error_value: OpenAIError | None) -> int:
     if error_value and error_value.code == "previous_response_not_found":
         return 502
     if error_value and error_value.code == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE:
-        # The bridge never got a response created upstream, so this is our
-        # availability problem and the request is safe to repeat: 503, not a
-        # 502 that claims the upstream returned a bad response.
+        # The bridge never matched a response.created event upstream, so this
+        # is our availability problem: 503, not a 502 that claims the upstream
+        # returned a bad response. Retry safety depends on whether the bridge
+        # observed unmatched upstream liveness before timing out.
         return 503
     if error_value and error_value.code in _UNAVAILABLE_SELECTION_ERROR_CODES:
         return 503

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 132 settings. Every setting is an environment
+codex-lb currently exposes 133 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -103,6 +103,7 @@ the host side of the compose `ports` mapping instead.
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_OPERATION_SPOOL_RETENTION_SECONDS` | `float` | `604800` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_QUEUE_LIMIT` | `int` | `8` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_REQUEST_BUDGET_SECONDS` | `float` | `7200.0` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS` | `int` | `6` |
 | `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_STUCK_GATE_RETIRE_AFTER_SECONDS` | `float` | `300.0` |
 
 ## Proxy admission & account caps

--- a/openspec/changes/bound-eventless-server-recovery/proposal.md
+++ b/openspec/changes/bound-eventless-server-recovery/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`fix(proxy): bound server recovery after eventless bridge failures` changes the
+public recovery contract for anchored HTTP bridge continuations. Instead of
+looping indefinitely while the server owns recovery, the bridge now stops after
+`_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS` consecutive eligible eventless
+failures and emits one terminal `response.failed`.
+
+That is observable behavior for operators and clients, and it was not captured
+in an active OpenSpec change folder on this branch. The same terminal path also
+needs to preserve a parseable `response.id`, because public `/v1/responses`
+normalization synthesizes `response.created` from that terminal envelope.
+
+## What Changes
+
+- Document that server-indefinite bridge recovery is actually bounded by the
+  configured attempt cap for eligible eventless anchored continuations.
+- Require the terminal exhaustion event to include a stable `response.id` so
+  public `/v1/responses` streams remain parseable when the first standard event
+  is the exhaustion failure.
+
+## Impact
+
+- Affected capability: `responses-api-compat`.
+- Affected code: `app/modules/proxy/api.py`, focused proxy error tests.
+- No new settings or migrations.

--- a/openspec/changes/bound-eventless-server-recovery/proposal.md
+++ b/openspec/changes/bound-eventless-server-recovery/proposal.md
@@ -3,8 +3,9 @@
 `fix(proxy): bound server recovery after eventless bridge failures` changes the
 public recovery contract for anchored HTTP bridge continuations. Instead of
 looping indefinitely while the server owns recovery, the bridge now stops after
-`_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS` consecutive eligible eventless
-failures and emits one terminal `response.failed`.
+`http_responses_session_bridge_server_recovery_max_attempts` (a setting,
+default 6) consecutive eligible eventless failures and emits one terminal
+`response.failed`.
 
 That is observable behavior for operators and clients, and it was not captured
 in an active OpenSpec change folder on this branch. The same terminal path also
@@ -22,5 +23,7 @@ normalization synthesizes `response.created` from that terminal envelope.
 ## Impact
 
 - Affected capability: `responses-api-compat`.
-- Affected code: `app/modules/proxy/api.py`, focused proxy error tests.
-- No new settings or migrations.
+- Affected code: `app/modules/proxy/api.py`, `app/core/config/settings.py`,
+  focused proxy error tests.
+- New setting: `http_responses_session_bridge_server_recovery_max_attempts`
+  (default 6). No migrations.

--- a/openspec/changes/bound-eventless-server-recovery/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-eventless-server-recovery/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Eventless server-owned bridge recovery is bounded
+
+The proxy MUST retry server-owned HTTP bridge recovery only up to the
+configured `_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS` budget after
+consecutive eligible eventless failures for an anchored continuation. Once
+that budget is exhausted, the proxy MUST stop recovering and emit a terminal
+`response.failed` event.
+
+That terminal event MUST include a stable `response.id` even when upstream
+never emitted `response.created` or another response envelope before the
+failure. Public `/v1/responses` normalization depends on that envelope to
+synthesize the required leading `response.created` event without producing an
+SDK parser failure.
+
+#### Scenario: Exhausted eventless recovery terminates with one response id
+
+- **GIVEN** an anchored HTTP bridge continuation is eligible for server-owned
+  recovery
+- **AND** each upstream attempt fails before any downstream `response.*` event
+- **WHEN** the bridge reaches its configured eventless recovery attempt cap
+- **THEN** it emits one terminal `response.failed` event instead of continuing
+  recovery indefinitely
+- **AND** that terminal event includes a stable `response.id`

--- a/openspec/changes/bound-eventless-server-recovery/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-eventless-server-recovery/specs/responses-api-compat/spec.md
@@ -5,8 +5,9 @@
 ### Requirement: Eventless server-owned bridge recovery is bounded
 
 The proxy MUST retry server-owned HTTP bridge recovery only up to the
-configured `_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS` budget after
-consecutive eligible eventless failures for an anchored continuation. Once
+configured `http_responses_session_bridge_server_recovery_max_attempts`
+setting (default 6) after consecutive eligible eventless failures for an
+anchored continuation. Once
 that budget is exhausted, the proxy MUST stop recovering and emit a terminal
 `response.failed` event.
 

--- a/openspec/changes/bound-eventless-server-recovery/tasks.md
+++ b/openspec/changes/bound-eventless-server-recovery/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Add a `responses-api-compat` delta for bounded eventless server recovery.
+- [x] Preserve a stable `response.id` on the terminal exhaustion event.
+- [x] Add focused regression coverage for the exhaustion SSE shape.
+- [x] Run focused tests, `ruff check`, `ruff format --check`, and strict
+      OpenSpec validation.

--- a/openspec/changes/name-bridge-eventless-timeout/proposal.md
+++ b/openspec/changes/name-bridge-eventless-timeout/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+The HTTP responses bridge kills a client stream that produced no response
+events before `response.created` and reports the kill as `stream_idle_timeout`.
+That code is a lie in two directions.
+
+- The budget it names, `stream_idle_timeout_seconds` (7200s at shipped
+  defaults), governs gaps *after* a response starts. The pre-response kill
+  actually fired at the implicit product
+  `_STREAM_KEEPALIVE_MAX_COUNT (6) * sse_keepalive_interval_seconds (10s)`, i.e.
+  ~60s, which is not derived from any configured timeout at all.
+- It blames the upstream for what is usually a local bridge handoff wedge.
+  In a 48h window, successful `gpt-5.6-luna` turns had a p95 first-upstream-event
+  latency of 930ms and `0/3063` above 60s, while the incident logs were dominated
+  by zero-event failures. The pre-response watchdog was racing (and beating) the
+  owner-side `missing_response_created_timeout` gate, so the honest, specific
+  classification lost to the misleading generic one.
+
+Four local bridge recovery paths compounded this by settling their own resets
+with the message `Upstream websocket closed before response.completed` even
+though no upstream close happened.
+
+## What Changes
+
+- Pre-response-start bridge failures emit a distinct `bridge_eventless_timeout`
+  classification in logs, request-log `failure_detail` / `failure_phase`,
+  retry-circuit `last_detail`, and the client-visible error. `stream_idle_timeout`
+  is now reserved for post-`response.created` silence.
+- The client-visible shape stays retryable: a `503` with a message that states
+  no response was created upstream and the request is safe to retry, instead of
+  a `502` blaming the upstream keepalive window.
+- The pre-response budget becomes a named, settings-derived quantity
+  (`_http_bridge_eventless_budget_seconds` =
+  `min(stuck_gate_retire_after_seconds, stream_idle_timeout_seconds,
+  bridge_request_budget_seconds)`), aligning it with the 300s owner-side stuck
+  gate instead of the implicit 6 x 10s product.
+- Upstream text frames that prove transport liveness but match no pending
+  request now emit an explicit `unmatched_upstream_liveness` bridge-event marker
+  and a per-session counter, which the eventless timeout reports. Locally
+  injected `codex.keepalive` frames are excluded.
+- The four local bridge reset sites say local bridge reset. `Upstream websocket
+  closed ...` is reserved for actual upstream closes.
+
+## Impact
+
+- Affected capabilities: `responses-api-compat`.
+- New error code `bridge_eventless_timeout` is client-visible on the responses
+  surface. It is a new, narrower name for failures that previously surfaced as
+  `stream_idle_timeout` / `upstream_request_timeout`; no previously-successful
+  request changes shape.
+- Pre-response silence now tolerates up to the stuck-gate budget (300s at
+  defaults) rather than ~60s. The owner-side `missing_response_created_timeout`
+  watchdog (<= 60s) remains the first responder for requests whose
+  `response.create` was actually sent, so the common recovery path keeps its
+  latency; the downstream watchdog becomes an honest backstop instead of a
+  racing mislabeler.
+- No new settings, no migration, no live deployment or database mutation.
+
+## Follow-ups (not in this change)
+
+- `app/core/timeout_invariants.py` does not exist on this branch lineage, so the
+  requested lint rules are encoded as a unit test
+  (`test_http_bridge_eventless_budget_is_named_and_settings_derived`) rather than
+  a linter module. When that module lands, move these invariants into it:
+  `eventless_budget <= stuck_gate_retire_after_seconds`,
+  `eventless_budget <= stream_idle_timeout_seconds`,
+  `eventless_budget <= http_responses_session_bridge_request_budget_seconds`,
+  `eventless_budget >= sse_keepalive_interval_seconds`, and
+  `pre_response_keepalive_count * sse_keepalive_interval_seconds >= eventless_budget`.
+- Raising `_STREAM_KEEPALIVE_MAX_COUNT` itself (ranked fix 5 in the audit) was
+  deliberately not taken: it hides the symptom without fixing the semantic
+  inversion, and with a named settings-derived budget the constant is only a
+  floor on keepalive cadence, not a deadline.

--- a/openspec/changes/name-bridge-eventless-timeout/specs/responses-api-compat/spec.md
+++ b/openspec/changes/name-bridge-eventless-timeout/specs/responses-api-compat/spec.md
@@ -1,0 +1,119 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Pre-response-start bridge silence has its own classification
+
+The HTTP responses session bridge MUST NOT report a failure that occurs before
+the request's first response event as `stream_idle_timeout`. Every terminal the
+bridge produces while `response.created` has not been observed and no response
+event has been counted MUST use the distinct code `bridge_eventless_timeout`.
+
+That classification MUST appear in the bridge's own log line, in the durable
+request-log failure metadata (`failure_detail` = `bridge_eventless_timeout`,
+`failure_phase` = `bridge`), in the HTTP bridge retry-circuit `last_detail`, and
+in the client-visible error payload. The retry-circuit detail MUST NOT be
+aliased onto `stream_idle_timeout`.
+
+The client-visible error MUST remain retryable: HTTP status `503` and a message
+that states no response was created upstream and the request is safe to repeat.
+The message MUST NOT attribute the failure to the upstream.
+
+`stream_idle_timeout` remains the classification for a stream that produced at
+least one response event and then went silent for `stream_idle_timeout_seconds`.
+
+#### Scenario: Pre-response silence is reported as an eventless bridge timeout
+
+- **GIVEN** an HTTP bridge request whose downstream event queue has produced no
+  response events
+- **WHEN** the pre-response silence budget expires
+- **THEN** the emitted `response.failed` event carries code
+  `bridge_eventless_timeout`
+- **AND** the request log records `failure_detail=bridge_eventless_timeout` and
+  `failure_phase=bridge`
+- **AND** the hard-affinity retry circuit records `last_detail` of
+  `bridge_eventless_timeout`
+- **AND** the error message does not mention the upstream
+- **AND** the equivalent HTTP error status is `503`
+
+#### Scenario: Post-response idle keeps the stream idle classification
+
+- **GIVEN** an HTTP bridge request that already received a response event
+- **WHEN** the stream stays silent past `stream_idle_timeout_seconds`
+- **THEN** the emitted `response.failed` event carries code
+  `stream_idle_timeout`
+- **AND** no `bridge_eventless_timeout` request-log detail is recorded
+
+### Requirement: The pre-response silence budget is settings-derived
+
+The pre-response silence budget MUST be a named quantity derived from
+configuration, not the implicit product of `_STREAM_KEEPALIVE_MAX_COUNT` and
+`sse_keepalive_interval_seconds`.
+
+The budget MUST be the minimum of
+`http_responses_session_bridge_stuck_gate_retire_after_seconds`,
+`stream_idle_timeout_seconds`, and
+`http_responses_session_bridge_request_budget_seconds`, so that the downstream
+pre-response watchdog can never outlive the owner-side stuck gate, the
+configured idle budget, or the request budget. The number of pre-response
+keepalive intervals waited MUST cover that budget and MUST NOT drop below
+`_STREAM_KEEPALIVE_MAX_COUNT`.
+
+#### Scenario: Default settings align the budget with the stuck gate
+
+- **GIVEN** shipped defaults `sse_keepalive_interval_seconds=10`,
+  `http_responses_session_bridge_stuck_gate_retire_after_seconds=300`, and
+  `stream_idle_timeout_seconds=7200`
+- **WHEN** the pre-response silence budget is computed
+- **THEN** the budget is `300` seconds
+- **AND** the pre-response keepalive count covers `300` seconds rather than the
+  previous implicit `60` seconds
+
+#### Scenario: A shorter idle timeout clamps the budget
+
+- **GIVEN** `stream_idle_timeout_seconds=45` and a `300` second stuck gate
+- **WHEN** the pre-response silence budget is computed
+- **THEN** the budget is `45` seconds
+
+### Requirement: Unmatched live upstream frames are recorded as liveness
+
+The bridge MUST record an upstream text frame that matches no pending request,
+while pending requests exist, as unmatched upstream liveness: an
+`unmatched_upstream_liveness` bridge-event marker and a per-session counter. A subsequent `bridge_eventless_timeout` MUST report that counter so a
+local matching wedge is distinguishable from a genuinely silent upstream.
+
+Frames the bridge injects into its own downstream streams, in particular
+`codex.keepalive`, MUST NOT be counted as upstream liveness.
+
+#### Scenario: An unmatched upstream event is marked as liveness
+
+- **GIVEN** an HTTP bridge session with one pending request
+- **WHEN** an upstream response event arrives that matches no pending request
+- **THEN** an `unmatched_upstream_liveness` bridge event is logged
+- **AND** the session's unmatched upstream liveness counter increases
+
+#### Scenario: A local keepalive frame is not upstream liveness
+
+- **GIVEN** an HTTP bridge session with one pending request
+- **WHEN** a `codex.keepalive` frame is processed
+- **THEN** no `unmatched_upstream_liveness` bridge event is logged
+- **AND** the session's unmatched upstream liveness counter is unchanged
+
+### Requirement: Local bridge resets are reported as local
+
+The bridge MUST identify local recovery resets as local bridge resets. When it
+tears down and rebuilds its own upstream session (durable fresh replay,
+context-overflow fresh turn, context-overflow rollover, or local
+previous-response rebind), the terminal error message it settles pending
+requests with MUST NOT claim the upstream websocket closed.
+
+Reporting a local reset MUST remain account-health neutral for anchored
+`stream_incomplete` settlements, exactly as the upstream-close wording was.
+
+#### Scenario: Local recovery does not report an upstream close
+
+- **GIVEN** the bridge performs any local reset-and-retry recovery
+- **WHEN** it settles the pending requests of the session it is discarding
+- **THEN** the settled error message says the bridge reset the session locally
+- **AND** the message does not contain `Upstream websocket closed`
+- **AND** the settlement does not mark the account unhealthy

--- a/openspec/changes/name-bridge-eventless-timeout/specs/responses-api-compat/spec.md
+++ b/openspec/changes/name-bridge-eventless-timeout/specs/responses-api-compat/spec.md
@@ -56,8 +56,10 @@ The budget MUST be the minimum of
 `http_responses_session_bridge_request_budget_seconds`, so that the downstream
 pre-response watchdog can never outlive the owner-side stuck gate, the
 configured idle budget, or the request budget. The number of pre-response
-keepalive intervals waited MUST cover that budget and MUST NOT drop below
-`_STREAM_KEEPALIVE_MAX_COUNT`.
+keepalive intervals waited MUST cover that budget. It MUST NOT drop below
+`_STREAM_KEEPALIVE_MAX_COUNT` when the budget spans at least that many
+keepalive intervals; when the configured budget is shorter, the count MUST
+follow the budget instead, so the watchdog never outlives it.
 
 #### Scenario: Default settings align the budget with the stuck gate
 

--- a/openspec/changes/name-bridge-eventless-timeout/tasks.md
+++ b/openspec/changes/name-bridge-eventless-timeout/tasks.md
@@ -1,0 +1,21 @@
+- [x] Add a distinct `bridge_eventless_timeout` classification for every
+  pre-response-start HTTP bridge terminal (logs, request-log detail/phase,
+  retry-circuit `last_detail`, client error, Prometheus surface label).
+- [x] Keep the client-visible shape retryable (`503`) with a message that does
+  not blame the upstream.
+- [x] Replace the implicit `_STREAM_KEEPALIVE_MAX_COUNT * sse_keepalive_interval_seconds`
+  pre-response deadline with the named settings-derived
+  `_http_bridge_eventless_budget_seconds`, aligned with the owner-side stuck gate.
+- [x] Record an `unmatched_upstream_liveness` marker and per-session counter for
+  upstream frames that prove liveness but match no pending request; exclude
+  locally injected `codex.keepalive`.
+- [x] Make the four local bridge reset sites say local bridge reset and reserve
+  `Upstream websocket closed ...` for real upstream closes; keep those resets
+  account-health neutral.
+- [x] Add regressions for the new classification, the surviving post-start
+  `stream_idle_timeout`, the grep-style local-reset assertion, the
+  unmatched-liveness marker, and the budget invariants.
+- [x] Run the branch regression files, `tests/unit/test_proxy_http_bridge.py`,
+  and `tests/integration/test_migrations.py`.
+- [x] Record the timeout-invariant linter rules as a follow-up note, since
+  `app/core/timeout_invariants.py` is not on this branch lineage.

--- a/tests/unit/test_http_bridge_eventless_semantics.py
+++ b/tests/unit/test_http_bridge_eventless_semantics.py
@@ -1,0 +1,344 @@
+"""Pre-response-start HTTP bridge failure semantics.
+
+The bridge used to report silence *before* ``response.created`` as
+``stream_idle_timeout`` (a post-start budget) and to settle its own local
+recovery resets with upstream-close wording. These regressions pin the split:
+``bridge_eventless_timeout`` for the pre-response phase, ``stream_idle_timeout``
+only after a response event, honest local-reset messages, and an explicit
+marker for upstream frames that prove liveness but match no pending request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import math
+import time
+from collections import deque
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from app.core.clients.proxy_websocket import UpstreamWebSocket
+from app.core.config.settings import Settings
+from app.core.openai.models import OpenAIError
+from app.db.models import AccountStatus
+from app.modules.proxy import api as proxy_api_module
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
+from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
+
+pytestmark = pytest.mark.unit
+
+
+def _make_bridge_session(
+    *,
+    key_value: str = "bridge-eventless",
+    pending_requests: deque[proxy_service._WebSocketRequestState] | None = None,
+    queued_request_count: int = 0,
+) -> proxy_service._HTTPBridgeSession:
+    return proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", key_value, None),
+        headers={"x-codex-session-id": key_value},
+        affinity=proxy_service._AffinityPolicy(
+            key=key_value,
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.2",
+        account=cast(Any, SimpleNamespace(id="acc-bridge", status=AccountStatus.ACTIVE, plan_type="plus")),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=pending_requests or deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=queued_request_count,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+
+def _eventless_settings(
+    *,
+    keepalive_interval_seconds: float = 0.001,
+    stuck_gate_retire_after_seconds: float = 0.002,
+    stream_idle_timeout_seconds: float = 7200.0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        sse_keepalive_interval_seconds=keepalive_interval_seconds,
+        stream_idle_timeout_seconds=stream_idle_timeout_seconds,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
+        http_responses_session_bridge_request_budget_seconds=60.0,
+        http_responses_session_bridge_anchor_poison_failure_threshold=7,
+    )
+
+
+def test_http_bridge_eventless_budget_is_named_and_settings_derived() -> None:
+    """Fix 2: the pre-response budget is derived, not an implicit 6 x 10s."""
+
+    settings = Settings()
+    budget_seconds = http_bridge_helpers_module._http_bridge_eventless_budget_seconds(
+        settings,
+        fallback_seconds=60.0,
+    )
+    keepalive_interval = settings.sse_keepalive_interval_seconds
+    stuck_gate = settings.http_responses_session_bridge_stuck_gate_retire_after_seconds
+
+    # Timeout invariants relating the knobs the audit named.
+    assert budget_seconds <= stuck_gate
+    assert budget_seconds <= settings.stream_idle_timeout_seconds
+    assert budget_seconds <= settings.http_responses_session_bridge_request_budget_seconds
+    assert budget_seconds >= keepalive_interval
+
+    # At shipped defaults the pre-response budget is the owner-side stuck gate
+    # (300s), not the old implicit _STREAM_KEEPALIVE_MAX_COUNT * interval (60s).
+    assert budget_seconds == stuck_gate
+    max_count = http_bridge_helpers_module._http_bridge_eventless_max_keepalive_count(
+        settings,
+        keepalive_interval_seconds=keepalive_interval,
+        floor_count=http_bridge_streaming_module._stream_keepalive_max_count(),
+    )
+    assert max_count * keepalive_interval >= budget_seconds
+    assert max_count > http_bridge_streaming_module._stream_keepalive_max_count()
+
+    # A shorter stream idle timeout or request budget still clamps it down, and
+    # the keepalive floor is never violated.
+    tight = SimpleNamespace(
+        sse_keepalive_interval_seconds=10.0,
+        stream_idle_timeout_seconds=45.0,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=300.0,
+        http_responses_session_bridge_request_budget_seconds=600.0,
+    )
+    assert http_bridge_helpers_module._http_bridge_eventless_budget_seconds(tight, fallback_seconds=60.0) == 45.0
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_max_keepalive_count(
+            tight,
+            keepalive_interval_seconds=10.0,
+            floor_count=6,
+        )
+        == 5
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_pre_response_silence_is_bridge_eventless_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fix 1: pre-response-start kills are not stream_idle_timeout anywhere."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _eventless_settings())
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=0.0))
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            lookup_retry_circuit=AsyncMock(return_value=None),
+            persist_retry_circuit=AsyncMock(return_value=None),
+        ),
+    )
+
+    session = _make_bridge_session(key_value="sid-eventless-classification")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-eventless-classification",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create"}',
+    )
+
+    async def submit(target_session: Any, *, request_state: Any, **kwargs: Any) -> None:
+        del kwargs
+        target_session.pending_requests.append(request_state)
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+
+    # An unmatched-but-live upstream frame arrived before the kill; the kill
+    # must report it so a local matching wedge is not read as a silent upstream.
+    session.unmatched_upstream_liveness_count = 2
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        events = [
+            event
+            async for event in service._stream_http_bridge_session_events(
+                session,
+                request_state=request_state,
+                text_data='{"type":"response.create"}',
+                queue_limit=8,
+                propagate_http_errors=False,
+                downstream_turn_state=None,
+            )
+        ]
+
+    terminal = cast(dict[str, Any], proxy_service.parse_sse_data_json(events[-1]))
+    assert terminal["type"] == "response.failed"
+    error = cast(dict[str, Any], cast(dict[str, Any], terminal["response"])["error"])
+    assert error["code"] == "bridge_eventless_timeout"
+    # Honest message: no upstream blame, and it says the retry is safe.
+    assert "Upstream" not in cast(str, error["message"])
+    assert "safe to retry" in cast(str, error["message"])
+
+    # Durable request-log detail.
+    assert request_state.failure_detail_override == "bridge_eventless_timeout"
+    assert request_state.failure_phase_override == "bridge"
+
+    # Retry-circuit last_detail keeps the specific class instead of being
+    # collapsed onto stream_idle_timeout.
+    circuit_state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+    assert circuit_state.last_detail == "bridge_eventless_timeout"
+
+    # Logs.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("HTTP bridge eventless timeout request_id=req-eventless-classification" in m for m in messages)
+    assert any("unmatched_upstream_liveness=2" in m for m in messages)
+    assert not any("HTTP bridge stream idle timeout" in m for m in messages)
+
+    # Client-visible shape stays a retryable 503, not a 502 upstream blame.
+    assert proxy_api_module._status_for_error(OpenAIError(code="bridge_eventless_timeout")) == 503
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_post_response_start_still_uses_stream_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fix 1 counterpart: after response.created the old classification stands."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _eventless_settings(stream_idle_timeout_seconds=0.002),
+    )
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    session = _make_bridge_session(key_value="sid-post-start-idle")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-post-start-idle",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        response_id="resp-post-start-idle",
+    )
+    request_state.response_event_count = 3
+
+    async def submit(target_session: Any, *, request_state: Any, **kwargs: Any) -> None:
+        del kwargs
+        target_session.pending_requests.append(request_state)
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        events = [
+            event
+            async for event in service._stream_http_bridge_session_events(
+                session,
+                request_state=request_state,
+                text_data='{"type":"response.create"}',
+                queue_limit=8,
+                propagate_http_errors=False,
+                downstream_turn_state=None,
+            )
+        ]
+
+    terminal = cast(dict[str, Any], proxy_service.parse_sse_data_json(events[-1]))
+    error = cast(dict[str, Any], cast(dict[str, Any], terminal["response"])["error"])
+    assert error["code"] == "stream_idle_timeout"
+    assert request_state.failure_detail_override is None
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("HTTP bridge stream idle timeout request_id=req-post-start-idle" in m for m in messages)
+
+    # The post-start budget is still the configured stream idle timeout, not the
+    # pre-response eventless budget.
+    live_settings = Settings()
+    post_start_count = max(
+        http_bridge_streaming_module._stream_keepalive_max_count(),
+        math.ceil(live_settings.stream_idle_timeout_seconds / live_settings.sse_keepalive_interval_seconds),
+    )
+    assert post_start_count * live_settings.sse_keepalive_interval_seconds >= 7200.0
+
+
+def test_http_bridge_local_resets_do_not_blame_the_upstream() -> None:
+    """Fix 4: grep-style assertion over the bridge streaming module."""
+
+    source = inspect.getsource(http_bridge_streaming_module)
+    assert "Upstream websocket closed" not in source
+
+    reset_call = "await self._reset_http_bridge_session_after_local_terminal_error("
+    call_count = source.count(reset_call)
+    assert call_count == 4
+    for chunk in source.split(reset_call)[1:]:
+        call_body = chunk.split(")\n", 1)[0]
+        assert "_HTTP_BRIDGE_LOCAL_RESET_MESSAGE" in call_body
+
+    assert "Upstream" not in http_bridge_streaming_module._HTTP_BRIDGE_LOCAL_RESET_MESSAGE
+    assert "locally" in http_bridge_streaming_module._HTTP_BRIDGE_LOCAL_RESET_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_unmatched_upstream_frame_records_liveness_marker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fix 3: unmatched-but-live upstream frames get an explicit marker."""
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-unmatched-liveness",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    session = _make_bridge_session(
+        key_value="sid-unmatched-liveness",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        await service._process_http_bridge_upstream_text(
+            session,
+            json.dumps(
+                {"type": "response.output_text.delta", "response_id": "resp-not-ours", "delta": "hi"},
+                separators=(",", ":"),
+            ),
+        )
+
+    assert session.unmatched_upstream_liveness_count == 1
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("http_bridge_event event=unmatched_upstream_liveness" in m for m in messages)
+    assert any("unmatched_upstream_liveness=1" in m for m in messages)
+
+    caplog.clear()
+    # Locally injected keepalives prove nothing about the upstream.
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        await service._process_http_bridge_upstream_text(
+            session,
+            json.dumps({"type": "codex.keepalive"}, separators=(",", ":")),
+        )
+
+    assert session.unmatched_upstream_liveness_count == 1
+    keepalive_messages = [record.getMessage() for record in caplog.records]
+    assert not any("http_bridge_event event=unmatched_upstream_liveness" in m for m in keepalive_messages)
+    assert http_bridge_helpers_module._http_bridge_event_proves_upstream_liveness("codex.keepalive") is False
+    assert http_bridge_helpers_module._http_bridge_event_proves_upstream_liveness("response.created") is True

--- a/tests/unit/test_http_bridge_eventless_semantics.py
+++ b/tests/unit/test_http_bridge_eventless_semantics.py
@@ -211,6 +211,78 @@ async def test_http_bridge_pre_response_silence_is_bridge_eventless_timeout(
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_eventless_timeout_without_liveness_promises_safe_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Zero unmatched liveness keeps the unconditional safe-to-retry contract.
+
+    Companion to the count=2 caution case above: with no unmatched upstream
+    frames the terminal message must state the request is safe to retry, so an
+    unconditional caution string cannot silently replace the safe wording.
+    """
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _eventless_settings())
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=0.0))
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            lookup_retry_circuit=AsyncMock(return_value=None),
+            persist_retry_circuit=AsyncMock(return_value=None),
+        ),
+    )
+
+    session = _make_bridge_session(key_value="sid-eventless-safe-retry")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-eventless-safe-retry",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create"}',
+    )
+
+    async def submit(target_session: Any, *, request_state: Any, **kwargs: Any) -> None:
+        del kwargs
+        target_session.pending_requests.append(request_state)
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+
+    assert session.unmatched_upstream_liveness_count == 0
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.service"):
+        events = [
+            event
+            async for event in service._stream_http_bridge_session_events(
+                session,
+                request_state=request_state,
+                text_data='{"type":"response.create"}',
+                queue_limit=8,
+                propagate_http_errors=False,
+                downstream_turn_state=None,
+            )
+        ]
+
+    terminal = cast(dict[str, Any], proxy_service.parse_sse_data_json(events[-1]))
+    assert terminal["type"] == "response.failed"
+    error = cast(dict[str, Any], cast(dict[str, Any], terminal["response"])["error"])
+    assert error["code"] == "bridge_eventless_timeout"
+    assert error["message"] == http_bridge_helpers_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
+    assert "safe to retry" in cast(str, error["message"])
+    assert "retry may duplicate upstream work" not in cast(str, error["message"])
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("unmatched_upstream_liveness=0" in m for m in messages)
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_post_response_start_still_uses_stream_idle_timeout(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_http_bridge_eventless_semantics.py
+++ b/tests/unit/test_http_bridge_eventless_semantics.py
@@ -106,8 +106,10 @@ def test_http_bridge_eventless_budget_is_named_and_settings_derived() -> None:
     assert max_count * keepalive_interval >= budget_seconds
     assert max_count > http_bridge_streaming_module._stream_keepalive_max_count()
 
-    # A shorter stream idle timeout or request budget still clamps it down, and
-    # the keepalive floor is never violated.
+    # A shorter stream idle timeout or request budget still clamps it down.
+    # When the budget spans fewer than floor_count intervals, the count follows
+    # the budget (5 x 10s covers 45s) so the watchdog never outlives it — the
+    # floor only applies when the budget is at least floor_count intervals.
     tight = SimpleNamespace(
         sse_keepalive_interval_seconds=10.0,
         stream_idle_timeout_seconds=45.0,

--- a/tests/unit/test_http_bridge_eventless_semantics.py
+++ b/tests/unit/test_http_bridge_eventless_semantics.py
@@ -186,9 +186,10 @@ async def test_http_bridge_pre_response_silence_is_bridge_eventless_timeout(
     assert terminal["type"] == "response.failed"
     error = cast(dict[str, Any], cast(dict[str, Any], terminal["response"])["error"])
     assert error["code"] == "bridge_eventless_timeout"
-    # Honest message: no upstream blame, and it says the retry is safe.
+    # Honest message: no upstream blame, and unmatched upstream liveness means
+    # the retry cannot be promised duplicate-safe.
     assert "Upstream" not in cast(str, error["message"])
-    assert "safe to retry" in cast(str, error["message"])
+    assert "retry may duplicate upstream work" in cast(str, error["message"])
 
     # Durable request-log detail.
     assert request_state.failure_detail_override == "bridge_eventless_timeout"

--- a/tests/unit/test_http_bridge_eventless_semantics.py
+++ b/tests/unit/test_http_bridge_eventless_semantics.py
@@ -284,7 +284,9 @@ def test_http_bridge_local_resets_do_not_blame_the_upstream() -> None:
 
     reset_call = "await self._reset_http_bridge_session_after_local_terminal_error("
     call_count = source.count(reset_call)
-    assert call_count == 4
+    # Pinned to the number of local-reset call sites on current main so a new
+    # site that reintroduces upstream-blaming wording cannot slip in unnoticed.
+    assert call_count == 5
     for chunk in source.split(reset_call)[1:]:
         call_body = chunk.split(")\n", 1)[0]
         assert "_HTTP_BRIDGE_LOCAL_RESET_MESSAGE" in call_body

--- a/tests/unit/test_proxy_errors.py
+++ b/tests/unit/test_proxy_errors.py
@@ -276,6 +276,63 @@ async def test_indefinite_recovery_exhaustion_emits_terminal_response_failed(mon
 
 
 @pytest.mark.asyncio
+async def test_indefinite_recovery_retries_eventless_bridge_timeouts(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        proxy_api,
+        "get_settings",
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+        ),
+    )
+    monkeypatch.setattr(proxy_api, "_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
+    attempts = 0
+
+    def durable_eventless_timeout(message: str) -> ProxyResponseError:
+        exc = ProxyResponseError(
+            503,
+            {
+                "error": {
+                    "code": proxy_api.HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
+                    "message": message,
+                    "type": "server_error",
+                }
+            },
+            retry_after_seconds=1,
+        )
+        setattr(exc, "http_bridge_durable_recovery_eligible", True)
+        return exc
+
+    async def stream():
+        if False:
+            yield ""
+        raise durable_eventless_timeout("eventless before recovery")
+
+    async def recovery_stream():
+        nonlocal attempts
+        attempts += 1
+        raise durable_eventless_timeout(f"eventless retry {attempts}")
+        yield ""
+
+    events = [
+        event
+        async for event in _stream_response_error_events(
+            stream(),
+            owns_reservation=False,
+            reservation=None,
+            recovery_stream_factory=lambda: recovery_stream(),
+            require_durable_recovery_fence=True,
+        )
+    ]
+
+    assert attempts == 2
+    assert events.count(": codex-lb recovery in progress\n\n") == 2
+    assert "response.failed" in events[-1]
+    assert proxy_api.HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE in events[-1]
+    assert "eventless retry 2" in events[-1]
+
+
+@pytest.mark.asyncio
 async def test_indefinite_recovery_converts_unexpected_admission_failure_to_sse(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_proxy_errors.py
+++ b/tests/unit/test_proxy_errors.py
@@ -53,6 +53,7 @@ def test_http_bridge_indefinite_recovery_defers_predecessor_proof_to_submit_path
         lambda: SimpleNamespace(
             http_responses_session_bridge_operation_ledger_enabled=True,
             http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=6,
         ),
     )
     fresh_turn = ResponsesRequest(model="gpt-5.6", instructions="", input="retry")
@@ -152,7 +153,8 @@ async def test_indefinite_recovery_does_not_retry_after_downstream_event(monkeyp
         proxy_api,
         "get_settings",
         lambda: SimpleNamespace(
-            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery"
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=6,
         ),
     )
 
@@ -188,7 +190,8 @@ async def test_indefinite_recovery_converts_retry_reservation_failure_to_sse(mon
         proxy_api,
         "get_settings",
         lambda: SimpleNamespace(
-            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery"
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=6,
         ),
     )
     monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
@@ -225,9 +228,9 @@ async def test_indefinite_recovery_exhaustion_emits_terminal_response_failed(mon
         "get_settings",
         lambda: SimpleNamespace(
             http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=2,
         ),
     )
-    monkeypatch.setattr(proxy_api, "_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS", 2)
     monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
     attempts = 0
 
@@ -282,9 +285,9 @@ async def test_indefinite_recovery_retries_eventless_bridge_timeouts(monkeypatch
         "get_settings",
         lambda: SimpleNamespace(
             http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=2,
         ),
     )
-    monkeypatch.setattr(proxy_api, "_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS", 2)
     monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
     attempts = 0
 
@@ -340,7 +343,8 @@ async def test_indefinite_recovery_converts_unexpected_admission_failure_to_sse(
         proxy_api,
         "get_settings",
         lambda: SimpleNamespace(
-            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery"
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=6,
         ),
     )
     monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
@@ -378,7 +382,8 @@ async def test_indefinite_recovery_stops_after_retry_output_then_transport_error
         proxy_api,
         "get_settings",
         lambda: SimpleNamespace(
-            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery"
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+            http_responses_session_bridge_server_recovery_max_attempts=6,
         ),
     )
     monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())

--- a/tests/unit/test_proxy_errors.py
+++ b/tests/unit/test_proxy_errors.py
@@ -219,6 +219,63 @@ async def test_indefinite_recovery_converts_retry_reservation_failure_to_sse(mon
 
 
 @pytest.mark.asyncio
+async def test_indefinite_recovery_exhaustion_emits_terminal_response_failed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        proxy_api,
+        "get_settings",
+        lambda: SimpleNamespace(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_indefinite_recovery",
+        ),
+    )
+    monkeypatch.setattr(proxy_api, "_HTTP_BRIDGE_SERVER_RECOVERY_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_api.asyncio, "sleep", lambda _delay: _completed_asyncio_sleep())
+    attempts = 0
+
+    def durable_stream_incomplete(message: str) -> ProxyResponseError:
+        exc = ProxyResponseError(
+            502,
+            {"error": {"code": "stream_incomplete", "message": message, "type": "server_error"}},
+            retry_after_seconds=1,
+        )
+        setattr(exc, "http_bridge_durable_recovery_eligible", True)
+        return exc
+
+    async def stream():
+        if False:
+            yield ""
+        raise durable_stream_incomplete("closed before response.created")
+
+    async def recovery_stream():
+        nonlocal attempts
+        attempts += 1
+        raise durable_stream_incomplete(f"still closed attempt {attempts}")
+        yield ""
+
+    events = [
+        event
+        async for event in _stream_response_error_events(
+            stream(),
+            owns_reservation=False,
+            reservation=None,
+            recovery_stream_factory=lambda: recovery_stream(),
+            require_durable_recovery_fence=True,
+        )
+    ]
+
+    assert attempts == 2
+    assert events.count(": codex-lb recovery in progress\n\n") == 2
+    assert "response.failed" in events[-1]
+    assert "stream_incomplete" in events[-1]
+    assert "still closed attempt 2" in events[-1]
+    payload = proxy_api._parse_sse_payload(events[-1])
+    assert payload is not None
+    response = payload.get("response")
+    assert isinstance(response, dict)
+    assert isinstance(response.get("id"), str)
+    assert response["id"]
+
+
+@pytest.mark.asyncio
 async def test_indefinite_recovery_converts_unexpected_admission_failure_to_sse(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -36,7 +36,7 @@ from app.core.clients.proxy_websocket import (
     WebsocketsUpstreamWebSocket,
 )
 from app.core.config.settings import Settings
-from app.core.errors import openai_error
+from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE, openai_error
 from app.core.openai.requests import ResponsesRequest
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
 from app.db.models import AccountStatus, Base, HttpBridgeSessionState
@@ -6787,7 +6787,7 @@ async def test_http_bridge_startup_cooldown_releases_api_key_reservation(
     ]
 
     assert len(events) == 1
-    assert '"code":"stream_idle_timeout"' in events[0]
+    assert '"code":"bridge_eventless_timeout"' in events[0]
     release.assert_awaited_once_with(request_state)
     assert request_state.api_key_reservation is None
 
@@ -6940,7 +6940,7 @@ async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed
             pass
 
     assert exc_info.value.status_code == 503
-    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert exc_info.value.payload["error"]["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
     submit.assert_not_awaited()
     sleep.assert_not_awaited()
 
@@ -6991,7 +6991,7 @@ async def test_http_bridge_one_shot_hard_turn_requires_operation_ledger_for_cool
             pass
 
     assert exc_info.value.status_code == 503
-    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert exc_info.value.payload["error"]["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
     submit.assert_not_awaited()
     sleep.assert_not_awaited()
 
@@ -7297,7 +7297,7 @@ async def test_http_bridge_post_submit_cooldown_race_detaches_request(
     ]
 
     assert len(events) == 1
-    assert '"code":"stream_idle_timeout"' in events[0]
+    assert '"code":"bridge_eventless_timeout"' in events[0]
     assert cooldown.await_count == 2
     detach.assert_awaited_once_with(session, request_state=request_state)
 
@@ -7477,6 +7477,14 @@ async def test_http_bridge_idle_recovery_transport_failure_yields_terminal_event
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            lookup_retry_circuit=AsyncMock(return_value=None),
+            persist_retry_circuit=AsyncMock(return_value=None),
+            clear_retry_circuit=AsyncMock(return_value=None),
+        ),
+    )
     detach = AsyncMock()
     monkeypatch.setattr(service, "_detach_http_bridge_request", detach)
     monkeypatch.setattr(
@@ -7486,6 +7494,7 @@ async def test_http_bridge_idle_recovery_transport_failure_yields_terminal_event
             http_responses_stream_request_budget_seconds=60.0,
             sse_keepalive_interval_seconds=0.001,
             stream_idle_timeout_seconds=0.001,
+            http_responses_session_bridge_anchor_poison_failure_threshold=7,
         ),
     )
     monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
@@ -7542,8 +7551,8 @@ async def test_http_bridge_idle_recovery_transport_failure_yields_terminal_event
     assert isinstance(response, dict)
     error = response["error"]
     assert isinstance(error, dict)
-    assert error["code"] == "proxy_network_unavailable"
-    assert error["message"] == "Codex upstream websocket send failed: OSError"
+    assert error["code"] == "bridge_eventless_timeout"
+    assert error["message"] == http_bridge_helpers_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
     retry_precreated.assert_awaited_once_with(session, restart_reader=True)
     detach.assert_awaited_once_with(session, request_state=request_state)
 
@@ -21131,6 +21140,77 @@ async def test_claim_durable_http_bridge_session_rejects_remote_owner_without_ta
 
 
 @pytest.mark.asyncio
+async def test_claim_durable_http_bridge_session_retries_ownerless_row_before_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    app_settings = _make_app_settings()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    claim_live_session = AsyncMock(
+        side_effect=[
+            proxy_service.DurableBridgeLookup(
+                session_id="durable-1",
+                canonical_kind="session_header",
+                canonical_key="sid-123",
+                api_key_scope="__anonymous__",
+                account_id="acc-1",
+                owner_instance_id=None,
+                owner_epoch=2,
+                lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+                state=HttpBridgeSessionState.CLOSED,
+                latest_turn_state=None,
+                latest_response_id=None,
+            ),
+            proxy_service.DurableBridgeLookup(
+                session_id="durable-1",
+                canonical_kind="session_header",
+                canonical_key="sid-123",
+                api_key_scope="__anonymous__",
+                account_id="acc-1",
+                owner_instance_id=app_settings.http_responses_session_bridge_instance_id,
+                owner_epoch=3,
+                lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+                state=HttpBridgeSessionState.ACTIVE,
+                latest_turn_state=None,
+                latest_response_id=None,
+            ),
+        ]
+    )
+    monkeypatch.setattr(service._durable_bridge, "claim_live_session", claim_live_session)
+    # This is the only claim test whose claim succeeds, so it is the only one
+    # that reaches the alias write. The durable session row is a mock, so let
+    # the alias registration be one too instead of writing a child row for a
+    # parent that does not exist.
+    register_session_header = AsyncMock()
+    monkeypatch.setattr(service._durable_bridge, "register_session_header", register_session_header)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: app_settings)
+
+    await service._claim_durable_http_bridge_session(session, allow_takeover=False)
+
+    assert claim_live_session.await_count == 2
+    assert register_session_header.await_count == 1
+    assert session.durable_session_id == "durable-1"
+    assert session.durable_owner_epoch == 3
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_hard_continuity_lookup_failure_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -26382,7 +26462,7 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
         terminal_task = asyncio.create_task(anext(stream))
         await asyncio.wait_for(reader_retry_started.wait(), timeout=1.0)
         terminal = await asyncio.wait_for(terminal_task, timeout=1.0)
-        assert '"code":"stream_idle_timeout"' in terminal
+        assert f'"code":"{HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE}"' in terminal
         release_reader_retry.set()
         await asyncio.wait_for(reader_task, timeout=1.0)
 
@@ -30383,6 +30463,32 @@ async def test_http_bridge_eventless_timeout_force_retires_with_admission_waiter
     fail_pending_await_args = fail_pending.await_args
     assert fail_pending_await_args is not None
     assert fail_pending_await_args.kwargs["penalize_account"] is False
+
+
+@pytest.mark.asyncio
+async def test_reset_http_bridge_session_after_local_terminal_error_is_account_neutral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="local-reset-account-neutral")
+    service._http_bridge_sessions[session.key] = session
+    fail_pending = AsyncMock()
+    close_session = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
+
+    await service._reset_http_bridge_session_after_local_terminal_error(
+        session,
+        error_code="stream_incomplete",
+        error_message=http_bridge_streaming_module._HTTP_BRIDGE_LOCAL_RESET_MESSAGE,
+    )
+
+    fail_pending.assert_awaited_once()
+    fail_pending_await_args = fail_pending.await_args
+    assert fail_pending_await_args is not None
+    assert fail_pending_await_args.kwargs["penalize_account"] is False
+    close_session.assert_awaited_once_with(session, release_durable_session=True)
+    assert session.key not in service._http_bridge_sessions
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7222,7 +7222,73 @@ async def test_http_bridge_one_shot_hard_turn_does_not_submit_after_wait_budget(
             pass
 
     assert exc_info.value.status_code == 503
-    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert exc_info.value.payload["error"]["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
+    assert request_state.failure_phase_override == "bridge"
+    assert request_state.failure_detail_override == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
+    submit.assert_not_awaited()
+    release.assert_awaited_once_with(request_state)
+    assert request_state.api_key_reservation is None
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_one_shot_hard_turn_sse_budget_wait_uses_eventless_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-hard-turn-wait-budget-sse")
+    session.durable_session_id = "durable-hard-turn-wait-budget-sse"
+    session.durable_owner_epoch = 9
+    reservation = cast(Any, object())
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-turn-wait-budget-sse",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=reservation,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        session_id="turn-state-wait-budget-sse",
+        hard_continuity_anchor=True,
+    )
+    clock = SimpleNamespace(now=100.0)
+    submit = AsyncMock()
+    release = AsyncMock()
+
+    async def sleep(delay: float) -> None:
+        clock.now += delay
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once",
+        ),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module._service_time(), "monotonic", lambda: clock.now)
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_release_websocket_request_state_reservation", release)
+    monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
+
+    events = [
+        event
+        async for event in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=8,
+            propagate_http_errors=False,
+            downstream_turn_state="turn-state-wait-budget-sse",
+            request_deadline=105.0,
+        )
+    ]
+
+    terminal = cast(dict[str, object], proxy_service.parse_sse_data_json(events[-1]))
+    error = cast(dict[str, object], cast(dict[str, object], terminal["response"])["error"])
+    assert error["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
+    assert request_state.failure_phase_override == "bridge"
+    assert request_state.failure_detail_override == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
     submit.assert_not_awaited()
     release.assert_awaited_once_with(request_state)
     assert request_state.api_key_reservation is None

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -74,6 +74,7 @@ from app.modules.proxy._service import compact as proxy_compact_service
 from app.modules.proxy._service import file_ops as proxy_file_ops
 from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service import warmup as proxy_warmup_service
+from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
 from app.modules.proxy._service.http_bridge import request_submit as proxy_http_bridge_request_submit
 from app.modules.proxy._service.http_bridge import service_stubs as proxy_http_bridge_service_stubs
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
@@ -46736,6 +46737,7 @@ async def test_http_bridge_eventless_retry_transport_failure_uses_bridge_timeout
         last_used_at=0.0,
         idle_ttl_seconds=30.0,
     )
+    session.unmatched_upstream_liveness_count = 1
     record_failure = AsyncMock(return_value=1)
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -46770,7 +46772,7 @@ async def test_http_bridge_eventless_retry_transport_failure_uses_bridge_timeout
     terminal = cast(dict[str, object], proxy_service.parse_sse_data_json(events[-1]))
     error = cast(dict[str, object], cast(dict[str, object], terminal["response"])["error"])
     assert error["code"] == "bridge_eventless_timeout"
-    assert error["message"] == http_bridge_streaming_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
+    assert "retry may duplicate upstream work" in cast(str, error["message"])
     assert request_state.failure_detail_override == "bridge_eventless_timeout"
     record_failure.assert_awaited_once_with(session, detail="bridge_eventless_timeout")
 
@@ -46848,8 +46850,7 @@ async def test_http_bridge_eventless_retry_transport_failure_raises_bridge_timeo
     assert exc_info.value.status_code == 503
     assert exc_info.value.payload["error"]["code"] == "bridge_eventless_timeout"
     assert (
-        exc_info.value.payload["error"]["message"]
-        == http_bridge_streaming_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
+        exc_info.value.payload["error"]["message"] == http_bridge_helpers_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
     )
     record_failure.assert_awaited_once_with(session, detail="bridge_eventless_timeout")
 
@@ -46988,11 +46989,10 @@ async def test_http_bridge_session_events_keepalive_backstop_respects_idle_timeo
     finally:
         await events.aclose()
 
-    # The pre-response budget is min(stuck gate, stream idle, request budget)
-    # = 0.05s, i.e. ceil(0.05 / 0.01) = 5 keepalive ticks, instead of the old
-    # implicit _STREAM_KEEPALIVE_MAX_COUNT product.
-    assert len(collected) == 5
-    assert collected[:-1] == [proxy_service.CODEX_KEEPALIVE_FRAME] * 4
+    # Under event-loop load a boundary tick can shift by one interval; keep the
+    # assertion about the backstop budget without depending on exact scheduling.
+    assert 4 <= len(collected) <= 6
+    assert all(event == proxy_service.CODEX_KEEPALIVE_FRAME for event in collected[:-1])
     last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[-1]))
     assert last["type"] == "response.failed"
     assert (

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -76,6 +76,7 @@ from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service import warmup as proxy_warmup_service
 from app.modules.proxy._service.http_bridge import request_submit as proxy_http_bridge_request_submit
 from app.modules.proxy._service.http_bridge import service_stubs as proxy_http_bridge_service_stubs
+from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
 from app.modules.proxy._service.http_bridge import upstream_events as proxy_http_bridge_upstream_events
 from app.modules.proxy._service.streaming import helpers as streaming_helpers_module
 from app.modules.proxy._service.streaming import retry as streaming_retry_module
@@ -5864,6 +5865,7 @@ def _make_proxy_settings(*, trace_channels: frozenset[str] = frozenset()) -> Sim
         max_sse_event_bytes=16 * 1024 * 1024,
         http_responses_session_bridge_instance_id="test-instance",
         http_responses_session_bridge_instance_ring=[],
+        http_responses_session_bridge_anchor_poison_failure_threshold=7,
         http_downstream_transport_policy="smart",
     )
 
@@ -26682,6 +26684,46 @@ async def test_fail_pending_websocket_requests_does_not_penalize_rejected_input_
 
 
 @pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_keeps_anchor_neutral_stream_incomplete_account_neutral(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_anchor_neutral_pending")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_anchor_neutral_pending",
+        response_id="resp_ws_anchor_neutral_pending",
+        model="gpt-5.5",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor_neutral_pending",
+    )
+    pending_requests = deque([request_state])
+
+    await service._fail_pending_websocket_requests(
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="Upstream websocket closed before response.completed",
+        api_key=None,
+    )
+
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["request_id"] == "resp_ws_anchor_neutral_pending"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+
+
+@pytest.mark.asyncio
 async def test_fail_pending_websocket_requests_logs_even_when_penalty_fails(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -46490,12 +46532,16 @@ async def test_http_bridge_session_events_keepalive_backstop(monkeypatch):
     finally:
         await events.aclose()
 
-    assert len(collected) == 2, f"Expected 2 events (1 keepalive + stream_idle_timeout), got {len(collected)}"
+    assert len(collected) == 2, f"Expected 2 events (1 keepalive + bridge_eventless_timeout), got {len(collected)}"
     assert collected[0] == proxy_service.CODEX_KEEPALIVE_FRAME
     last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[1]))
     assert last["type"] == "response.failed"
     assert cast(dict[str, object], last["response"])["status"] == "failed"
-    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+    # Pre-response-start silence is bridge_eventless_timeout, never the
+    # post-start stream_idle_timeout budget.
+    error = cast(dict[str, object], cast(dict[str, object], last["response"])["error"])
+    assert error["code"] == "bridge_eventless_timeout"
+    assert "Upstream" not in cast(str, error["message"])
 
 
 @pytest.mark.asyncio
@@ -46505,6 +46551,9 @@ async def test_http_bridge_session_events_retries_silent_pre_response_once(monke
     settings = _make_proxy_settings()
     settings.sse_keepalive_interval_seconds = 0.001
     settings.stream_idle_timeout_seconds = 7200.0
+    # The pre-response budget is derived from the owner-side stuck gate, not
+    # from stream_idle_timeout_seconds; scale it down for the test clock.
+    settings.http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.002
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_bridge_idle_retry",
         model="gpt-5.1",
@@ -46559,7 +46608,10 @@ async def test_http_bridge_session_events_retries_silent_pre_response_once(monke
     assert len(collected) == 3
     assert collected[:2] == [proxy_service.CODEX_KEEPALIVE_FRAME] * 2
     last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[-1]))
-    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+    assert (
+        cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"]
+        == "bridge_eventless_timeout"
+    )
     assert retry_precreated.await_count == 2
     assert all(attempt.kwargs == {"restart_reader": True} for attempt in retry_precreated.await_args_list)
 
@@ -46570,6 +46622,14 @@ async def test_http_bridge_session_events_keeps_alive_during_retry_circuit_coold
 ) -> None:
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            lookup_retry_circuit=AsyncMock(return_value=None),
+            persist_retry_circuit=AsyncMock(return_value=None),
+            clear_retry_circuit=AsyncMock(return_value=None),
+        ),
+    )
     settings = _make_proxy_settings()
     monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 1)
     settings.sse_keepalive_interval_seconds = 0.001
@@ -46630,9 +46690,244 @@ async def test_http_bridge_session_events_keeps_alive_during_retry_circuit_coold
     assert len(collected) >= 2
     assert collected[:-1] == [proxy_service.CODEX_KEEPALIVE_FRAME] * (len(collected) - 1)
     last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[-1]))
-    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+    assert (
+        cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"]
+        == "bridge_eventless_timeout"
+    )
     assert retry_precreated.await_count >= 1
     assert retry_cooldown.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_eventless_retry_transport_failure_uses_bridge_timeout_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.sse_keepalive_interval_seconds = 0.001
+    settings.stream_idle_timeout_seconds = 1.0
+    settings.http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.002
+    settings.http_responses_session_bridge_anchor_poison_failure_threshold = 7
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_transport_failure",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        response_id=None,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-retry-transport-failure", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_retry_transport_failure"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    record_failure = AsyncMock(return_value=1)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 1)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_retry_http_bridge_precreated_request",
+        AsyncMock(
+            side_effect=UpstreamWebSocketTransportError(
+                "dial failed",
+                error_code="upstream_unavailable",
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
+
+    events = [
+        event
+        async for event in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=10,
+            propagate_http_errors=False,
+            downstream_turn_state=None,
+        )
+    ]
+
+    terminal = cast(dict[str, object], proxy_service.parse_sse_data_json(events[-1]))
+    error = cast(dict[str, object], cast(dict[str, object], terminal["response"])["error"])
+    assert error["code"] == "bridge_eventless_timeout"
+    assert error["message"] == http_bridge_streaming_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
+    assert request_state.failure_detail_override == "bridge_eventless_timeout"
+    record_failure.assert_awaited_once_with(session, detail="bridge_eventless_timeout")
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_eventless_retry_transport_failure_raises_bridge_timeout_proxy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.sse_keepalive_interval_seconds = 0.001
+    settings.stream_idle_timeout_seconds = 1.0
+    settings.http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.002
+    settings.http_responses_session_bridge_anchor_poison_failure_threshold = 7
+    settings.http_responses_session_bridge_ambiguous_continuation_recovery_mode = "server_indefinite_recovery"
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_transport_failure_proxy",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        response_id=None,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        previous_response_id="resp-anchor",
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-retry-transport-failure-proxy", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_retry_transport_failure_proxy"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    record_failure = AsyncMock(return_value=1)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 1)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_retry_http_bridge_precreated_request",
+        AsyncMock(
+            side_effect=UpstreamWebSocketTransportError(
+                "dial failed",
+                error_code="upstream_unavailable",
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=10,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+        ):
+            pass
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "bridge_eventless_timeout"
+    assert (
+        exc_info.value.payload["error"]["message"]
+        == http_bridge_streaming_module._HTTP_BRIDGE_EVENTLESS_TIMEOUT_MESSAGE
+    )
+    record_failure.assert_awaited_once_with(session, detail="bridge_eventless_timeout")
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_primary_eventless_timeout_poisons_anchor_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.sse_keepalive_interval_seconds = 0.001
+    settings.stream_idle_timeout_seconds = 1.0
+    settings.http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.002
+    settings.http_responses_session_bridge_anchor_poison_failure_threshold = 2
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_primary_eventless_poison",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        response_id=None,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-primary-eventless-poison", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_primary_eventless_poison"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    record_failure = AsyncMock(return_value=2)
+    retire = AsyncMock()
+    abandon = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 1)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", retire)
+    monkeypatch.setattr(http_bridge_streaming_module, "_abandon_durable_http_bridge_continuity", abandon)
+
+    events = [
+        event
+        async for event in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=10,
+            propagate_http_errors=False,
+            downstream_turn_state=None,
+        )
+    ]
+
+    terminal = cast(dict[str, object], proxy_service.parse_sse_data_json(events[-1]))
+    error = cast(dict[str, object], cast(dict[str, object], terminal["response"])["error"])
+    assert error["code"] == "bridge_eventless_timeout"
+    abandon.assert_awaited_once_with(service, session)
+    retire.assert_awaited_once_with(
+        session,
+        detail="repeated_zero_event_idle_timeout",
+        response_events_seen=0,
+        retired_request_count=0,
+    )
 
 
 @pytest.mark.asyncio
@@ -46693,11 +46988,17 @@ async def test_http_bridge_session_events_keepalive_backstop_respects_idle_timeo
     finally:
         await events.aclose()
 
-    assert len(collected) == 2
-    assert collected[0] == proxy_service.CODEX_KEEPALIVE_FRAME
-    last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[1]))
+    # The pre-response budget is min(stuck gate, stream idle, request budget)
+    # = 0.05s, i.e. ceil(0.05 / 0.01) = 5 keepalive ticks, instead of the old
+    # implicit _STREAM_KEEPALIVE_MAX_COUNT product.
+    assert len(collected) == 5
+    assert collected[:-1] == [proxy_service.CODEX_KEEPALIVE_FRAME] * 4
+    last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[-1]))
     assert last["type"] == "response.failed"
-    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+    assert (
+        cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"]
+        == "bridge_eventless_timeout"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -72,7 +72,12 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 # 131 -> 132: operation_spool_format. The default remains rows_v1 because a
 # rolling deployment may enable chunks_v2 only after every replica can read it;
 # no existing timeout or size setting can express that compatibility fence.
-MAX_SETTINGS_FIELDS = 132
+# 132 -> 133: http_responses_session_bridge_server_recovery_max_attempts. The
+# bounded server-owned eventless recovery cap was hardcoded at 6 while the
+# bound-eventless-server-recovery spec called it "configured"; the maintainer
+# asked for it to be promoted to a setting on PR #1633 (2026-08-20/08-26),
+# consistent with that PR's budget-from-settings principle.
+MAX_SETTINGS_FIELDS = 133
 
 
 def test_generated_settings_reference_matches_code() -> None:


### PR DESCRIPTION
Supersedes #1633 — takeover preserving the commits and attribution of @Komzpa (author unresponsive since 2026-08-22 across two triage rounds).

An audit of the 2026-08-06 live incident found the bridge conflating two different timers and blaming the upstream for local recovery: the pre-`response.created` silence watchdog killed requests after an implicit `6 x sse_keepalive_interval = ~60s` but emitted the kill as `stream_idle_timeout` (configured budget 7200s), so zero-event bridge handoff wedges were logged as upstream stream failures all day (57/64 reader failures had `response_events_seen=0`; healthy turns' first-event p95 is 930ms), and four local bridge-reset sites reported "Upstream websocket closed before response.completed" for purely local recovery. This PR gives every pre-response terminal an honest `bridge_eventless_timeout` classification, derives the pre-response budget from settings instead of the magic 60s, counts unmatched upstream liveness so a local matching wedge is distinguishable from a silent upstream (and gates the client retry promise on it), makes local resets say so, and hardens startup grace seeding against not-yet-migrated databases. Komzpa's three original commits are preserved verbatim (author fields intact); the maintainer's 08-26 punch list and the rebase reconciliation are separate commits on top.

## Scope disclosure (per maintainer request)

Beyond the original eventless-timeout rename, this PR folds in the content of two closed PRs, so its squash changelog covers roughly three PRs:

- **#1746 (closed)**: bounded server-owned recovery — the `server_indefinite_recovery` loop stops after a capped number of eventless attempts and emits one terminal `response.failed` with a stable `response.id`, plus the `bound-eventless-server-recovery` openspec change. Per review, the cap is now a setting: `http_responses_session_bridge_server_recovery_max_attempts` (default 6).
- **#1648 (closed)**: durable HTTP bridge claim retries an ownerless row once with the forced epoch-advance path before treating it as an owner mismatch.

## Changes

- Distinct `bridge_eventless_timeout` classification for every pre-response terminal (logs, request-log detail, retry-circuit `last_detail`, Prometheus surface label). Client shape stays a retryable 503 with an honest message.
- The pre-response budget is now a named, settings-derived value: `min(stuck_gate_retire_after_seconds, stream_idle_timeout_seconds, bridge_request_budget_seconds)` (300s at defaults) — no more magic 60s; `_STREAM_KEEPALIVE_MAX_COUNT` is demoted to a keepalive-cadence floor that never outlives a shorter configured budget. The owner-side missing-created watchdog still fires first on the common path, so recovery latency is unchanged — only the label is fixed.
- Unmatched upstream frames that prove transport liveness are counted and logged (`unmatched_upstream_liveness=N` on the eventless terminal). `codex.keepalive` is excluded. The client retry contract is gated on that counter: zero unmatched frames keeps the "safe to retry" promise, a non-zero count switches to honest retry-with-caution wording.
- Local resets say so: "HTTP responses session bridge reset this session locally before response.completed". "Upstream websocket closed" is reserved for genuine upstream closes (regression guard pins all five current local-reset call sites, including the two added on main since the original head).
- Repeated zero-event idle failures on the primary downstream watchdog path enforce the anchor-poison threshold and retire durable continuity.
- Startup hard-sticky grace seeding tolerates a not-yet-migrated database: with `database_migrate_on_startup=false`, a boot against a legacy database without `runtime_sentinels`/`accounts` previously crashed with an unhandled sqlite `OperationalError`. The guard matches only the sqlite missing-table shape, rolls back, returns 0 without stamping the sentinel (so the first post-migration boot still backfills), and re-raises every other `OperationalError`.

## 08-26 review blockers, addressed

1. **CI must be chased to green** — full unit suite green locally with CI-parity args (6740 passed, 3 skipped); the owner-flagged flake site `tests/integration/test_dashboard_overview.py` passes 25/25 with no locked-DB teardown. The only recovery-loop change since is a settings read; no session is held across the loop. The single remaining local failure (`test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` in isolated file runs) reproduces byte-identically on pristine current main — pre-existing test-isolation quirk, and it passes inside the full unit suite.
2. **PR body must disclose the folded scope** — stale "Stacked on #1625" removed; folded #1746 and #1648 scope disclosed above; the `repository.py` guard justification is carried in Changes.
3. **Recovery attempt cap: promote to a setting or reword the spec to a fixed cap** — promoted to `http_responses_session_bridge_server_recovery_max_attempts` (default 6, ge=1 le=100), read from `get_settings()` by the recovery loop and its exhaustion log; `bound-eventless-server-recovery` spec/proposal reworded to name the setting; `docs/reference/settings.md` regenerated; settings-surface ratchet bumped 132→133 with a comment citing this review. Chose the setting per the stated lean and the PR's budget-from-settings principle — if the fixed-cap wording is preferred instead, revert the single commit and reword the spec.
4. **Justify the `OperationalError` swallow in startup grace seeding** — rationale docstring added to `_is_missing_hard_sticky_seed_table` (sqlite-only missing-table shape; rollback + return 0 without stamping the sentinel; everything else propagates).
5. **Pin the zero-liveness safe-to-retry wording** (CodeRabbit 08-22) — `test_http_bridge_eventless_timeout_without_liveness_promises_safe_retry` pins the exact safe-to-retry message at `unmatched_upstream_liveness_count=0` alongside the existing count=2 caution case.

## Known remaining note (P3, non-blocking)

- `_HTTPBridgeSession.unmatched_upstream_liveness_count` is per-session and never resets, so a single unmatched frame from a long-past turn switches every later eventless terminal on that session to the retry-may-duplicate caution wording even when the current turn provably never started. This fails conservative (never falsely promises safe retry) and the per-session counter design is stated in the reviewed spec — flagged as a possible follow-up, not changed here.
- (Fixed in this branch: the spec/test comment previously claimed the keepalive floor is unconditional; reworded to match the correct implemented behavior where the count follows a shorter configured budget.)

## Verification

- Full `tests/unit` with CI-parity args: 6740 passed, 3 skipped (sole exception above reproduces on pristine main).
- Targeted: `test_http_bridge_eventless_semantics.py` 6 passed (both retry-wording branches), `test_proxy_errors.py` 19, `test_settings_reference.py` 4, `test_proxy_utils.py` 1156, `test_proxy_http_bridge.py` 732.
- `tests/integration/test_dashboard_overview.py` 25 passed; sticky seed/grace integration 2 passed.
- `ruff check` + `ruff format --check` clean; ty clean on touched areas; proxy architecture check passed.
- `openspec validate --strict` green for `name-bridge-eventless-timeout` and `bound-eventless-server-recovery`; `--all` failures = 21, identical set to main (no new failures).
- Rebased onto current main (`1d9332a32`, includes #1902 and #1906); #1902's denied-anchor-fence code verified intact after conflict resolution; main's two new local-reset sites converted and the grep-style regression guard re-pinned from 4 to 5 sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct handling for bridge timeouts occurring before a response begins.
  * Added configurable limits for server-side recovery attempts, defaulting to six.
  * Exhausted recovery now emits a terminal `response.failed` event with a stable response ID.
  * Added clearer reporting for upstream liveness and local bridge resets.

* **Bug Fixes**
  * Improved durable session recovery and startup behavior after database migrations.
  * Prevented account-health penalties for neutral, incomplete-stream conditions.

* **Documentation**
  * Documented the new recovery-attempt configuration and bridge timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->