### PR TITLE
fix(api-keys): serve unslashed collection routes

### DIFF
--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -119,6 +119,7 @@ def _build_limit_inputs(payload: ApiKeyCreateRequest | ApiKeyUpdateRequest) -> l
     return limit_inputs
 
 
+@router.post("", response_model=ApiKeyCreateResponse, include_in_schema=False)
 @router.post("/", response_model=ApiKeyCreateResponse)
 async def create_api_key(
     request: Request,
@@ -165,6 +166,7 @@ async def create_api_key(
     )
 
 
+@router.get("", response_model=list[ApiKeyResponse], include_in_schema=False)
 @router.get("/", response_model=list[ApiKeyResponse])
 async def list_api_keys(
     context: ApiKeysContext = Depends(get_api_keys_context),

--- a/openspec/changes/fix-api-key-collection-route-equivalence/.openspec.yaml
+++ b/openspec/changes/fix-api-key-collection-route-equivalence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fix-api-key-collection-route-equivalence/design.md
+++ b/openspec/changes/fix-api-key-collection-route-equivalence/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The API-key router has the prefix `/api/api-keys`, while its collection
+handlers are registered only at `"/"`. Starlette therefore owns the missing
+slash behavior instead of the API-key module, and direct clients can receive a
+redirect before the request reaches the collection operation. The application
+also has a catch-all SPA route, but it intentionally rejects `api/` paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Serve both collection URL forms directly for GET and POST.
+- Keep one canonical OpenAPI operation per collection method.
+- Preserve existing dependencies, response models, detail routes, and SPA
+  fallback behavior.
+
+**Non-Goals:**
+
+- Changing global slash redirect behavior.
+- Adding compatibility aliases for API-key detail routes.
+- Changing authentication, API-key persistence, schemas, or frontend calls.
+
+## Decisions
+
+Register an additional `""` decorator on each existing collection handler and
+exclude that alias from the generated schema. Both decorators therefore invoke
+the same typed function with the same dependencies and response model, while
+the existing `"/"` route remains the documented canonical path.
+
+Alternative: disable slash redirects globally. Rejected because it changes
+every router and does not itself register the missing API-key path.
+
+Alternative: change the SPA catch-all. Rejected because API compatibility
+belongs to the API-key router, and broadening the fallback would increase the
+blast radius without fixing direct route ownership.
+
+## Risks / Trade-offs
+
+- Duplicate OpenAPI operations could confuse generated clients -> hide the
+  unslashed compatibility aliases from the schema.
+- Decorator drift could make route forms diverge -> stack both decorators on
+  the same handlers and assert request-level response equivalence.

--- a/openspec/changes/fix-api-key-collection-route-equivalence/proposal.md
+++ b/openspec/changes/fix-api-key-collection-route-equivalence/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The API-key collection handlers are registered only with a trailing slash even
+though the dashboard contract and callers use both forms. Requests to
+`/api/api-keys` therefore depend on redirect or fallback behavior instead of
+reaching the collection operation directly.
+
+## What Changes
+
+- Make `GET /api/api-keys` and `GET /api/api-keys/` return the same collection
+  response without a redirect.
+- Make `POST /api/api-keys` and `POST /api/api-keys/` run the same creation
+  operation without redirect-dependent request-body handling.
+- Keep the trailing-slash routes canonical in OpenAPI and leave API-key detail
+  routes and the global SPA fallback unchanged.
+- Add request-level regression coverage for both collection route forms.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Require equivalent direct handling for API-key collection routes
+  with and without a trailing slash.
+
+## Impact
+
+- API surface: dashboard API-key collection `GET` and `POST` routes.
+- Code: `app/modules/api_keys/api.py`.
+- Tests: `tests/integration/test_api_keys_api.py`.
+- No dependency, database, schema, frontend, or configuration changes.

--- a/openspec/changes/fix-api-key-collection-route-equivalence/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-collection-route-equivalence/specs/api-keys/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: API-key collection routes preserve trailing-slash behavior
+
+The API-key collection operations MUST serve both `/api/api-keys` and
+`/api/api-keys/` directly. Equivalent route forms MUST use the same
+authentication, validation, persistence, and response contracts, and the
+unslashed form MUST NOT depend on an HTTP redirect or the dashboard SPA
+fallback.
+
+#### Scenario: List API keys through either collection URL
+
+- **WHEN** a dashboard client sends `GET /api/api-keys` or
+  `GET /api/api-keys/`
+- **THEN** both requests return the same API-key collection response directly
+- **AND** neither request returns an HTTP redirect
+
+#### Scenario: Create an API key through either collection URL
+
+- **WHEN** a dashboard client sends the same valid creation payload to
+  `POST /api/api-keys` or `POST /api/api-keys/`
+- **THEN** both requests run the API-key creation operation directly
+- **AND** neither request depends on redirect handling to preserve the request
+  body

--- a/openspec/changes/fix-api-key-collection-route-equivalence/tasks.md
+++ b/openspec/changes/fix-api-key-collection-route-equivalence/tasks.md
@@ -1,0 +1,21 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add request-level GET and POST coverage for API-key collection URLs
+  with and without a trailing slash
+- [x] 1.2 Capture the current unslashed collection behavior failing the new
+  regression without following redirects
+
+## 2. Route Compatibility
+
+- [x] 2.1 Register hidden unslashed aliases on the existing API-key collection
+  handlers
+- [x] 2.2 Verify canonical collection and detail route behavior remains
+  unchanged
+
+## 3. Verification
+
+- [x] 3.1 Run focused API-key integration tests and changed-file static checks
+- [x] 3.2 Validate OpenSpec and exercise slash/no-slash behavior through a live
+  HTTP server
+- [x] 3.3 Review the final diff and confirm no global routing or SPA fallback
+  behavior changed

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -145,6 +145,29 @@ async def _create_model_source(
 
 
 @pytest.mark.asyncio
+async def test_api_key_collection_routes_accept_equivalent_slash_forms(async_client):
+    canonical_list = await async_client.get("/api/api-keys/")
+    unslashed_list = await async_client.get("/api/api-keys", follow_redirects=False)
+    unslashed_create = await async_client.post(
+        "/api/api-keys",
+        json={"name": "unslashed-key", "allowedModels": []},
+        follow_redirects=False,
+    )
+
+    assert {
+        "canonical_get": canonical_list.status_code,
+        "unslashed_get": unslashed_list.status_code,
+        "unslashed_post": unslashed_create.status_code,
+    } == {
+        "canonical_get": 200,
+        "unslashed_get": 200,
+        "unslashed_post": 200,
+    }
+    assert unslashed_list.json() == canonical_list.json()
+    assert unslashed_create.json()["key"].startswith("sk-clb-")
+
+
+@pytest.mark.asyncio
 async def test_api_keys_crud_and_regenerate(async_client):
     create = await async_client.post(
         "/api/api-keys/",


### PR DESCRIPTION
## Summary

Serve `GET` and `POST /api/api-keys` directly instead of allowing the dashboard catch-all to return 404/405 for the unslashed collection path. Keep the existing trailing-slash routes canonical in OpenAPI.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] **Breaking change**

Linked issue: No exact open issue found in the bounded related-work search.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/fix-api-key-collection-route-equivalence/`

## Changes

- Register hidden unslashed aliases on the existing API-key collection GET and POST handlers.
- Add request-level coverage proving slash/no-slash GET equivalence and direct unslashed POST body handling.
- Specify the compatibility contract without changing detail routes or the global SPA fallback.

## Test plan

```text
.venv/bin/python -m pytest tests/integration/test_api_keys_api.py -q
# 101 passed

.venv/bin/ruff check app/modules/api_keys/api.py tests/integration/test_api_keys_api.py
.venv/bin/ty check app/modules/api_keys/api.py tests/integration/test_api_keys_api.py
.venv/bin/ruff format --check app/modules/api_keys/api.py tests/integration/test_api_keys_api.py
openspec validate fix-api-key-collection-route-equivalence --strict
git diff --check
```

`openspec validate --specs` reports the existing unrelated baseline failures in eight other capabilities; the owning `api-keys` spec and this scoped strict change both pass.

## Output

Live uvicorn/curl QA against an isolated SQLite database:

- `GET /api/api-keys` -> `200 []`
- `GET /api/api-keys/` -> `200 []`
- parsed GET bodies -> identical
- `POST /api/api-keys` with a valid JSON body -> direct `200` with a generated `sk-clb-` key

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related work was checked; no exact issue was found.
- [x] Added integration coverage.
- [x] Ran the relevant focused local checks.
- [x] Scoped OpenSpec validation is clean; unrelated global baseline failures are documented above.
- [x] Simplicity gates reviewed; no setting, default, README section, environment example, or dashboard navigation changed.
- [x] CHANGELOG is not edited by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key collection endpoints now work equivalently with or without a trailing slash.
  * Listing and creating API keys no longer require a redirect when using the slash-free URL.
  * Existing authentication, validation, and response behavior remains unchanged.

* **Tests**
  * Added coverage confirming both URL formats return equivalent results and support API key creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->