### PR TITLE
fix(api-keys): enforce generated key format

### DIFF
--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -1390,7 +1390,7 @@ def _get_usage_sections_with_default(row: ApiKey) -> str:
 
 
 def _generate_plain_key() -> str:
-    return f"sk-clb-{secrets.token_urlsafe(32)}"
+    return f"sk-clb-{secrets.token_hex(24)}"
 
 
 def _hash_key(plain_key: str) -> str:

--- a/openspec/changes/fix-api-key-format-contract/proposal.md
+++ b/openspec/changes/fix-api-key-format-contract/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The API-key specification and original design require generated credentials to
+use `sk-clb-` followed by 48 lowercase hexadecimal characters. The current
+generator uses `secrets.token_urlsafe(32)`, so every created or regenerated key
+instead has a 43-character base64url suffix. Native authentication still works,
+but strict consumers can reject the returned credential because it violates the
+published contract.
+
+## What Changes
+
+- Generate new and regenerated API keys with `secrets.token_hex(24)`.
+- Assert the complete generated-key format through service and API regression
+  coverage instead of checking only the prefix.
+- Preserve hash-based authentication for already-issued base64url keys.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Enforce the documented generated-key format for creation and
+  regeneration while preserving existing-key authentication.
+
+## Impact
+
+The change is limited to the API-key plaintext generator, focused API-key
+tests, and the API-key specification. It adds no API fields, settings,
+dependencies, migrations, persistence changes, or frontend behavior.

