### PR TITLE
fix(middleware): bound zstd decoded output

### DIFF
--- a/app/core/middleware/request_decompression.py
+++ b/app/core/middleware/request_decompression.py
@@ -77,16 +77,8 @@ def _decompress_deflate(data: bytes, max_size: int) -> bytes:
 
 
 def _decompress_zstd(data: bytes, max_size: int) -> bytes:
-    try:
-        decompressed = zstd.ZstdDecompressor().decompress(data, max_output_size=max_size)
-        if len(decompressed) > max_size:
-            raise _DecompressedBodyTooLarge(max_size)
-        return decompressed
-    except _DecompressedBodyTooLarge:
-        raise
-    except Exception:
-        with zstd.ZstdDecompressor().stream_reader(io.BytesIO(data)) as reader:
-            return _read_limited(reader, max_size)
+    with zstd.ZstdDecompressor().stream_reader(io.BytesIO(data)) as reader:
+        return _read_limited(reader, max_size)
 
 
 def _decompress_body(data: bytes, encodings: list[str], max_size: int) -> bytes:

--- a/openspec/changes/bound-zstd-decoded-memory/.openspec.yaml
+++ b/openspec/changes/bound-zstd-decoded-memory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/bound-zstd-decoded-memory/design.md
+++ b/openspec/changes/bound-zstd-decoded-memory/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Gzip already wraps a file-like decoder with `_read_limited`, and deflate bounds
+each decompressor call to the remaining decoded-byte budget plus one byte.
+Zstd instead calls `ZstdDecompressor.decompress()` first. Its
+`max_output_size` controls a one-shot allocation size; it is not a streaming
+quota. The fallback reader runs only after that attempt raises.
+
+Official python-zstandard guidance recommends streaming APIs when the exact
+output size is unknown because one-shot decompression can require large
+allocations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound retained zstd output incrementally using the existing decoded limit.
+- Reuse the middleware's established bounded-reader behavior.
+- Preserve all current response envelopes and encoding composition.
+
+**Non-Goals:**
+
+- Adding a new zstd window-size setting.
+- Changing raw-body limits or multipart exceptions.
+- Changing support for concatenated frames or trailing data beyond current
+  `stream_reader` behavior.
+
+## Decisions
+
+Always create a zstd `stream_reader` over the encoded bytes and pass it to
+`_read_limited`. Each read is capped by the existing 64 KiB chunk size, and the
+consumer checks cumulative output before extending its retained buffer.
+
+Alternative: keep one-shot decompression with a smaller
+`max_output_size`. Rejected because that argument still sizes a native
+allocation rather than enforcing output incrementally.
+
+Alternative: introduce a new zstd-specific helper or setting. Rejected because
+the existing bounded-reader contract already provides the required behavior
+with less code and no new operator surface.
+
+## Risks / Trade-offs
+
+- Streaming may add small iterator/read overhead -> request bodies are already
+  bounded and correctness takes priority over one-shot throughput.
+- Decoder exceptions must retain existing mapping -> the middleware continues
+  to catch the same zstandard exceptions at the request boundary.

--- a/openspec/changes/bound-zstd-decoded-memory/proposal.md
+++ b/openspec/changes/bound-zstd-decoded-memory/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The zstd request-decompression path first decodes the complete body in one
+native allocation and applies the configured decoded-size limit only after that
+operation returns. A highly compressible request can therefore exceed the
+advertised ingress memory bound before the middleware rejects it.
+
+## What Changes
+
+- Decode zstd request bodies through an incrementally consumed reader.
+- Enforce the existing decoded-body limit before retaining each output chunk.
+- Preserve the existing exact-boundary, oversized-body, invalid-encoding, and
+  stacked-encoding behavior.
+- Add request-level regression coverage that prevents the one-shot path from
+  returning.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `http-ingress-limits`: Require zstd decoded output to remain incrementally
+  bounded while decompression is in progress.
+
+## Impact
+
+- Middleware: `app/core/middleware/request_decompression.py`.
+- Tests: `tests/unit/test_request_decompression_middleware.py` and existing
+  request-decompression integration coverage.
+- No settings, dependencies, schemas, routes, database, or frontend changes.

--- a/openspec/changes/bound-zstd-decoded-memory/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/bound-zstd-decoded-memory/specs/http-ingress-limits/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Zstd decoded output is bounded incrementally
+
+The request-decompression middleware MUST consume zstd decoded output
+incrementally. Before retaining each decoded chunk, it MUST enforce the
+route-specific decompressed-body limit. The middleware MUST NOT decode an
+entire zstd body through a one-shot output allocation before applying that
+limit.
+
+#### Scenario: Highly compressed zstd body exceeds decoded limit
+
+- **WHEN** a zstd request body expands beyond the route-specific decoded-body
+  limit
+- **THEN** the middleware stops consuming decoded output once the next bounded
+  chunk exceeds the remaining budget
+- **AND** the request receives the existing body-too-large response
+- **AND** the service remains available for subsequent requests
+
+#### Scenario: Zstd body ends at the decoded limit
+
+- **WHEN** a valid zstd request body expands to exactly the route-specific
+  decoded-body limit
+- **THEN** the middleware delivers the complete decoded body downstream

