### PR TITLE
chore: release v1.25.0-beta.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.1"  # x-release-please-version
+__version__ = "1.25.0-beta.2"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.1
-appVersion: 1.25.0-beta.1
+version: 1.25.0-beta.2
+appVersion: 1.25.0-beta.2
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.1",
+  "version": "1.25.0-beta.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.1"
+version = "1.25.0-beta.2"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0b1"
+version = "1.25.0-beta.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.2 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.2 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.1
- fix(proxy): quarantine the bridge key when the retry circuit opens on a poisoned anchor (#1891) (b5adf35)
- fix(db): skip SQLite scan after verified clean shutdown (#1907) (
d35799)
- fix(proxy): preserve stale-anchor error shape presence (#1955) (
03515b)
- fix(proxy): preserve recovery spool fence during local rebind (#1956) (
48ea38)
- fix(images): release API-key reservation when cancelled before first SSE frame (#1970) (
8297d1)
- fix(security): bind firewall to raw peer (#1987) (
40fda3)
- fix(middleware): bound zstd decoded output (#1983) (
601f17)
- fix(helm): default global backpressure off (#1984) (
267bca)
- fix(oauth): fence stale dashboard poll generations (#1985) (
32e45f)
- fix(api-keys): enforce generated key format (#1980) (
45ac3e)
- fix(api-keys): serve unslashed collection routes (#1982) (
3ea07e)
- fix(proxy): recover Codex edge-challenge WebSocket failures (#1994) (
b1f099)
- fix(auth): keep reauth-required accounts routable (#1877) (
182966)
- feat(dashboard): weekly runway model + per-key burn attribution (#1797) (
ebd2e5)
- feat(nix): add flake.nix (#1948) (
fcdd63)
- feat(dashboard): redesign weekly pace card as runway timeline (#1798) (
0bade4)
- feat(ui): persisted dashboard refresh cadence and smooth quota percent (#1996) (
973770)
- feat(proxy): add native Codex traffic parity (#1995) (
82a58a)
- fix(transcribe): make subscription transcription reservation release cancellation-safe (#1966) (
a6b499)
- fix(proxy): defer Live cancellation through lease release (#1986) (
0e0782)
- fix(proxy): type required HTTP-bridge reconnect owner provenance (#1988) (
4440a5)
- fix(auth): reject duplicate trusted identity fields (#2010) (
695ece)
- fix(oauth): stop callback query secrets from reaching logs (#2011) (
000201)
- fix(api): preserve OpenAI root error envelopes (#2013) (
8c4f5a)
- fix(proxy): release reset-credit claims on cancellation (#2015) (
630c3a)
- fix(proxy): preserve warmup usage on cancellation (#2016) (
9c3306)
- fix(request-logs): keep rolling windows current (#2019) (
58665a)
- fix(metrics): aggregate latency histogram buckets (#2020) (
23f106)
- fix(config): reject invalid operator values (#2023) (
3eafbc)
- fix(proxy): cancel uvicorn keep-alive timer on every connection_lost and lower --timeout-keep-alive default (
02b61d)
- fix(proxy): release the aiohttp ClientResponse when a routed SSE stream stops before EOF (
8afe06)
- perf(proxy): share one process-wide SSLContext across per-call Codex sessions (
862efa)
- perf(proxy-responses): stamp the account installation id once per request via identity memo and client_metadata splice (
0b127a)
- perf(proxy): replace the last BaseHTTPMiddleware (image route started_at) with a pure ASGI middleware (
d771aa)
- perf(proxy-responses): compute to_payload once per bridge prepare and early-exit the 8 KiB usage estimate (
f39539)
- perf(dashboard): bound projection history to the EWMA tail plus a 3h floor and cheapen per-row hydration/signature (
4808f6)
- perf(proxy-responses): parse each bridge SSE event once and relay unchanged upstream JSON text without re-dump (
55db6d)
- perf(proxy-responses): reuse the reader wakeup task and use fast_acquire locks in the HTTP-bridge relay loop (
2cf2ef)
- perf(proxy): clone selection-cache Account/UsageHistory rows via new_instance + instance_dict instead of the ORM constructor (
4d6fad)
- perf(proxy): stop deep-validating and re-dumping passthrough JSON fields (input/tools/messages) in request models (
972a73)
- fix(proxy): keep proxy credentials out of aiohttp ConnectionKey and redact URL userinfo in rendered logs (
9c188d)
- fix(logging): redact secrets in asyncio loop exception-handler context and harden proxy username validation (
6ecbd8)
- fix(audit): restrict log access to admins (#2022) (
0ca5c7)
- fix(api-keys): prevent caching returned secrets (#2021) (
a07ce5)
- fix(proxy): prevent level-cancellation busy spins (#1958) (
887cba)
- fix(dashboard): recover failed routes (#2018) (
628b62)
- fix(proxy): retire cooldown-suppressed HTTP bridge sessions (#2072) (
018659)
- fix(http-bridge): abandon expired ambiguous operations (#2071) (
dd28d7)
- fix(metrics): bound request metric path and method label cardinality (#1967) (
fed547)
- fix(proxy): settle keyed streams before health (#1989) (
da1dce)
- fix(proxy): settle accepted background JSON (#2014) (
b328cc)
- fix(proxy): report duplicate tool-call replay terminal (#2082) (
be9fa0)
- fix(http-bridge): reject unsafe forwarded headers (#2087) (
63ac6a)
- fix(proxy): normalize native HTTP compression (#2012) (
dee12b)
- fix(dashboard): recover from overview load errors (#2017) (
80265f)
- fix(logging): bound secret patterns to the current line (#2091) (
8d02c8)
- fix(openspec): repair and enforce canonical validation (#2025) (
1c54f9)
- fix(proxy): normalize SDK transcription headers (#2031) (
e9100e)
- fix(compact): fail over revoked refresh accounts (#2080) (
b2c5ff)
- fix(proxy): forward canonical prompt-cache continuations (#2036) (
aec4d7)
- fix(usage): deactivate accounts only on explicit terminal signals, not bare 404/402 (#2055) (
caad3d)
- fix(proxy): ignore detached durable bridge rows as continuity owner evidence (#2063) (
7e1c1e)
- fix(http-bridge): treat usage_limit_reached as a terminal in the account capacity wait (#2124) (
80ea67)
- feat(usage): coalesced on-demand account refresh after usage_limit_reached (#2125) (
35ccf8)
- fix(deps): require anyio>=4.14 to close Lock cancelled-waiter deadlock (#2129) (
c08517)
- fix(proxy): stop level-cancel cascade from respinning deferred probe cleanup (#2130) (
8dc74b)

## Release-candidate validation
Validated candidate: e75930a46f692652365b015aa10c05a256cd9611

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run [34109773669](https://github.com/Soju06/codex-lb/actions/runs/34109773669) green on the candidate SHA: pytest unit / integration-core-1..3 / integration-bridge / e2e / PostgreSQL, alembic migration checks (sqlite + PostgreSQL), ruff, ty, Rust workspace; the two fixes in this train (#2129, #2130) additionally ran the full local unit suite (8062/8063 passed, only pre-existing `main` failures)
- [x] Frontend tests/build — same CI run green: vite build, vitest + coverage, tsc, eslint, Playwright dashboard smoke
- [x] Wheel/package validation — CI `Package (build)` green; additionally `uv build` from this exact SHA produced `codex_lb-1.25.0b2-py3-none-any.whl`, installed into a clean CPython 3.14 venv: `app.__version__ == "1.25.0-beta.2"`, `codex-lb==1.25.0b2`, `anyio==4.15.1`
- [x] Docker/container smoke — CI `Docker build` + `Helm smoke install (kind)` green; additionally built the image locally from this exact SHA and booted it (sqlite, `docker run`): `/health/ready` 200 after ~22s, `/health` `{"status":"ok"}`, `/health/startup` 200, unauthenticated `/v1/models` and `/api/accounts` 401 (`invalid_api_key` / dashboard auth), migration head `20260830_000000_add_quota_warmup_claim_expiry` current, `app.__version__ == 1.25.0-beta.2`, anyio 4.15.1 inside the image, zero ERROR/CRITICAL/Traceback lines and zero loop-lag warnings after 20s idle; verified the #2129/#2130 code paths are present in `/app`
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this train's headline changes are backend-internal resilience fixes (#2129 anyio Lock cancelled-waiter deadlock via dependency floor, #2130 level-cancel cascade busy spin); live validation happens at the soju07 zdt deploy with its 180s observation window and auto-rollback

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b2" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.2
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.2 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