--- a/openspec/changes/fix-api-key-format-contract/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-format-contract/specs/api-keys/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: API Key creation
+
+The system SHALL allow the admin to create API keys via `POST /api/api-keys` with a `name` (required), `allowed_models` (optional list), `weekly_token_limit` (optional integer), `expires_at` (optional ISO 8601 datetime), `assigned_account_ids` (optional list), and `usage_sections` (optional comma-separated string, defaults to `"upstream_limits,account_pool_usage"`). The system MUST generate a key in the format `sk-clb-{48 hex chars}`, store only the `sha256` hash in the database, and return the plain key exactly once in the creation response. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt`, normalize them to UTC naive for persistence, and return the expiration as UTC in API responses.
+
+When `assigned_account_ids` is omitted or empty, the created key SHALL remain unscoped and apply to all accounts. When `assigned_account_ids` is provided with one or more valid account IDs, the created key SHALL enable account-assignment scope and persist those assignments.
+
+#### Scenario: Create unscoped key without assigned accounts
+
+- **WHEN** admin submits `POST /api/api-keys` without `assignedAccountIds`
+- **THEN** the created key returns `accountAssignmentScopeEnabled = false`
+- **AND** `assignedAccountIds = []`
+
+#### Scenario: Create scoped key with assigned accounts
+
+- **WHEN** admin submits `POST /api/api-keys` with `assignedAccountIds` containing valid account IDs
+- **THEN** the created key returns `accountAssignmentScopeEnabled = true`
+- **AND** `assignedAccountIds` matches the supplied accounts
+
+#### Scenario: Reject unknown assigned account IDs on create
+
+- **WHEN** admin submits `POST /api/api-keys` with an unknown account ID in `assignedAccountIds`
+- **THEN** the system returns 400
+
+#### Scenario: Create key and show plain key
+
+- **WHEN** admin submits `POST /api/api-keys` with a valid payload
+- **THEN** the response contains a key matching `sk-clb-[0-9a-f]{48}`
+- **AND** the full plain key is returned exactly once
+- **AND** the system never returns the plain key on subsequent reads
+
+#### Scenario: Create key with timezone-aware expiration
+
+- **WHEN** admin submits `POST /api/api-keys` with `{ "name": "dev-key", "expiresAt": "2025-12-31T00:00:00Z" }`
+- **THEN** the system persists the expiration successfully without PostgreSQL datetime binding errors
+- **AND** the response returns `expiresAt` representing the same UTC instant
+
+### Requirement: API Key regeneration
+
+The system SHALL allow regenerating an API key via `POST /api/api-keys/{id}/regenerate`. This MUST generate a new key matching `sk-clb-[0-9a-f]{48}` with a new hash and prefix while preserving all other properties (name, models, limits, expiration). The new plain key MUST be returned exactly once.
+
+#### Scenario: Regenerate key
+
+- **WHEN** admin calls `POST /api/api-keys/{id}/regenerate`
+- **THEN** the system returns the updated key object with a new `key` and `keyPrefix`
+- **AND** the new key matches `sk-clb-[0-9a-f]{48}`
+- **AND** the old key immediately stops authenticating
+
+## ADDED Requirements
+
+### Requirement: Previously issued API key compatibility
+
+The system MUST continue authenticating an already-issued API key by its stored
+SHA-256 hash regardless of whether its plaintext suffix uses the current
+48-character hexadecimal format or the earlier 43-character base64url format.
+
+#### Scenario: Authenticate an already-issued base64url key
+
+- **GIVEN** an API key created before the generated-key format correction has a stored hash
+- **WHEN** the client authenticates with that unchanged plaintext key
+- **THEN** the system authenticates it through the existing hash lookup
+- **AND** the system does not require key rotation or data migration

--- a/openspec/changes/fix-api-key-format-contract/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-format-contract/specs/api-keys/spec.md
@@ -2,9 +2,9 @@
 
 ### Requirement: API Key creation
 
-The system SHALL allow the admin to create API keys via `POST /api/api-keys` with a `name` (required), `allowed_models` (optional list), `weekly_token_limit` (optional integer), `expires_at` (optional ISO 8601 datetime), `assigned_account_ids` (optional list), and `usage_sections` (optional comma-separated string, defaults to `"upstream_limits,account_pool_usage"`). The system MUST generate a key in the format `sk-clb-{48 hex chars}`, store only the `sha256` hash in the database, and return the plain key exactly once in the creation response. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt`, normalize them to UTC naive for persistence, and return the expiration as UTC in API responses.
+The system SHALL allow the admin to create API keys via `POST /api/api-keys` with a `name` (required), `allowedModels` (optional list), `weeklyTokenLimit` (optional integer), `expiresAt` (optional ISO 8601 datetime), `assignedAccountIds` (optional list), and `usageSections` (optional comma-separated string, defaults to `"upstream_limits,account_pool_usage"`). The system MUST generate a key in the format `sk-clb-{48 hex chars}`, store only the `sha256` hash in the database, and return the plain key exactly once in the creation response. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt`, normalize them to UTC naive for persistence, and return the expiration as UTC in API responses.
 
-When `assigned_account_ids` is omitted or empty, the created key SHALL remain unscoped and apply to all accounts. When `assigned_account_ids` is provided with one or more valid account IDs, the created key SHALL enable account-assignment scope and persist those assignments.
+When `assignedAccountIds` is omitted or empty, the created key SHALL remain unscoped and apply to all accounts. When `assignedAccountIds` is provided with one or more valid account IDs, the created key SHALL enable account-assignment scope and persist those assignments.
 
 #### Scenario: Create unscoped key without assigned accounts
 

--- a/openspec/changes/fix-api-key-format-contract/tasks.md
+++ b/openspec/changes/fix-api-key-format-contract/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specification
+
+- [x] 1.1 Define exact creation and regeneration format scenarios.
+- [x] 1.2 Define compatibility for already-issued base64url keys.
+
+## 2. Regression
+
+- [ ] 2.1 Add exact-format coverage for service creation and regeneration.
+- [ ] 2.2 Add exact-format coverage through the API create/regenerate path.
+- [ ] 2.3 Capture the focused tests failing against the current generator.
+
+## 3. Implementation
+
+- [ ] 3.1 Generate new API keys with `secrets.token_hex(24)`.
+- [ ] 3.2 Preserve hash validation and existing-key compatibility unchanged.
+
+## 4. Verification
+
+- [ ] 4.1 Run focused API-key unit and integration tests.
+- [ ] 4.2 Exercise create, list, and regenerate through a live local HTTP API.
+- [ ] 4.3 Run changed-file format, lint, type, and strict OpenSpec checks.
+- [ ] 4.4 Run the repository risk-based local CI gate.
+- [ ] 4.5 Complete independent PR-readiness review and cleanup.

--- a/openspec/changes/fix-api-key-format-contract/tasks.md
+++ b/openspec/changes/fix-api-key-format-contract/tasks.md
@@ -5,18 +5,18 @@
 
 ## 2. Regression
 
-- [ ] 2.1 Add exact-format coverage for service creation and regeneration.
-- [ ] 2.2 Add exact-format coverage through the API create/regenerate path.
-- [ ] 2.3 Capture the focused tests failing against the current generator.
+- [x] 2.1 Add exact-format coverage for service creation and regeneration.
+- [x] 2.2 Add exact-format coverage through the API create/regenerate path.
+- [x] 2.3 Capture the focused tests failing against the current generator.
 
 ## 3. Implementation
 
-- [ ] 3.1 Generate new API keys with `secrets.token_hex(24)`.
-- [ ] 3.2 Preserve hash validation and existing-key compatibility unchanged.
+- [x] 3.1 Generate new API keys with `secrets.token_hex(24)`.
+- [x] 3.2 Preserve hash validation and existing-key compatibility unchanged.
 
 ## 4. Verification
 
-- [ ] 4.1 Run focused API-key unit and integration tests.
+- [x] 4.1 Run focused API-key unit and integration tests.
 - [ ] 4.2 Exercise create, list, and regenerate through a live local HTTP API.
 - [ ] 4.3 Run changed-file format, lint, type, and strict OpenSpec checks.
 - [ ] 4.4 Run the repository risk-based local CI gate.

--- a/openspec/changes/fix-api-key-format-contract/tasks.md
+++ b/openspec/changes/fix-api-key-format-contract/tasks.md
@@ -17,7 +17,7 @@
 ## 4. Verification
 
 - [x] 4.1 Run focused API-key unit and integration tests.
-- [ ] 4.2 Exercise create, list, and regenerate through a live local HTTP API.
-- [ ] 4.3 Run changed-file format, lint, type, and strict OpenSpec checks.
-- [ ] 4.4 Run the repository risk-based local CI gate.
-- [ ] 4.5 Complete independent PR-readiness review and cleanup.
+- [x] 4.2 Exercise create, list, and regenerate through a live local HTTP API.
+- [x] 4.3 Run changed-file format, lint, type, and strict OpenSpec checks.
+- [x] 4.4 Run the repository risk-based local CI gate.
+- [x] 4.5 Complete independent PR-readiness review and cleanup.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import re
 from dataclasses import replace
 from datetime import timedelta
 from types import SimpleNamespace
@@ -159,7 +160,7 @@ async def test_api_keys_crud_and_regenerate(async_client):
     assert create.status_code == 200
     payload = create.json()
     assert payload["name"] == "dev-key"
-    assert payload["key"].startswith("sk-clb-")
+    assert re.fullmatch(r"sk-clb-[0-9a-f]{48}", payload["key"])
     assert payload["accountAssignmentScopeEnabled"] is False
     assert payload["assignedAccountIds"] == []
     assert len(payload["limits"]) == 1
@@ -195,7 +196,7 @@ async def test_api_keys_crud_and_regenerate(async_client):
     assert regenerated.status_code == 200
     regenerated_payload = regenerated.json()
     assert regenerated_payload["id"] == key_id
-    assert regenerated_payload["key"].startswith("sk-clb-")
+    assert re.fullmatch(r"sk-clb-[0-9a-f]{48}", regenerated_payload["key"])
     assert regenerated_payload["key"] != first_key
 
     deleted = await async_client.delete(f"/api/api-keys/{key_id}")

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Collection
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
@@ -41,6 +42,7 @@ from app.modules.api_keys.service import (
     ApiKeyValidationError,
     LimitRuleInput,
     _build_api_key_trends,
+    _hash_key,
     _is_sqlite_database_locked,
     _normalize_usage_sections,
 )
@@ -597,7 +599,7 @@ async def test_create_key_stores_hash_and_prefix() -> None:
         )
     )
 
-    assert created.key.startswith("sk-clb-")
+    assert re.fullmatch(r"sk-clb-[0-9a-f]{48}", created.key)
     assert created.key_prefix == created.key[:15]
     assert created.allowed_models == ["o3-pro"]
     assert created.traffic_class == "foreground"
@@ -1353,6 +1355,28 @@ async def test_create_key_with_limits() -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_key_accepts_legacy_base64url_format() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="legacy-key",
+            allowed_models=None,
+            expires_at=None,
+        )
+    )
+    legacy_key = f"sk-clb-{'A' * 43}"
+    row = await repo.get_by_id(created.id)
+    assert row is not None
+    row.key_hash = _hash_key(legacy_key)
+    row.key_prefix = legacy_key[:15]
+
+    validated = await service.validate_key(legacy_key)
+
+    assert validated.id == created.id
+
+
+@pytest.mark.asyncio
 async def test_validate_key_checks_expiry_and_limit() -> None:
     repo = _FakeApiKeysRepository()
     service = ApiKeysService(repo)
@@ -1995,7 +2019,7 @@ async def test_regenerate_key_rotates_hash_and_prefix() -> None:
     row_after = await repo.get_by_id(created.id)
     assert row_after is not None
 
-    assert regenerated.key.startswith("sk-clb-")
+    assert re.fullmatch(r"sk-clb-[0-9a-f]{48}", regenerated.key)
     assert row_after.key_hash != old_hash
     assert row_after.key_prefix != old_prefix
 


### PR DESCRIPTION
## Summary

Generate created and regenerated API keys in the documented
`sk-clb-{48 lowercase hex chars}` format while preserving hash-based
authentication for already-issued base64url keys.

## Type of change

- [x] `fix:` — bug fix
- [ ] Breaking change

Linked issue: None — standalone defect fix; this PR is not issue-resolving.

## OpenSpec

- [x] This PR includes an OpenSpec change
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/fix-api-key-format-contract/`

