### PR TITLE
fix(oauth): fence stale dashboard poll generations

### DIFF
--- a/frontend/src/features/accounts/components/oauth-dialog-stale-poll.test.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog-stale-poll.test.tsx
@@ -123,6 +123,7 @@ describe("OauthDialog stale poll generation", () => {
       throw new Error("poll A did not start");
     }
     const pendingPollA = pollA;
+    expect(getOauthStatusMock).toHaveBeenCalledWith("flow-a");
 
     await user.click(screen.getByRole("button", { name: "Change method" }));
     await screen.findByRole("heading", { name: "Add account with OAuth" });

--- a/frontend/src/features/accounts/components/oauth-dialog-stale-poll.test.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog-stale-poll.test.tsx
@@ -1,0 +1,146 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, type PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OauthDialog } from "@/features/accounts/components/oauth-dialog";
+import { useOauth } from "@/features/accounts/hooks/use-oauth";
+
+const startOauthMock = vi.fn();
+const completeOauthMock = vi.fn();
+const submitManualOauthCallbackMock = vi.fn();
+const getOauthStatusMock = vi.fn();
+
+vi.mock("@/features/accounts/api", () => ({
+  startOauth: (...args: unknown[]) => startOauthMock(...args),
+  completeOauth: (...args: unknown[]) => completeOauthMock(...args),
+  submitManualOauthCallback: (...args: unknown[]) => submitManualOauthCallbackMock(...args),
+  getOauthStatus: (...args: unknown[]) => getOauthStatusMock(...args),
+}));
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  if (resolve === undefined) {
+    throw new Error("deferred executor did not run");
+  }
+  return { promise, resolve };
+}
+
+function browserOauthStart(flowId: string) {
+  return {
+    flowId,
+    method: "browser",
+    authorizationUrl: `https://auth.example.com/authorize?flow=${flowId}`,
+    callbackUrl: "http://127.0.0.1:1455/auth/callback",
+    verificationUrl: null,
+    userCode: null,
+    deviceAuthId: null,
+    intervalSeconds: 3600,
+    expiresInSeconds: 600,
+  };
+}
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+}
+
+describe("OauthDialog stale poll generation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getOauthStatusMock.mockResolvedValue({ status: "pending", errorMessage: null });
+  });
+
+  it("keeps flow B pending in the dialog when a stale flow A poll succeeds", async () => {
+    const statusA = createDeferred<{ status: string; errorMessage: null }>();
+    const pollRef: { current: (() => Promise<void>) | null } = { current: null };
+    startOauthMock
+      .mockResolvedValueOnce(browserOauthStart("flow-a"))
+      .mockResolvedValueOnce(browserOauthStart("flow-b"));
+    completeOauthMock.mockResolvedValue({ status: "success", errorMessage: null });
+    getOauthStatusMock.mockImplementation((flowId: unknown) => {
+      if (flowId === "flow-a") {
+        return statusA.promise;
+      }
+      return Promise.resolve({ status: "pending", errorMessage: null });
+    });
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const user = userEvent.setup({ delay: null });
+
+    function Harness() {
+      const oauth = useOauth();
+      pollRef.current = oauth.poll;
+      return (
+        <OauthDialog
+          open
+          state={oauth.state}
+          onOpenChange={() => {}}
+          onStart={async (method) => {
+            await oauth.start(method);
+          }}
+          onComplete={async () => {}}
+          onManualCallback={async (callbackUrl) => {
+            await oauth.manualCallback(callbackUrl);
+          }}
+          onReset={oauth.reset}
+        />
+      );
+    }
+
+    render(createElement(Harness), {
+      wrapper: function Wrapper({ children }: PropsWithChildren) {
+        return createElement(QueryClientProvider, { client: queryClient }, children);
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Start sign-in" }));
+    expect(await screen.findByText("https://auth.example.com/authorize?flow=flow-a")).toBeInTheDocument();
+
+    const poll = pollRef.current;
+    if (poll === null) {
+      throw new Error("poll was not exposed");
+    }
+    let pollA: Promise<void> | undefined;
+    act(() => {
+      pollA = poll();
+    });
+    if (pollA === undefined) {
+      throw new Error("poll A did not start");
+    }
+    const pendingPollA = pollA;
+
+    await user.click(screen.getByRole("button", { name: "Change method" }));
+    await screen.findByRole("heading", { name: "Add account with OAuth" });
+    await user.click(screen.getByRole("button", { name: "Start sign-in" }));
+    expect(await screen.findByText("https://auth.example.com/authorize?flow=flow-b")).toBeInTheDocument();
+
+    await act(async () => {
+      statusA.resolve({ status: "success", errorMessage: null });
+      await pendingPollA;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("https://auth.example.com/authorize?flow=flow-b")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Waiting for authorization to complete...")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Account added" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Authorization failed" })).not.toBeInTheDocument();
+    expect(completeOauthMock).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/accounts/hooks/use-oauth.test.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.test.ts
@@ -43,6 +43,34 @@ function renderUseOauth(queryClient = createTestQueryClient()) {
   };
 }
 
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  if (resolve === undefined) {
+    throw new Error("deferred executor did not run");
+  }
+  return { promise, resolve };
+}
+
+function browserOauthStart(flowId: string) {
+  return {
+    flowId,
+    method: "browser",
+    authorizationUrl: `https://auth.example.com/authorize?flow=${flowId}`,
+    callbackUrl: "http://127.0.0.1:1455/auth/callback",
+    verificationUrl: null,
+    userCode: null,
+    deviceAuthId: null,
+    intervalSeconds: 3600,
+    expiresInSeconds: 600,
+  };
+}
+
 describe("useOauth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -438,5 +466,107 @@ describe("useOauth", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not complete or mutate flow B when a stale flow A poll succeeds after restart", async () => {
+    const statusA = createDeferred<{ status: string; errorMessage: null }>();
+    startOauthMock
+      .mockResolvedValueOnce(browserOauthStart("flow-a"))
+      .mockResolvedValueOnce(browserOauthStart("flow-b"));
+    completeOauthMock.mockResolvedValue({ status: "success", errorMessage: null });
+    getOauthStatusMock.mockImplementation((flowId: unknown) => {
+      if (flowId === "flow-a") {
+        return statusA.promise;
+      }
+      return Promise.resolve({ status: "pending", errorMessage: null });
+    });
+
+    const { queryClient, result } = renderUseOauth();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await act(async () => {
+      await result.current.start("browser");
+    });
+    expect(result.current.state.flowId).toBe("flow-a");
+    expect(result.current.state.status).toBe("pending");
+
+    let pollA: Promise<void> | undefined;
+    act(() => {
+      pollA = result.current.poll();
+    });
+    if (pollA === undefined) {
+      throw new Error("poll A did not start");
+    }
+    expect(getOauthStatusMock).toHaveBeenCalledWith("flow-a");
+
+    await act(async () => {
+      result.current.reset();
+      await result.current.start("browser");
+    });
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+    expect(result.current.state.authorizationUrl).toBe(
+      "https://auth.example.com/authorize?flow=flow-b",
+    );
+
+    const pendingPollA = pollA;
+    await act(async () => {
+      statusA.resolve({ status: "success", errorMessage: null });
+      await pendingPollA;
+    });
+
+    expect(completeOauthMock).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+    expect(result.current.state.errorMessage).toBeNull();
+    expect(result.current.state.authorizationUrl).toBe(
+      "https://auth.example.com/authorize?flow=flow-b",
+    );
+  });
+
+  it("does not write a stale flow A poll error onto flow B after restart", async () => {
+    const statusA = createDeferred<{ status: string; errorMessage: string }>();
+    startOauthMock
+      .mockResolvedValueOnce(browserOauthStart("flow-a"))
+      .mockResolvedValueOnce(browserOauthStart("flow-b"));
+    getOauthStatusMock.mockImplementation((flowId: unknown) => {
+      if (flowId === "flow-a") {
+        return statusA.promise;
+      }
+      return Promise.resolve({ status: "pending", errorMessage: null });
+    });
+
+    const { result } = renderUseOauth();
+
+    await act(async () => {
+      await result.current.start("browser");
+    });
+
+    let pollA: Promise<void> | undefined;
+    act(() => {
+      pollA = result.current.poll();
+    });
+    if (pollA === undefined) {
+      throw new Error("poll A did not start");
+    }
+
+    await act(async () => {
+      result.current.reset();
+      await result.current.start("browser");
+    });
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+
+    const pendingPollA = pollA;
+    await act(async () => {
+      statusA.resolve({ status: "error", errorMessage: "stale flow A failed" });
+      await pendingPollA;
+    });
+
+    expect(completeOauthMock).not.toHaveBeenCalled();
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+    expect(result.current.state.errorMessage).toBeNull();
   });
 });

--- a/frontend/src/features/accounts/hooks/use-oauth.test.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.test.ts
@@ -46,15 +46,18 @@ function renderUseOauth(queryClient = createTestQueryClient()) {
 function createDeferred<T>(): {
   readonly promise: Promise<T>;
   readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
 } {
   let resolve: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((res) => {
+  let reject: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  if (resolve === undefined) {
+  if (resolve === undefined || reject === undefined) {
     throw new Error("deferred executor did not run");
   }
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function browserOauthStart(flowId: string) {
@@ -565,6 +568,83 @@ describe("useOauth", () => {
     });
 
     expect(completeOauthMock).not.toHaveBeenCalled();
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+    expect(result.current.state.errorMessage).toBeNull();
+  });
+
+  it("does not apply a stale start success onto flow B after restart", async () => {
+    const startA = createDeferred<ReturnType<typeof browserOauthStart>>();
+    startOauthMock
+      .mockImplementationOnce(() => startA.promise)
+      .mockResolvedValueOnce(browserOauthStart("flow-b"));
+
+    const { result } = renderUseOauth();
+
+    let pendingStartA: Promise<unknown> | undefined;
+    act(() => {
+      pendingStartA = result.current.start("browser");
+    });
+    if (pendingStartA === undefined) {
+      throw new Error("start A did not begin");
+    }
+    expect(result.current.state.status).toBe("starting");
+
+    await act(async () => {
+      result.current.reset();
+      await result.current.start("browser");
+    });
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+
+    const startedA = pendingStartA;
+    await act(async () => {
+      startA.resolve(browserOauthStart("flow-a"));
+      await startedA;
+    });
+
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+    expect(result.current.state.authorizationUrl).toBe(
+      "https://auth.example.com/authorize?flow=flow-b",
+    );
+    expect(result.current.state.errorMessage).toBeNull();
+  });
+
+  it("does not apply a stale start error onto flow B after restart", async () => {
+    const startA = createDeferred<ReturnType<typeof browserOauthStart>>();
+    startOauthMock
+      .mockImplementationOnce(() => startA.promise)
+      .mockResolvedValueOnce(browserOauthStart("flow-b"));
+
+    const { result } = renderUseOauth();
+
+    let pendingStartA: Promise<unknown> | undefined;
+    act(() => {
+      pendingStartA = result.current.start("browser");
+    });
+    if (pendingStartA === undefined) {
+      throw new Error("start A did not begin");
+    }
+
+    await act(async () => {
+      result.current.reset();
+      await result.current.start("browser");
+    });
+    expect(result.current.state.flowId).toBe("flow-b");
+    expect(result.current.state.status).toBe("pending");
+
+    const startedA = pendingStartA;
+    let startAError: unknown;
+    await act(async () => {
+      startA.reject(new Error("stale start failed"));
+      startAError = await startedA.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+    });
+    expect(startAError).toBeInstanceOf(Error);
+
     expect(result.current.state.flowId).toBe("flow-b");
     expect(result.current.state.status).toBe("pending");
     expect(result.current.state.errorMessage).toBeNull();

--- a/frontend/src/features/accounts/hooks/use-oauth.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.ts
@@ -30,6 +30,7 @@ export function useOauth() {
   const queryClient = useQueryClient();
   const [state, setState] = useState<OAuthState>(INITIAL_OAUTH_STATE);
   const stateRef = useRef<OAuthState>(INITIAL_OAUTH_STATE);
+  const generationRef = useRef(0);
   const pollTimerRef = useRef<number | null>(null);
   const countdownTimerRef = useRef<number | null>(null);
 
@@ -56,20 +57,34 @@ export function useOauth() {
   }, []);
 
   const reset = useCallback(() => {
+    generationRef.current += 1;
     clearPollTimer();
     clearCountdownTimer();
     setOauthState(INITIAL_OAUTH_STATE);
   }, [clearCountdownTimer, clearPollTimer, setOauthState]);
 
   const poll = useCallback(async () => {
+    const generation = generationRef.current;
+    const flowId = stateRef.current.flowId;
+    const deviceAuthId = stateRef.current.deviceAuthId;
+    const userCode = stateRef.current.userCode;
+    const isCurrent = () =>
+      generationRef.current === generation && stateRef.current.flowId === flowId;
+
     try {
-      const status = await getOauthStatus(stateRef.current.flowId ?? undefined);
+      const status = await getOauthStatus(flowId ?? undefined);
+      if (!isCurrent()) {
+        return;
+      }
       if (status.status === "success") {
         const response = await completeOauth({
-          ...(stateRef.current.flowId ? { flowId: stateRef.current.flowId } : {}),
-          deviceAuthId: stateRef.current.deviceAuthId ?? undefined,
-          userCode: stateRef.current.userCode ?? undefined,
+          ...(flowId ? { flowId } : {}),
+          deviceAuthId: deviceAuthId ?? undefined,
+          userCode: userCode ?? undefined,
         });
+        if (!isCurrent()) {
+          return;
+        }
         setOauthState((prev) =>
           OAuthStateSchema.parse({
             ...prev,
@@ -105,6 +120,9 @@ export function useOauth() {
         clearCountdownTimer();
       }
     } catch (error) {
+      if (!isCurrent()) {
+        return;
+      }
       clearPollTimer();
       clearCountdownTimer();
       setOauthState((prev) =>
@@ -147,6 +165,7 @@ export function useOauth() {
   }, [clearCountdownTimer, setOauthState]);
 
   const start = useCallback(async (forceMethod?: "browser" | "device", accountId?: string) => {
+    generationRef.current += 1;
     clearPollTimer();
     clearCountdownTimer();
     setOauthState((prev) => ({ ...prev, status: "starting", errorMessage: null }));

--- a/frontend/src/features/accounts/hooks/use-oauth.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.ts
@@ -166,12 +166,16 @@ export function useOauth() {
 
   const start = useCallback(async (forceMethod?: "browser" | "device", accountId?: string) => {
     generationRef.current += 1;
+    const generation = generationRef.current;
     clearPollTimer();
     clearCountdownTimer();
     setOauthState((prev) => ({ ...prev, status: "starting", errorMessage: null }));
 
     try {
       const response = await startOauth({ forceMethod, accountId });
+      if (generationRef.current !== generation) {
+        return stateRef.current;
+      }
       const method = response.method === "device" ? "device" : "browser";
       const nextState = OAuthStateSchema.parse({
         flowId: response.flowId ?? null,
@@ -206,6 +210,9 @@ export function useOauth() {
 
       return nextState;
     } catch (error) {
+      if (generationRef.current !== generation) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : "Failed to start OAuth";
       clearPollTimer();
       clearCountdownTimer();

--- a/openspec/changes/fence-stale-oauth-polls/.openspec.yaml
+++ b/openspec/changes/fence-stale-oauth-polls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/fence-stale-oauth-polls/design.md
+++ b/openspec/changes/fence-stale-oauth-polls/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`useOauth` stores the active dashboard OAuth flow in React state and a mirrored `stateRef`. `poll()` reads `stateRef.current` to choose the flow ID, awaits `getOauthStatus`, then reads `stateRef.current` again to complete, apply status, or invalidate account caches.
+
+`reset()` and `start()` replace that state while the earlier `poll()` is still awaiting. After the await, the stale poll observes the new flow and can:
+
+- call `completeOauth` with the new flow's credentials
+- write success or error onto the new flow
+- invalidate account/dashboard caches because the old flow succeeded
+
+The backend already keys status by flow ID. The defect is client-side generation mixing, not API identity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Drop stale poll results after reset or restart.
+- Keep current-flow success, error, and pending behavior unchanged.
+- Prove the race with a deferred-promise unit test (no sleeps) and a mocked-browser surface check.
+
+**Non-Goals:**
+
+- Backend OAuth store, API, or schema changes.
+- Visible dialog copy, layout, or styling changes.
+- Broad OAuth state-machine refactor of `complete` / `manualCallback`.
+- Aborting in-flight HTTP; fencing the apply path is enough.
+
+## Decisions
+
+### Generation fence, not abort-only
+
+Keep a monotonic generation counter on the hook instance. `reset()` and `start()` increment it before replacing state. `poll()` snapshots the generation plus the current flow ID, `deviceAuthId`, and `userCode` before any await.
+
+After the status await and after the completion await, `poll()` continues only when the generation is unchanged and the captured flow ID still matches the live flow. Otherwise it returns without `completeOauth`, without `setOauthState`, and without cache invalidation.
+
+Aborting the HTTP request is optional later; a late response must still be ignored even if abort is unavailable.
+
+### Capture credentials before awaits
+
+Completion MUST use the captured flow credentials, never `stateRef.current` after an await. Re-reading the live ref is the defect.
+
+### Identity check is in addition to generation
+
+Generation covers reset-to-idle and restart-to-a-new-flow. The flow-ID check is the second latch so a poll cannot complete a different live flow even if a future caller mutates state without bumping generation.
+
+### Alternatives considered
+
+- **Compare flow ID only:** reset-to-idle then a later start can reuse timing windows; generation is the reset latch.
+- **React Query / AbortController as the only fence:** still need an apply-side generation check for responses that complete after abort.
+- **Fence `complete` and `manualCallback` in the same change:** those paths are not the reported poll race; leave them unless a second failing test appears.
+
+## Risks / Trade-offs
+
+- [Stale poll still runs HTTP] → Accept; ignore the result. Do not add a new client dependency for cancellation.
+- [Generation bump on both reset and start] → Harmless extra increment when start follows reset; still monotonic.
+- [Timer-scheduled polls after restart] → `start` already reschedules timers against the new generation; stale interval callbacks are cleared on reset/start.
+
+## Migration Plan
+
+Frontend-only. Deploy with the dashboard bundle. Rollback is the previous bundle. No data migration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fence-stale-oauth-polls/design.md
+++ b/openspec/changes/fence-stale-oauth-polls/design.md
@@ -33,6 +33,8 @@ Keep a monotonic generation counter on the hook instance. `reset()` and `start()
 
 After the status await and after the completion await, `poll()` continues only when the generation is unchanged and the captured flow ID still matches the live flow. Otherwise it returns without `completeOauth`, without `setOauthState`, and without cache invalidation.
 
+`start()` uses the same generation: it increments before `startOauth`, then applies the new flow only if that generation is still current after the await (and skips error-state writes in `catch` when it is not). Closing or restarting while start is in flight is the UI path that needs this latch.
+
 Aborting the HTTP request is optional later; a late response must still be ignored even if abort is unavailable.
 
 ### Capture credentials before awaits
@@ -47,7 +49,7 @@ Generation covers reset-to-idle and restart-to-a-new-flow. The flow-ID check is 
 
 - **Compare flow ID only:** reset-to-idle then a later start can reuse timing windows; generation is the reset latch.
 - **React Query / AbortController as the only fence:** still need an apply-side generation check for responses that complete after abort.
-- **Fence `complete` and `manualCallback` in the same change:** those paths are not the reported poll race; leave them unless a second failing test appears.
+- **Fence `complete` and `manualCallback` in the same change:** those paths are not the reported poll race; leave them unless a second failing test appears. `start` is fenced because its await has the same generation-mixing shape as poll.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fence-stale-oauth-polls/proposal.md
+++ b/openspec/changes/fence-stale-oauth-polls/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The dashboard OAuth hook polls status and then completes using whatever flow credentials sit in the current React state after each await. If the operator resets or restarts OAuth while an in-flight poll is still waiting, that stale poll can complete, error, or invalidate caches for the new flow. The API already keys status by flow ID; the client must stop applying a previous generation's result to the current generation.
+
+## What Changes
+
+- Fence dashboard OAuth polling with a monotonic generation that reset and restart invalidate.
+- Capture the in-flight flow ID and completion credentials before awaits, and ignore stale status or completion results after generation or identity no longer match.
+- Keep the current-flow success, error, and pending paths unchanged when no reset or restart occurs.
+- Add a deterministic deferred-promise regression that starts flow A, resets and starts flow B, then resolves A without mutating B.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `account-identity`: a reset or restarted dashboard OAuth flow MUST ignore stale poll completions from a previous generation so the current flow's identity, status, and account-cache invalidation stay isolated.
+
+## Impact
+
+- Frontend only: `frontend/src/features/accounts/hooks/use-oauth.ts` and `use-oauth.test.ts`.
+- No backend, API, schema, or visible OAuth dialog contract changes.
+- No new settings, dependencies, or dashboard navigation.

--- a/openspec/changes/fence-stale-oauth-polls/specs/account-identity/spec.md
+++ b/openspec/changes/fence-stale-oauth-polls/specs/account-identity/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Dashboard OAuth polls ignore stale generations
 
-The dashboard OAuth client MUST isolate in-flight status polls by a monotonic generation that reset and restart invalidate. A poll MUST capture the flow ID and completion credentials before awaiting status or completion. After each of those awaits, the client MUST continue only when the generation is still current and the captured flow ID still identifies the live flow. A fenced poll MUST NOT complete OAuth, MUST NOT write success or error onto a newer flow, and MUST NOT invalidate account or dashboard caches. An uninterrupted current-flow poll MUST still apply success, error, and pending results as it does today.
+The dashboard OAuth client MUST isolate in-flight status polls and start continuations by a monotonic generation that reset and restart invalidate. A poll MUST capture the flow ID and completion credentials before awaiting status or completion. After each of those awaits, the client MUST continue only when the generation is still current and the captured flow ID still identifies the live flow. After awaiting OAuth start, the client MUST apply the new flow only when that start's generation is still current. A fenced poll or start MUST NOT complete OAuth, MUST NOT write success or error onto a newer flow, and MUST NOT invalidate account or dashboard caches. An uninterrupted current-flow poll MUST still apply success, error, and pending results as it does today.
 
 #### Scenario: Stale successful poll after reset and restart is ignored
 
@@ -19,6 +19,22 @@ The dashboard OAuth client MUST isolate in-flight status polls by a monotonic ge
 - **GIVEN** dashboard OAuth flow A is pending and a status poll for A is awaiting
 - **AND** the operator resets and starts flow B
 - **WHEN** the in-flight poll for A later resolves as error
+- **THEN** the client does not write A's error onto flow B
+- **AND** flow B remains the live pending flow
+
+#### Scenario: Stale start success after reset and restart is ignored
+
+- **GIVEN** dashboard OAuth start A is awaiting
+- **AND** the operator resets and starts flow B
+- **WHEN** start A later resolves as success
+- **THEN** the client does not replace flow B with A's credentials
+- **AND** flow B remains the live pending flow
+
+#### Scenario: Stale start error after reset and restart is ignored
+
+- **GIVEN** dashboard OAuth start A is awaiting
+- **AND** the operator resets and starts flow B
+- **WHEN** start A later fails
 - **THEN** the client does not write A's error onto flow B
 - **AND** flow B remains the live pending flow
 

--- a/openspec/changes/fence-stale-oauth-polls/specs/account-identity/spec.md
+++ b/openspec/changes/fence-stale-oauth-polls/specs/account-identity/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Dashboard OAuth polls ignore stale generations
+
+The dashboard OAuth client MUST isolate in-flight status polls by a monotonic generation that reset and restart invalidate. A poll MUST capture the flow ID and completion credentials before awaiting status or completion. After each of those awaits, the client MUST continue only when the generation is still current and the captured flow ID still identifies the live flow. A fenced poll MUST NOT complete OAuth, MUST NOT write success or error onto a newer flow, and MUST NOT invalidate account or dashboard caches. An uninterrupted current-flow poll MUST still apply success, error, and pending results as it does today.
+
+#### Scenario: Stale successful poll after reset and restart is ignored
+
+- **GIVEN** dashboard OAuth flow A is pending and a status poll for A is awaiting
+- **AND** the operator resets and starts flow B
+- **WHEN** the in-flight poll for A later resolves as success
+- **THEN** the client does not call OAuth completion for A or B
+- **AND** it does not mark flow B success or error
+- **AND** it does not invalidate account or dashboard caches
+- **AND** flow B remains the live pending flow
+
+#### Scenario: Stale error poll after reset and restart is ignored
+
+- **GIVEN** dashboard OAuth flow A is pending and a status poll for A is awaiting
+- **AND** the operator resets and starts flow B
+- **WHEN** the in-flight poll for A later resolves as error
+- **THEN** the client does not write A's error onto flow B
+- **AND** flow B remains the live pending flow
+
+#### Scenario: Current-flow poll success still completes
+
+- **GIVEN** dashboard OAuth flow A is pending and no reset or restart has occurred
+- **WHEN** a status poll for A resolves as success and completion succeeds
+- **THEN** the client completes flow A
+- **AND** it marks the live flow success
+- **AND** it invalidates account and dashboard caches

--- a/openspec/changes/fence-stale-oauth-polls/tasks.md
+++ b/openspec/changes/fence-stale-oauth-polls/tasks.md
@@ -1,0 +1,18 @@
+## 1. Regression
+
+- [x] 1.1 Add a deferred-promise `useOauth` test that starts flow A, awaits poll A, resets and starts flow B, then resolves A as success without completing OAuth, mutating B, or invalidating caches
+- [x] 1.2 Add the matching stale-error case so A's error cannot land on B
+- [x] 1.3 Run the focused hook tests and confirm the stale-success case fails on the unfenced hook
+
+## 2. Fence
+
+- [x] 2.1 Add a monotonic generation incremented by `reset` and `start`
+- [x] 2.2 Capture flow ID and completion credentials before poll awaits, and ignore the result when generation or flow identity no longer match after the status await and after the completion await
+- [x] 2.3 Keep current-flow success, error, and pending poll behavior unchanged
+
+## 3. Verify
+
+- [x] 3.1 Re-run focused and complete `use-oauth` tests until they pass without sleeps
+- [x] 3.2 Run ESLint on changed files, frontend typecheck, and frontend build
+- [x] 3.3 Prove the visible OAuth dialog keeps flow B pending after a mocked stale flow-A success
+- [x] 3.4 Validate the scoped OpenSpec change strictly

--- a/openspec/changes/fence-stale-oauth-polls/tasks.md
+++ b/openspec/changes/fence-stale-oauth-polls/tasks.md
@@ -14,5 +14,5 @@
 
 - [x] 3.1 Re-run focused and complete `use-oauth` tests until they pass without sleeps
 - [x] 3.2 Run ESLint on changed files, frontend typecheck, and frontend build
-- [x] 3.3 Prove the visible OAuth dialog keeps flow B pending after a mocked stale flow-A success
+- [x] 3.3 Prove the visible OAuth dialog keeps flow B pending after a mocked stale flow-A success, including a committed OauthDialog + useOauth regression that starts A, resets/restarts B through the dialog, and ignores a late A success
 - [x] 3.4 Validate the scoped OpenSpec change strictly

--- a/openspec/changes/fence-stale-oauth-polls/tasks.md
+++ b/openspec/changes/fence-stale-oauth-polls/tasks.md
@@ -9,6 +9,7 @@
 - [x] 2.1 Add a monotonic generation incremented by `reset` and `start`
 - [x] 2.2 Capture flow ID and completion credentials before poll awaits, and ignore the result when generation or flow identity no longer match after the status await and after the completion await
 - [x] 2.3 Keep current-flow success, error, and pending poll behavior unchanged
+- [x] 2.4 Ignore stale `startOauth` success and error continuations after reset/restart
 
 ## 3. Verify
 


### PR DESCRIPTION
## Summary

Dashboard OAuth polling read live hook state after `await`, so a late flow-A status poll could complete OAuth, write success/error, or invalidate account caches after the operator had already reset and started flow B.

This change fences polls with a monotonic generation invalidated by reset/restart, captures flow credentials before awaits, and ignores stale results. Current-flow success/error/pending behavior is unchanged.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: no exact issue found.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fence-stale-oauth-polls/`

## Changes

- Add a generation fence in `useOauth` so reset/restart invalidates in-flight status polls.
- Capture flow ID and completion credentials before poll awaits; do not re-read live state afterward.
- Add deferred-promise regressions for a stale success and a stale error after restart.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each cannot be a default: none
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

No visual or style changes. The OAuth dialog contract is unchanged; only stale generation mixing is rejected.

## Test plan

```
cd frontend
bun run test src/features/accounts/hooks/use-oauth.test.ts
bunx eslint src/features/accounts/hooks/use-oauth.ts src/features/accounts/hooks/use-oauth.test.ts
bun run typecheck
bun run build
openspec validate fence-stale-oauth-polls --strict
```

- Focused hook tests were run red on the unfenced hook (stale success called `completeOauth` with flow B; stale error wrote error onto flow B), then green after the fence.
- All 15 `use-oauth` tests pass without sleeps or timer luck.
- Built dashboard in Chromium with mocked deferred flow-A status: start A, reset/restart B, release A as success; dialog stayed on flow B pending with no complete call.

Intentionally unrun locally: full `make ci` / `pre-commit run local-ci` (GitHub required CI is the integration gate).

## Related work

- #753 / #496 isolated concurrent backend browser OAuth flows by flow id.
- #1839 fenced the shared test OAuth store.
- Neither covers this dashboard poll applying a previous generation after reset/restart.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant frontend lint/type/test/build subset locally.
- [x] If touching specs: `openspec validate fence-stale-oauth-polls --strict` passes.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated OAuth responses from affecting newly restarted or reset sign-in flows.
  * Ensured stale success and error results cannot overwrite current status, timers, or account data.
  * Preserved expected behavior for uninterrupted OAuth flows.

* **Tests**
  * Added regression coverage for stale polling and OAuth start responses.
  * Verified the active flow remains pending when an earlier flow completes late.
  * Confirmed stale results do not trigger completion or account-data refresh actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->