### PR TITLE
fix(security): bind firewall to raw peer

### DIFF
--- a/app/core/middleware/api_firewall.py
+++ b/app/core/middleware/api_firewall.py
@@ -6,6 +6,7 @@ from typing import cast
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.datastructures import Headers
+from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.config.settings import get_settings
@@ -16,6 +17,7 @@ from app.core.request_locality import (
     parse_trusted_proxy_networks,
     resolve_connection_client_ip,
 )
+from app.core.socket_peer import raw_socket_peer_host
 from app.db.session import get_background_session
 from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
@@ -47,10 +49,9 @@ class ApiFirewallMiddleware:
             await self.app(scope, receive, send)
             return
 
-        client = scope.get("client")
         client_ip = resolve_connection_client_ip(
             Headers(scope=scope),
-            client[0] if client else None,
+            raw_socket_peer_host(HTTPConnection(scope)),
             trust_proxy_headers=self._trust_proxy_headers,
             trusted_proxy_networks=self._trusted_proxy_networks,
             allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,
@@ -103,7 +104,7 @@ def _resolve_client_ip(
 ) -> str | None:
     return resolve_connection_client_ip(
         request.headers,
-        request.client.host if request.client else None,
+        raw_socket_peer_host(request),
         trust_proxy_headers=trust_proxy_headers,
         trusted_proxy_networks=trusted_proxy_networks,
         allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -149,6 +149,7 @@ from app.core.request_locality import (
 )
 from app.core.resilience.overload import is_local_overload_error_code, merge_retry_after_headers
 from app.core.runtime_logging import log_error_response
+from app.core.socket_peer import raw_socket_peer_host
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.json_guards import is_json_list, is_json_mapping
@@ -8225,7 +8226,7 @@ async def _websocket_firewall_denial_response(websocket: WebSocket) -> JSONRespo
     settings = get_settings()
     client_ip = resolve_connection_client_ip(
         websocket.headers,
-        websocket.client.host if websocket.client else None,
+        raw_socket_peer_host(websocket),
         trust_proxy_headers=settings.firewall_trust_proxy_headers,
         trusted_proxy_networks=parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs),
         allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,

--- a/openspec/changes/bind-api-firewall-to-raw-peer/.openspec.yaml
+++ b/openspec/changes/bind-api-firewall-to-raw-peer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/bind-api-firewall-to-raw-peer/design.md
+++ b/openspec/changes/bind-api-firewall-to-raw-peer/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The outermost trusted-proxy middleware already captures the server-observed HTTP/WebSocket peer before Uvicorn-compatible projection mutates `scope["client"]`. Firewall enforcement still reads the projected client, however, and then passes it to the forwarded-chain resolver as if it were the socket peer. A forwarded identity can therefore incorrectly establish its own trust or directly satisfy the allowlist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make captured raw peer identity the sole socket-source input for HTTP and protected WebSocket firewall resolution.
+- Preserve the existing trust-off, trusted-chain, malformed-chain, repeated-field, singleton-header, cache, and empty-allowlist semantics.
+- Fail closed under an active allowlist when capture is absent.
+- Keep projected client and scheme visible to all downstream consumers.
+
+**Non-Goals:**
+
+- Changing forwarded chain names or parsing, trusted CIDR semantics, caches, `FirewallService`, projection, scheme, locality, drain, dashboard/header auth, logs, `actor_ip`, bridge metadata, `FORWARDED_ALLOW_IPS`, or unauthenticated proxy CIDRs.
+- Adding fallback identity, settings, dependencies, or migration behavior.
+
+## Decisions
+
+1. Both firewall entry points obtain their resolver socket input through `raw_socket_peer_host` at enforcement time. This reuses the capture contract and naturally returns no identity when capture is absent. Reading projected `client` as a fallback was rejected because it recreates the trust confusion.
+2. HTTP retains `resolve_connection_client_ip` and its cache path; only the socket input changes. The direct `_resolve_client_ip` helper follows the same raw-peer contract so helper and middleware behavior cannot diverge.
+3. WebSocket retains its existing repository/service flow; only the socket input changes. This keeps HTTP and WebSocket policy aligned without introducing a new abstraction.
+4. Tests drive the real HTTP middleware and real WebSocket firewall helper through capture-then-project middleware. The adversarial matrix gives raw and projected peers opposite allowlist/trust status, so each result proves which identity controlled enforcement.
+
+## Risks / Trade-offs
+
+- [Direct tests or non-owned ASGI launchers omit capture] → Active allowlists deny rather than trusting a mutable projected identity; empty allowlists remain allow-all.
+- [Firewall proxy trust accidentally changes] → Preserve the resolver, configured CIDRs, and accepted chain-header set unchanged, with existing positive and malformed-chain regressions retained.
+- [Downstream behavior regresses] → Assert projected client and scheme after firewall enforcement in the real-surface ASGI proof.

--- a/openspec/changes/bind-api-firewall-to-raw-peer/proposal.md
+++ b/openspec/changes/bind-api-firewall-to-raw-peer/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The API firewall currently treats the downstream projected client as its socket source, so proxy-header projection can change whether a protected HTTP or WebSocket request is allowed. Firewall trust must instead start from the server-captured raw peer while preserving projection for downstream consumers.
+
+## What Changes
+
+- Resolve protected HTTP and WebSocket firewall identity from the captured raw socket peer.
+- Continue applying the existing trusted forwarded-chain algorithm only when firewall proxy trust is enabled and the raw peer belongs to the configured trusted CIDRs.
+- Fail closed when raw-peer capture is absent and the allowlist is non-empty; preserve empty-allowlist allow-all behavior.
+- Preserve downstream projected client and scheme behavior unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-firewall`: Bind HTTP and protected WebSocket firewall enforcement to the captured pre-projection socket peer.
+
+## Impact
+
+Affected seams are the API firewall middleware, protected WebSocket firewall check, and their HTTP/WebSocket regression coverage. No setting, dependency, API schema, cache contract, forwarded-header parser, projection behavior, or non-firewall consumer changes.

--- a/openspec/changes/bind-api-firewall-to-raw-peer/specs/api-firewall/spec.md
+++ b/openspec/changes/bind-api-firewall-to-raw-peer/specs/api-firewall/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Trusted proxy header handling
+
+For protected HTTP and WebSocket requests, firewall IP resolution MUST use the captured pre-projection raw socket peer as its socket source. It MUST NOT fall back to the downstream projected client when capture is absent. With proxy-header trust disabled, firewall identity MUST be the raw socket peer. With proxy-header trust enabled, the firewall MUST use forwarded client headers only when the raw socket peer belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Other client-IP headers, including `X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP`, MUST NOT affect firewall identity. Every repeated field value MUST be combined in arrival order before resolution. A missing raw-peer capture or a missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed. An empty allowlist MUST remain allow-all. Downstream consumers MUST continue to observe the projected client and scheme.
+
+#### Scenario: Proxy trust disabled ignores a listed projection
+
+- **WHEN** proxy-header trust is disabled
+- **AND** the captured raw peer is not allowlisted
+- **AND** proxy projection replaces the downstream client with an allowlisted address
+- **THEN** both protected HTTP and WebSocket firewall enforcement deny the request
+- **AND** downstream projection does not determine firewall identity
+
+#### Scenario: Proxy trust disabled allows a listed raw peer
+
+- **WHEN** proxy-header trust is disabled
+- **AND** the captured raw peer is allowlisted
+- **AND** proxy projection replaces the downstream client with an unlisted address
+- **THEN** both protected HTTP and WebSocket firewall enforcement allow the request
+- **AND** downstream consumers continue to observe the projected client and scheme
+
+#### Scenario: Untrusted raw peer cannot establish forwarded trust
+
+- **WHEN** proxy-header trust is enabled
+- **AND** the captured raw peer is outside configured trusted CIDRs and is not allowlisted
+- **AND** proxy projection replaces the downstream client with a trusted, allowlisted address
+- **THEN** both protected HTTP and WebSocket firewall enforcement deny the request
+
+#### Scenario: Missing capture fails closed with active allowlist
+
+- **WHEN** raw-peer capture is absent
+- **AND** the allowlist contains one or more entries
+- **THEN** both protected HTTP and WebSocket firewall enforcement deny the request
+- **AND** the projected client is not used as fallback identity
+
+#### Scenario: Missing capture preserves empty allow-all mode
+
+- **WHEN** raw-peer capture is absent
+- **AND** the allowlist is empty
+- **THEN** both protected HTTP and WebSocket firewall enforcement allow the request
+
+#### Scenario: Trusted proxy chain
+
+- **WHEN** `firewall_trust_proxy_headers=true`
+- **AND** the captured raw socket peer and downstream proxy hops match configured trusted CIDRs
+- **AND** a valid `X-Forwarded-For` or `Forwarded` chain is present
+- **THEN** the firewall resolves the originating client by traversing the chain from right to left
+
+#### Scenario: Trusted proxy appends a separate field
+
+- **WHEN** a client supplies a spoofed loopback value in the first `X-Forwarded-For` or `Forwarded` field
+- **AND** a trusted raw socket proxy appends the actual remote client in a second field
+- **THEN** the firewall combines both fields in arrival order
+- **AND** resolves the actual remote client rather than the spoofed loopback value
+
+#### Scenario: Singleton proxy headers do not authorize firewall access
+
+- **WHEN** a trusted raw socket proxy supplies only `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request
+
+#### Scenario: Untrusted proxy source
+
+- **WHEN** the captured raw socket peer is outside the configured trusted CIDR list
+- **THEN** the firewall ignores forwarded client headers
+- **AND** uses the raw socket peer IP
+
+#### Scenario: Trusted source supplies no complete valid chain
+
+- **WHEN** proxy-header trust is enabled and the captured raw socket peer is trusted
+- **AND** the forwarded client chain is missing or contains an invalid hop
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request

--- a/openspec/changes/bind-api-firewall-to-raw-peer/tasks.md
+++ b/openspec/changes/bind-api-firewall-to-raw-peer/tasks.md
@@ -1,0 +1,17 @@
+## 1. Regression Matrix
+
+- [x] 1.1 Add deterministic real HTTP middleware coverage for raw-versus-projected trust rows and missing capture.
+- [x] 1.2 Add deterministic real WebSocket firewall helper coverage for raw-versus-projected trust rows and missing capture.
+- [x] 1.3 Run the focused matrix before production edits and preserve the RED output.
+
+## 2. Firewall Binding
+
+- [x] 2.1 Supply the captured raw peer to HTTP middleware and helper firewall resolution.
+- [x] 2.2 Supply the captured raw peer to protected WebSocket firewall resolution.
+- [x] 2.3 Run the focused matrix GREEN while retaining trusted-chain, malformed, repeated, singleton, cache, and allow-all coverage.
+
+## 3. Verification
+
+- [x] 3.1 Run focused suites, Ruff, ty, strict OpenSpec validation, formatting, diff checks, and changed-file diagnostics.
+- [x] 3.2 Execute an ASGI HTTP/WebSocket real-surface proof showing raw-peer enforcement with downstream client/scheme projection preserved.
+- [x] 3.3 Remove temporary driver state and review the final diff against the security disposition and scope constraints.

--- a/tests/integration/test_api_firewall_middleware.py
+++ b/tests/integration/test_api_firewall_middleware.py
@@ -1,8 +1,42 @@
 from __future__ import annotations
 
 import pytest
+from fastapi.testclient import TestClient
+from starlette.testclient import WebSocketDenialResponse
+
+from app.db.session import get_background_session
+from app.modules.firewall.repository import FirewallRepository
 
 pytestmark = pytest.mark.integration
+
+
+async def _add_firewall_ip(ip_address: str) -> None:
+    async with get_background_session() as session:
+        await FirewallRepository(session).add(ip_address)
+        await session.commit()
+
+
+def test_protected_websocket_route_denies_unlisted_raw_peer_after_projection(
+    app_instance,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: the real app stack projects an allowlisted forwarded client over an unlisted raw peer.
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    with TestClient(app_instance, client=("127.0.0.1", 50001)) as client:
+        assert client.portal is not None
+        client.portal.call(_add_firewall_ip, "203.0.113.9")
+
+        # When: the protected WebSocket endpoint handles the projected handshake.
+        with pytest.raises(WebSocketDenialResponse) as denial:
+            with client.websocket_connect(
+                "/v1/responses",
+                headers={"X-Forwarded-For": "203.0.113.9", "X-Forwarded-Proto": "https"},
+            ):
+                pytest.fail("the unlisted raw peer must not complete the WebSocket handshake")
+
+    # Then: the route returns the real firewall denial before authentication or upstream work.
+    assert denial.value.status_code == 403
+    assert denial.value.json()["error"]["code"] == "ip_forbidden"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_firewall_ip_resolution.py
+++ b/tests/unit/test_firewall_ip_resolution.py
@@ -5,6 +5,7 @@ from starlette.requests import Request
 
 from app.core.middleware.api_firewall import _resolve_client_ip
 from app.core.request_locality import parse_trusted_proxy_networks
+from app.core.socket_peer import _capture_raw_socket_peer
 
 pytestmark = pytest.mark.unit
 
@@ -25,6 +26,7 @@ def _make_request(
         "server": ("testserver", 80),
         "http_version": "1.1",
     }
+    _capture_raw_socket_peer(scope)
     return Request(scope)
 
 

--- a/tests/unit/test_firewall_raw_peer.py
+++ b/tests/unit/test_firewall_raw_peer.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+from fastapi import WebSocket
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from starlette.types import Message, Receive, Scope, Send
+
+import app.core.middleware.api_firewall as api_firewall_module
+import app.modules.proxy.api as proxy_api_module
+from app.core.middleware.api_firewall import ApiFirewallMiddleware
+from app.core.middleware.firewall_cache import FirewallIPCache
+from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
+from app.core.request_locality import parse_trusted_proxy_networks
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass(frozen=True, slots=True)
+class FirewallPeerCase:
+    trust_proxy_headers: bool
+    raw_host: str
+    projected_host: str
+    trusted_proxy_cidrs: tuple[str, ...]
+    allowlist: frozenset[str]
+    capture_raw_peer: bool
+    expected_allowed: bool
+
+
+CASES = (
+    pytest.param(
+        FirewallPeerCase(
+            trust_proxy_headers=False,
+            raw_host="198.51.100.10",
+            projected_host="203.0.113.9",
+            trusted_proxy_cidrs=(),
+            allowlist=frozenset({"203.0.113.9"}),
+            capture_raw_peer=True,
+            expected_allowed=False,
+        ),
+        id="trust-off-raw-unlisted-projected-listed-denies",
+    ),
+    pytest.param(
+        FirewallPeerCase(
+            trust_proxy_headers=False,
+            raw_host="198.51.100.10",
+            projected_host="203.0.113.9",
+            trusted_proxy_cidrs=(),
+            allowlist=frozenset({"198.51.100.10"}),
+            capture_raw_peer=True,
+            expected_allowed=True,
+        ),
+        id="trust-off-raw-listed-projected-unlisted-allows",
+    ),
+    pytest.param(
+        FirewallPeerCase(
+            trust_proxy_headers=True,
+            raw_host="198.51.100.10",
+            projected_host="10.0.0.2",
+            trusted_proxy_cidrs=("10.0.0.0/8",),
+            allowlist=frozenset({"10.0.0.2"}),
+            capture_raw_peer=True,
+            expected_allowed=False,
+        ),
+        id="trust-on-raw-untrusted-projected-trusted-listed-denies",
+    ),
+    pytest.param(
+        FirewallPeerCase(
+            trust_proxy_headers=False,
+            raw_host="198.51.100.10",
+            projected_host="203.0.113.9",
+            trusted_proxy_cidrs=(),
+            allowlist=frozenset({"203.0.113.9"}),
+            capture_raw_peer=False,
+            expected_allowed=False,
+        ),
+        id="missing-capture-active-allowlist-denies",
+    ),
+    pytest.param(
+        FirewallPeerCase(
+            trust_proxy_headers=False,
+            raw_host="198.51.100.10",
+            projected_host="203.0.113.9",
+            trusted_proxy_cidrs=(),
+            allowlist=frozenset(),
+            capture_raw_peer=False,
+            expected_allowed=True,
+        ),
+        id="missing-capture-empty-allowlist-allows",
+    ),
+)
+
+
+class FirewallRepositoryFake:
+    def __init__(self, allowlist: frozenset[str]) -> None:
+        self._allowlist = allowlist
+
+    async def list_ip_addresses(self) -> set[str]:
+        return set(self._allowlist)
+
+
+@asynccontextmanager
+async def _session() -> AsyncIterator[None]:
+    yield None
+
+
+def _configure_firewall_backend(monkeypatch: pytest.MonkeyPatch, allowlist: frozenset[str]) -> None:
+    repository = FirewallRepositoryFake(allowlist)
+    for module in (api_firewall_module, proxy_api_module):
+        monkeypatch.setattr(module, "get_background_session", _session)
+        monkeypatch.setattr(module, "FirewallRepository", lambda _session_value: repository)
+
+
+def _headers(case: FirewallPeerCase) -> list[tuple[bytes, bytes]]:
+    return [
+        (b"x-forwarded-for", case.projected_host.encode()),
+        (b"x-forwarded-proto", b"https"),
+    ]
+
+
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.asyncio
+async def test_http_firewall_uses_raw_peer_when_projection_differs(
+    monkeypatch: pytest.MonkeyPatch,
+    case: FirewallPeerCase,
+) -> None:
+    # Given: an allowlist and capture-then-project transport with opposing peer identities.
+    _configure_firewall_backend(monkeypatch, case.allowlist)
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    projected_scope: list[tuple[str | None, str]] = []
+
+    async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    firewall = ApiFirewallMiddleware(
+        downstream,
+        trust_proxy_headers=case.trust_proxy_headers,
+        trusted_proxy_networks=parse_trusted_proxy_networks(list(case.trusted_proxy_cidrs)),
+        firewall_cache=FirewallIPCache(),
+    )
+
+    async def observe_projection(scope: Scope, receive: Receive, send: Send) -> None:
+        client = scope.get("client")
+        projected_scope.append((client[0] if client else None, scope["scheme"]))
+        await firewall(scope, receive, send)
+
+    app = TrustedProxyHeadersMiddleware(observe_projection) if case.capture_raw_peer else observe_projection
+    transport_host = case.raw_host if case.capture_raw_peer else case.projected_host
+
+    # When: the protected HTTP request crosses the real firewall middleware.
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=(transport_host, 50001)),
+        base_url=("http://lb.example" if case.capture_raw_peer else "https://lb.example"),
+    ) as client:
+        response = await client.get("/v1/models", headers=dict(_headers(case)))
+
+    # Then: raw identity controls enforcement while projection remains visible at the firewall boundary.
+    assert projected_scope == [(case.projected_host, "https")]
+    assert (response.status_code == 200) is case.expected_allowed
+
+
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.asyncio
+async def test_websocket_firewall_uses_raw_peer_when_projection_differs(
+    monkeypatch: pytest.MonkeyPatch,
+    case: FirewallPeerCase,
+) -> None:
+    # Given: the same allowlist and capture-then-project identities on a protected WebSocket scope.
+    _configure_firewall_backend(monkeypatch, case.allowlist)
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    monkeypatch.setattr(
+        proxy_api_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            firewall_trust_proxy_headers=case.trust_proxy_headers,
+            firewall_trusted_proxy_cidrs=list(case.trusted_proxy_cidrs),
+        ),
+    )
+    projected_scope: list[tuple[str | None, str]] = []
+    denial: JSONResponse | None = None
+
+    async def fail_receive() -> Message:
+        raise AssertionError("firewall check must not receive a WebSocket frame")
+
+    async def fail_send(_message: Message) -> None:
+        raise AssertionError("firewall check must not send a WebSocket frame")
+
+    async def check_firewall(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal denial
+        client = scope.get("client")
+        projected_scope.append((client[0] if client else None, scope["scheme"]))
+        denial = await proxy_api_module._websocket_firewall_denial_response(WebSocket(scope, receive, send))
+
+    scope: Scope = {
+        "type": "websocket",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "scheme": ("ws" if case.capture_raw_peer else "wss"),
+        "server": ("lb.example", 80),
+        "client": ((case.raw_host if case.capture_raw_peer else case.projected_host), 50001),
+        "root_path": "",
+        "path": "/v1/responses",
+        "raw_path": b"/v1/responses",
+        "query_string": b"",
+        "headers": _headers(case),
+        "subprotocols": [],
+        "state": {},
+        "extensions": {},
+    }
+    app = TrustedProxyHeadersMiddleware(check_firewall) if case.capture_raw_peer else check_firewall
+
+    # When: the scope crosses projection and the real protected WebSocket firewall helper.
+    await app(scope, fail_receive, fail_send)
+
+    # Then: raw identity controls enforcement while the projected WebSocket client and scheme remain intact.
+    assert projected_scope == [(case.projected_host, "wss")]
+    assert (denial is None) is case.expected_allowed

--- a/tests/unit/test_hot_path_caches.py
+++ b/tests/unit/test_hot_path_caches.py
@@ -18,6 +18,7 @@ from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.crypto import TokenEncryptor
 from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.firewall_cache import get_firewall_ip_cache, reset_firewall_ip_cache_for_testing
+from app.core.middleware.trusted_proxy_headers import add_trusted_proxy_headers_middleware
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.api_keys.service import ApiKeyData, ApiKeysRepositoryProtocol
 from app.modules.proxy.account_cache import get_account_selection_cache
@@ -114,6 +115,7 @@ async def test_firewall_middleware_uses_cache_for_repeated_ip(monkeypatch: pytes
 
     app = FastAPI()
     add_api_firewall_middleware(app)
+    add_trusted_proxy_headers_middleware(app)
 
     @app.get("/v1/test")
     async def _v1_test() -> dict[str, str]:


### PR DESCRIPTION
## Summary

Bind protected HTTP and WebSocket firewall trust to the server-captured raw socket peer instead of the downstream client projected from proxy headers. Downstream client/scheme projection remains unchanged, while missing capture fails closed under an active allowlist.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] Breaking change

Linked issue: None — the live related-work search found no matching issue. Related capture/projection context: #1380 and superseded #1390; both explicitly left firewall behavior unchanged.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/bind-api-firewall-to-raw-peer/`

## Changes

- Feed the captured pre-projection peer into HTTP middleware/helper firewall resolution.
- Feed the captured pre-projection peer into protected WebSocket firewall resolution.
- Add a deterministic HTTP/WebSocket adversarial matrix for trust-off inversion, untrusted raw peers, missing capture, and empty allow-all.
- Add a real `/v1/responses` WebSocket handshake denial regression through the application middleware and route stack.

Forwarded chain parsing/names, caches, `FirewallService`, projection, locality, drain, dashboard/header auth, logs, actor IP, bridge metadata, `FORWARDED_ALLOW_IPS`, and unauthenticated proxy CIDRs are unchanged.

## Simplicity

- [x] Works with zero new configuration
- [x] No new required setup step
- New settings: None
- [x] No README, `.env.example`, dashboard, dependency, API/schema, or migration change

## Test plan

```text
Failing-first HTTP+WebSocket matrix:       8 failed before production edits
Fixed HTTP+WebSocket matrix:              10 passed
Final focused HTTP+WebSocket suites:      68 passed
Executable ASGI HTTP+WebSocket proof:     PASS for rows A-D
Ruff check / format:                      passed / 6 files formatted
Focused ty check:                         passed
Strict OpenSpec change + api-firewall:    passed
Independent local Codex review:           clean after adding real WS route coverage
```

ASGI proof observed the captured raw peer controlling every allow/deny result while downstream HTTP `client`/`https` and WebSocket `client`/`wss` projection remained visible.

## Screenshots / output

No dashboard-visible change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related work checked; no issue-closing claim applies.
- [x] Added HTTP middleware, WebSocket helper, and real WebSocket route coverage.
- [x] Ran the focused security, integration, lint, format, type, and OpenSpec gates.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` was not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API firewall checks now use the server-captured network peer for HTTP and WebSocket authorization.
  * Prevented forwarded or projected client identities from bypassing firewall allowlists.
  * Added fail-closed behavior when the raw peer is unavailable or proxy information is invalid.
  * Preserved trusted-proxy handling and downstream client metadata behavior.

* **Tests**
  * Added coverage for raw-versus-projected identities, trusted proxy chains, missing peer data, and protected WebSocket denials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->