## Changes

- Replace the drifted `secrets.token_urlsafe(32)` generator with the specified
  `secrets.token_hex(24)` format for creation and regeneration.
- Pin the exact format at service and HTTP API seams.
- Pin continued authentication of already-issued 43-character base64url keys
  through the unchanged SHA-256 lookup path.

## Security and compatibility

- New key entropy changes from 256 to 192 bits to match the existing published
  contract and original design; 192 bits remains cryptographically strong.
- Stored values remain SHA-256 hashes plus display prefixes; plaintext remains
  one-time-only.
- Existing keys require no migration or rotation because validation remains
  format-agnostic and hash-based.

## Test plan

```text
uv run pytest -q \
  tests/unit/test_api_keys_service.py::test_create_key_stores_hash_and_prefix \
  tests/unit/test_api_keys_service.py::test_regenerate_key_rotates_hash_and_prefix \
  tests/integration/test_api_keys_api.py::test_api_keys_crud_and_regenerate
# 3 passed

uv run pytest -q tests/unit/test_api_keys_service.py \
  -k 'validate_key or create_key_stores_hash_and_prefix or regenerate_key_rotates_hash_and_prefix'
# 8 passed, 79 deselected

uv run pytest -q \
  tests/unit/test_api_keys_service.py \
  tests/integration/test_api_keys_api.py \
  tests/e2e/test_api_key_lifecycle.py
# 188 passed

uv run ruff format --check app/modules/api_keys/service.py \
  tests/unit/test_api_keys_service.py tests/integration/test_api_keys_api.py
# 3 files already formatted

uv run ruff check app/modules/api_keys/service.py \
  tests/unit/test_api_keys_service.py tests/integration/test_api_keys_api.py
# All checks passed

uv run ty check app/modules/api_keys/service.py \
  tests/unit/test_api_keys_service.py tests/integration/test_api_keys_api.py
# All checks passed

openspec validate fix-api-key-format-contract --strict
openspec validate api-keys --strict
# Both valid
```

