### PR TITLE
fix(proxy): defer WebSocket cancellation through lease release

### DIFF
--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -13,6 +13,7 @@ from typing import Any, Iterator, Mapping, NoReturn, cast
 
 import aiohttp
 import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 from fastapi import WebSocket
 from pydantic import ValidationError
 
@@ -328,6 +329,7 @@ from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_WEBSOCKET,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _account_capacity_wait_payload,
+    _await_task_deferring_cancellation,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
     _DownstreamWebSocketActivity,
@@ -942,9 +944,10 @@ async def _await_owned_websocket_task_after_reader_cancellation(
 async def _release_websocket_response_create_ownership_for_cleanup(
     request_state: _WebSocketRequestState,
     response_create_gate: asyncio.Semaphore,
-) -> None:
-    """Release every create owner even when one release side effect fails."""
+) -> asyncio.CancelledError | None:
+    """Release every create owner and return cancellation after cleanup."""
 
+    cancellation: asyncio.CancelledError | None = None
     response_create_admission = request_state.response_create_admission
     account_response_create_lease = request_state.account_response_create_lease
     account_response_create_release = request_state.account_response_create_release
@@ -968,16 +971,39 @@ async def _release_websocket_response_create_ownership_for_cleanup(
                 )
         if account_response_create_lease is not None and account_response_create_release is not None:
             try:
-                await account_response_create_release(account_response_create_lease)
+                release_task = asyncio.create_task(
+                    account_response_create_release(account_response_create_lease),
+                    name="proxy-websocket-terminal-response-create-lease-release",
+                )
+                _, cancellation = await _await_task_deferring_cancellation(release_task)
+            except asyncio.CancelledError as exc:
+                release_error = exc.__cause__
+                if release_error is None:
+                    raise
+                _facade().logger.warning(
+                    "Failed to release websocket account create lease during terminal cleanup request_id=%s",
+                    request_state.request_log_id or request_state.request_id,
+                    exc_info=(type(release_error), release_error, release_error.__traceback__),
+                )
+                cancellation = exc
             except Exception:
                 _facade().logger.warning(
                     "Failed to release websocket account create lease during terminal cleanup request_id=%s",
                     request_state.request_log_id or request_state.request_id,
                     exc_info=True,
                 )
+                try:
+                    await checkpoint_if_cancelled()
+                except asyncio.CancelledError as exc:
+                    cancellation = exc
+                if cancellation is None:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        cancellation = asyncio.CancelledError()
     finally:
         if response_create_gate_acquired:
             response_create_gate.release()
