### PR TITLE
fix(proxy): refuse disabled model sources and spare account health from model-scoped rejections

### DIFF
--- a/app/modules/model_sources/repository.py
+++ b/app/modules/model_sources/repository.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
-from sqlalchemy import delete, select
+from sqlalchemy import ColumnElement, and_, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db.models import ModelSource, ModelSourceModel
+
+
+def _enablement_filter(only_disabled: bool) -> ColumnElement[bool]:
+    """Enabled-state predicate for a per-capability source lookup.
+
+    ``only_disabled`` selects the exact complement of the routable set: rows
+    that match the model and the route shape but that an operator switched off,
+    at the source or at the individual model. Routing needs that complement to
+    tell "no source serves this model" apart from "the source that serves this
+    model is switched off" -- the latter must not fall through to a
+    subscription account, which rejects the model outright.
+    """
+    if only_disabled:
+        return or_(ModelSource.is_enabled.is_(False), ModelSourceModel.is_enabled.is_(False))
+    return and_(ModelSource.is_enabled.is_(True), ModelSourceModel.is_enabled.is_(True))
 
 
 class ModelSourcesRepository:
@@ -38,16 +53,16 @@ class ModelSourcesRepository:
         *,
         allowed_source_ids: set[str] | None = None,
         require_streaming: bool = False,
+        only_disabled: bool = False,
     ) -> ModelSource | None:
         stmt = (
             select(ModelSource)
             .options(selectinload(ModelSource.models))
             .join(ModelSourceModel, ModelSourceModel.source_id == ModelSource.id)
             .where(ModelSource.kind == "openai_compatible")
-            .where(ModelSource.is_enabled.is_(True))
             .where(ModelSource.supports_chat_completions.is_(True))
             .where(ModelSourceModel.model == model)
-            .where(ModelSourceModel.is_enabled.is_(True))
+            .where(_enablement_filter(only_disabled))
             .order_by(ModelSource.name, ModelSource.id)
             .limit(1)
         )
@@ -66,16 +81,16 @@ class ModelSourcesRepository:
         *,
         allowed_source_ids: set[str] | None = None,
         require_streaming: bool = False,
+        only_disabled: bool = False,
     ) -> ModelSource | None:
         stmt = (
             select(ModelSource)
             .options(selectinload(ModelSource.models))
             .join(ModelSourceModel, ModelSourceModel.source_id == ModelSource.id)
             .where(ModelSource.kind == "openai_compatible")
-            .where(ModelSource.is_enabled.is_(True))
             .where(ModelSource.supports_responses.is_(True))
             .where(ModelSourceModel.model == model)
-            .where(ModelSourceModel.is_enabled.is_(True))
+            .where(_enablement_filter(only_disabled))
             .order_by(ModelSource.name, ModelSource.id)
             .limit(1)
         )

--- a/app/modules/model_sources/selection.py
+++ b/app/modules/model_sources/selection.py
@@ -34,8 +34,19 @@ async def select_responses_model_source(
     *,
     raw_model: str | None = None,
     require_streaming: bool = False,
+    only_disabled: bool = False,
 ) -> tuple[ModelSource, str] | None:
-    """Resolve ``model`` to a Responses-capable model source, if any."""
+    """Resolve ``model`` to a Responses-capable model source, if any.
+
+    ``only_disabled`` inverts the enabled-state filter and leaves every other
+    rule -- candidate order, API key model allowlist, source assignment scope,
+    subscription-registry precedence, route shape, streaming -- untouched, so
+    the answer is exactly "the source this request would have used, had the
+    operator not switched it off". Callers use it after the ordinary lookup
+    misses, to refuse the request instead of handing a source-owned model to a
+    subscription account that cannot serve it. Sharing one function keeps the
+    two lookups from drifting apart the way the transports once did.
+    """
     assigned_source_ids = allowed_source_ids_for_api_key(api_key)
     exact_allowed_models = set(api_key.allowed_models) if api_key and api_key.allowed_models else None
     candidates = [candidate for candidate in (raw_model, model) if candidate]
@@ -55,6 +66,7 @@ async def select_responses_model_source(
                 candidate,
                 allowed_source_ids=assigned_source_ids,
                 require_streaming=require_streaming,
+                only_disabled=only_disabled,
             )
             if source is not None:
                 break

--- a/app/modules/model_sources/selection.py
+++ b/app/modules/model_sources/selection.py
@@ -92,10 +92,20 @@ async def responses_model_is_source_owned(
     *,
     raw_model: str | None = None,
 ) -> bool:
-    """True when ``model`` is served by an enabled Responses-capable source.
+    """True when ``model`` is served by a Responses-capable source, even a disabled one.
 
     Used by the WebSocket path, which cannot forward to a model source and must
     fail the session so the client falls back to the HTTP transport.
+
+    Disabled-source ownership counts as ownership here: the WebSocket transport
+    cannot serve a source-owned model regardless of the source's enabled state,
+    and dispatching the turn to a subscription account instead produces the
+    opaque upstream 400 (``The '<model>' model is not supported when using
+    Codex with a ChatGPT account.``). Bouncing the turn to HTTP lands it on the
+    disabled-source denial there, which answers 503 ``model_source_disabled``
+    and names the actual condition. The second, ``only_disabled`` probe runs
+    only after the ordinary lookup misses, so enabled sources keep resolving in
+    a single query.
 
     The API key's ``enforced_model`` is considered alongside the requested
     model, matching how the HTTP handlers build their candidate list: an