Known upstream baseline: local OpenSpec 1.4.1 reports eight unrelated main-spec
errors. Current OpenSpec 1.11.0 reduces this to one unchanged upstream defect:
`openspec/specs/model-source-routing/spec.md` lacks `## Purpose`. The affected
`api-keys` capability and this change both pass strict validation.

## Screenshots / output

No dashboard-visible UI changed, so screenshots are not applicable.

Redacted live HTTP proof: create and regenerate returned HTTP 200, keys matched
`^sk-clb-[0-9a-f]{48}$` with length 55, list responses omitted plaintext, and
regenerated fingerprints differed.

## Checklist

- [x] Title uses Conventional Commits format.
- [x] No related issue exists; this PR explicitly states it is not issue-resolving.
- [x] Regression tests cover the service and HTTP API seams.
- [x] Relevant Sensitive-level local validation passed.
- [x] Affected OpenSpec change and `api-keys` spec pass strict validation.
- [x] Simplicity gates P1–P5 reviewed; no setting, setup step, README section,
      nav item, dependency, schema, migration, or default changed.
- [x] `CHANGELOG.md` was not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API keys now use the consistent `sk-clb-` prefix followed by 48 lowercase hexadecimal characters when created or regenerated.
  * Existing API keys in the previous format remain valid for authentication.
  * Regenerated keys continue to replace the previous key securely.

* **Tests**
  * Added coverage to verify exact formats for newly created and regenerated keys.
  * Added regression coverage for continued support of legacy keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->