### PR TITLE
fix(proxy): settle keyed streams before health

### DIFF
--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -686,12 +686,6 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 if rewritten_error is not None:
                     rewritten_code, rewritten_message, upstream_error_code = rewritten_error
-                    if upstream_error_code is not None:
-                        await proxy._handle_stream_error(
-                            account,
-                            upstream_error,
-                            upstream_error_code,
-                        )
                     first, event, first_payload, event_type = _facade()._build_rewritten_stream_response_failed_event(
                         response_id=response_id,
                         error_code=rewritten_code,
@@ -702,8 +696,9 @@ class _StreamingMixin(_StreamingRetryMixin):
                     upstream_error = cast(
                         UpstreamError, {"message": rewritten_message, "type": "upstream_error", "code": rewritten_code}
                     )
-                    settlement.error = upstream_error
-                    settlement.account_health_error = False
+                    if upstream_error_code is not None:
+                        settlement.error_code = upstream_error_code
+                        settlement.account_health_error = True
                 else:
                     error_code = code
                     error_message = raw_error_message
@@ -857,12 +852,6 @@ class _StreamingMixin(_StreamingRetryMixin):
                                 else request_id
                             )
                             rewritten_code, rewritten_message, upstream_error_code = rewritten_error
-                            if upstream_error_code is not None:
-                                await proxy._handle_stream_error(
-                                    account,
-                                    _upstream_error_from_openai(error),
-                                    upstream_error_code,
-                                )
                             (
                                 line,
                                 event,
@@ -877,7 +866,9 @@ class _StreamingMixin(_StreamingRetryMixin):
                             error_message = rewritten_message
                             settlement.error = _upstream_error_from_openai(error)
                             settlement.record_success = False
-                            settlement.account_health_error = False
+                            if upstream_error_code is not None:
+                                settlement.error_code = upstream_error_code
+                                settlement.account_health_error = True
                         else:
                             error_code = raw_error_code
                             error_message = raw_error_message
@@ -968,17 +959,14 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if rewritten_error is not None:
                 rewritten_code, rewritten_message, upstream_error_code = rewritten_error
-                if upstream_error_code is not None:
-                    await proxy._handle_stream_error(
-                        account,
-                        _upstream_error_from_openai(error),
-                        upstream_error_code,
-                    )
                 status = "error"
                 error_code = rewritten_code
                 error_message = rewritten_message
                 settlement.record_success = False
-                settlement.account_health_error = False
+                settlement.error = _upstream_error_from_openai(error)
+                if upstream_error_code is not None:
+                    settlement.error_code = upstream_error_code
+                    settlement.account_health_error = True
                 yield _facade()._build_rewritten_stream_response_failed_event(
                     response_id=request_id,
                     error_code=rewritten_code,
@@ -1048,7 +1036,8 @@ class _StreamingMixin(_StreamingRetryMixin):
             settlement.input_tokens = input_tokens
             settlement.output_tokens = output_tokens
             settlement.cached_input_tokens = cached_input_tokens
-            settlement.error_code = error_code
+            if settlement.error_code is None:
+                settlement.error_code = error_code
             settlement.error_message = error_message
             await proxy._write_request_log(
                 account_id=account_id_value,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -536,6 +536,16 @@ class _StreamingMixin(_StreamingRetryMixin):
                 surface="stream",
             )
 
+        async def _record_or_defer_owner_recovery_health(error: UpstreamError, code: str | None) -> None:
+            if code is None:
+                return
+            if api_key_reservation is None:
+                await proxy._handle_stream_error(account, error, code)
+                return
+            settlement.error_code = code
+            settlement.account_health_error = True
+            settlement.settlement_order_required = True
+
         api_key_reservation_heartbeat_stop = asyncio.Event()
         api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
         if api_key_reservation is not None:
@@ -693,12 +703,10 @@ class _StreamingMixin(_StreamingRetryMixin):
                     )
                     error_code = rewritten_code
                     error_message = rewritten_message
+                    await _record_or_defer_owner_recovery_health(upstream_error, upstream_error_code)
                     upstream_error = cast(
                         UpstreamError, {"message": rewritten_message, "type": "upstream_error", "code": rewritten_code}
                     )
-                    if upstream_error_code is not None:
-                        settlement.error_code = upstream_error_code
-                        settlement.account_health_error = True
                 else:
                     error_code = code
                     error_message = raw_error_message
@@ -866,9 +874,9 @@ class _StreamingMixin(_StreamingRetryMixin):
                             error_message = rewritten_message
                             settlement.error = _upstream_error_from_openai(error)
                             settlement.record_success = False
-                            if upstream_error_code is not None:
-                                settlement.error_code = upstream_error_code
-                                settlement.account_health_error = True
+                            await _record_or_defer_owner_recovery_health(
+                                _upstream_error_from_openai(error), upstream_error_code
+                            )
                         else:
                             error_code = raw_error_code
                             error_message = raw_error_message
@@ -964,9 +972,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 error_message = rewritten_message
                 settlement.record_success = False
                 settlement.error = _upstream_error_from_openai(error)
-                if upstream_error_code is not None:
-                    settlement.error_code = upstream_error_code
-                    settlement.account_health_error = True
+                await _record_or_defer_owner_recovery_health(_upstream_error_from_openai(error), upstream_error_code)
                 yield _facade()._build_rewritten_stream_response_failed_event(
                     response_id=request_id,
                     error_code=rewritten_code,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -536,7 +536,11 @@ class _StreamingRetryMixin:
             apply_pending_penalty = post_refresh_transient_replacement_selected and bool(
                 pending_post_refresh_transient_penalties
             )
-            wait_for_health_write = apply_pending_penalty or bool(deferred_account_error_backoffs)
+            wait_for_health_write = (
+                current_settlement.account_health_error
+                or apply_pending_penalty
+                or bool(deferred_account_error_backoffs)
+            )
             settle_kwargs = {"wait_for_settlement": True} if wait_for_health_write else {}
             settled_result = await proxy._settle_stream_api_key_usage(
                 api_key,
@@ -2518,10 +2522,14 @@ class _StreamingRetryMixin:
                         outcome="owner_previsible_retryable_failure",
                     )
                     continue
-                except _TerminalStreamError as exc:
-                    health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                    if health_write_allowed and _facade()._should_penalize_stream_error(exc.code):
-                        await proxy._handle_stream_error(account, exc.error, exc.code)
+                except _TerminalStreamError:
+                    health_write_allowed = await _settle_stream_usage_before_pending_penalty(settlement)
+                    if health_write_allowed and settlement.account_health_error:
+                        await proxy._handle_stream_error(
+                            account,
+                            _stream_settlement_error_payload(settlement),
+                            settlement.error_code or "upstream_error",
+                        )
                     return
                 except ProxyResponseError as exc:
                     if _facade()._is_proxy_budget_exhausted_error(exc):
@@ -3011,27 +3019,22 @@ class _StreamingRetryMixin:
                         ordered_settlement_required = bool(
                             pending_post_refresh_transient_penalties or deferred_account_error_backoffs
                         )
-                        health_write_allowed = True
                         if ordered_settlement_required:
                             health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                        if (
-                            health_write_allowed
-                            and settlement.account_health_error
-                            and not current_account_penalty_queued
-                        ):
-                            await proxy._handle_stream_error(
-                                account,
-                                _stream_settlement_error_payload(settlement),
-                                settlement.error_code or "upstream_error",
-                            )
-                        elif health_write_allowed and settlement.record_success:
-                            await proxy._load_balancer.record_success(account)
-                        if (
-                            not settled
-                            and not ordered_settlement_required
-                            and not settlement.usage_settlement_transferred
-                        ):
-                            settled = await _settle_stream_usage_before_pending_penalty(settlement)
+                            if (
+                                health_write_allowed
+                                and settlement.account_health_error
+                                and not current_account_penalty_queued
+                            ):
+                                await proxy._handle_stream_error(
+                                    account,
+                                    _stream_settlement_error_payload(settlement),
+                                    settlement.error_code or "upstream_error",
+                                )
+                            elif health_write_allowed and settlement.record_success:
+                                await proxy._load_balancer.record_success(account)
+                        else:
+                            await _finalize_terminal_settlement_after_downstream_close(settlement, account)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -531,13 +531,16 @@ class _StreamingRetryMixin:
 
         async def _settle_stream_usage_before_pending_penalty(
             current_settlement: _StreamSettlement,
+            *,
+            settlement_order_required: bool = False,
         ) -> bool:
             nonlocal settled
             apply_pending_penalty = post_refresh_transient_replacement_selected and bool(
                 pending_post_refresh_transient_penalties
             )
             wait_for_health_write = (
-                current_settlement.account_health_error
+                settlement_order_required
+                or current_settlement.settlement_order_required
                 or apply_pending_penalty
                 or bool(deferred_account_error_backoffs)
             )
@@ -633,13 +636,18 @@ class _StreamingRetryMixin:
         async def _finalize_terminal_settlement_after_downstream_close(
             current_settlement: _StreamSettlement,
             account: Account,
+            *,
+            settlement_order_required: bool = False,
         ) -> None:
             nonlocal settled
 
             async def _finalize() -> None:
                 nonlocal settled
                 if not settled:
-                    settled = await _settle_stream_usage_before_pending_penalty(current_settlement)
+                    settled = await _settle_stream_usage_before_pending_penalty(
+                        current_settlement,
+                        settlement_order_required=settlement_order_required,
+                    )
                 if not settled:
                     return
                 if current_settlement.account_health_error:
@@ -848,7 +856,11 @@ class _StreamingRetryMixin:
                         # health result before propagating cancellation so the
                         # reservation is not released as abandoned.
                         if settlement.status in {"success", "error"} and not settled:
-                            await _finalize_terminal_settlement_after_downstream_close(settlement, account)
+                            await _finalize_terminal_settlement_after_downstream_close(
+                                settlement,
+                                account,
+                                settlement_order_required=True,
+                            )
                         raise
                     network_recovery.log_recovered()
                     return
@@ -3034,7 +3046,11 @@ class _StreamingRetryMixin:
                             elif health_write_allowed and settlement.record_success:
                                 await proxy._load_balancer.record_success(account)
                         else:
-                            await _finalize_terminal_settlement_after_downstream_close(settlement, account)
+                            await _finalize_terminal_settlement_after_downstream_close(
+                                settlement,
+                                account,
+                                settlement_order_required=True,
+                            )
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -2474,15 +2474,22 @@ class _StreamingRetryMixin:
                             break  # outer loop: select different account
                         finally:
                             pop_stream_timeout_overrides(stream_timeout_tokens)
-                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
-                        if settled and settlement.account_health_error:
-                            await proxy._handle_stream_error(
+                        if settlement.settlement_order_required:
+                            await _finalize_terminal_settlement_after_downstream_close(
+                                settlement,
                                 account,
-                                _stream_settlement_error_payload(settlement),
-                                settlement.error_code or "upstream_error",
+                                settlement_order_required=True,
                             )
-                        elif settled and settlement.record_success:
-                            await proxy._load_balancer.record_success(account)
+                        else:
+                            settled = await _settle_stream_usage_before_pending_penalty(settlement)
+                            if settled and settlement.account_health_error:
+                                await proxy._handle_stream_error(
+                                    account,
+                                    _stream_settlement_error_payload(settlement),
+                                    settlement.error_code or "upstream_error",
+                                )
+                            elif settled and settlement.record_success:
+                                await proxy._load_balancer.record_success(account)
                         network_recovery.log_recovered()
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
@@ -2535,13 +2542,20 @@ class _StreamingRetryMixin:
                     )
                     continue
                 except _TerminalStreamError:
-                    health_write_allowed = await _settle_stream_usage_before_pending_penalty(settlement)
-                    if health_write_allowed and settlement.account_health_error:
-                        await proxy._handle_stream_error(
+                    if settlement.settlement_order_required:
+                        await _finalize_terminal_settlement_after_downstream_close(
+                            settlement,
                             account,
-                            _stream_settlement_error_payload(settlement),
-                            settlement.error_code or "upstream_error",
+                            settlement_order_required=True,
                         )
+                    else:
+                        health_write_allowed = await _settle_stream_usage_before_pending_penalty(settlement)
+                        if health_write_allowed and settlement.account_health_error:
+                            await proxy._handle_stream_error(
+                                account,
+                                _stream_settlement_error_payload(settlement),
+                                settlement.error_code or "upstream_error",
+                            )
                     return
                 except ProxyResponseError as exc:
                     if _facade()._is_proxy_budget_exhausted_error(exc):

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -828,6 +828,7 @@ class _StreamSettlement:
     error_message: str | None = None
     error: UpstreamError | None = None
     account_health_error: bool = False
+    settlement_order_required: bool = False
     record_success: bool = True
     downstream_visible: bool = False
     downstream_text_visible: bool = False

--- a/openspec/changes/settle-keyed-stream-before-health/.openspec.yaml
+++ b/openspec/changes/settle-keyed-stream-before-health/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/settle-keyed-stream-before-health/design.md
+++ b/openspec/changes/settle-keyed-stream-before-health/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The keyed HTTP SSE stream holds a shared `_StreamSettlement` until terminal
+usage is known. Mid-loop penalties already use
+`_settle_stream_usage_before_pending_penalty`, and downstream-close terminal
+work already uses `_finalize_terminal_settlement_after_downstream_close`.
+Three owner-unavailable rewrite branches in the stream mixin bypass that order,
+and the retry loop's empty-queue terminal branch writes health/success before
+its `finally` can release the reservation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make confirmed settlement or fail-safe release the gate for health writes.
+- Preserve the original upstream recovery code for health classification while
+  retaining the sanitized client/log error code.
+- Reuse the existing settlement tracker and helpers without another coordinator
+  or ownership type.
+- Prove first-event, later-event, raised-error, empty-queue, and unconfirmed
+  cleanup behavior deterministically.
+
+**Non-Goals:**
+
+- Missing-usage policy, unary routes, WebSocket/compact/precreated bridge paths,
+  or source-ownership/stale-anchor matching changes.
+- Client-visible error-envelope changes.
+
+## Decisions
+
+1. Owner-unavailable rewrite branches retain the original error code, mark the
+   existing settlement as ordering-sensitive, and settle through
+   `_settle_stream_usage_before_pending_penalty` before invoking health.
+   Reusing the existing helper preserves fallback-release and transfer
+   semantics; an inline release would create a second cleanup owner.
+2. The empty-queue terminal branch uses
+   `_finalize_terminal_settlement_after_downstream_close` before terminal
+   health/success. This keeps one terminal path responsible for usage and
+   cleanup and avoids duplicating finalization logic.
+3. Health is conditional on a confirmed helper result. The client and request
+   log continue to use `previous_response_owner_unavailable`; only account
+   recovery receives the original upstream code.
+4. Tests use an order ledger and event-controlled fakes. No timing waits or
+   sleeps are needed.
+
+## Risks / Trade-offs
+
+- [Risk] Ordering-sensitive error paths wait for persistence before health. ->
+  Mitigation: this is the required correctness exception already used by keyed
+  mid-loop and WebSocket settlement.
+- [Risk] Overlapping PRs alter the same files. -> Mitigation: preserve their
+  independent stale-anchor shape and source-ownership behavior and document the
+  overlap for maintainers.

--- a/openspec/changes/settle-keyed-stream-before-health/design.md
+++ b/openspec/changes/settle-keyed-stream-before-health/design.md
@@ -28,15 +28,16 @@ its `finally` can release the reservation.
 
 ## Decisions
 
-1. Owner-unavailable rewrite branches retain the original error code, mark the
-   existing settlement as ordering-sensitive, and settle through
-   `_settle_stream_usage_before_pending_penalty` before invoking health.
+1. Owner-unavailable rewrite branches retain the original error code, set an
+   explicit ordering marker on the existing settlement state, and settle
+   through `_settle_stream_usage_before_pending_penalty` before invoking health.
    Reusing the existing helper preserves fallback-release and transfer
    semantics; an inline release would create a second cleanup owner.
-2. The empty-queue terminal branch uses
+2. The empty-queue terminal branch passes explicit ordering ownership to
    `_finalize_terminal_settlement_after_downstream_close` before terminal
    health/success. This keeps one terminal path responsible for usage and
-   cleanup and avoids duplicating finalization logic.
+   cleanup, including successful terminals, without making unrelated stream
+   errors wait synchronously.
 3. Health is conditional on a confirmed helper result. The client and request
    log continue to use `previous_response_owner_unavailable`; only account
    recovery receives the original upstream code.

--- a/openspec/changes/settle-keyed-stream-before-health/proposal.md
+++ b/openspec/changes/settle-keyed-stream-before-health/proposal.md
@@ -33,8 +33,9 @@ recovery state cannot become observably inconsistent.
 
 ## Impact
 
-The change is limited to HTTP SSE Responses streaming settlement order in
-`streaming/mixin.py` and `streaming/retry.py`, focused helper and
+The change is limited to HTTP SSE Responses streaming settlement order in the
+existing stream settlement state, `streaming/mixin.py`, and
+`streaming/retry.py`, focused helper and
 `/v1/responses` regressions, and the three supporting OpenSpec deltas. It does
 not change usage-missing policy, unary routes, WebSocket/compact behavior, or
 client-visible error shapes.

--- a/openspec/changes/settle-keyed-stream-before-health/proposal.md
+++ b/openspec/changes/settle-keyed-stream-before-health/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Keyed HTTP Responses streams can still write account health while their API-key
+reservation remains open when an upstream failure is rewritten as
+`previous_response_owner_unavailable` or when a terminal bridge queue drains
+empty. Settlement must be confirmed before health so quota state and account
+recovery state cannot become observably inconsistent.
+
+## What Changes
+
+- Settle keyed stream usage before account-health writes on all three
+  owner-unavailable rewrite paths.
+- Finalize terminal keyed settlement before empty-queue health or success
+  writes.
+- Withhold health when neither ordered settlement nor fail-safe release confirms
+  cleanup.
+- Preserve the public/logged owner-unavailable envelope while health uses the
+  original upstream recovery code.
+- Preserve stale-anchor shape matching and source-ownership routing behavior.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `api-keys`: require confirmed stream reservation settlement before rewrite and
+  empty-queue terminal health writes.
+- `model-source-routing`: preserve owner-unavailable routing and original-code
+  health semantics while adding settlement ordering.
+- `responses-api-compat`: preserve the client and request-log error envelope and
+  stale-anchor recovery shape across the ordered terminal paths.
+
+## Impact
+
+The change is limited to HTTP SSE Responses streaming settlement order in
+`streaming/mixin.py` and `streaming/retry.py`, focused helper and
+`/v1/responses` regressions, and the three supporting OpenSpec deltas. It does
+not change usage-missing policy, unary routes, WebSocket/compact behavior, or
+client-visible error shapes.

--- a/openspec/changes/settle-keyed-stream-before-health/specs/api-keys/spec.md
+++ b/openspec/changes/settle-keyed-stream-before-health/specs/api-keys/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Stream reservation settlement is detached from the response path
+
+Settling a stream API-key reservation MUST NOT block the response/stream close,
+with deliberate ordering exceptions for account-health writes. When a keyed
+websocket stream terminates with an account-health error, when a keyed HTTP SSE
+failure is rewritten to `previous_response_owner_unavailable`, or when a keyed
+HTTP SSE terminal queue drains empty before terminal health or success is
+recorded, the finalizer MUST wait for settlement to commit before the
+load-balancer health write (the settlement-ordering invariant). If the primary
+settlement fails, the finalizer MUST wait for fallback release to commit before
+recording account health. If neither operation confirms settlement, the
+account-health write MUST remain unapplied. Tracked persistence ownership MUST
+remain registered through an ordering-sensitive fallback release, including
+cancellation before the primary coroutine starts or during that release, so
+graceful shutdown drains both phases. When the existing stream-retry path
+deliberately defers an account-health penalty until the same
+ordering-sensitive settlement, it MUST likewise apply neither that penalty nor
+an immediately following terminal health write unless settlement is confirmed,
+and it MUST NOT start a second settlement for the transferred reservation. In
+all other cases the settlement MUST run as a tracked background task; when it
+fails or is cancelled, the reservation MUST still be released by the tracking
+fallback, and the request's finalization path MUST NOT double-release a
+transferred settlement. Reservations MUST continue to count toward key limits
+until finalized or released, so deferred settlement can never admit usage a
+synchronous settlement would have rejected.
+
+#### Scenario: Response close precedes settlement completion
+
+- **GIVEN** a keyed stream whose settlement transaction is still running
+- **WHEN** the stream closes
+- **THEN** the close does not wait for the settlement
+- **AND** the settlement finalizes the reservation exactly once in the background
+
+#### Scenario: Failed detached settlement still releases the reservation
+
+- **GIVEN** a detached settlement whose finalize raises
+- **WHEN** the settlement task completes
+- **THEN** the tracking fallback releases the reservation
+
+#### Scenario: Websocket health-error settlement precedes the health write
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** the finalizer settles the reservation
+- **THEN** it waits for the settlement to commit before recording the account-health error
+
+#### Scenario: Websocket health waits for fallback settlement
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **AND** its primary settlement fails
+- **WHEN** fallback release remains in progress
+- **THEN** the finalizer does not record the account-health error
+- **AND** it records the error only after fallback release commits
+
+#### Scenario: Unconfirmed websocket settlement leaves health unapplied
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** both primary settlement and fallback release fail
+- **THEN** the finalizer does not record the account-health error
+- **AND** the upstream connection is still scheduled for reconnect and retirement
+
+#### Scenario: Owner-unavailable rewrite settles before health
+
+- **GIVEN** a keyed HTTP SSE stream rewrites an upstream failure to
+  `previous_response_owner_unavailable`
+- **WHEN** the stream records account-health recovery for the original failure
+- **THEN** reservation settlement or fail-safe release confirms first
+
+#### Scenario: Empty terminal queue settles before health or success
+
+- **GIVEN** a keyed HTTP SSE bridge queue drains empty on a terminal path
+- **WHEN** the stream records terminal account health or success
+- **THEN** reservation settlement or fail-safe release confirms first
+
+#### Scenario: Unconfirmed HTTP stream settlement leaves health unapplied
+
+- **GIVEN** a keyed HTTP SSE stream reaches an ordering-sensitive terminal path
+- **WHEN** both primary settlement and fallback release fail
+- **THEN** the stream does not record account health
+
+#### Scenario: Unconfirmed retry settlement drops deferred health
+
+- **GIVEN** a keyed stream retry has deferred an account-health penalty until replacement selection
+- **WHEN** neither primary settlement nor fallback release confirms settlement
+- **THEN** the deferred penalty and any immediately following terminal health write remain unapplied
+- **AND** the retry path does not start a second settlement for the transferred reservation
+
+#### Scenario: Shutdown drains pending settlements
+
+- **WHEN** the service shuts down gracefully with settlements in flight
+- **THEN** shutdown waits for them up to the configured drain timeout
+- **AND** a pending ordering-sensitive fallback release remains part of that drain despite cancellation before primary startup or during fallback

--- a/openspec/changes/settle-keyed-stream-before-health/specs/model-source-routing/spec.md
+++ b/openspec/changes/settle-keyed-stream-before-health/specs/model-source-routing/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Owner-unavailable stream health preserves the recovery cause
+
+The service SHALL use the original upstream error code for account-health
+recovery when a Responses stream rewrites an upstream failure to
+`previous_response_owner_unavailable`. The rewrite MUST NOT change
+source-ownership selection, owner pinning, or stale-anchor matching.
+
+#### Scenario: Owner-unavailable rewrite records original recovery code
+
+- **WHEN** an upstream Responses failure with an account-recovery code is
+  rewritten to `previous_response_owner_unavailable`
+- **THEN** account health receives the original upstream code
+- **AND** source ownership and stale-anchor classification remain unchanged

--- a/openspec/changes/settle-keyed-stream-before-health/specs/responses-api-compat/spec.md
+++ b/openspec/changes/settle-keyed-stream-before-health/specs/responses-api-compat/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Ordered owner-unavailable settlement preserves external errors
+
+Settlement ordering for streaming Responses owner-unavailable failures MUST NOT
+change the downstream or request-log error envelope. The client and request log
+MUST continue to use `previous_response_owner_unavailable`, including when the
+original upstream code is retained for account-health recovery.
+
+#### Scenario: Ordered rewrite keeps the public and logged classifier
+
+- **WHEN** a streaming `/v1/responses` failure is rewritten after ordered
+  reservation settlement
+- **THEN** the downstream error code is `previous_response_owner_unavailable`
+- **AND** the request-log error code is `previous_response_owner_unavailable`
+- **AND** no raw stale-anchor identifier or source-ownership detail is exposed

--- a/openspec/changes/settle-keyed-stream-before-health/tasks.md
+++ b/openspec/changes/settle-keyed-stream-before-health/tasks.md
@@ -1,0 +1,26 @@
+## 1. Regression coverage
+
+- [ ] 1.1 Add deterministic order-ledger RED coverage for first-event,
+  later-event, and raised `ProxyResponseError` owner-unavailable rewrites.
+- [ ] 1.2 Add deterministic RED coverage for empty-queue terminal settlement and
+  unconfirmed settle/release health suppression.
+- [ ] 1.3 Exercise settlement ordering through streaming `POST /v1/responses`.
+
+## 2. Implementation
+
+- [ ] 2.1 Reuse `_StreamSettlement` and
+  `_settle_stream_usage_before_pending_penalty` at all three rewrite sites.
+- [ ] 2.2 Reuse
+  `_finalize_terminal_settlement_after_downstream_close` for empty-queue
+  terminal ordering.
+- [ ] 2.3 Preserve the owner-unavailable client/log envelope, original recovery
+  code for health, and independent stale-anchor/source-ownership behavior.
+
+## 3. Validation and delivery
+
+- [ ] 3.1 Run focused helper and `/v1/responses` route tests plus the deterministic
+  order driver.
+- [ ] 3.2 Run Ruff, ty, LSP diagnostics, `make lint`, and strict OpenSpec
+  validation.
+- [ ] 3.3 Review overlap with PRs #1955 and #1905, clean temporary artifacts,
+  and publish the exact verified head.

--- a/openspec/changes/settle-keyed-stream-before-health/tasks.md
+++ b/openspec/changes/settle-keyed-stream-before-health/tasks.md
@@ -1,26 +1,26 @@
 ## 1. Regression coverage
 
-- [ ] 1.1 Add deterministic order-ledger RED coverage for first-event,
+- [x] 1.1 Add deterministic order-ledger RED coverage for first-event,
   later-event, and raised `ProxyResponseError` owner-unavailable rewrites.
-- [ ] 1.2 Add deterministic RED coverage for empty-queue terminal settlement and
+- [x] 1.2 Add deterministic RED coverage for empty-queue terminal settlement and
   unconfirmed settle/release health suppression.
-- [ ] 1.3 Exercise settlement ordering through streaming `POST /v1/responses`.
+- [x] 1.3 Exercise settlement ordering through streaming `POST /v1/responses`.
 
 ## 2. Implementation
 
-- [ ] 2.1 Reuse `_StreamSettlement` and
+- [x] 2.1 Reuse `_StreamSettlement` and
   `_settle_stream_usage_before_pending_penalty` at all three rewrite sites.
-- [ ] 2.2 Reuse
+- [x] 2.2 Reuse
   `_finalize_terminal_settlement_after_downstream_close` for empty-queue
   terminal ordering.
-- [ ] 2.3 Preserve the owner-unavailable client/log envelope, original recovery
+- [x] 2.3 Preserve the owner-unavailable client/log envelope, original recovery
   code for health, and independent stale-anchor/source-ownership behavior.
 
 ## 3. Validation and delivery
 
-- [ ] 3.1 Run focused helper and `/v1/responses` route tests plus the deterministic
+- [x] 3.1 Run focused helper and `/v1/responses` route tests plus the deterministic
   order driver.
-- [ ] 3.2 Run Ruff, ty, LSP diagnostics, `make lint`, and strict OpenSpec
+- [x] 3.2 Run Ruff, ty, LSP diagnostics, `make lint`, and strict OpenSpec
   validation.
-- [ ] 3.3 Review overlap with PRs #1955 and #1905, clean temporary artifacts,
-  and publish the exact verified head.
+- [x] 3.3 Review overlap with PRs #1955 and #1905, clean temporary artifacts,
+  and prepare the exact verified head for publication.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2620,7 +2620,7 @@ async def test_backend_responses_post_refresh_terminal_disconnect_finalizes_sett
             "request_id": request_id,
             "input_tokens": 1,
             "output_tokens": 1,
-            "wait_for_settlement": False,
+            "wait_for_settlement": True,
         }
     ]
     assert success_account_ids == [expected_account_id]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16278,6 +16278,226 @@ async def test_stream_with_retry_keyed_cancel_mid_deferred_health_flush_does_not
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "upstream_path",
+    ["first_event", "later_event", "proxy_response_error"],
+)
+async def test_stream_responses_route_keyed_owner_rewrite_settles_before_original_health(
+    monkeypatch,
+    upstream_path: str,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account(f"acc_keyed_owner_rewrite_{upstream_path}")
+    api_key = _make_api_key_data(f"key_keyed_owner_rewrite_{upstream_path}")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id=f"resv_keyed_owner_rewrite_{upstream_path}",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    order: list[str] = []
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> proxy_service.ApiKeyUsageReservationData:
+        return reservation
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        *_args: object,
+        **kwargs: object,
+    ) -> bool:
+        assert settled_api_key is api_key
+        assert settled_reservation is reservation
+        assert kwargs.get("wait_for_settlement") is True
+        settlement.usage_settlement_transferred = True
+        order.append("settle")
+        return True
+
+    async def handle_stream_error(
+        failed_account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del error, http_status
+        assert failed_account is account
+        order.append(f"health:{code}")
+        return {"failure_class": "rate_limit"}
+
+    async def core_stream(*_args: object, **_kwargs: object):
+        if upstream_path == "proxy_response_error":
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error("usage_limit_reached", "owner quota exhausted"),
+            )
+        if upstream_path == "later_event":
+            yield 'data: {"type":"response.created","response":{"id":"resp_owner_rewrite"}}\n\n'
+        yield (
+            'data: {"type":"response.failed","response":{"id":"resp_owner_rewrite","status":"failed",'
+            '"error":{"code":"usage_limit_reached","message":"owner quota exhausted"}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", core_stream)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_resolve_websocket_previous_response_owner",
+        AsyncMock(return_value=account.id),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp_owner_anchor",
+            "stream": True,
+        }
+    )
+    response = await proxy_api._stream_responses(
+        request,
+        payload,
+        context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+        api_key=api_key,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    chunks = [chunk async for chunk in response.body_iterator]
+    body = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
+    assert '"code":"previous_response_owner_unavailable"' in body
+    assert request_logs.calls[-1]["error_code"] == "previous_response_owner_unavailable"
+    assert order == ["settle", "health:usage_limit_reached"]
+    service._load_balancer.record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("settlement_confirmed", "expected_order"),
+    [(True, ["settle", "health:rate_limit_exceeded"]), (False, ["settle"])],
+    ids=["confirmed", "unconfirmed_drop"],
+)
+async def test_stream_with_retry_keyed_empty_terminal_queue_settles_before_health(
+    monkeypatch,
+    settlement_confirmed: bool,
+    expected_order: list[str],
+):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_keyed_empty_terminal_queue")
+    api_key = _make_api_key_data("key_keyed_empty_terminal_queue")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_keyed_empty_terminal_queue",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    order: list[str] = []
+    stream_calls = 0
+
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        *_args: object,
+        **kwargs: object,
+    ) -> bool:
+        assert settled_api_key is api_key
+        assert settled_reservation is reservation
+        assert kwargs.get("wait_for_settlement") is True
+        settlement.usage_settlement_transferred = True
+        order.append("settle")
+        return settlement_confirmed
+
+    async def handle_stream_error(
+        failed_account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del error, http_status
+        assert failed_account is account
+        if code != "invalid_api_key":
+            order.append(f"health:{code}")
+        return {"failure_class": "rate_limit"}
+
+    async def fake_stream_once(
+        _account: Account,
+        *_args: object,
+        **kwargs: object,
+    ):
+        nonlocal stream_calls
+        stream_calls += 1
+        if stream_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired"),
+            )
+        settlement = cast(proxy_service._StreamSettlement, kwargs["settlement"])
+        settlement.status = "error"
+        settlement.record_success = False
+        settlement.account_health_error = True
+        settlement.error_code = "rate_limit_exceeded"
+        settlement.error_message = "rate limited"
+        settlement.error = {"message": "rate limited"}
+        yield proxy_service.format_sse_event(
+            proxy_service.response_failed_event(
+                "rate_limit_exceeded",
+                "rate limited",
+                response_id="resp_empty_terminal_queue",
+            )
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 1)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-keyed-empty-terminal-queue"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=api_key,
+            api_key_reservation=reservation,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert "rate_limit_exceeded" in chunks[-1]
+    assert order == expected_order
+    service._load_balancer.record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_route_keyed_refresh_connect_settles_before_account_health(
     monkeypatch,
 ):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16282,6 +16282,87 @@ async def test_stream_with_retry_keyed_cancel_mid_deferred_health_flush_does_not
     "upstream_path",
     ["first_event", "later_event", "proxy_response_error"],
 )
