### PR TITLE
fix(helm): default global backpressure off

### DIFF
--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -147,7 +147,7 @@ config:
   # (failure threshold and recovery timeout are fixed application constants)
   circuitBreakerEnabled: true
   # @param config.backpressureMaxConcurrentRequests Max concurrent in-flight requests
-  backpressureMaxConcurrentRequests: 200
+  backpressureMaxConcurrentRequests: 0
   # @param config.shutdownDrainTimeoutSeconds Shared application drain timeout in seconds
   shutdownDrainTimeoutSeconds: 30
   # @param config.httpConnectorLimit Global HTTP connection pool limit

--- a/openspec/changes/disable-helm-global-backpressure-default/.openspec.yaml
+++ b/openspec/changes/disable-helm-global-backpressure-default/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/disable-helm-global-backpressure-default/design.md
+++ b/openspec/changes/disable-helm-global-backpressure-default/design.md
@@ -1,0 +1,51 @@
+## Context
+
+Application `Settings.backpressure_max_concurrent_requests` defaults to `0`.
+`app.main` installs `BackpressureMiddleware` only when that value is greater
+than zero. A positive value is one process-wide semaphore shared by HTTP,
+websocket, compact, and dashboard traffic.
+
+The Helm chart already renders
+`CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS` from
+`config.backpressureMaxConcurrentRequests`, but `values.yaml` currently
+defaults that field to `200`. A default Helm install therefore turns the
+global cap on and can starve one traffic class from another.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Align the chart default with the application default of `0`.
+- Keep the existing ConfigMap key and operator override path.
+- Prove default `"0"` and override `"37"` through real Helm rendering.
+
+**Non-Goals:**
+
+- Changing runtime Python, middleware, or Settings defaults.
+- Removing the optional global cap.
+- Editing README, CHANGELOG, settings docs, or unrelated chart values.
+- Changing per-class bulkhead or account-local admission limits.
+
+## Decisions
+
+Change only `deploy/helm/codex-lb/values.yaml`
+`config.backpressureMaxConcurrentRequests` from `200` to `0`. Leave
+`templates/configmap.yaml` unchanged because it already quotes
+`.Values.config.backpressureMaxConcurrentRequests`.
+
+Cover the contract in `tests/unit/test_helm_replica_artifacts.py` with a
+real `helm template` assertion against the rendered ConfigMap, not a
+values-file string check. Use `37` as the explicit override so the test
+cannot pass by echoing a leftover `200`.
+
+Keep the optional positive override. Operators who want a global cap can
+still set the Helm value; the default install must not.
+
+## Risks / Trade-offs
+
+- Un-overridden Helm upgrades lose the previous global cap of `200`.
+  Mitigation: that cap contradicted split-by-class admission and the
+  application default. Operators who need a global limit set the value
+  explicitly.
+- A values-only test could miss ConfigMap wiring drift. Mitigation: parse
+  the rendered ConfigMap `data` field from `helm template`.

--- a/openspec/changes/disable-helm-global-backpressure-default/proposal.md
+++ b/openspec/changes/disable-helm-global-backpressure-default/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The Helm chart defaults `config.backpressureMaxConcurrentRequests` to `200`,
+so a default install sets `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS=200`.
+A positive value installs one process-wide semaphore across every traffic
+class, which contradicts the application default of `0` (disabled) and the
+split-by-class admission contract.
+
+## What Changes
+
+- Change the chart default for `config.backpressureMaxConcurrentRequests`
+  from `200` to `0` so default Helm installs leave global backpressure off.
+- Keep the existing ConfigMap wiring and allow operators to set a positive
+  override when they want a global cap.
+- Add a real Helm-render regression that the default ConfigMap value is
+  `"0"` and that an explicit override of `37` renders `"37"`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: Default Helm installs MUST leave the global
+  backpressure cap disabled (`0`). A positive operator override remains
+  allowed; the default MUST NOT install one semaphore across traffic classes.
+
+## Impact
+
+Only `deploy/helm/codex-lb/values.yaml` production behavior changes, plus
+OpenSpec artifacts and the Helm-render regression. Runtime Python, global
+middleware, README, CHANGELOG, settings docs, and other chart values stay
+unchanged. Existing Helm releases that already override the value keep that
+override; un-overridden upgrades stop applying the unintended global cap.

--- a/openspec/changes/disable-helm-global-backpressure-default/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/disable-helm-global-backpressure-default/specs/proxy-admission-control/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Helm default leaves global backpressure disabled
+
+The Helm chart MUST default `config.backpressureMaxConcurrentRequests` to
+`0` so a default install sets
+`CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS` to `"0"`. A value of `0`
+MUST leave the process-wide backpressure semaphore uninstalled. A positive
+operator override MUST still render into that ConfigMap key. The default
+MUST NOT install one global concurrent-request cap across proxy HTTP,
+websocket, compact, and dashboard traffic.
+
+#### Scenario: Default Helm ConfigMap disables global backpressure
+
+- **WHEN** the chart is rendered with default values
+- **THEN** the ConfigMap `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS`
+  value is `"0"`
+
+#### Scenario: Explicit Helm override renders the global cap
+
+- **WHEN** an operator sets `config.backpressureMaxConcurrentRequests=37`
+- **THEN** the ConfigMap `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS`
+  value is `"37"`