--- a/openspec/changes/bound-zstd-decoded-memory/tasks.md
+++ b/openspec/changes/bound-zstd-decoded-memory/tasks.md
@@ -1,0 +1,18 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add request-level coverage that rejects a one-shot zstd allocation
+  attempt before bounded streaming
+- [x] 1.2 Capture the regression failing before middleware changes
+
+## 2. Bounded Decompression
+
+- [x] 2.1 Route all zstd decoding through the existing bounded reader
+- [x] 2.2 Preserve exact-boundary, overflow, invalid, and stacked encoding
+  behavior
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit and integration request-decompression tests
+- [x] 3.2 Run static checks and strict scoped OpenSpec validation
+- [x] 3.3 Exercise oversized zstd rejection through a live HTTP server and
+  verify cleanup

--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -14,6 +14,7 @@ from httpx import ASGITransport, AsyncByteStream, AsyncClient
 from starlette.requests import ClientDisconnect
 from starlette.types import Message, Receive, Scope, Send
 
+import app.core.middleware.request_decompression as request_decompression_module
 from app.core.middleware.request_body_limit import add_request_body_limit_middleware
 from app.core.middleware.request_decompression import (
     RequestDecompressionMiddleware,
@@ -280,6 +281,43 @@ async def test_request_decompression_rejects_one_byte_over_decoded_boundary(
 
     assert response.status_code == 413
     assert response.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_zstd_streams_without_one_shot_allocation_attempt(monkeypatch):
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+    real_decompressor = zstd.ZstdDecompressor
+
+    class AllocationBudgetDecompressor:
+        one_shot_attempted = False
+
+        def decompress(self, *_args, **_kwargs):
+            type(self).one_shot_attempted = True
+            raise MemoryError("one-shot output allocation exceeded the test budget")
+
+        def stream_reader(self, source):
+            if type(self).one_shot_attempted:
+                raise MemoryError("one-shot attempt consumed the test allocation budget")
+            return real_decompressor().stream_reader(source)
+
+    monkeypatch.setattr(
+        request_decompression_module.zstd,
+        "ZstdDecompressor",
+        AllocationBudgetDecompressor,
+    )
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/echo",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Decode zstd request bodies only through the existing bounded stream reader. The previous fast path performed a one-shot native output allocation before the decoded-body limit could reject the request.

## Type of change

- [x] `fix:` — bug fix
- [ ] **Breaking change**

Linked issue: No exact open issue found in the bounded related-work search.

## OpenSpec

- [x] This PR includes an OpenSpec change

Change directory: `openspec/changes/bound-zstd-decoded-memory/`

## Changes

- Remove the one-shot zstd decompression/fallback branch.
- Route zstd output through `stream_reader` plus the existing cumulative decoded-byte guard.
- Add request-level regression coverage for the pre-limit allocation attempt.

## Test plan

```text
.venv/bin/python -m pytest tests/unit/test_request_decompression_middleware.py -q
# 33 passed

.venv/bin/python -m pytest tests/integration/test_request_decompression.py -q
# 7 passed

.venv/bin/ruff check app/core/middleware/request_decompression.py tests/unit/test_request_decompression_middleware.py
.venv/bin/ty check app/core/middleware/request_decompression.py tests/unit/test_request_decompression_middleware.py
.venv/bin/ruff format --check app/core/middleware/request_decompression.py tests/unit/test_request_decompression_middleware.py
openspec validate bound-zstd-decoded-memory --strict
git diff --check
```

The owning `http-ingress-limits` main spec passes. Global spec validation retains unrelated upstream baseline failures in other capabilities.

## Output

Live isolated uvicorn QA with `CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES=128`:

- valid zstd JSON expanding beyond the limit -> direct `413 payload_too_large`
- subsequent `/health` -> `200 {"status":"ok"}`

Reference: python-zstandard recommends streaming for unknown output sizes because one-shot decompression can require large allocations: https://python-zstandard.readthedocs.io/en/latest/decompressor.html

## Checklist

- [x] Conventional Commit title
- [x] No exact issue found
- [x] Request-level regression added
- [x] Focused tests and static checks pass
- [x] Scoped OpenSpec validation passes
- [x] Simplicity gates reviewed; no setting, default, dependency, README, environment example, or dashboard navigation changed
- [x] CHANGELOG not edited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of compressed requests by decoding zstd data incrementally.
  * Prevented large decompressed requests from requiring excessive memory.
  * Preserved existing request-size limits, exact-limit behavior, invalid-encoding handling, and stacked compression support.

* **Tests**
  * Added regression coverage confirming compressed requests remain functional without one-shot memory allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->