+async def test_stream_unkeyed_owner_rewrite_records_health_before_terminal_delivery(
+    monkeypatch,
+    upstream_path: str,
+):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account(f"acc_unkeyed_owner_rewrite_{upstream_path}")
+    health_codes: list[str] = []
+    health_errors: list[UpstreamError] = []
+
+    async def handle_stream_error(
+        failed_account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del http_status
+        assert failed_account is account
+        health_codes.append(code)
+        health_errors.append(error)
+        return {"failure_class": "rate_limit"}
+
+    async def core_stream(*_args: object, **_kwargs: object):
+        if upstream_path == "proxy_response_error":
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "usage_limit_reached",
+                    "owner quota exhausted",
+                    resets_at=1_700_003_600,
+                ),
+            )
+        if upstream_path == "later_event":
+            yield 'data: {"type":"response.created","response":{"id":"resp_unkeyed_owner_rewrite"}}\n\n'
+        yield (
+            'data: {"type":"response.failed","response":{"id":"resp_unkeyed_owner_rewrite","status":"failed",'
+            '"error":{"code":"usage_limit_reached","message":"owner quota exhausted",'
+            '"resets_at":1700003600}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", core_stream)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_resolve_websocket_previous_response_owner",
+        AsyncMock(return_value=account.id),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp_owner_anchor",
+            "stream": True,
+        }
+    )
+    stream = service.stream_responses(payload, {"session_id": "sid-unkeyed-owner-rewrite"})
+    if upstream_path == "later_event":
+        created = await anext(stream)
+        assert "response.created" in created
+        assert health_codes == []
+
+    terminal = await anext(stream)
+
+    assert '"code":"previous_response_owner_unavailable"' in terminal
+    assert health_codes == ["usage_limit_reached"]
+    assert health_errors == [{"message": "owner quota exhausted", "resets_at": 1_700_003_600}]
+    await cast(Any, stream).aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "upstream_path",
+    ["first_event", "later_event", "proxy_response_error"],
+)
 async def test_stream_responses_route_keyed_owner_rewrite_settles_before_original_health(
     monkeypatch,
     upstream_path: str,
@@ -16387,13 +16468,29 @@ async def test_stream_responses_route_keyed_owner_rewrite_settles_before_origina
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("settlement_confirmed", "expected_order"),
-    [(True, ["settle", "health:rate_limit_exceeded"]), (False, ["settle"])],
-    ids=["confirmed", "unconfirmed_drop"],
+    ("terminal_outcome", "settlement_confirmed", "close_after_terminal", "expected_order"),
+    [
+        ("health", True, False, ["settle", "health:rate_limit_exceeded"]),
+        ("health", False, False, ["settle"]),
+        ("success", True, False, ["settle", "success"]),
+        ("success", False, False, ["settle"]),
+        ("health", True, True, ["settle", "health:rate_limit_exceeded"]),
+        ("success", True, True, ["settle", "success"]),
+    ],
+    ids=[
+        "health_confirmed",
+        "health_unconfirmed_drop",
+        "success_confirmed",
+        "success_unconfirmed_drop",
+        "health_downstream_close",
+        "success_downstream_close",
+    ],
 )