--- a/openspec/changes/disable-helm-global-backpressure-default/tasks.md
+++ b/openspec/changes/disable-helm-global-backpressure-default/tasks.md
@@ -1,0 +1,22 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a real Helm-render assertion in
+      `tests/unit/test_helm_replica_artifacts.py` that the default ConfigMap
+      `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS` equals `"0"` and that
+      `--set config.backpressureMaxConcurrentRequests=37` renders `"37"`.
+- [x] 1.2 Run that focused test before changing values and capture the RED
+      failure showing the actual default `"200"`.
+
+## 2. Chart Default
+
+- [x] 2.1 Change only `deploy/helm/codex-lb/values.yaml`
+      `config.backpressureMaxConcurrentRequests` from `200` to `0`.
+
+## 3. Verification
+
+- [x] 3.1 Re-run the focused Helm-render test and confirm GREEN.
+- [x] 3.2 Run settings backpressure tests, Helm lint/template checks,
+      formatting/diff checks, and scoped strict OpenSpec validation.
+- [x] 3.3 Render the chart with literal `helm template` for the default and
+      the `37` override, parse the ConfigMap values, and confirm exact `0`
+      and `37`.

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -254,6 +254,21 @@ def test_helm_codex_prewarm_defaults_off_like_settings() -> None:
     ) in configmap
 
 
+def test_helm_default_disables_global_backpressure_and_honors_override() -> None:
+    default_rendered = _helm_template("--show-only", "templates/configmap.yaml")
+    override_rendered = _helm_template(
+        "--set",
+        "config.backpressureMaxConcurrentRequests=37",
+        "--show-only",
+        "templates/configmap.yaml",
+    )
+    (default_configmap,) = _helm_documents(default_rendered)
+    (override_configmap,) = _helm_documents(override_rendered)
+
+    assert default_configmap["data"]["CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS"] == "0"
+    assert override_configmap["data"]["CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS"] == "37"
+
+
 def test_helm_pool_budget_values_flow_to_runtime_and_hpa_templates() -> None:
     configmap = (_CHART_DIR / "templates" / "configmap.yaml").read_text()
     deployment = (_CHART_DIR / "templates" / "deployment.yaml").read_text()


### PR DESCRIPTION
## Summary

Helm defaulted `config.backpressureMaxConcurrentRequests` to `200`, so a default chart install set `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS=200` and installed one process-wide semaphore across HTTP, websocket, compact, and dashboard traffic. Application Settings already default that cap to `0` (disabled). This PR aligns the chart default with Settings and keeps the explicit override path.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: no exact issue found.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/disable-helm-global-backpressure-default/`

`proxy-admission-control` now requires the Helm default to leave the global backpressure cap disabled, while still rendering a positive operator override.

## Changes

- Set `config.backpressureMaxConcurrentRequests: 0` in `deploy/helm/codex-lb/values.yaml`
- Add a real Helm-render regression that the default ConfigMap value is `"0"` and `--set config.backpressureMaxConcurrentRequests=37` renders `"37"`
- Leave ConfigMap wiring, runtime Python, middleware, README, CHANGELOG, and settings docs unchanged

## Simplicity

- [x] Aligns an existing default to **off** (no new setting)
- [x] No new required setup step
- New setting(s) and why each can't be a default: none
- [x] README sections / `.env.example` / dashboard nav unchanged

Un-overridden Helm upgrades stop applying the previous global cap of `200`. Operators who want a global limit can still set the chart value explicitly.

## Test plan

```
uv run pytest tests/unit/test_helm_replica_artifacts.py::test_helm_default_disables_global_backpressure_and_honors_override -q
uv run pytest tests/unit/test_settings_multi_replica.py::test_settings_multi_replica_defaults tests/unit/test_settings_multi_replica.py::test_settings_backpressure_max_concurrent_requests_from_env -q
helm lint --strict deploy/helm/codex-lb/ --set postgresql.auth.password=test-password
make helm-template
openspec validate disable-helm-global-backpressure-default --strict
helm template codex-lb deploy/helm/codex-lb --show-only templates/configmap.yaml
helm template codex-lb deploy/helm/codex-lb --set config.backpressureMaxConcurrentRequests=37 --show-only templates/configmap.yaml
```

Focused Helm-render test was red on the pre-change default (`'200' == '0'`), then green after the values change. Literal `helm template` ConfigMap values were `"0"` (default) and `"37"` (override).

Intentionally unrun locally: full `make ci` / `local-ci`, kubeconform, kind smoke, frontend checks. Those remain CI-covered.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above (none found).
- [x] Added or updated tests covering the change.
- [x] Ran the focused local subset above.
- [x] If touching specs: `openspec validate disable-helm-global-backpressure-default --strict` passes.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Helm deployments now disable global backpressure by default.
  * Administrators can still enable a specific positive request limit through configuration overrides.

* **Bug Fixes**
  * Corrected the default deployment setting to align with application behavior.

* **Tests**
  * Added coverage verifying the default setting and custom override values render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->