+    return cancellation
 
 
 async def _process_and_forward_upstream_websocket_text(
@@ -1448,10 +1474,19 @@ class _WebSocketMixin:
                 _track_websocket_owned_task(proxy, account_lease_release_task)
             release_task = account_lease_release_task
             try:
-                await asyncio.shield(release_task)
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
             finally:
                 if release_task.done():
                     account_lease_release_task = None
+            if cancellation is not None:
+                raise cancellation
 
         async def retire_current_upstream() -> None:
             nonlocal account, upstream, upstream_control, upstream_reader
@@ -2637,8 +2672,19 @@ class _WebSocketMixin:
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
                         _track_websocket_owned_task(proxy, retired_create_lease_release_task)
-                        await asyncio.shield(retired_create_lease_release_task)
+                        try:
+                            _, cancellation = await _await_task_deferring_cancellation(
+                                retired_create_lease_release_task
+                            )
+                        except Exception:
+                            await checkpoint_if_cancelled()
+                            current_task = asyncio.current_task()
+                            if current_task is not None and current_task.cancelling():
+                                raise asyncio.CancelledError() from None
+                            raise
                         retired_create_lease_release_task = None
+                        if cancellation is not None:
+                            raise cancellation
                         if request_state_to_fail is not None:
                             owned_request_state = request_state_to_fail
                             request_state_failure_task = asyncio.create_task(
@@ -2804,8 +2850,19 @@ class _WebSocketMixin:
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
                         _track_websocket_owned_task(proxy, retired_create_lease_release_task)
-                        await asyncio.shield(retired_create_lease_release_task)
+                        try:
+                            _, cancellation = await _await_task_deferring_cancellation(
+                                retired_create_lease_release_task
+                            )
+                        except Exception:
+                            await checkpoint_if_cancelled()
+                            current_task = asyncio.current_task()
+                            if current_task is not None and current_task.cancelling():
+                                raise asyncio.CancelledError() from None
+                            raise
                         retired_create_lease_release_task = None
+                        if cancellation is not None:
+                            raise cancellation
                         upstream_control = None
                         upstream = None
                         await release_current_account_lease()
@@ -2861,6 +2918,7 @@ class _WebSocketMixin:
                 return _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining is None else max(float(remaining), 0.0)
 
             cleanup_phase = "not_started"
+            connection_lease_released = asyncio.Event()
 
             async def finalize_websocket_scope() -> None:
                 nonlocal cleanup_phase
@@ -3002,6 +3060,8 @@ class _WebSocketMixin:
                         "Failed to release websocket connection lease during scope cleanup",
                         exc_info=True,
                     )
+                finally:
+                    connection_lease_released.set()
                 cleanup_phase = "complete"
 
             cleanup_task = asyncio.create_task(
@@ -3022,10 +3082,14 @@ class _WebSocketMixin:
 
             cleanup_task.add_done_callback(log_scope_cleanup_failure)
             scope_cleanup_timeout = current_scope_cleanup_timeout()
-            done, _ = await asyncio.wait(
-                {cleanup_task},
-                timeout=scope_cleanup_timeout,
+            cleanup_wait_task = asyncio.create_task(
+                asyncio.wait(
+                    {cleanup_task},
+                    timeout=scope_cleanup_timeout,
+                ),
+                name="proxy-websocket-finalization-scope-cleanup-wait",
             )
+            (done, _), cancellation = await _await_task_deferring_cancellation(cleanup_wait_task)
             if not done:
                 _facade().logger.warning(
                     "Websocket scope cleanup exceeded its cleanup budget "
@@ -3034,6 +3098,15 @@ class _WebSocketMixin:
                     cleanup_phase,
                     sum(1 for task in proxy._background_cleanup_tasks if not task.done()),
                 )
+                if scope_cancelled or cancellation is not None:
+                    connection_lease_wait_task = asyncio.create_task(
+                        connection_lease_released.wait(),
+                        name="proxy-websocket-finalization-connection-lease-wait",
+                    )
+                    _, connection_cancellation = await _await_task_deferring_cancellation(connection_lease_wait_task)
+                    cancellation = cancellation or connection_cancellation
+            if cancellation is not None:
+                raise cancellation
 
     async def _prepare_websocket_response_create_request(
         self,
@@ -3618,7 +3691,20 @@ class _WebSocketMixin:
             selected_stream_lease = request_state.websocket_stream_lease
             request_state.websocket_stream_lease = None
             if account is None:
-                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                release_task = asyncio.create_task(
+                    proxy._load_balancer.release_account_lease(selected_stream_lease),
+                    name="proxy-websocket-connect-stream-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 if (
                     last_failover_exc is not None
                     and not require_preferred_account
@@ -3679,7 +3765,20 @@ class _WebSocketMixin:
                 # acquired stream lease so it does not keep consuming a
                 # stream-concurrency slot for a connection that never opens,
                 # exclude it, and reselect a healthy account.
-                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                release_task = asyncio.create_task(
+                    proxy._load_balancer.release_account_lease(selected_stream_lease),
+                    name="proxy-websocket-connect-stream-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 selected_stream_lease = None
                 # Record a capacity-style failure so that if every account
                 # attempt hits a transient refresh-claim failover, the loop
@@ -3748,7 +3847,20 @@ class _WebSocketMixin:
                     # Release the dead route's stream lease before recording
                     # the backoff so its concurrency slot never outlives the
                     # failed connection attempt.
-                    await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                    release_task = asyncio.create_task(
+                        proxy._load_balancer.release_account_lease(selected_stream_lease),
+                        name="proxy-websocket-connect-stream-lease-release",
+                    )
+                    try:
+                        _, cancellation = await _await_task_deferring_cancellation(release_task)
+                    except Exception:
+                        await checkpoint_if_cancelled()
+                        current_task = asyncio.current_task()
+                        if current_task is not None and current_task.cancelling():
+                            raise asyncio.CancelledError() from None
+                        raise
+                    if cancellation is not None:
+                        raise cancellation
                     selected_stream_lease = None
                     if confirmed_pre_dispatch:
                         await _record_or_defer_confirmed_route_backoff(account)
@@ -3759,7 +3871,20 @@ class _WebSocketMixin:
                 error = _parse_openai_error(exc.payload)
                 error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
                 error_message = error.message if error else None
-                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                release_task = asyncio.create_task(
+                    proxy._load_balancer.release_account_lease(selected_stream_lease),
+                    name="proxy-websocket-connect-stream-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 selected_stream_lease = None
                 if confirmed_pre_dispatch:
                     await _record_or_defer_confirmed_route_backoff(account)
@@ -3776,11 +3901,37 @@ class _WebSocketMixin:
                 )
                 return None, None
             except BaseException:
-                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                release_task = asyncio.create_task(
+                    proxy._load_balancer.release_account_lease(selected_stream_lease),
+                    name="proxy-websocket-connect-stream-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 raise
 
             if connect_result is None:
-                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                release_task = asyncio.create_task(
+                    proxy._load_balancer.release_account_lease(selected_stream_lease),
+                    name="proxy-websocket-connect-stream-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 return None, None
             request_state.websocket_stream_lease = selected_stream_lease
             _clear_websocket_precreated_replay_fallback(request_state)
@@ -5753,7 +5904,20 @@ class _WebSocketMixin:
                 # to a replacement account, and the reconnect/send path
                 # re-acquires the account-local slot only when this field is
                 # clear.
-                await proxy._release_request_state_account_response_create_lease(request_state)
+                release_task = asyncio.create_task(
+                    proxy._release_request_state_account_response_create_lease(request_state),
+                    name="proxy-websocket-owner-replay-response-create-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 request_state.excluded_account_ids.add(account.id)
                 request_state.affinity_policy = replace(
                     request_state.affinity_policy,
@@ -5782,7 +5946,20 @@ class _WebSocketMixin:
                 )
                 request_state.error_param_override = _websocket_event_error_param(event_type, payload)
                 request_state.error_http_status_override = _facade()._http_error_status_from_payload(payload) or 400
-                await proxy._release_request_state_account_response_create_lease(request_state)
+                release_task = asyncio.create_task(
+                    proxy._release_request_state_account_response_create_lease(request_state),
+                    name="proxy-websocket-model-replay-response-create-lease-release",
+                )
+                try:
+                    _, cancellation = await _await_task_deferring_cancellation(release_task)
+                except Exception:
+                    await checkpoint_if_cancelled()
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise asyncio.CancelledError() from None
+                    raise
+                if cancellation is not None:
+                    raise cancellation
                 request_state.excluded_account_ids.add(account.id)
                 request_state.affinity_policy = replace(
                     request_state.affinity_policy,
@@ -6592,6 +6769,7 @@ class _WebSocketMixin:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         finalization_task: asyncio.Task[bool] | None = None
+        leases_released = asyncio.Event()
         await pending_lock.acquire()
         try:
             remaining = list(pending_requests)
@@ -6612,6 +6790,7 @@ class _WebSocketMixin:
                         status=status,
                         penalize_account=penalize_account,
                         suppress_sequenced_downstream_errors=suppress_sequenced_downstream_errors,
+                        leases_released=leases_released,
                     ),
                     name="proxy-websocket-finalization-pending-requests",
                 )
@@ -6627,18 +6806,13 @@ class _WebSocketMixin:
 
         try:
             settlement_succeeded = await asyncio.shield(finalization_task)
-        except asyncio.CancelledError:
-            remaining_timeout = shutdown_state.remaining_post_drain_cleanup_timeout_seconds()
-            timeout_seconds = (
-                _facade()._TASK_CANCEL_TIMEOUT_SECONDS
-                if remaining_timeout is None
-                else max(float(remaining_timeout), 0.0)
+        except asyncio.CancelledError as cancellation:
+            lease_wait_task = asyncio.create_task(
+                leases_released.wait(),
+                name="proxy-websocket-finalization-pending-lease-wait",
             )
-            if not finalization_task.done() and timeout_seconds > 0:
-                # Do not cancel the child at the bound: it is the sole owner of
-                # the claimed states and remains visible to lifespan draining.
-                await asyncio.wait({finalization_task}, timeout=timeout_seconds)
-            raise
+            await _await_task_deferring_cancellation(lease_wait_task)
+            raise cancellation
         return settlement_succeeded
 
     async def _finalize_claimed_websocket_requests(
@@ -6657,6 +6831,7 @@ class _WebSocketMixin:
         status: str,
         penalize_account: bool,
         suppress_sequenced_downstream_errors: bool,
+        leases_released: asyncio.Event | None = None,
     ) -> bool:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
@@ -6700,6 +6875,54 @@ class _WebSocketMixin:
                     exc_info=True,
                 )
 
+        deferred_cancellation: asyncio.CancelledError | None = None
+        for request_state in remaining:
+            if response_create_gate is not None:
+                response_create_cancellation = await _release_websocket_response_create_ownership_for_cleanup(
+                    request_state,
+                    response_create_gate,
+                )
+                deferred_cancellation = deferred_cancellation or response_create_cancellation
+            if request_state.websocket_stream_lease is not None:
+                websocket_stream_lease = request_state.websocket_stream_lease
+                request_state.websocket_stream_lease = None
+                stream_cancellation: asyncio.CancelledError | None = None
+                try:
+                    release_task = asyncio.create_task(
+                        proxy._load_balancer.release_account_lease(websocket_stream_lease),
+                        name="proxy-websocket-terminal-stream-lease-release",
+                    )
+                    _, stream_cancellation = await _await_task_deferring_cancellation(release_task)
+                except asyncio.CancelledError as exc:
+                    release_error = exc.__cause__
+                    if release_error is None:
+                        raise
+                    _facade().logger.warning(
+                        "Failed to release websocket stream lease during terminal cleanup request_id=%s",
+                        request_state.request_log_id or request_state.request_id,
+                        exc_info=(type(release_error), release_error, release_error.__traceback__),
+                    )
+                    stream_cancellation = exc
+                except Exception:
+                    _facade().logger.warning(
+                        "Failed to release websocket stream lease during terminal cleanup request_id=%s",
+                        request_state.request_log_id or request_state.request_id,
+                        exc_info=True,
+                    )
+                    try:
+                        await checkpoint_if_cancelled()
+                    except asyncio.CancelledError as exc:
+                        stream_cancellation = exc
+                    if stream_cancellation is None:
+                        current_task = asyncio.current_task()
+                        if current_task is not None and current_task.cancelling():
+                            stream_cancellation = asyncio.CancelledError()
+                deferred_cancellation = deferred_cancellation or stream_cancellation
+        if leases_released is not None:
+            leases_released.set()
+        if deferred_cancellation is not None:
+            raise deferred_cancellation
+
         request_log_handoff_succeeded = True
         last_index = len(remaining) - 1
         for index, request_state in enumerate(remaining):
@@ -6734,22 +6957,6 @@ class _WebSocketMixin:
                         exc_info=True,
                     )
 
-            if response_create_gate is not None:
-                await _release_websocket_response_create_ownership_for_cleanup(
-                    request_state,
-                    response_create_gate,
-                )
-            if request_state.websocket_stream_lease is not None:
-                websocket_stream_lease = request_state.websocket_stream_lease
-                request_state.websocket_stream_lease = None
-                try:
-                    await proxy._load_balancer.release_account_lease(websocket_stream_lease)
-                except Exception:
-                    _facade().logger.warning(
-                        "Failed to release websocket stream lease during terminal cleanup request_id=%s",
-                        request_state.request_log_id or request_state.request_id,
-                        exc_info=True,
-                    )
             if request_state.event_queue is not None:
                 try:
                     await request_state.event_queue.put(
@@ -6932,10 +7139,12 @@ class _WebSocketMixin:
         )
         response_create_gate = request_state.response_create_gate
         if response_create_gate is not None:
-            await _release_websocket_response_create_ownership_for_cleanup(
+            cancellation = await _release_websocket_response_create_ownership_for_cleanup(
                 request_state,
                 response_create_gate,
             )
+            if cancellation is not None:
+                raise cancellation
         try:
             await proxy._send_downstream_websocket_text(
                 websocket,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -3069,6 +3069,7 @@ class _WebSocketMixin:
                 name="proxy-websocket-finalization-scope-cleanup",
             )
             _track_websocket_owned_task(proxy, cleanup_task)
+            cleanup_task.add_done_callback(lambda _task: connection_lease_released.set())
 
             def log_scope_cleanup_failure(done_task: asyncio.Task[None]) -> None:
                 if done_task.cancelled():
@@ -3099,12 +3100,24 @@ class _WebSocketMixin:
                     sum(1 for task in proxy._background_cleanup_tasks if not task.done()),
                 )
                 if scope_cancelled or cancellation is not None:
-                    connection_lease_wait_task = asyncio.create_task(
-                        connection_lease_released.wait(),
-                        name="proxy-websocket-finalization-connection-lease-wait",
+                    remaining_timeout = shutdown_state.remaining_post_drain_cleanup_timeout_seconds()
+                    timeout_seconds = (
+                        _facade()._TASK_CANCEL_TIMEOUT_SECONDS
+                        if remaining_timeout is None
+                        else max(float(remaining_timeout), 0.0)
                     )
-                    _, connection_cancellation = await _await_task_deferring_cancellation(connection_lease_wait_task)
-                    cancellation = cancellation or connection_cancellation
+                    if not connection_lease_released.is_set() and timeout_seconds > 0:
+                        connection_lease_wait_task = asyncio.create_task(
+                            asyncio.wait_for(connection_lease_released.wait(), timeout=timeout_seconds),
+                            name="proxy-websocket-finalization-connection-lease-wait",
+                        )
+                        try:
+                            _, connection_cancellation = await _await_task_deferring_cancellation(
+                                connection_lease_wait_task
+                            )
+                            cancellation = cancellation or connection_cancellation
+                        except TimeoutError:
+                            pass
             if cancellation is not None:
                 raise cancellation
 
@@ -6769,7 +6782,6 @@ class _WebSocketMixin:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         finalization_task: asyncio.Task[bool] | None = None
-        leases_released = asyncio.Event()
         await pending_lock.acquire()
         try:
             remaining = list(pending_requests)
@@ -6790,7 +6802,6 @@ class _WebSocketMixin:
                         status=status,
                         penalize_account=penalize_account,
                         suppress_sequenced_downstream_errors=suppress_sequenced_downstream_errors,
-                        leases_released=leases_released,
                     ),
                     name="proxy-websocket-finalization-pending-requests",
                 )
@@ -6807,11 +6818,18 @@ class _WebSocketMixin:
         try:
             settlement_succeeded = await asyncio.shield(finalization_task)
         except asyncio.CancelledError as cancellation:
-            lease_wait_task = asyncio.create_task(
-                leases_released.wait(),
-                name="proxy-websocket-finalization-pending-lease-wait",
+            remaining_timeout = shutdown_state.remaining_post_drain_cleanup_timeout_seconds()
+            timeout_seconds = (
+                _facade()._TASK_CANCEL_TIMEOUT_SECONDS
+                if remaining_timeout is None
+                else max(float(remaining_timeout), 0.0)
             )
-            await _await_task_deferring_cancellation(lease_wait_task)
+            if not finalization_task.done() and timeout_seconds > 0:
+                finalization_wait_task = asyncio.create_task(
+                    asyncio.wait({finalization_task}, timeout=timeout_seconds),
+                    name="proxy-websocket-finalization-pending-lease-wait",
+                )
+                await _await_task_deferring_cancellation(finalization_wait_task)
             raise cancellation
         return settlement_succeeded
 
@@ -6831,7 +6849,6 @@ class _WebSocketMixin:
         status: str,
         penalize_account: bool,
         suppress_sequenced_downstream_errors: bool,
-        leases_released: asyncio.Event | None = None,
     ) -> bool:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
@@ -6918,8 +6935,6 @@ class _WebSocketMixin:
                         if current_task is not None and current_task.cancelling():
                             stream_cancellation = asyncio.CancelledError()
                 deferred_cancellation = deferred_cancellation or stream_cancellation
-        if leases_released is not None:
-            leases_released.set()
         if deferred_cancellation is not None:
             raise deferred_cancellation
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -92,6 +92,7 @@ from app.core.resilience.network_recovery import (
 from app.core.types import JsonValue
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import get_request_id, reset_request_id, set_request_id
+from app.core.utils.shared_future import _await_task_deferring_cancellation
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
 from app.core.utils.sse import format_sse_event
 from app.core.utils.time import utcnow as utcnow
@@ -329,7 +330,6 @@ from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_WEBSOCKET,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _account_capacity_wait_payload,
-    _await_task_deferring_cancellation,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
     _DownstreamWebSocketActivity,

--- a/openspec/changes/defer-websocket-lease-release-cancellation/.openspec.yaml
+++ b/openspec/changes/defer-websocket-lease-release-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/defer-websocket-lease-release-cancellation/design.md
+++ b/openspec/changes/defer-websocket-lease-release-cancellation/design.md
@@ -1,0 +1,31 @@
+## Context
+
+Direct WebSocket lifecycle code clears account-lease ownership before awaiting the corresponding asynchronous release. A cancellation delivered during that await can stop the release after the ownership reference is gone, permanently consuming account-local capacity. The codebase already has `_await_task_deferring_cancellation`, which lets an owned task finish while retaining the caller's cancellation for later propagation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Finish each scoped direct WebSocket lease release exactly once before cancellation escapes.
+- Preserve ownership ordering by clearing the owning field before release starts.
+- Preserve ordinary release success and failure behavior.
+- Prove repeated cancellation with event-gated tests and a lifecycle driver.
+
+**Non-Goals:**
+
+- Changing Live, HTTP bridge, settlement, health, affinity, or routing behavior.
+- Adding another cancellation helper, shield loop, timeout, setting, or dependency.
+- Protecting release calls whose caller still retains ownership.
+
+## Decisions
+
+1. Move the established cancellation-deferring helper unchanged from the streaming retry module into common service support. This is the smallest dependency-neutral location shared by streaming and direct WebSocket code. Importing from the Live implementation or duplicating its loop would couple sibling transports or create divergent cancellation semantics.
+2. At each scoped direct WebSocket seam, clear ownership first, create one owned release task, await it through `_await_task_deferring_cancellation`, and re-raise the returned cancellation only after release completes. A bare `asyncio.shield` is insufficient because repeated or level cancellation can interrupt the outer await while cleanup is still suspended.
+3. Keep release failures on their existing path. Cleanup sites that currently log release failures continue to log them; sites that propagate release failures continue to propagate them. Cancellation deferral changes ordering only when cancellation races an in-progress release.
+4. Use events that subscribe before cancellation and gate release completion explicitly. Tests assert ownership is already clear at release entry, inject repeated cancellation while release is suspended, and require `release-finish` before `cancel-reraised` with one release call.
+
+## Risks / Trade-offs
+
+- [Risk] Cancellation latency now includes the lease release duration. → Mitigation: only already-required ownership cleanup is deferred; no extra retry or timeout is introduced.
+- [Risk] Broad conversion could alter HTTP bridge or non-owned release behavior. → Mitigation: edit only direct WebSocket call sites that clear ownership before release.
+- [Risk] A release exception can race cancellation. → Mitigation: retain the established helper's result/exception semantics and existing caller-specific error handling.

--- a/openspec/changes/defer-websocket-lease-release-cancellation/proposal.md
+++ b/openspec/changes/defer-websocket-lease-release-cancellation/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Direct WebSocket cancellation can interrupt an account-lease release after the request has cleared its ownership reference. The lost release consumes account-local stream capacity indefinitely, so cancellation must remain pending until lease cleanup completes.
+
+## What Changes
+
+- Require direct WebSocket connection and request-stream leases to finish releasing exactly once before cancellation is propagated.
+- Cover connect-attempt, terminal-stream, current-account, and response-create cleanup seams only where ownership is cleared before release.
+- Preserve existing non-cancellation success and failure behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: Require direct WebSocket account capacity to be returned before cancellation escapes lease cleanup.
+
+## Impact
+
+- Affects direct WebSocket lifecycle cleanup in `app/modules/proxy/_service/websocket/mixin.py` and focused cancellation tests.
+- Reuses the common cancellation-deferring task helper; no new setting, API, dependency, database change, HTTP bridge behavior, or Live behavior.

--- a/openspec/changes/defer-websocket-lease-release-cancellation/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/defer-websocket-lease-release-cancellation/specs/proxy-admission-control/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Direct WebSocket lease release survives cancellation
+
+The proxy MUST clear direct WebSocket ownership before releasing an account connection, stream, or response-create lease. Once ownership is cleared, the proxy MUST finish that release exactly once before propagating cancellation, including repeated cancellation received while release is suspended. Existing non-cancellation release success and failure semantics MUST remain unchanged.
+
+#### Scenario: Cancellation races direct WebSocket connect-attempt release
+
+- **GIVEN** a direct WebSocket connect attempt has cleared its selected stream lease from request ownership
+- **WHEN** cancellation is delivered repeatedly while account-lease release is suspended
+- **THEN** the release finishes exactly once before cancellation is propagated
+
+#### Scenario: Cancellation races terminal direct WebSocket stream cleanup
+
+- **GIVEN** terminal direct WebSocket cleanup has cleared a request's stream lease from request ownership
+- **WHEN** cancellation is delivered while account-lease release is suspended
+- **THEN** the release finishes exactly once before cancellation is propagated
+
+#### Scenario: Cancellation races current-account connection cleanup
+
+- **GIVEN** direct WebSocket connection cleanup has cleared the current account lease from connection ownership
+- **WHEN** cancellation is delivered repeatedly while account-lease release is suspended
+- **THEN** the connection lease release finishes exactly once before cancellation is propagated
+
+#### Scenario: Cancellation races direct WebSocket response-create cleanup
+
+- **GIVEN** direct WebSocket cleanup has cleared a response-create lease from request ownership
+- **WHEN** cancellation is delivered while account-lease release is suspended
+- **THEN** the response-create lease release finishes exactly once before cancellation is propagated

--- a/openspec/changes/defer-websocket-lease-release-cancellation/tasks.md
+++ b/openspec/changes/defer-websocket-lease-release-cancellation/tasks.md
@@ -1,0 +1,20 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add event-gated connect-attempt and terminal-stream tests that clear ownership before suspending release.
+- [x] 1.2 Add event-gated current-account and response-create cleanup tests with repeated cancellation.
+- [x] 1.3 Run the focused tests before production edits and record the expected cancellation-order failures.
+
+## 2. Cancellation-Safe Cleanup
+
+- [x] 2.1 Relocate the existing cancellation-deferring task helper to common service support without changing its behavior.
+- [x] 2.2 Use the common helper at direct WebSocket connect-attempt and terminal stream-lease release seams.
+- [x] 2.3 Use the common helper for current-account and scoped response-create lease cleanup.
+- [x] 2.4 Preserve existing normal and release-failure behavior while re-raising cancellation only after release finishes.
+
+## 3. Verification
+
+- [x] 3.1 Run focused connect, terminal, and scope cancellation tests without sleeps or polling.
+- [x] 3.2 Run Ruff, ty, LSP diagnostics, and the repository lint target for changed Python files.
+- [x] 3.3 Run strict scoped and full OpenSpec validation.
+- [x] 3.4 Run an event-gated lifecycle driver proving ownership clear, repeated cancellation, exactly-once release, and release-before-reraise ordering.
+- [x] 3.5 Review the final diff, task completion, and cleanup evidence.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -23676,7 +23676,7 @@ async def test_connect_proxy_websocket_pinned_forced_refresh_transient_error_sta
 
 
 @pytest.mark.asyncio
-async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stream_lease(monkeypatch):
+async def test_connect_proxy_websocket_repeated_cancellation_finishes_erased_stream_lease_release(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_ws_cancel_handoff")
     request_state = proxy_service._WebSocketRequestState(
@@ -23688,8 +23688,11 @@ async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stre
         started_at=0.0,
     )
     selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="stream")
-    started = asyncio.Event()
-    release = asyncio.Event()
+    connect_started = asyncio.Event()
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    release_events: list[str] = []
+    original_release = service._load_balancer.release_account_lease
 
     async def fake_select_websocket_connect_account(*args: object, **kwargs: object) -> Account:
         del args, kwargs
@@ -23698,12 +23701,23 @@ async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stre
 
     async def blocking_connect_attempt(*args: object, **kwargs: object) -> tuple[Account, object]:
         del args, kwargs
-        started.set()
-        await release.wait()
-        return account, object()
+        connect_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def release_account_lease(lease: AccountLease | None) -> None:
+        assert request_state.websocket_stream_lease is None
+        assert lease is selected_lease
+        release_events.append("release-start")
+        release_started.set()
+        await finish_release.wait()
+        await original_release(lease)
+        release_events.append("release-finish")
 
     monkeypatch.setattr(service, "_select_websocket_connect_account", fake_select_websocket_connect_account)
     monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", blocking_connect_attempt)
+    monkeypatch.setattr(websocket_mixin, "responses_model_is_source_owned", AsyncMock(return_value=False))
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_proxy_settings())
 
     task = asyncio.create_task(
@@ -23720,15 +23734,18 @@ async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stre
             websocket=cast(WebSocket, SimpleNamespace()),
         )
     )
-    try:
-        await asyncio.wait_for(started.wait(), timeout=1.0)
-        assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 1, 0.0)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-    finally:
-        release.set()
+    await asyncio.wait_for(connect_started.wait(), timeout=1.0)
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 1, 0.0)
 
+    task.cancel()
+    await asyncio.wait_for(release_started.wait(), timeout=1.0)
+    task.cancel()
+    finish_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1.0)
+    release_events.append("cancel-reraised")
+
+    assert release_events == ["release-start", "release-finish", "cancel-reraised"]
     assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
 
@@ -27111,7 +27128,7 @@ async def test_fail_pending_websocket_requests_marks_client_disconnect_without_p
 
 
 @pytest.mark.asyncio
-async def test_fail_pending_websocket_requests_releases_orphaned_stream_lease(monkeypatch):
+async def test_terminal_websocket_repeated_cancellation_releases_entire_erased_stream_lease_batch(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_ws_orphaned_lease")
@@ -27120,36 +27137,82 @@ async def test_fail_pending_websocket_requests_releases_orphaned_stream_lease(mo
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
     monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
 
-    lease = await service._load_balancer.acquire_account_lease(account.id, kind="stream")
-    assert lease is not None
+    leases = [await service._load_balancer.acquire_account_lease(account.id, kind="stream") for _ in range(2)]
+    assert all(lease is not None for lease in leases)
+    release_started = asyncio.Event()
+    finish_first_release = asyncio.Event()
+    release_events: list[str] = []
+    original_release = service._load_balancer.release_account_lease
+    request_states = [
+        proxy_service._WebSocketRequestState(
+            request_id=f"ws_req_orphaned_{index}",
+            response_id=f"resp_ws_orphaned_{index}",
+            model="gpt-5.5",
+            service_tier="auto",
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=0.0,
+            websocket_stream_lease=lease,
+        )
+        for index, lease in enumerate(leases)
+    ]
+    post_release_io_started = asyncio.Event()
 
-    request_state = proxy_service._WebSocketRequestState(
-        request_id="ws_req_orphaned",
-        response_id="resp_ws_orphaned",
-        model="gpt-5.5",
-        service_tier="auto",
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=0.0,
+    class _BlockedEventQueue:
+        async def put(self, _value: str | None) -> None:
+            post_release_io_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    request_states[0].event_queue = cast(Any, _BlockedEventQueue())
+
+    async def release_account_lease(released_lease: AccountLease | None) -> None:
+        index = leases.index(released_lease)
+        assert request_states[index].websocket_stream_lease is None
+        release_events.append(f"release-{index}-start")
+        if index == 0:
+            release_started.set()
+            await finish_first_release.wait()
+        await original_release(released_lease)
+        release_events.append(f"release-{index}-finish")
+
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    terminal_cleanup = asyncio.create_task(
+        service._finalize_claimed_websocket_requests(
+            account=account,
+            account_id_value=account.id,
+            remaining=request_states,
+            error_code="stream_incomplete",
+            error_message="Upstream websocket closed before response.completed",
+            api_key=None,
+            websocket=None,
+            client_send_lock=None,
+            response_create_gate=None,
+            downstream_activity=None,
+            status="error",
+            penalize_account=False,
+            suppress_sequenced_downstream_errors=False,
+        )
     )
-    request_state.websocket_stream_lease = lease
-    pending_requests = deque([request_state])
+    await asyncio.wait_for(release_started.wait(), timeout=1)
 
-    await service._fail_pending_websocket_requests(
-        account=account,
-        account_id_value=account.id,
-        pending_requests=pending_requests,
-        pending_lock=anyio.Lock(),
-        error_code="stream_incomplete",
-        error_message="Upstream websocket closed before response.completed",
-        api_key=None,
-    )
+    terminal_cleanup.cancel()
+    terminal_cleanup.cancel()
+    finish_first_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(terminal_cleanup, timeout=1)
+    release_events.append("cancel-reraised")
 
-    assert request_state.websocket_stream_lease is None
+    assert release_events == [
+        "release-0-start",
+        "release-0-finish",
+        "release-1-start",
+        "release-1-finish",
+        "cancel-reraised",
+    ]
+    assert post_release_io_started.is_set() is False
     snapshot = await service._load_balancer.account_pressure_snapshot(account.id)
     assert snapshot[1] == 0, f"inflight_streams should be 0, got {snapshot[1]}"
-    assert list(pending_requests) == []
-    assert await service.drain_persistence_tasks(timeout_seconds=1)
 
 
 @pytest.mark.asyncio
@@ -30040,8 +30103,10 @@ async def test_process_upstream_websocket_text_transparently_retries_precreated_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_during_release", [False, True], ids=["normal", "repeated-cancellation"])
 async def test_process_upstream_websocket_text_owner_replay_releases_old_account_create_lease(
     monkeypatch,
+    cancel_during_release: bool,
 ):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -30054,6 +30119,24 @@ async def test_process_upstream_websocket_text_owner_replay_releases_old_account
 
     old_lease = await service._load_balancer.acquire_account_lease(old_account.id, kind="response_create")
     assert old_lease is not None
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    release_events: list[str] = []
+    original_release = service._load_balancer.release_account_lease
+
+    async def release_account_lease(lease: AccountLease | None) -> None:
+        if lease is not old_lease:
+            await original_release(lease)
+            return
+        assert pending_request.account_response_create_lease is None
+        assert pending_request.account_response_create_release is None
+        release_events.append("release-start")
+        release_started.set()
+        await finish_release.wait()
+        await original_release(lease)
+        release_events.append("release-finish")
+
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
 
     anchored_payload = {
         "type": "response.create",
@@ -30085,7 +30168,7 @@ async def test_process_upstream_websocket_text_owner_replay_releases_old_account
         fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
         fresh_upstream_request_is_retry_safe=True,
         account_response_create_lease=old_lease,
-        account_response_create_release=service._load_balancer.release_account_lease,
+        account_response_create_release=original_release,
     )
     pending_requests = deque([pending_request])
     upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -30099,16 +30182,31 @@ async def test_process_upstream_websocket_text_owner_replay_releases_old_account
         },
     }
 
-    downstream_text = await service._process_upstream_websocket_text(
-        json.dumps(upstream_payload, separators=(",", ":")),
-        account=old_account,
-        account_id_value=old_account.id,
-        pending_requests=pending_requests,
-        pending_lock=anyio.Lock(),
-        api_key=None,
-        upstream_control=upstream_control,
-        response_create_gate=response_create_gate,
+    processing = asyncio.create_task(
+        service._process_upstream_websocket_text(
+            json.dumps(upstream_payload, separators=(",", ":")),
+            account=old_account,
+            account_id_value=old_account.id,
+            pending_requests=pending_requests,
+            pending_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=upstream_control,
+            response_create_gate=response_create_gate,
+        )
     )
+    await asyncio.wait_for(release_started.wait(), timeout=1)
+    if cancel_during_release:
+        processing.cancel()
+        processing.cancel()
+    finish_release.set()
+    if cancel_during_release:
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(processing, timeout=1)
+        release_events.append("cancel-reraised")
+        assert release_events == ["release-start", "release-finish", "cancel-reraised"]
+        assert await service._load_balancer.account_pressure_snapshot(old_account.id) == (0, 0, 0.0)
+        return
+    downstream_text = await asyncio.wait_for(processing, timeout=1)
 
     assert downstream_text == json.dumps(upstream_payload, separators=(",", ":"))
     finalize_request_state.assert_not_awaited()

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -187,8 +187,10 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
     request_sent = asyncio.Event()
     cleanup_started = asyncio.Event()
     cleanup_cancelled = asyncio.Event()
+    cleanup_budget_exceeded = asyncio.Event()
     release_cleanup = asyncio.Event()
     cleanup_request_ids: list[str] = []
+    connection_lease = object()
 
     class _BlockingDownstreamWebSocket:
         def __init__(self) -> None:
@@ -239,7 +241,12 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
         state.response_create_gate_acquired = True
         state.awaiting_response_created = True
 
-    async def connect_upstream(*_args: object, **_kwargs: object) -> tuple[Account, UpstreamWebSocket]:
+    async def connect_upstream(
+        *_args: object,
+        request_state: proxy_service._WebSocketRequestState,
+        **_kwargs: object,
+    ) -> tuple[Account, UpstreamWebSocket]:
+        request_state.websocket_stream_lease = cast(Any, connection_lease)
         account = cast(Account, SimpleNamespace(id="account_pending_cleanup", codex_installation_id=None))
         return account, cast(UpstreamWebSocket, upstream)
 
@@ -272,7 +279,16 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
     monkeypatch.setattr(service, "_relay_upstream_websocket_messages", relay_until_cancelled)
     monkeypatch.setattr(service, "_acquire_account_response_create_lease_or_overload", AsyncMock(return_value=object()))
     monkeypatch.setattr(service, "_fail_pending_websocket_requests", block_cleanup)
-    monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    original_warning = proxy_service.logger.warning
+
+    def observe_cleanup_warning(message: str, *args: object, **kwargs: Any) -> None:
+        if message.startswith("Websocket scope cleanup exceeded its cleanup budget"):
+            cleanup_budget_exceeded.set()
+        original_warning(message, *args, **kwargs)
+
+    monkeypatch.setattr(proxy_service.logger, "warning", observe_cleanup_warning)
 
     scope_task = asyncio.create_task(
         service.proxy_responses_websocket(
@@ -290,9 +306,10 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
     started_at = asyncio.get_running_loop().time()
     scope_task.cancel()
     await asyncio.wait_for(cleanup_started.wait(), timeout=1)
-    await asyncio.sleep(0.01)
+    await asyncio.wait_for(cleanup_budget_exceeded.wait(), timeout=1)
     assert scope_task.done() is False
 
+    release_cleanup.set()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(scope_task, timeout=1)
     elapsed = asyncio.get_running_loop().time() - started_at
@@ -301,20 +318,11 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
     assert cleanup_request_ids == [request_state.request_id]
     assert 0.05 <= elapsed < 0.3
     assert any(
-        task.get_name() == "proxy-websocket-finalization-scope-cleanup"
-        for task in service._background_cleanup_tasks
-        if not task.done()
-    )
-    assert any(
         "Websocket scope cleanup exceeded its cleanup budget" in message and "cleanup_phase=pending_requests" in message
         for message in caplog.messages
     )
-
-    persistence_drain = asyncio.create_task(service.drain_persistence_tasks(timeout_seconds=1))
-    await asyncio.sleep(0)
-    assert persistence_drain.done() is False
-    release_cleanup.set()
-    assert await asyncio.wait_for(persistence_drain, timeout=1)
+    release_account_lease.assert_awaited_once_with(connection_lease)
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert service._background_cleanup_tasks == set()
 
 
@@ -740,12 +748,11 @@ async def test_cancelled_scope_isolates_owned_reconnect_child_failure_and_finish
     await asyncio.wait_for(child_started.wait(), timeout=1)
 
     scope_task.cancel()
-    await asyncio.sleep(0)
+    scope_task.cancel()
     release_child.set()
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(scope_task, timeout=1)
-    await asyncio.sleep(0)
 
     assert upstream.sent_text == []
     assert [request_id for attempt in cleanup_attempts for request_id in attempt] == [
@@ -946,6 +953,83 @@ async def test_drain_start_during_admission_rejects_turn_before_connect_or_send(
             "Failed to release websocket account create lease during terminal cleanup request_id=request_late_drain"
             in caplog.messages
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancellation_mode", ["edge", "level"])
+async def test_response_create_release_failure_reraises_cancellation_after_erased_cleanup(
+    caplog: pytest.LogCaptureFixture,
+    cancellation_mode: str,
+) -> None:
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    request_state = _request_state("request_cancelled_failed_create_release")
+    request_state.response_create_gate = gate
+    request_state.response_create_gate_acquired = True
+    request_state.awaiting_response_created = True
+    account_create_lease = object()
+    request_state.account_response_create_lease = cast(Any, account_create_lease)
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    release_events: list[str] = []
+    cancel_scopes: list[anyio.CancelScope] = []
+
+    async def fail_release(lease: object | None) -> None:
+        assert lease is account_create_lease
+        assert request_state.account_response_create_lease is None
+        assert request_state.account_response_create_release is None
+        release_events.append("release-start")
+        release_started.set()
+        await finish_release.wait()
+        release_events.append("release-failed")
+        raise RuntimeError("account create release failed")
+
+    async def release_ownership() -> bool:
+        async def release_and_reraise() -> None:
+            cancellation = await websocket_mixin._release_websocket_response_create_ownership_for_cleanup(
+                request_state,
+                gate,
+            )
+            if cancellation is not None:
+                raise cancellation
+
+        if cancellation_mode == "level":
+            with anyio.CancelScope() as cancel_scope:
+                cancel_scopes.append(cancel_scope)
+                try:
+                    await release_and_reraise()
+                except asyncio.CancelledError:
+                    release_events.append("cancel-reraised")
+                    return True
+            return False
+        await release_and_reraise()
+        return True
+
+    request_state.account_response_create_release = cast(Any, fail_release)
+    caplog.set_level(logging.WARNING)
+    cleanup = asyncio.create_task(release_ownership())
+    await asyncio.wait_for(release_started.wait(), timeout=1)
+
+    if cancellation_mode == "level":
+        cancel_scopes[0].cancel()
+        finish_release.set()
+        assert await asyncio.wait_for(cleanup, timeout=1)
+    else:
+        cleanup.cancel()
+        cleanup.cancel()
+        finish_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(cleanup, timeout=1)
+        release_events.append("cancel-reraised")
+
+    assert release_events == ["release-start", "release-failed", "cancel-reraised"]
+    assert gate.locked() is False
+    assert request_state.response_create_gate is None
+    assert request_state.account_response_create_lease is None
+    assert (
+        "Failed to release websocket account create lease during terminal cleanup "
+        "request_id=request_cancelled_failed_create_release" in caplog.messages
+    )
 
 
 @pytest.mark.asyncio
@@ -1804,9 +1888,11 @@ async def test_reader_cancellation_after_transport_end_claim_waits_for_child_own
 
 
 @pytest.mark.asyncio
-async def test_scope_cancellation_finalizes_turn_when_connection_lease_release_fails(
+@pytest.mark.parametrize("release_fails", [False, True], ids=["release-succeeds", "release-fails"])
+async def test_scope_repeated_cancellation_finishes_erased_connection_lease_release(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    release_fails: bool,
 ) -> None:
     request_logs = _RequestLogsRecorder()
 
@@ -1867,6 +1953,9 @@ async def test_scope_cancellation_finalizes_turn_when_connection_lease_release_f
     captured_response_create_gate: asyncio.Semaphore | None = None
     upstream_send_completed = asyncio.Event()
     upstream_closed = asyncio.Event()
+    connection_release_started = asyncio.Event()
+    finish_connection_release = asyncio.Event()
+    connection_release_events: list[str] = []
 
     class _Downstream:
         def __init__(self) -> None:
@@ -1954,7 +2043,13 @@ async def test_scope_cancellation_finalizes_turn_when_connection_lease_release_f
     async def release_lease(lease: object | None) -> None:
         release_calls.append(lease)
         if lease is connection_lease:
-            raise RuntimeError("connection lease release failed")
+            assert request_state.websocket_stream_lease is None
+            connection_release_events.append("release-start")
+            connection_release_started.set()
+            await finish_connection_release.wait()
+            connection_release_events.append("release-finish")
+            if release_fails:
+                raise RuntimeError("connection lease release failed")
 
     async def release_reservation(
         reservation_to_release: ApiKeyUsageReservationData | None,
@@ -1990,11 +2085,19 @@ async def test_scope_cancellation_finalizes_turn_when_connection_lease_release_f
     await asyncio.wait_for(upstream_send_completed.wait(), timeout=1)
 
     scope_task.cancel()
+    await asyncio.wait_for(connection_release_started.wait(), timeout=1)
+    second_cancellation_processed = asyncio.get_running_loop().create_future()
+    scope_task.cancel()
+    asyncio.get_running_loop().call_soon(second_cancellation_processed.set_result, None)
+    await asyncio.wait_for(second_cancellation_processed, timeout=1)
+    assert scope_task.done() is False
+    finish_connection_release.set()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(scope_task, timeout=1)
+    connection_release_events.append("cancel-reraised")
     assert await service.drain_persistence_tasks(timeout_seconds=1)
-    await asyncio.sleep(0)
 
+    assert connection_release_events == ["release-start", "release-finish", "cancel-reraised"]
     assert release_calls.count(account_create_lease) == 1
     assert release_calls.count(connection_lease) == 1
     assert admission_releases == [request_state.request_id]
@@ -2006,7 +2109,10 @@ async def test_scope_cancellation_finalizes_turn_when_connection_lease_release_f
     assert len(request_logs.calls) == 1
     assert request_logs.calls[0]["request_id"] == request_state.request_id
     assert request_logs.calls[0]["status"] == "cancelled"
-    assert "Failed to release websocket connection lease during scope cleanup" in caplog.messages
+    if release_fails:
+        assert "Failed to release websocket connection lease during scope cleanup" in caplog.messages
+    else:
+        assert "Failed to release websocket connection lease during scope cleanup" not in caplog.messages
     assert service._background_cleanup_tasks == set()
 
 


### PR DESCRIPTION
## Summary

Ensure direct WebSocket account connection, stream, and response-create leases finish releasing exactly once before repeated or level cancellation is propagated. Terminal finalization releases the complete claimed lease batch before unrelated terminal I/O.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] **Breaking change**

Linked issue: Related to #1711 (partial reliability fix; does not fully resolve that report). Historical context: #1281.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/defer-websocket-lease-release-cancellation/`

## Changes

- Relocate the existing cancellation-deferring task helper to common proxy support without changing its streaming semantics.
- Clear direct WebSocket lease ownership before release, finish the owned release task, then propagate cancellation.
- Gate terminal and scope callers on the lease-release ownership phase while preserving bounded ancillary cleanup and existing release-failure handling.
- Add event-gated connect, terminal-batch, response-create, and scope lifecycle regressions with no timing sleeps.

## Simplicity

- [x] No new setting, required setup, README section, `.env.example` entry, dashboard navigation, dependency, or default change.

## Test plan

```text
# Deterministic RED-derived WebSocket seam nodes
# 11 passed

make lint
# proxy architecture checks passed; Ruff check/format passed

ty check <changed Python files>
# All checks passed

openspec validate defer-websocket-lease-release-cancellation --strict
openspec validate proxy-admission-control --strict
# Both valid
```

The full repository strict-spec sweep remains baseline-red in eight unrelated existing specs; the changed OpenSpec and affected main capability validate strictly.

Lifecycle driver:

```json
{"events":["release-start","release-finish","cancel-reraised"],"ownership_cleared":true,"release_count":1}
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related issue context is linked without claiming full resolution.
- [x] Added tests covering the direct WebSocket product path.
- [x] Ran the relevant local lint, type, test, and OpenSpec gates.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited.

Related implementation: #1986 handles the separate Live transport and explicitly leaves direct WebSocket cleanup to this focused PR. Both use the same common helper relocation; this branch does not depend on the Live branch at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket cancellation handling so connection, stream, and response cleanup completes reliably before cancellation is propagated.
  * Ensured repeated cancellation does not abandon or duplicate lease releases.
  * Added bounded waits when cleanup exceeds its available time.

* **Tests**
  * Expanded coverage for repeated cancellation, cleanup failures, lease-release ordering, and terminal WebSocket cleanup scenarios.

* **Documentation**
  * Added design and capability documentation for cancellation-safe WebSocket lease cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->