-async def test_stream_with_retry_keyed_empty_terminal_queue_settles_before_health(
+async def test_stream_with_retry_keyed_empty_terminal_queue_settles_before_terminal_effect(
     monkeypatch,
+    terminal_outcome: str,
     settlement_confirmed: bool,
+    close_after_terminal: bool,
     expected_order: list[str],
 ):
     settings = _make_proxy_settings()
@@ -16447,19 +16544,22 @@ async def test_stream_with_retry_keyed_empty_terminal_queue_settles_before_healt
                 proxy_module.openai_error("invalid_api_key", "expired"),
             )
         settlement = cast(proxy_service._StreamSettlement, kwargs["settlement"])
-        settlement.status = "error"
-        settlement.record_success = False
-        settlement.account_health_error = True
-        settlement.error_code = "rate_limit_exceeded"
-        settlement.error_message = "rate limited"
-        settlement.error = {"message": "rate limited"}
-        yield proxy_service.format_sse_event(
-            proxy_service.response_failed_event(
-                "rate_limit_exceeded",
-                "rate limited",
-                response_id="resp_empty_terminal_queue",
+        if terminal_outcome == "health":
+            settlement.status = "error"
+            settlement.record_success = False
+            settlement.account_health_error = True
+            settlement.error_code = "rate_limit_exceeded"
+            settlement.error_message = "rate limited"
+            settlement.error = {"message": "rate limited"}
+            yield proxy_service.format_sse_event(
+                proxy_service.response_failed_event(
+                    "rate_limit_exceeded",
+                    "rate limited",
+                    response_id="resp_empty_terminal_queue",
+                )
             )
-        )
+            return
+        yield 'data: {"type":"response.completed","response":{"id":"resp_empty_terminal_queue"}}\n\n'
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -16473,28 +16573,34 @@ async def test_stream_with_retry_keyed_empty_terminal_queue_settles_before_healt
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
     monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
     monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
-    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(
+        service._load_balancer,
+        "record_success",
+        AsyncMock(side_effect=lambda _account: order.append("success")),
+    )
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
-    chunks = [
-        chunk
-        async for chunk in service._stream_with_retry(
-            payload,
-            {"session_id": "sid-keyed-empty-terminal-queue"},
-            codex_session_affinity=False,
-            propagate_http_errors=False,
-            openai_cache_affinity=False,
-            api_key=api_key,
-            api_key_reservation=reservation,
-            suppress_text_done_events=False,
-            request_transport="http",
-            upstream_stream_transport_override="http",
-        )
-    ]
+    stream = service._stream_with_retry(
+        payload,
+        {"session_id": "sid-keyed-empty-terminal-queue"},
+        codex_session_affinity=False,
+        propagate_http_errors=False,
+        openai_cache_affinity=False,
+        api_key=api_key,
+        api_key_reservation=reservation,
+        suppress_text_done_events=False,
+        request_transport="http",
+        upstream_stream_transport_override="http",
+    )
+    if close_after_terminal:
+        chunks = [await anext(stream)]
+        await cast(Any, stream).aclose()
+    else:
+        chunks = [chunk async for chunk in stream]
 
-    assert "rate_limit_exceeded" in chunks[-1]
+    expected_terminal = "rate_limit_exceeded" if terminal_outcome == "health" else "response.completed"
+    assert expected_terminal in chunks[-1]
     assert order == expected_order
-    service._load_balancer.record_success.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16468,6 +16468,145 @@ async def test_stream_responses_route_keyed_owner_rewrite_settles_before_origina
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "upstream_path",
+    ["first_event", "later_event", "proxy_response_error"],
+)
+async def test_stream_responses_route_keyed_owner_rewrite_preserves_health_after_disconnect_during_settlement(
+    monkeypatch,
+    upstream_path: str,
+):
+    """A body-task disconnect must not drop owner health after keyed settlement."""
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account(f"acc_keyed_owner_disconnect_{upstream_path}")
+    api_key = _make_api_key_data(f"key_keyed_owner_disconnect_{upstream_path}")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id=f"resv_keyed_owner_disconnect_{upstream_path}",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    order: list[str] = []
+    settlement_started = asyncio.Event()
+    release_settlement = asyncio.Event()
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> proxy_service.ApiKeyUsageReservationData:
+        return reservation
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        *_args: object,
+        **kwargs: object,
+    ) -> bool:
+        assert settled_api_key is api_key
+        assert settled_reservation is reservation
+        assert kwargs.get("wait_for_settlement") is True
+        settlement.usage_settlement_transferred = True
+        order.append("settle")
+        settlement_started.set()
+        with anyio.CancelScope(shield=True):
+            await release_settlement.wait()
+        return True
+
+    async def handle_stream_error(
+        failed_account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del error, http_status
+        assert failed_account is account
+        await asyncio.sleep(0)
+        order.append(f"health:{code}")
+        return {"failure_class": "rate_limit"}
+
+    async def core_stream(*_args: object, **_kwargs: object):
+        if upstream_path == "proxy_response_error":
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error("usage_limit_reached", "owner quota exhausted"),
+            )
+        if upstream_path == "later_event":
+            yield 'data: {"type":"response.created","response":{"id":"resp_owner_disconnect"}}\n\n'
+        yield (
+            'data: {"type":"response.failed","response":{"id":"resp_owner_disconnect","status":"failed",'
+            '"error":{"code":"usage_limit_reached","message":"owner quota exhausted"}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", core_stream)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_resolve_websocket_previous_response_owner",
+        AsyncMock(return_value=account.id),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp_owner_anchor",
+            "stream": True,
+        }
+    )
+    response = await proxy_api._stream_responses(
+        request,
+        payload,
+        context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+        api_key=api_key,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    chunks: list[str] = []
+    cancel_scope_ready = asyncio.Event()
+    body_cancel_scope: anyio.CancelScope | None = None
+
+    async def consume_body() -> None:
+        nonlocal body_cancel_scope
+        with anyio.CancelScope() as cancel_scope:
+            body_cancel_scope = cancel_scope
+            cancel_scope_ready.set()
+            async for chunk in response.body_iterator:
+                chunks.append(chunk.decode() if isinstance(chunk, bytes) else str(chunk))
+
+    body_task = asyncio.create_task(consume_body())
+    try:
+        await asyncio.wait_for(cancel_scope_ready.wait(), timeout=1)
+        await asyncio.wait_for(settlement_started.wait(), timeout=1)
+        assert body_cancel_scope is not None
+        body_cancel_scope.cancel()
+        release_settlement.set()
+        await asyncio.wait_for(body_task, timeout=1)
+    finally:
+        release_settlement.set()
+        if not body_task.done():
+            body_task.cancel()
+        await asyncio.gather(body_task, return_exceptions=True)
+
+    assert '"code":"previous_response_owner_unavailable"' in "".join(chunks)
+    assert request_logs.calls[-1]["error_code"] == "previous_response_owner_unavailable"
+    assert order == ["settle", "health:usage_limit_reached"]
+    service._load_balancer.record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("terminal_outcome", "settlement_confirmed", "close_after_terminal", "expected_order"),
     [
         ("health", True, False, ["settle", "health:rate_limit_exceeded"]),


### PR DESCRIPTION
## Summary

Keyed HTTP Responses streams now confirm API-key reservation settlement (or fail-safe release) before account-health/success writes on owner-unavailable rewrites and empty-queue terminal paths.

## Type of change

- [x] `fix:` — bug fix (one documented behavior change, see below)

Linked issue: focused follow-up; does not close a tracked issue.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful Responses path and preserves its external error contract

Change directory: `openspec/changes/settle-keyed-stream-before-health/`

## Changes

- Reuse `_StreamSettlement`, `_settle_stream_usage_before_pending_penalty`, and `_finalize_terminal_settlement_after_downstream_close` to gate keyed terminal health/success on confirmed cleanup.
- Preserve `previous_response_owner_unavailable` for clients and request logs while account recovery receives the original upstream code and reset metadata.
- Preserve immediate health timing for unkeyed streams and suppress health/success when ordered settlement remains unconfirmed.
- Cover first-event, later-event, raised `ProxyResponseError`, full-drain, downstream-close, success, and unconfirmed terminal variants without sleeps.

## Behavior change

First-event `previous_response_not_found`, `missing_tool_output`, and malformed-`param` equivalents that are rewritten to `stream_incomplete` no longer record a generic account error (`record_error(account)`): on `main` the `except _TerminalStreamError` path applied `_should_penalize_stream_error("stream_incomplete")`, while this PR keys on `settlement.account_health_error`, which stays `False` for these rewrites. Owner-unavailable quota/rate-limit rewrites remain health-affecting: they preserve the original upstream health code and apply it only after keyed settlement.

Terminal owner-health writes on the later-event / raised `ProxyResponseError` path and the first-event `_TerminalStreamError` path now go through `_finalize_terminal_settlement_after_downstream_close(..., settlement_order_required=True)` (owned finalization task + `_await_task_deferring_cancellation`), exactly like the post-refresh branch, so a downstream disconnect that lands during the shielded settlement cannot cancel the subsequent `mark_quota_exceeded` / `mark_rate_limit` write.

## Simplicity

- [x] No setting, setup step, README section, environment variable, or dashboard surface is added.
- [x] The change reuses existing settlement ownership and helpers; no coordinator, type, or protocol is introduced.

## Test plan

```text
set -o pipefail; .venv/bin/python -m pytest tests/unit/test_proxy_utils.py -k "test_stream_responses_route_keyed_owner_rewrite_preserves_health_after_disconnect_during_settlement" -q -p no:cacheprovider
# 3 passed, 1180 deselected in 0.38s

set -o pipefail; .venv/bin/python -m pytest tests/unit/test_proxy_utils.py -q -p no:cacheprovider
# 1183 passed in 26.16s

set -o pipefail; .venv/bin/python -m pytest tests/integration/test_proxy_responses.py -q -p no:cacheprovider
# 72 passed in 19.91s

set -o pipefail; .venv/bin/ruff check app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
set -o pipefail; .venv/bin/ruff format --check app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
set -o pipefail; .venv/bin/ty check app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
# All checks passed! / 2 files already formatted / All checks passed!

set -o pipefail; npx -y @fission-ai/openspec@1.11.0 validate settle-keyed-stream-before-health --strict
set -o pipefail; npx -y @fission-ai/openspec@1.8.0 validate settle-keyed-stream-before-health --strict
# Change 'settle-keyed-stream-before-health' is valid (both)
```

Disconnect-during-settle regression provenance (`test_stream_responses_route_keyed_owner_rewrite_preserves_health_after_disconnect_during_settlement`, three parametrized paths): previous PR head `1cfebc402` — `3 failed` (settlement completes, owner health write never lands); pristine `upstream/main` — `3 failed`; this head — `3 passed`.

No full local CI was run; focused tests, lint/type gates, strict change validation, and an independent committed-diff review cover this seam.

## Related work / conflict disposition

- #1955 overlaps `streaming/mixin.py`, `streaming/retry.py`, and settlement support for stale-anchor error-shape and cleanup extraction. This PR does not alter its shape matching or public sanitization invariant.
- #1905 overlaps `streaming/retry.py`, settlement support, and Responses tests for source ownership. This PR does not alter owner lookup, source selection, or pinning.
- Neither PR is a semantic prerequisite. The overlap is mechanical around shared hot files; this branch remains based on current `main` and preserves both independent invariants.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Added deterministic regression coverage at the `/v1/responses` product surface and helper lifecycle seams.
- [x] Ran the relevant lint, format, type, architecture, unit, integration, and strict OpenSpec checks.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming reliability by settling API-key usage before account-health updates.
  - Preserved the expected `previous_response_owner_unavailable` error for clients and request logs.
  - Retained original upstream error information for accurate account recovery handling.
  - Added fail-safe behavior when settlement cannot be confirmed, preventing premature health updates.

- **Tests**
  - Added coverage for retries, terminal disconnects, owner-unavailable responses, and settlement ordering across Responses API scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->