@@ -126,12 +136,23 @@ async def responses_model_is_source_owned(
     if not model and not raw:
         return False
     try:
+        if (
+            await select_responses_model_source(
+                model or raw or "",
+                api_key,
+                raw_model=raw,
+                require_streaming=True,
+            )
+            is not None
+        ):
+            return True
         return (
             await select_responses_model_source(
                 model or raw or "",
                 api_key,
                 raw_model=raw,
                 require_streaming=True,
+                only_disabled=True,
             )
             is not None
         )

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -864,11 +864,12 @@ def _is_account_neutral_request_rejection(
     on a self-inconsistent conversation drives its serving accounts into
     ``error_count`` backoff and starves unrelated tenants.
 
-    Keep this set narrow. Not every upstream ``invalid_request_error`` is
-    account neutral -- the model-entitlement rejection matched by
-    ``_is_account_model_unsupported_error`` is genuinely account scoped -- so
-    membership is decided by the specific classified message, never by the
-    ``invalid_request_error`` code alone.
+    Keep this set narrow: membership is decided by the specific classified
+    message, never by the ``invalid_request_error`` code alone. The
+    model-entitlement rejection is deliberately not a member -- it is handled
+    by ``_is_model_scoped_rejection`` below, which likewise keeps the account's
+    health untouched but still lets failover try accounts whose entitlements
+    may differ.
     """
     if code != "invalid_request_error":
         return False

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -388,6 +388,7 @@ from app.modules.proxy.durable_bridge_coordinator import (
 from app.modules.proxy.helpers import (
     _normalize_error_code,
     classify_upstream_failure,
+    is_model_scoped_upstream_rejection,
     is_upstream_model_capacity_error,
 )
 from app.modules.proxy.http_bridge_forwarding import (
@@ -876,6 +877,36 @@ def _is_account_neutral_request_rejection(
     return bool(_facade()._is_missing_tool_output_message(message))
 
 
+def _is_model_scoped_rejection(
+    *,
+    http_status: int | None,
+    message: str | None,
+) -> bool:
+    """Return whether upstream rejected the requested model, not the account.
+
+    The ChatGPT model-entitlement rejection is scoped to the model named in the
+    message. It proves nothing about the account's ability to serve the models
+    it *is* entitled to, so it must never move that account's ``error_count``:
+    otherwise one client looping on a model no account can serve drives every
+    serving account into ``ERROR_BACKOFF_THRESHOLD`` backoff and starves all
+    unrelated traffic on those accounts -- the exact failure mode when a model
+    reaches subscription selection because its OpenAI-compatible model source
+    is disabled or unreachable.
+
+    Failover is deliberately untouched: the classified failure is still
+    returned, so the caller keeps trying other accounts, whose entitlements may
+    differ.
+
+    The normalized code is not part of the match. Upstream delivers this
+    rejection with neither ``code`` nor ``type`` on the streaming path, which
+    normalizes to ``upstream_error``; on other paths it arrives as
+    ``invalid_request_error``. Only the exact message shape decides membership.
+    """
+    if http_status is not None and http_status != 400:
+        return False
+    return is_model_scoped_upstream_rejection(message)
+
+
 async def _handle_stream_error(
     proxy: Any,
     account: Account,
@@ -900,6 +931,17 @@ async def _handle_stream_error(
     ):
         _facade().logger.info(
             "Skipped account error penalty for account-neutral request rejection account_id=%s request_id=%s code=%s",
+            "<redacted>" if privacy_policy.redacts_sensitive_details else account.id,
+            get_request_id(),
+            code,
+        )
+        return classified
+    if _is_model_scoped_rejection(
+        http_status=http_status,
+        message=error.get("message"),
+    ):
+        _facade().logger.info(
+            "Skipped account error penalty for model-scoped upstream rejection account_id=%s request_id=%s code=%s",
             "<redacted>" if privacy_policy.redacts_sensitive_details else account.id,
             get_request_id(),
             code,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1815,7 +1815,10 @@ class _WebSocketMixin:
                                     # response.create that switches to a source-owned model
                                     # would otherwise be forwarded to the subscription account
                                     # already attached to the open upstream. Model sources are
-                                    # only reachable from the HTTP request path.
+                                    # only reachable from the HTTP request path. Ownership
+                                    # includes disabled sources, which no subscription account
+                                    # can serve either; over HTTP those meet the 503
+                                    # ``model_source_disabled`` denial.
                                     #
                                     # Gated on an existing upstream on purpose: a first turn has
                                     # no socket yet and must fall through to the connect guard,
@@ -3478,6 +3481,9 @@ class _WebSocketMixin:
         # model is not supported when using Codex with a ChatGPT account."
         # Codex clients fall back to the HTTP transport when a WebSocket
         # connect fails, and that path routes to the source correctly.
+        # Ownership includes disabled sources: no subscription account can
+        # serve those either, and the HTTP fallback answers them with the
+        # informative 503 ``model_source_disabled`` denial.
         #
         # Evaluated once per connect series rather than inside the failover
         # loop below: source ownership is a property of the requested model, so

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4573,6 +4573,17 @@ async def _disabled_model_source_denial(
     Returns ``None`` when no disabled source claims the model, leaving every
     other request on its existing path.
     """
+    if _allowed_source_ids_for_api_key(api_key) is None:
+        registry_models = get_model_registry().get_models_with_fallback()
+        candidates = [candidate for candidate in (raw_model, model) if candidate]
+        if candidates and all(candidate in registry_models for candidate in candidates):
+            # Mirrors the subscription-registry precedence rule inside the
+            # lookups: an unscoped key never source-routes a registry slug, so
+            # every candidate would be skipped and the probe is a guaranteed
+            # miss. Returning early keeps the extra background session off the
+            # ordinary subscription hot path, where this helper runs on every
+            # request whose model no source claims.
+            return None
     selection = (
         await _select_responses_model_source(
             model,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1126,8 +1126,8 @@ async def responses(
         error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)
     try:
-        source_selection = (
-            None
+        source_selection, continuity_suppressed = (
+            (None, False)
             if source_route_excluded
             else await _select_responses_model_source_with_continuity(
                 request,
@@ -1143,6 +1143,20 @@ async def responses(
     source = source_selection[0] if source_selection is not None else None
     if source_selection is not None:
         responses_payload.model = source_selection[1]
+    elif not source_route_excluded and not continuity_suppressed:
+        # The ordinary lookup itself missed (continuity suppression means an
+        # enabled source claimed the model, so the disabled probe must not
+        # override the recorded subscription anchor).
+        disabled_denial = await _disabled_model_source_denial(
+            request,
+            responses_payload.model,
+            api_key,
+            route="responses",
+            raw_model=raw_source_model,
+            require_streaming=True,
+        )
+        if disabled_denial is not None:
+            return disabled_denial
     if source is not None:
         # Opportunistic admission gates subscription *account* capacity;
         # source-routed requests use no account, so a closed/empty pool must
@@ -1305,8 +1319,8 @@ async def v1_responses(
         error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)
     try:
-        source_selection = (
-            None
+        source_selection, continuity_suppressed = (
+            (None, False)
             if source_route_excluded
             else await _select_responses_model_source_with_continuity(
                 request,
@@ -1322,6 +1336,20 @@ async def v1_responses(
     source = source_selection[0] if source_selection is not None else None
     if source_selection is not None:
         responses_payload.model = source_selection[1]
+    elif not source_route_excluded and not continuity_suppressed:
+        # The ordinary lookup itself missed (continuity suppression means an
+        # enabled source claimed the model, so the disabled probe must not
+        # override the recorded subscription anchor).
+        disabled_denial = await _disabled_model_source_denial(
+            request,
+            responses_payload.model,
+            api_key,
+            route="responses",
+            raw_model=raw_source_model,
+            require_streaming=responses_payload.stream is True,
+        )
+        if disabled_denial is not None:
+            return disabled_denial
     if source is not None:
         # Opportunistic admission gates subscription *account* capacity;
         # source-routed requests use no account, so a closed/empty pool must
@@ -4261,6 +4289,7 @@ async def v1_chat_completions(
     if prohibit_fast_mode and _is_fast_mode_model_alias(effective_model):
         effective_model = responses_payload.model
     validate_model_access(api_key, responses_payload.model)
+    source_route_attempted = not responses_shaped_payload and payload.messages is not None
     source_selection = (
         await _select_chat_model_source(
             responses_payload.model,
@@ -4268,11 +4297,24 @@ async def v1_chat_completions(
             raw_model=effective_model,
             require_streaming=payload.stream is True,
         )
-        if not responses_shaped_payload and payload.messages is not None
+        if source_route_attempted
         else None
     )
     source = source_selection[0] if source_selection is not None else None
     request_model = source_selection[1] if source_selection is not None else responses_payload.model
+    if source is None and source_route_attempted:
+        # Before any reservation is taken, so a refusal strands nothing.
+        disabled_denial = await _disabled_model_source_denial(
+            request,
+            responses_payload.model,
+            api_key,
+            route="chat",
+            raw_model=effective_model,
+            require_streaming=payload.stream is True,
+            headers=rate_limit_headers,
+        )
+        if disabled_denial is not None:
+            return disabled_denial
     if source is None:
         apply_enforced_service_tier_model_fallback(
             responses_payload,
@@ -4409,7 +4451,15 @@ async def _select_chat_model_source(
     *,
     raw_model: str | None = None,
     require_streaming: bool = False,
+    only_disabled: bool = False,
 ) -> tuple[ModelSource, str] | None:
+    """Resolve ``model`` to a Chat Completions-capable model source, if any.
+
+    ``only_disabled`` mirrors :func:`select_responses_model_source`: every rule
+    stays the same except the enabled-state filter, which is inverted, so the
+    result names the source the request would have used had it not been
+    switched off.
+    """
     assigned_source_ids = _allowed_source_ids_for_api_key(api_key)
     exact_allowed_models = set(api_key.allowed_models) if api_key and api_key.allowed_models else None
     candidates = [candidate for candidate in (raw_model, model) if candidate]
@@ -4429,6 +4479,7 @@ async def _select_chat_model_source(
                 candidate,
                 allowed_source_ids=assigned_source_ids,
                 require_streaming=require_streaming,
+                only_disabled=only_disabled,
             )
             if source is not None:
                 break
@@ -4447,6 +4498,7 @@ async def _select_responses_model_source(
     *,
     raw_model: str | None = None,
     require_streaming: bool = False,
+    only_disabled: bool = False,
 ) -> tuple[ModelSource, str] | None:
     # Shared with the WebSocket path so both transports agree on which models
     # belong to a model source.
@@ -4455,6 +4507,7 @@ async def _select_responses_model_source(
         api_key,
         raw_model=raw_model,
         require_streaming=require_streaming,
+        only_disabled=only_disabled,
     )
 
 
@@ -4466,8 +4519,17 @@ async def _select_responses_model_source_with_continuity(
     *,
     raw_model: str | None = None,
     require_streaming: bool = False,
-) -> tuple[ModelSource, str] | None:
-    """Select a source unless recorded subscription continuity owns the anchor."""
+) -> tuple[tuple[ModelSource, str] | None, bool]:
+    """Select a source unless recorded subscription continuity owns the anchor.
+
+    Returns ``(selection, continuity_suppressed)``. ``continuity_suppressed``
+    is ``True`` only when an enabled source claimed the model but a recorded
+    subscription owner for ``previous_response_id`` pinned the turn to a
+    subscription account instead. Callers use it to tell that case apart from
+    a genuine lookup miss: only a genuine miss may consult the disabled-source
+    denial, because a continuity-suppressed turn already has a subscription
+    anchor that must keep being served.
+    """
     source_selection = await _select_responses_model_source(
         payload.model,
         api_key,
@@ -4475,14 +4537,72 @@ async def _select_responses_model_source_with_continuity(
         require_streaming=require_streaming,
     )
     if source_selection is None or payload.previous_response_id is None:
-        return source_selection
+        return source_selection, False
     owner_account_id = await context.service._resolve_websocket_previous_response_owner(
         previous_response_id=payload.previous_response_id,
         api_key=api_key,
         session_id=proxy_affinity_module._owner_lookup_session_id_from_headers(request.headers),
         surface="http_source_route",
     )
-    return None if owner_account_id is not None else source_selection
+    if owner_account_id is not None:
+        return None, True
+    return source_selection, False
+
+
+async def _disabled_model_source_denial(
+    request: Request,
+    model: str,
+    api_key: ApiKeyData | None,
+    *,
+    route: Literal["chat", "responses"],
+    raw_model: str | None = None,
+    require_streaming: bool = False,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse | None:
+    """Refuse a request whose model source exists but is switched off.
+
+    Called only after the ordinary lookup missed. A miss has two very different
+    causes that the routing code cannot otherwise tell apart: the model belongs
+    to nobody, or it belongs to a model source (or a source model) an operator
+    disabled. Only the first may fall through to subscription selection --
+    handing a source-owned slug to a ChatGPT account produces
+    ``The '<model>' model is not supported when using Codex with a ChatGPT
+    account.``, which burns the account's health signal and tells the operator
+    nothing about the source they switched off.
+
+    Returns ``None`` when no disabled source claims the model, leaving every
+    other request on its existing path.
+    """
+    selection = (
+        await _select_responses_model_source(
+            model,
+            api_key,
+            raw_model=raw_model,
+            require_streaming=require_streaming,
+            only_disabled=True,
+        )
+        if route == "responses"
+        else await _select_chat_model_source(
+            model,
+            api_key,
+            raw_model=raw_model,
+            require_streaming=require_streaming,
+            only_disabled=True,
+        )
+    )
+    if selection is None:
+        return None
+    source, matched_model = selection
+    # The source name is operator-facing configuration, not a client-visible
+    # identifier, so the envelope names the model and the condition only.
+    reason = "is disabled" if not source.is_enabled else "has that model disabled"
+    error = openai_error(
+        "model_source_disabled",
+        f"The model '{matched_model}' is served by an OpenAI-compatible model source that {reason}. "
+        "Enable the source and its model in codex-lb, or request a different model.",
+        error_type="upstream_error",
+    )
+    return _logged_error_json_response(request, 503, error, headers=headers)
 
 
 async def _select_embeddings_model_source(model: str, api_key: ApiKeyData | None) -> ModelSource | None:

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Iterable
 
 from pydantic import ValidationError
@@ -40,6 +41,29 @@ _TRANSIENT_CODES = frozenset(
     {"server_error", "upstream_error", "stream_incomplete", "overloaded_error", "server_is_overloaded"}
 )
 _MODEL_CAPACITY_MESSAGE_MARKERS = ("selected model is at capacity",)
+_MODEL_UNSUPPORTED_MESSAGE_RE = re.compile(
+    r"^The '.+' model is not supported when using Codex with a ChatGPT account\.$"
+)
+
+
+def is_model_scoped_upstream_rejection(message: str | None) -> bool:
+    """Match the ChatGPT model-entitlement rejection for *any* requested model.
+
+    The rejection names the model, not the account: it reproduces on every
+    request for that model and says nothing about whether the serving account
+    can still stream the models it is entitled to. Callers use it to keep the
+    rejection out of account health while leaving failover alone -- a different
+    account may hold a different entitlement.
+
+    Unlike ``_is_account_model_unsupported_error`` this does not require the
+    caller to know the requested model or the normalized error code. Upstream
+    delivers this rejection over the Codex WebSocket with neither ``code`` nor
+    ``type`` populated, which normalizes to the ``upstream_error`` fallback, so
+    a code-gated match misses it on the live stream path.
+    """
+    if message is None:
+        return False
+    return _MODEL_UNSUPPORTED_MESSAGE_RE.fullmatch(" ".join(message.split())) is not None
 
 
 def _is_account_model_unsupported_error(

--- a/openspec/changes/refuse-disabled-model-source-routing/proposal.md
+++ b/openspec/changes/refuse-disabled-model-source-routing/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Source routing filters on `is_enabled` inside the lookup itself
+(`ModelSourcesRepository.find_chat_source_for_model` /
+`find_responses_source_for_model`), so a disabled source and a model nobody
+configured produce the same answer: `None`. Both then fall through to
+subscription account selection, and the subscription upstream rejects the
+request:
+
+```
+The '<model>' model is not supported when using Codex with a ChatGPT account.
+```
+
+On a live instance this repeated hundreds of times per hour for a model whose
+only source had been switched off: every attempt selected a ChatGPT account,
+spent its health signal on a request no account could serve, and told the
+caller nothing about the source that was actually off.
+
+This is the same failure #1658/#1659 fixed for the WebSocket transport — a
+source-owned model reaching a subscription account — reached through a
+different door. The HTTP routes need the same guarantee, and it must be stated
+in terms an operator can act on.
+
+## What Changes
+
+- Add `only_disabled` to the chat and Responses source lookups. It inverts the
+  enabled-state filter and leaves every other rule — candidate order, API key
+  model allowlist, source assignment scope, subscription-registry precedence,
+  route shape, streaming — untouched, so a hit is exactly "the source this
+  request would have used, had the operator not switched it off".
+- Refuse such a request on `/v1/chat/completions`, `/v1/responses`, and
+  `/backend-api/codex/responses` with `503` and error code
+  `model_source_disabled`, instead of falling through to subscription routing.
+- Leave every other miss on its existing path: a model no source claims, a
+  source scoped away from the API key, a route-shape mismatch, and a
+  subscription slug that an unscoped key never source-routes all behave exactly
+  as before.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`

--- a/openspec/changes/refuse-disabled-model-source-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/refuse-disabled-model-source-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: A disabled model source refuses its models instead of falling through
+
+The system SHALL NOT dispatch to a subscription account a request whose model
+is served by an OpenAI-compatible model source that an operator has switched
+off. It SHALL refuse such a request with HTTP status `503` and error code
+`model_source_disabled`.
+
+"Switched off" covers both a disabled source row and a disabled model row on an
+enabled source. The refusal SHALL apply on `/v1/chat/completions`,
+`/v1/responses`, and `/backend-api/codex/responses`.
+
+The refusal SHALL be decided by the ordinary source-selection rules with the
+enabled-state filter inverted and nothing else changed: same candidate list
+(raw client alias and normalized model), same API key model allowlist, same
+source assignment scope, same subscription-registry precedence, same route
+shape, same streaming requirement. A request that the ordinary lookup would
+have missed for any reason other than enabled state MUST keep its existing
+behaviour, including a model no source exposes, a source the API key is not
+assigned to, a chat-only source asked for a Responses route, and a
+subscription-registry slug that an unscoped API key never source-routes.
+
+Requests excluded from source routing — a terminal `compaction_trigger`, and
+Responses requests pinned to the subscription account that received an uploaded
+file — MUST NOT be refused, and MUST proceed to subscription routing as before.
+
+The refusal MUST happen before any usage reservation is taken, so a refused
+request strands no reservation, and MUST NOT create a request log entry for a
+dispatch that never happened.
+
+#### Scenario: Chat request for a disabled source's model is refused
+
+- **GIVEN** an OpenAI-compatible model source exposes model `m` and is disabled
+- **WHEN** a client calls `POST /v1/chat/completions` with model `m`
+- **THEN** the response is `503` with error code `model_source_disabled`
+- **AND** no subscription account is selected for the request
+- **AND** no usage reservation is left held
+
+#### Scenario: Responses request for a disabled source's model is refused
+
+- **GIVEN** a Responses-capable OpenAI-compatible model source exposes model `m` and is disabled
+- **WHEN** a client calls `POST /v1/responses` or `POST /backend-api/codex/responses` with model `m`
+- **THEN** the response is `503` with error code `model_source_disabled`
+- **AND** no subscription account is selected for the request
+
+#### Scenario: A disabled model on an enabled source is refused
+
+- **GIVEN** an enabled OpenAI-compatible model source whose model row for `m` is disabled
+- **WHEN** a client calls `POST /v1/chat/completions` with model `m`
+- **THEN** the response is `503` with error code `model_source_disabled`
+
+#### Scenario: A model no source exposes is unaffected
+
+- **GIVEN** no model source exposes model `m`, enabled or disabled
+- **WHEN** a client calls `POST /v1/chat/completions` with model `m`
+- **THEN** subscription routing proceeds exactly as it did before this requirement
+
+#### Scenario: A subscription slug shadowed by a disabled source is unaffected
+
+- **GIVEN** a disabled OpenAI-compatible model source lists a slug the subscription model registry already serves
+- **AND** an API key without source assignment scoping
+- **WHEN** the key requests that slug
+- **THEN** the request is not refused with `model_source_disabled`
+- **AND** subscription routing proceeds unchanged

--- a/openspec/changes/refuse-disabled-model-source-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/refuse-disabled-model-source-routing/specs/responses-api-compat/spec.md
@@ -25,6 +25,15 @@ Requests excluded from source routing — a terminal `compaction_trigger`, and
 Responses requests pinned to the subscription account that received an uploaded
 file — MUST NOT be refused, and MUST proceed to subscription routing as before.
 
+The WebSocket transport cannot forward to a model source, so its
+source-ownership guards SHALL treat a model owned only by a switched-off source
+as source-owned: the turn fails with the existing service-level
+`model_source_requires_http_transport` refusal instead of dispatching to a
+subscription account, and the client's HTTP fallback then meets the
+`model_source_disabled` refusal above. The guards' existing exclusions — a
+structurally excluded request and a recorded previous-response subscription
+owner — keep bypassing the guard unchanged.
+
 The refusal MUST happen before any usage reservation is taken, so a refused
 request strands no reservation, and MUST NOT create a request log entry for a
 dispatch that never happened.
@@ -55,6 +64,13 @@ dispatch that never happened.
 - **GIVEN** no model source exposes model `m`, enabled or disabled
 - **WHEN** a client calls `POST /v1/chat/completions` with model `m`
 - **THEN** subscription routing proceeds exactly as it did before this requirement
+
+#### Scenario: A WebSocket turn for a disabled source's model bounces to HTTP
+
+- **GIVEN** a Responses-capable OpenAI-compatible model source exposes model `m` and is disabled
+- **WHEN** a client requests model `m` over the WebSocket transport, at connect time or on a later turn over an already-open socket
+- **THEN** the turn is refused with the service-level `model_source_requires_http_transport` failure that makes Codex clients retry over the HTTP transport
+- **AND** the turn is not forwarded to a subscription account upstream
 
 #### Scenario: A subscription slug shadowed by a disabled source is unaffected
 

--- a/openspec/changes/refuse-disabled-model-source-routing/tasks.md
+++ b/openspec/changes/refuse-disabled-model-source-routing/tasks.md
@@ -1,0 +1,20 @@
+## Tasks
+
+- [x] Add an `only_disabled` enabled-state filter to
+      `find_chat_source_for_model` / `find_responses_source_for_model`, sharing
+      one predicate so the routable set and its complement cannot drift.
+- [x] Thread `only_disabled` through `select_responses_model_source` and
+      `_select_chat_model_source`, so the refusal lookup reuses the selection
+      rules rather than restating them.
+- [x] Add `_disabled_model_source_denial` and call it from
+      `/v1/chat/completions`, `/v1/responses`, and
+      `/backend-api/codex/responses` after the ordinary lookup misses.
+- [x] On the chat route, run the refusal before the usage reservation is taken
+      so a refusal strands nothing.
+- [x] Keep the existing source-routing exclusions intact: file-pinned
+      Responses requests and terminal compaction triggers skip the refusal and
+      continue to subscription routing.
+- [x] Add the spec delta for `responses-api-compat`.
+- [x] Cover the refusal (disabled source, disabled source model, all three
+      routes) and the negative controls (unknown model, subscription slug
+      shadowed by a disabled source) with integration tests.

--- a/openspec/changes/refuse-disabled-model-source-routing/tasks.md
+++ b/openspec/changes/refuse-disabled-model-source-routing/tasks.md
@@ -14,6 +14,10 @@
 - [x] Keep the existing source-routing exclusions intact: file-pinned
       Responses requests and terminal compaction triggers skip the refusal and
       continue to subscription routing.
+- [x] Recognize disabled-source ownership in the WebSocket source-ownership
+      guard (`responses_model_is_source_owned`), so both the connect-time and
+      the socket-reuse guard bounce such turns to the HTTP transport where the
+      refusal fires, and cover both guard sites with regression tests.
 - [x] Add the spec delta for `responses-api-compat`.
 - [x] Cover the refusal (disabled source, disabled source model, all three
       routes) and the negative controls (unknown model, subscription slug

--- a/openspec/changes/spare-account-health-from-model-rejections/proposal.md
+++ b/openspec/changes/spare-account-health-from-model-rejections/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+A model registered only on an OpenAI-compatible model source stops resolving to
+that source the moment the source is disabled or removed, because source lookup
+filters on `is_enabled`. The request then falls through to ordinary subscription
+account selection, and every ChatGPT account rejects it with HTTP 400 and the
+message `The '<model>' model is not supported when using Codex with a ChatGPT
+account.`
+
+Today each of those rejections records a transient account error. A single
+client polling one unroutable model therefore drives *every* serving account
+past `ERROR_BACKOFF_THRESHOLD` and pins it at the 300-second error-backoff
+ceiling. On a live deployment one such client produced 4,800 rejections in six
+hours across three healthy Pro accounts — one client request fans out to all
+three accounts, so all three were penalized by every poll. Unrelated foreground
+traffic on those accounts was then denied: sticky selection passes
+`allow_backoff_fallback=False`, so a session hard-pinned to a poisoned account
+failed with `continuity_owner_unavailable` / `No available accounts` while the
+account itself was active with 1–7% quota used.
+
+The rejection names the model, not the account. It says nothing about whether
+the account can still serve the models it *is* entitled to, so it is not an
+account-health signal. Excluding that account for the rest of the request —
+which failover already does — is the correct and sufficient response.
+
+## What Changes
+
+- A model-entitlement rejection no longer records a transient account error,
+  rate-limit penalty, quota penalty, or permanent failure.
+- Failure classification, the failover decision, and the client-visible status
+  and body are unchanged, so a differently entitled account is still tried.
+- Membership is decided by the exact rejection message and a 400 status, not by
+  the normalized error code. Upstream delivers this rejection over the Codex
+  streaming path with neither `code` nor `type` set, which normalizes to the
+  `upstream_error` fallback; the previous code-gated matcher never saw it there.
+- The skip is logged, matching the existing account-neutral skip log.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `account-routing`: model-entitlement rejections are health neutral while
+  remaining failover-eligible.
+
+## Impact
+
+- `app/modules/proxy/helpers.py` gains a code-agnostic matcher for the
+  rejection message.
+- `app/modules/proxy/_service/streaming/helpers.py` skips the account-health
+  penalty for it in `_handle_stream_error`, the single funnel every transport
+  uses for stream-error account health.
+- No schema, config, or API surface changes.

--- a/openspec/changes/spare-account-health-from-model-rejections/specs/account-routing/spec.md
+++ b/openspec/changes/spare-account-health-from-model-rejections/specs/account-routing/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Upstream rejections of the request payload are account neutral
+
+When upstream rejects a request because of the request payload itself, the proxy MUST NOT mutate the selected account's health: it MUST NOT record a transient account error, a rate-limit penalty, a quota penalty, or a permanent failure for that account. An upstream failure qualifies as a payload rejection only when it would reproduce identically on every account. The proxy MUST decide membership from the classified upstream message, never from the `invalid_request_error` code alone, and MUST require the upstream HTTP status to be 400 whenever a status is known. An upstream missing-tool-output rejection — the `invalid_request_error` whose message identifies a tool call with no matching tool output — MUST qualify. The proxy MUST also leave account health untouched for the model-entitlement rejection `The '<model>' model is not supported when using Codex with a ChatGPT account.`: that rejection is scoped to the named model and is not evidence about the account's ability to serve the models it is entitled to. Because upstream delivers that rejection on the streaming path with neither an error `code` nor an error `type`, which normalizes to the `upstream_error` fallback, the proxy MUST decide it from the message and the 400 status alone and MUST NOT require a particular normalized error code. Skipping the penalty MUST be logged so the decision is observable, and MUST NOT change the failure classification, the failover decision, or the status and body returned to the client.
+
+#### Scenario: Missing-tool-output rejection leaves account health untouched
+
+- **GIVEN** account A is selected for a request whose input references a tool call with no matching tool output
+- **WHEN** upstream returns HTTP 400 `invalid_request_error` with a missing-tool-output message
+- **THEN** the proxy does not increment account A's transient error count and does not mark it rate-limited, quota-exceeded, or permanently failed
+- **AND** the failure is still classified `non_retryable` and surfaced to the client unchanged
+
+#### Scenario: Repeated client payload rejection cannot starve unrelated sessions
+
+- **GIVEN** one client repeatedly re-sends the same payload that upstream rejects for a missing tool output
+- **WHEN** those requests are served by accounts shared with other sessions
+- **THEN** no serving account enters error backoff because of that payload
+- **AND** a session hard-pinned to one of those accounts is not failed with a saturated-hard-affinity selection error caused by that payload
+
+#### Scenario: Model-entitlement rejection leaves account health untouched
+
+- **GIVEN** account A is selected for a model it is not entitled to use
+- **WHEN** upstream returns HTTP 400 stating the model is not supported when using Codex with a ChatGPT account, with the error code normalized to `upstream_error` or to `invalid_request_error`
+- **THEN** the proxy does not increment account A's transient error count and does not mark it rate-limited, quota-exceeded, or permanently failed
+- **AND** the skip is logged
+
+#### Scenario: Model-entitlement rejection still fails over
+
+- **GIVEN** account A returned the model-entitlement rejection for the requested model
+- **WHEN** the proxy classifies that failure
+- **THEN** the classification and failover decision are unchanged, so an account with a different entitlement is still attempted
+- **AND** the status and body returned to the client when every attempt is exhausted are unchanged
+
+#### Scenario: A model no source can serve cannot poison subscription accounts
+
+- **GIVEN** a model that resolves to no enabled model source and therefore reaches subscription account selection
+- **WHEN** a client polls that model repeatedly and every subscription account returns the model-entitlement rejection
+- **THEN** no serving account enters error backoff because of those rejections
+- **AND** unrelated traffic hard-pinned to those accounts is not denied with a continuity-owner-unavailable or no-available-accounts selection error caused by them
+
+#### Scenario: A genuine upstream failure still penalizes the account
+
+- **GIVEN** account A is selected for a request
+- **WHEN** upstream fails with an `upstream_error` whose message is not the model-entitlement rejection
+- **THEN** the proxy records the account-health penalty for account A as before

--- a/openspec/changes/spare-account-health-from-model-rejections/specs/account-routing/spec.md
+++ b/openspec/changes/spare-account-health-from-model-rejections/specs/account-routing/spec.md
@@ -39,6 +39,12 @@ When upstream rejects a request because of the request payload itself, the proxy
 - **THEN** no serving account enters error backoff because of those rejections
 - **AND** unrelated traffic hard-pinned to those accounts is not denied with a continuity-owner-unavailable or no-available-accounts selection error caused by them
 
+#### Scenario: Model-entitlement rejection still penalizes the account
+
+- **GIVEN** account A is selected for a request
+- **WHEN** upstream fails with a non-400 status whose message matches the model-entitlement rejection
+- **THEN** the proxy records the account-health penalty for account A as before, because only a genuine HTTP 400 qualifies as the model-scoped rejection
+
 #### Scenario: A genuine upstream failure still penalizes the account
 
 - **GIVEN** account A is selected for a request

--- a/openspec/changes/spare-account-health-from-model-rejections/tasks.md
+++ b/openspec/changes/spare-account-health-from-model-rejections/tasks.md
@@ -1,0 +1,15 @@
+## 1. Match the rejection independently of the error code
+
+- [x] 1.1 Add `is_model_scoped_upstream_rejection(message)` to `app/modules/proxy/helpers.py`, matching the exact entitlement message for any model after whitespace folding, and leave `_is_account_model_unsupported_error` (model- and code-scoped, used by the replay paths) unchanged.
+
+## 2. Keep the rejection out of account health
+
+- [x] 2.1 Add `_is_model_scoped_rejection` to `app/modules/proxy/_service/streaming/helpers.py`, requiring HTTP 400 whenever a status is known.
+- [x] 2.2 Return the classified failure from `_handle_stream_error` before any health mutation when it matches, logging the skip.
+
+## 3. Verification
+
+- [x] 3.1 Assert no `record_error`/`record_errors`/`mark_rate_limit`/`mark_quota_exceeded`/`mark_permanent_failure` for both the `upstream_error` and `invalid_request_error` code shapes.
+- [x] 3.2 Assert the failure is still classified `retryable_transient` so failover is unaffected.
+- [x] 3.3 Negative controls: a genuine `upstream_error` with an unrelated message, the same message at a non-400 status, and a `rate_limit_exceeded` failure all keep their existing penalties.
+- [x] 3.4 Run `uv run ruff check`, `uv run ty check`, and the unit suite.

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -727,6 +727,12 @@ async def test_disabled_source_does_not_capture_a_subscription_model_slug(async_
     """
     await _enable_api_key_auth(async_client)
     model = "gpt-5.6-sol"
+    from app.core.openai.model_registry import get_model_registry
+
+    # Precondition: without registry membership the disabled source would win
+    # the lookup and this test would assert model_source_disabled instead of
+    # subscription precedence.
+    assert model in get_model_registry().get_models_with_fallback()
     source_id = await _create_model_source(
         async_client,
         name="disabled-shadow-source",

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -555,6 +555,198 @@ async def test_source_unreachable_returns_error_envelope_and_releases_reservatio
         assert result.scalars().all() == []
 
 
+async def _set_source_enabled(async_client, source_id: str, enabled: bool) -> None:
+    response = await async_client.patch(f"/api/model-sources/{source_id}", json={"isEnabled": enabled})
+    assert response.status_code == 200
+    assert response.json()["isEnabled"] is enabled
+
+
+async def _disable_source_model(async_client, source_id: str, model: str) -> None:
+    response = await async_client.patch(
+        f"/api/model-sources/{source_id}",
+        json={
+            "models": [
+                {
+                    "model": model,
+                    "displayName": model,
+                    "contextWindow": 8192,
+                    "maxOutputTokens": 1024,
+                    "supportsStreaming": True,
+                    "supportsTools": True,
+                    "isEnabled": False,
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["models"][0]["isEnabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_source_chat_is_refused_instead_of_hitting_a_subscription(async_client):
+    """A disabled source's model must not be handed to a subscription account.
+
+    Subscription upstreams answer such a request with "The '<model>' model is
+    not supported when using Codex with a ChatGPT account.", which tells the
+    caller nothing and spends the account's health signal on a request no
+    account could ever serve.
+    """
+    await _enable_api_key_auth(async_client)
+    model = "disabled-source-chat-model"
+    source_id = await _create_model_source(
+        async_client,
+        name="disabled-chat-source",
+        model=model,
+        base_url=f"http://127.0.0.1:{_free_port()}/v1",
+    )
+    await _set_source_enabled(async_client, source_id, False)
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "disabled-source-chat-key",
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 1_000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": model, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 503
+    error = response.json()["error"]
+    assert error["code"] == "model_source_disabled"
+    assert model in error["message"]
+
+    # Refused before any account was selected, so nothing was dispatched and no
+    # reservation was taken.
+    async with SessionLocal() as session:
+        result = await session.execute(select(RequestLog).where(RequestLog.model == model))
+        assert result.scalars().all() == []
+        result = await session.execute(
+            select(ApiKeyUsageReservation).where(ApiKeyUsageReservation.status == "reserved")
+        )
+        assert result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_source_model_row_chat_is_refused_instead_of_hitting_a_subscription(async_client):
+    await _enable_api_key_auth(async_client)
+    model = "disabled-row-chat-model"
+    source_id = await _create_model_source(
+        async_client,
+        name="disabled-row-chat-source",
+        model=model,
+        base_url=f"http://127.0.0.1:{_free_port()}/v1",
+    )
+    await _disable_source_model(async_client, source_id, model)
+    created = await async_client.post("/api/api-keys/", json={"name": "disabled-row-chat-key"})
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": model, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 503
+    error = response.json()["error"]
+    assert error["code"] == "model_source_disabled"
+    assert "has that model disabled" in error["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1/responses", "/backend-api/codex/responses"])
+async def test_disabled_source_responses_is_refused_instead_of_hitting_a_subscription(async_client, path):
+    await _enable_api_key_auth(async_client)
+    model = "disabled-source-responses-model"
+    source_id = await _create_model_source(
+        async_client,
+        name="disabled-responses-source",
+        model=model,
+        base_url=f"http://127.0.0.1:{_free_port()}/v1",
+        supports_responses=True,
+    )
+    await _set_source_enabled(async_client, source_id, False)
+    created = await async_client.post("/api/api-keys/", json={"name": "disabled-source-responses-key"})
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    response = await async_client.post(
+        path,
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": model, "input": "hi", "stream": True},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "model_source_disabled"
+
+    async with SessionLocal() as session:
+        result = await session.execute(select(RequestLog).where(RequestLog.model == model))
+        assert result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_still_falls_through_to_subscription_routing(async_client):
+    """Negative control: a model no source ever claimed keeps today's path.
+
+    The refusal above must key on "a model source owns this slug and is off",
+    not on "the slug is unfamiliar" -- custom subscription catalogs and alias
+    slugs legitimately reach the account pool.
+    """
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post("/api/api-keys/", json={"name": "unknown-model-key"})
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "no-source-ever-claimed-this", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    # Unchanged behaviour: subscription selection runs and reports the account
+    # pool's own verdict.
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "no_accounts"
+
+
+@pytest.mark.asyncio
+async def test_disabled_source_does_not_capture_a_subscription_model_slug(async_client):
+    """Negative control: subscription slugs keep winning over source rows.
+
+    An unscoped key never source-routes a slug the subscription registry
+    already serves, so a disabled source that happens to list that slug must
+    not start refusing subscription traffic.
+    """
+    await _enable_api_key_auth(async_client)
+    model = "gpt-5.6-sol"
+    source_id = await _create_model_source(
+        async_client,
+        name="disabled-shadow-source",
+        model=model,
+        base_url=f"http://127.0.0.1:{_free_port()}/v1",
+    )
+    await _set_source_enabled(async_client, source_id, False)
+    created = await async_client.post("/api/api-keys/", json={"name": "shadow-slug-key"})
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": model, "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.json()["error"]["code"] == "no_accounts"
+
+
 @pytest.mark.asyncio
 async def test_patch_model_source_returns_updated_model_list(async_client):
     source_id = await _create_model_source(

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -766,6 +766,97 @@ async def test_stream_http_502_unknown_code_fails_over_to_second_account(async_c
 
 
 # ===========================================================================
+# Streaming — Model-entitlement rejection is health neutral through the route
+# ===========================================================================
+
+
+_MODEL_ENTITLEMENT_REJECTION_MESSAGE = (
+    "The 'gpt-5.1' model is not supported when using Codex with a ChatGPT account."
+)
+
+
+@pytest.mark.asyncio
+async def test_stream_model_entitlement_rejection_keeps_account_health_after_failover(async_client, monkeypatch):
+    """Routed regression: the entitlement 400 must not move any account's health.
+
+    The unit tests call ``_handle_stream_error`` directly; this drives the whole
+    HTTP route through selection, dispatch and failover with the exact upstream
+    rejection observed in the incident — HTTP 400, message only, neither
+    ``code`` nor ``type`` — and asserts the accounts that served the attempts
+    keep ``error_count`` 0 and no error backoff. It fails if any transport path
+    loses the message before the neutrality check or writes account health
+    somewhere ``_handle_stream_error`` is not consulted.
+    """
+    account_id_1 = await _import_account(async_client, "acc_entitle_a", "entitle_a@example.com")
+    account_id_2 = await _import_account(async_client, "acc_entitle_b", "entitle_b@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        raise ProxyResponseError(
+            400,
+            {"error": {"message": _MODEL_ENTITLEMENT_REJECTION_MESSAGE}},
+            failure_phase="status",
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    # Failover is untouched: another account may hold a different entitlement,
+    # so the rejection must fan out before it surfaces to the client.
+    assert set(seen_account_ids) == {"acc_entitle_a", "acc_entitle_b"}
+    events = _extract_events(lines)
+    assert not any(e.get("type") == "response.completed" for e in events)
+
+    from app.dependencies import get_proxy_service_for_app
+
+    service = get_proxy_service_for_app(async_client._transport.app)
+    for imported_account_id in (account_id_1, account_id_2):
+        runtime = service._load_balancer._runtime.get(imported_account_id)
+        assert runtime is None or runtime.error_count == 0, (
+            f"model-scoped rejection must not move error_count for {imported_account_id}"
+        )
+        assert runtime is None or runtime.last_error_at is None, (
+            f"model-scoped rejection must not arm error backoff for {imported_account_id}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_genuine_400_failover_still_records_error_control(async_client, monkeypatch):
+    """Control for the neutrality regression above: the same route and status
+    with a non-entitlement message must keep penalizing, proving the runtime
+    assertions would catch a health write."""
+    account_id_1 = await _import_account(async_client, "acc_entitle_ctl_a", "entitle_ctl_a@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        raise ProxyResponseError(
+            400,
+            {"error": {"message": "Upstream request failed"}},
+            failure_phase="status",
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        [line async for line in resp.aiter_lines() if line]
+
+    from app.dependencies import get_proxy_service_for_app
+
+    service = get_proxy_service_for_app(async_client._transport.app)
+    runtime = service._load_balancer._runtime.get(account_id_1)
+    assert runtime is not None and runtime.error_count >= 1, (
+        "a genuine upstream 400 on the identical path must keep recording an account error"
+    )
+
+
+# ===========================================================================
 # Streaming — Non-server_error is NOT retried via transient path
 # ===========================================================================
 

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -770,9 +770,7 @@ async def test_stream_http_502_unknown_code_fails_over_to_second_account(async_c
 # ===========================================================================
 
 
-_MODEL_ENTITLEMENT_REJECTION_MESSAGE = (
-    "The 'gpt-5.1' model is not supported when using Codex with a ChatGPT account."
-)
+_MODEL_ENTITLEMENT_REJECTION_MESSAGE = "The 'gpt-5.1' model is not supported when using Codex with a ChatGPT account."
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -68,6 +68,7 @@ from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy import affinity as proxy_affinity
 from app.modules.proxy import api as proxy_api
+from app.modules.proxy import helpers as proxy_helpers_module
 from app.modules.proxy import request_policy as proxy_request_policy
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import compact as proxy_compact_service
@@ -278,8 +279,9 @@ async def test_process_network_failure_does_not_update_account_health() -> None:
             "No tool output found for function call call_abc.",
             True,
         ),
-        # A model-entitlement rejection is account scoped and must stay
-        # penalizing even though it shares the invalid_request_error code.
+        # A model-entitlement rejection is not a payload-shape rejection, so it
+        # is not a member of this narrow set. Its own health-neutrality is
+        # decided by ``_is_model_scoped_rejection`` instead.
         (
             "invalid_request_error",
             400,
@@ -338,8 +340,101 @@ async def test_missing_tool_output_rejection_does_not_penalize_account() -> None
     load_balancer.mark_permanent_failure.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+            True,
+        ),
+        (
+            "The 'qwen3-4b-instruct-2507-q8-notools:latest' model is not supported "
+            "when using Codex with a ChatGPT account.",
+            True,
+        ),
+        # Whitespace folding matches the existing entitlement matcher.
+        (
+            "The 'gpt-5.3-codex' model is not supported\n  when using Codex with a ChatGPT account.",
+            True,
+        ),
+        ("No tool output found for function call call_abc.", False),
+        ("The selected model is at capacity.", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_model_scoped_upstream_rejection(message: str | None, expected: bool) -> None:
+    assert proxy_helpers_module.is_model_scoped_upstream_rejection(message) is expected
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # The live streaming path normalizes this rejection to the
+        # ``upstream_error`` fallback because upstream sends neither ``code``
+        # nor ``type``; other paths surface ``invalid_request_error``.
+        "upstream_error",
+        "invalid_request_error",
+    ],
+)
 @pytest.mark.asyncio
-async def test_account_scoped_invalid_request_error_still_penalizes_account() -> None:
+async def test_model_scoped_rejection_does_not_penalize_account(code: str) -> None:
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        record_errors=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {
+            "message": (
+                "The 'qwen3-4b-instruct-2507-q8-notools:latest' model is not supported "
+                "when using Codex with a ChatGPT account."
+            )
+        },
+        code,
+        400,
+    )
+
+    # Failover is untouched: another account may hold a different entitlement.
+    assert classified["error_code"] == code
+    load_balancer.record_error.assert_not_awaited()
+    load_balancer.record_errors.assert_not_awaited()
+    load_balancer.mark_rate_limit.assert_not_awaited()
+    load_balancer.mark_quota_exceeded.assert_not_awaited()
+    load_balancer.mark_permanent_failure.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_scoped_rejection_classification_still_fails_over() -> None:
+    """The health skip must not turn the rejection into a terminal success."""
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."},
+        "upstream_error",
+        400,
+    )
+
+    assert classified["failure_class"] == "retryable_transient"
+
+
+@pytest.mark.asyncio
+async def test_genuine_upstream_error_still_penalizes_account() -> None:
+    """Negative control: a real ChatGPT upstream failure keeps penalizing."""
     load_balancer = SimpleNamespace(
         record_error=AsyncMock(),
         mark_rate_limit=AsyncMock(),
@@ -351,12 +446,57 @@ async def test_account_scoped_invalid_request_error_still_penalizes_account() ->
     await streaming_helpers_module._handle_stream_error(
         proxy,
         cast(Account, SimpleNamespace(id="acc-1")),
-        {"message": "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."},
-        "invalid_request_error",
+        {"message": "Upstream request failed"},
+        "upstream_error",
         400,
     )
 
     load_balancer.record_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_400_model_rejection_message_still_penalizes_account() -> None:
+    """Negative control: only a genuine 400 is an entitlement rejection."""
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."},
+        "server_error",
+        500,
+    )
+
+    load_balancer.record_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_still_marks_rate_limit() -> None:
+    """Negative control: quota/rate-limit accounting is unchanged."""
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": "Rate limit reached"},
+        "rate_limit_exceeded",
+        429,
+    )
+
+    load_balancer.mark_rate_limit.assert_awaited_once()
+    load_balancer.record_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -368,17 +368,17 @@ def test_is_model_scoped_upstream_rejection(message: str | None, expected: bool)
 
 
 @pytest.mark.parametrize(
-    "code",
+    ("code", "expected_failure_class"),
     [
         # The live streaming path normalizes this rejection to the
         # ``upstream_error`` fallback because upstream sends neither ``code``
         # nor ``type``; other paths surface ``invalid_request_error``.
-        "upstream_error",
-        "invalid_request_error",
+        ("upstream_error", "retryable_transient"),
+        ("invalid_request_error", "non_retryable"),
     ],
 )
 @pytest.mark.asyncio
-async def test_model_scoped_rejection_does_not_penalize_account(code: str) -> None:
+async def test_model_scoped_rejection_does_not_penalize_account(code: str, expected_failure_class: str) -> None:
     load_balancer = SimpleNamespace(
         record_error=AsyncMock(),
         record_errors=AsyncMock(),
@@ -403,6 +403,7 @@ async def test_model_scoped_rejection_does_not_penalize_account(code: str) -> No
 
     # Failover is untouched: another account may hold a different entitlement.
     assert classified["error_code"] == code
+    assert classified["failure_class"] == expected_failure_class
     load_balancer.record_error.assert_not_awaited()
     load_balancer.record_errors.assert_not_awaited()
     load_balancer.mark_rate_limit.assert_not_awaited()

--- a/tests/unit/test_proxy_websocket_model_source_guard.py
+++ b/tests/unit/test_proxy_websocket_model_source_guard.py
@@ -424,8 +424,13 @@ class _AliasSourceCatalog:
                 *,
                 allowed_source_ids=None,  # noqa: ANN001
                 require_streaming: bool = False,
+                only_disabled: bool = False,
             ):  # noqa: ANN202
                 catalog.seen_candidates.append(candidate)
+                # Every source in this fake catalog is enabled, so the
+                # disabled-source lookup is always a miss.
+                if only_disabled:
+                    return None
                 if candidate in catalog.source_models:
                     return SimpleNamespace(id="src_alias", name="alias-source", enabled=True)
                 return None

--- a/tests/unit/test_proxy_websocket_model_source_guard.py
+++ b/tests/unit/test_proxy_websocket_model_source_guard.py
@@ -435,7 +435,7 @@ class _AliasSourceCatalog:
                         return SimpleNamespace(id="src_disabled", name="disabled-source", is_enabled=False)
                     return None
                 if candidate in catalog.source_models:
-                    return SimpleNamespace(id="src_alias", name="alias-source", enabled=True)
+                    return SimpleNamespace(id="src_alias", name="alias-source", is_enabled=True)
                 return None
 
         @asynccontextmanager

--- a/tests/unit/test_proxy_websocket_model_source_guard.py
+++ b/tests/unit/test_proxy_websocket_model_source_guard.py
@@ -407,8 +407,9 @@ class _AliasSourceCatalog:
     ``responses_model_is_source_owned`` itself would test the stub instead).
     """
 
-    def __init__(self, source_models: set[str]) -> None:
+    def __init__(self, source_models: set[str], disabled_source_models: set[str] | None = None) -> None:
         self.source_models = source_models
+        self.disabled_source_models = disabled_source_models or set()
         self.seen_candidates: list[str] = []
 
     def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -427,9 +428,11 @@ class _AliasSourceCatalog:
                 only_disabled: bool = False,
             ):  # noqa: ANN202
                 catalog.seen_candidates.append(candidate)
-                # Every source in this fake catalog is enabled, so the
-                # disabled-source lookup is always a miss.
+                # ``only_disabled`` selects the complement of the routable
+                # set, mirroring the real repository's enablement filter.
                 if only_disabled:
+                    if candidate in catalog.disabled_source_models:
+                        return SimpleNamespace(id="src_disabled", name="disabled-source", is_enabled=False)
                     return None
                 if candidate in catalog.source_models:
                     return SimpleNamespace(id="src_alias", name="alias-source", enabled=True)
@@ -916,3 +919,124 @@ async def test_connect_guard_skips_terminal_compaction_trigger_requests(
     assert prepared.request_state.source_route_excluded is True, (
         "preparation must record the HTTP source-route exclusion on the request state"
     )
+
+
+@pytest.mark.asyncio
+async def test_source_ownership_counts_disabled_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model whose only source is disabled is still source-owned.
+
+    The WebSocket transport cannot serve a source-owned model whether the
+    source is enabled or not; dispatching it to a subscription account instead
+    yields the opaque upstream 400. Recognizing disabled ownership makes the
+    guards bounce the turn to HTTP, where the disabled-source denial answers
+    503 ``model_source_disabled``.
+    """
+    catalog = _AliasSourceCatalog(set(), disabled_source_models={"qwen3.8-max"})
+    catalog.install(monkeypatch)
+
+    assert await responses_model_is_source_owned("qwen3.8-max", None) is True
+    assert await responses_model_is_source_owned("model-nobody-configured", None) is False, (
+        "a model no source claims must keep falling through to subscription selection"
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_guard_fails_session_for_disabled_source_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The connect guard must bounce a disabled-source model to HTTP.
+
+    The real ``responses_model_is_source_owned`` runs against a catalog where
+    the model's only source is disabled: without the ``only_disabled`` probe
+    the guard misses, the turn dispatches to a subscription account, and the
+    incident's entitlement 400 comes back on exactly this transport.
+    """
+    settings = _make_proxy_settings()
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+
+    catalog = _AliasSourceCatalog(set(), disabled_source_models={"qwen3.8-max"})
+    catalog.install(monkeypatch)
+
+    emitted: dict[str, object] = {}
+    selection_calls = 0
+
+    async def fake_emit(self, websocket, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        emitted.update(kwargs)
+
+    async def fake_select(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        nonlocal selection_calls
+        selection_calls += 1
+        return None
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_emit_websocket_connect_failure", fake_emit)
+    monkeypatch.setattr(proxy_service.ProxyService, "_select_websocket_connect_account", fake_select)
+
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+
+    account, upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="capacity_weighted",
+        model="qwen3.8-max",
+        request_state=_request_state("qwen3.8-max"),
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=AsyncMock(),
+    )
+
+    assert account is None
+    assert upstream is None
+    assert selection_calls == 0, "the guard must short-circuit before subscription account selection"
+    assert emitted.get("error_code") == "model_source_requires_http_transport"
+    assert emitted.get("status_code") == 503, "a 4xx is terminal client-side and would strand the HTTP fallback"
+    assert "qwen3.8-max" in catalog.seen_candidates, "the disabled-source probe must reach the catalog"
+
+
+@pytest.mark.asyncio
+async def test_reuse_guard_rejects_a_later_disabled_source_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A later turn that switches to a disabled-source model must not be forwarded.
+
+    Socket reuse bypasses connect-time selection, so without disabled-source
+    recognition in the reuse guard the frame goes to the subscription account
+    already attached to the open upstream and is rejected by the backend with
+    the unsupported-model 400.
+    """
+    settings = _make_proxy_settings()
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+
+    catalog = _AliasSourceCatalog(set(), disabled_source_models={"qwen3.8-max"})
+    catalog.install(monkeypatch)
+
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_source_guard_disabled_reuse")
+    upstream = _QueuedTestUpstreamWebSocket(_completed_turn("resp_turn_one"))
+
+    async def fake_connect(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        return account, upstream
+
+    released = AsyncMock()
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", fake_connect)
+    monkeypatch.setattr(proxy_service.ProxyService, "_release_websocket_request_state_reservation", released)
+    monkeypatch.setattr(service, "_resolve_compact_turn_state_owner", AsyncMock(return_value=None))
+
+    downstream = _Downstream([_create_frame("gpt-5.6-sol"), _create_frame("qwen3.8-max")])
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        api_key=None,
+    )
+
+    assert any("resp_turn_one" in text for text in downstream.sent_text), "the subscription turn must complete"
+    assert any("model_source_requires_http_transport" in text for text in downstream.sent_text), (
+        "the disabled-source turn must be rejected by the reuse guard"
+    )
+    assert len(upstream.sent_text) == 1, "the rejected turn must not be forwarded upstream"
+    assert released.await_count >= 1, "the rejected turn must release its usage reservation"


### PR DESCRIPTION
Supersedes #1856 — takeover preserving the commits and attribution of @Komzpa (author unresponsive since 2026-08-20 across two triage rounds).

When a model's OpenAI-compatible source is disabled, requests for that model used to fall through to subscription-account selection, where upstream answers an opaque 400 (`The '<model>' model is not supported when using Codex with a ChatGPT account.`) — and that rejection penalized the serving account's health, driving unrelated tenants into error backoff. This PR keeps @Komzpa's two fixes: (1) requests for disabled-source models are refused with an explicit 503 `model_source_disabled` instead of being misrouted, and (2) the model-entitlement rejection is classified as model-scoped and no longer mutates account health (failover across accounts is deliberately preserved, since entitlements may differ). The branch is rebased onto current main (1d9332a32), where the denial now composes with main's continuity-aware selection: `_select_responses_model_source_with_continuity` returns `(selection, continuity_suppressed)` so the denial fires only on genuine lookup misses, never on continuity-pinned turns, and the `/v1/responses` denial is gated on main's shared `source_route_excluded` predicate.

## Owner blockers from the 2026-08-26 review — all addressed

1. **WebSocket guard gap** — `responses_model_is_source_owned` (app/modules/model_sources/selection.py) now runs a second `only_disabled=True` probe after the enabled lookup misses, closing both mixin.py guard sites (connect-time and socket-reuse) symmetrically. Disabled-source models bounce to HTTP via the existing 503 `model_source_requires_http_transport`, where the new `model_source_disabled` denial answers. 3 regression tests added (helper + both guard sites; each fails without the probe), and the responses-api-compat spec delta gained the WebSocket requirement and scenario.
2. **Routed health-neutrality regression test** — new `test_stream_model_entitlement_rejection_keeps_account_health_after_failover` in tests/integration/test_proxy_transient_retry.py drives the full `/backend-api/codex/responses` route with the exact incident 400 (message only, no code/type), asserts failover fans out to both accounts while their runtime `error_count` stays 0 with no armed backoff — plus a genuine-400 control proving the assertions would catch a health write. Fails with the health fix reverted.
3. **Two one-line asserts** — the parameterized model-scoped rejection test now asserts the classified `failure_class` per code (`upstream_error` → `retryable_transient`, `invalid_request_error` → `non_retryable`; a blanket `retryable_transient` assert would be factually wrong for the latter), and the disabled-shadow-source integration test asserts the gpt-5.6-sol registry precondition before creating the source.

Also applied the owner's optional hot-path note: `_disabled_model_source_denial` short-circuits before opening a background session when the key is unscoped and every candidate resolves in the subscription registry.

## Known remaining notes (P3, non-blocking)

- The WS-side `only_disabled` probe opens a second background-session context when the enabled probe misses (common subscription-model case). No SQL executes for unscoped keys with registry models — the HTTP-side registry short-circuit was not mirrored into the shared helper to keep the owner-sanctioned probe shape simple. Perf-note only.
- The 503-vs-4xx status choice for the disabled-source denial remains the maintainer-confirm-at-merge item flagged on #1856 (owner said not a blocker).

## Test evidence

On final head (rebased onto origin/main 1d9332a32, includes #1906):

- Full unit suite: 6678 passed / 3 skipped
- tests/integration/test_model_source_routing.py: 101 passed
- tests/integration/test_proxy_transient_retry.py: 35 passed (incl. 2 new routed health tests)
- tests/integration/test_proxy_websocket_responses.py: 131 passed (no bridge-shard flake)
- tests/integration/test_proxy_responses.py + test_proxy_chat_completions.py: 89 passed
- tests/unit/test_proxy_websocket_model_source_guard.py: 16 passed (3 new)
- ruff check + ruff format clean; ty check clean; `openspec validate --strict` valid for both touched change dirs (`--all` still exactly the 21 pre-existing failures)
- Reverted-fix verification: the 3 new WS guard tests and the routed health-neutrality test each fail with the corresponding app fix reverted and pass with it

Commit stack: 2 original commits by @Komzpa (author fields intact) + takeover commits authored on top; no squash, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
