### PR TITLE
refactor(core): consolidate defer-cancellation waits into one canonical helper

### DIFF
--- a/app/core/utils/shared_future.py
+++ b/app/core/utils/shared_future.py
@@ -20,6 +20,7 @@ touch the shared future's callback list.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 from typing import TypeVar, cast
 
 import anyio
@@ -116,3 +117,20 @@ async def _await_task_deferring_cancellation(
         except asyncio.CancelledError as exc:
             cancellation = exc
     return cast(_TaskResultT, result), cancellation
+
+
+async def _await_result_deferring_cancellation(
+    awaitable: "Awaitable[_TaskResultT]",
+) -> tuple[_TaskResultT, asyncio.CancelledError | None]:
+    """``_await_task_deferring_cancellation`` for a bare awaitable."""
+
+    return await _await_task_deferring_cancellation(asyncio.ensure_future(awaitable))
+
+
+async def _await_cleanup_deferring_cancellation(
+    awaitable: "Awaitable[object]",
+) -> asyncio.CancelledError | None:
+    """Finish required cleanup, returning the deferred cancellation marker."""
+
+    _, cancellation = await _await_result_deferring_cancellation(awaitable)
+    return cancellation

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool
 
 from app.core.config.settings import get_settings
+from app.core.utils.shared_future import _await_cleanup_deferring_cancellation
 from app.db.sqlite_utils import (
     IntegrityCheck,
     SqliteFileIdentity,
@@ -513,17 +514,7 @@ def mark_sqlite_shutdown_clean() -> None:
 
 
 async def _shielded(awaitable: Awaitable[object]) -> None:
-    task = asyncio.ensure_future(awaitable)
-    cancellation: asyncio.CancelledError | None = None
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                await asyncio.shield(task)
-                break
-            except asyncio.CancelledError as exc:
-                if task.cancelled():
-                    raise
-                cancellation = cancellation or exc
+    cancellation = await _await_cleanup_deferring_cancellation(awaitable)
     if cancellation is not None:
         raise cancellation
 

--- a/app/modules/model_sources/forwarding.py
+++ b/app/modules/model_sources/forwarding.py
@@ -10,12 +10,14 @@ from math import isfinite
 from typing import cast
 
 import aiohttp
-import anyio
 
 from app.core.clients.http import lease_http_session
 from app.core.crypto import TokenEncryptor
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_mapping
+from app.core.utils.shared_future import (
+    _await_cleanup_deferring_cancellation as _shared_await_cleanup_deferring_cancellation,
+)
 from app.db.models import ModelSource
 
 _DEFAULT_SOURCE_TIMEOUT_SECONDS = 600
@@ -113,32 +115,13 @@ class SourceUsageHolder:
 async def _await_cleanup_deferring_cancellation(awaitable: Awaitable[object]) -> None:
     """Finish owned upstream cleanup even if the caller is cancelled again."""
 
-    task = asyncio.ensure_future(awaitable)
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                await asyncio.shield(task)
-                return
-            except asyncio.CancelledError:
-                if task.cancelled():
-                    raise
+    await _shared_await_cleanup_deferring_cancellation(awaitable)
 
 
 async def _await_result_deferring_cancellation(awaitable: Awaitable[object]) -> bool:
     """Finish owned cleanup and report whether cancellation arrived mid-flight."""
 
-    task = asyncio.ensure_future(awaitable)
-    cancellation_deferred = False
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                await asyncio.shield(task)
-                return cancellation_deferred
-            except asyncio.CancelledError:
-                if task.cancelled():
-                    raise
-                cancellation_deferred = True
-    raise RuntimeError("unreachable shielded cancellation-deferral state")
+    return await _shared_await_cleanup_deferring_cancellation(awaitable) is not None
 
 
 async def forward_chat_completion(

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -14,6 +14,7 @@ from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
 from app.core.openai.models import CompactResponsePayload
 from app.core.utils.request_id import get_request_id
+from app.core.utils.shared_future import wait_on_shared_future
 from app.db.models import Account
 from app.modules.api_keys.service import (
     API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
@@ -208,10 +209,11 @@ class _ApiKeyUsageMixin:
         drain the same request state concurrently without applying a penalty
         twice or corrupting the queue.
 
-        Each attempt runs as an owned task awaited through ``asyncio.shield``
-        (the ``_await_task_deferring_cancellation`` pattern; importing it from
-        ``http_bridge.helpers`` would cycle through that module's import of
-        this one). Caller cancellation therefore cannot abandon a
+        Each attempt runs as an owned task awaited through
+        ``wait_on_shared_future`` (the ``_await_task_deferring_cancellation``
+        pattern, inlined because the cancelled-attempt path must re-queue the
+        claimed penalty before re-raising). Caller cancellation therefore
+        cannot abandon a
         half-applied penalty for a later drain to replay: every claimed entry
         is drained to completion first — no later path owns the queue once
         terminal ownership is relinquished — and the cancellation re-raises
@@ -228,8 +230,8 @@ class _ApiKeyUsageMixin:
         penalties = request_state.deferred_keyed_stream_health
         # The anyio shield keeps a level-cancelled Starlette scope from
         # re-raising into every ``await``, which would otherwise busy-spin
-        # this loop until the owned task completes; the inner asyncio.shield
-        # loop defers edge task cancellation the same way.
+        # this loop until the owned task completes; the inner wait loop
+        # defers edge task cancellation the same way.
         with anyio.CancelScope(shield=True):
             while penalties:
                 penalty = penalties.pop(0)
@@ -238,7 +240,10 @@ class _ApiKeyUsageMixin:
                 )
                 while True:
                     try:
-                        await asyncio.shield(apply_task)
+                        # wait_on_shared_future keeps repeated waits off the
+                        # task's done-callback list (3.14 shield leaks one per
+                        # cancelled wait).
+                        await wait_on_shared_future(apply_task)
                         break
                     except asyncio.CancelledError as exc:
                         if apply_task.cancelled():
@@ -510,7 +515,7 @@ class _ApiKeyUsageMixin:
             )
             while not fallback_task.done():
                 try:
-                    await asyncio.shield(fallback_task)
+                    await wait_on_shared_future(fallback_task)
                 except asyncio.CancelledError:
                     # Keep waiting for the owned fallback. Cancellation is not
                     # a failed release; retry only when the fallback itself is
@@ -584,7 +589,7 @@ class _ApiKeyUsageMixin:
             with anyio.CancelScope(shield=True):
                 while True:
                     try:
-                        settlement_committed = await asyncio.shield(task)
+                        settlement_committed = await wait_on_shared_future(task)
                         break
                     except asyncio.CancelledError:
                         # Caller cancellation must not race fallback release

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -8,6 +8,7 @@ from collections.abc import Coroutine, Mapping
 from typing import Any, Protocol, cast
 
 import anyio
+from anyio.lowlevel import checkpoint_if_cancelled
 
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
@@ -260,6 +261,15 @@ class _ApiKeyUsageMixin:
                             exc_info=True,
                         )
                         break
+        if deferred_cancellation is None:
+            # The shield also blocks the level cancellation this drain
+            # promises to re-raise after the queue empties. Probe without
+            # suspending so it surfaces here instead of at an arbitrary
+            # later checkpoint.
+            try:
+                await checkpoint_if_cancelled()
+            except asyncio.CancelledError as exc:
+                deferred_cancellation = exc
         if deferred_cancellation is not None:
             raise deferred_cancellation
 

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -5,7 +5,7 @@ import json
 import sys
 import time
 from collections import deque
-from collections.abc import Awaitable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -60,6 +60,9 @@ from app.core.openai.requests import (
     extract_input_file_ids,
 )
 from app.core.types import JsonValue
+from app.core.utils.shared_future import (
+    _await_cleanup_deferring_cancellation as _await_cleanup_deferring_cancellation,
+)
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.core.utils.time import to_utc_naive, utcnow
@@ -1856,23 +1859,6 @@ async def _release_websocket_response_create_gate(
     response_create_gate.release()
     if cancellation is not None:
         raise cancellation
-
-
-async def _await_cleanup_deferring_cancellation(awaitable: Awaitable[object]) -> asyncio.CancelledError | None:
-    """Finish response-create lease cleanup before propagating cancellation."""
-
-    task = asyncio.ensure_future(awaitable)
-    cancellation: asyncio.CancelledError | None = None
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                await asyncio.shield(task)
-                break
-            except asyncio.CancelledError as exc:
-                cancellation = cancellation or exc
-                if task.cancelled():
-                    raise
-    return cancellation
 
 
 def _pop_terminal_websocket_request_state(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -158,6 +158,12 @@ from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.json_guards import is_json_list, is_json_mapping
 from app.core.utils.request_id import ensure_request_id, get_request_id
+from app.core.utils.shared_future import (
+    _await_cleanup_deferring_cancellation as _shared_await_cleanup_deferring_cancellation,
+)
+from app.core.utils.shared_future import (
+    _await_result_deferring_cancellation as _shared_await_result_deferring_cancellation,
+)
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
@@ -2207,23 +2213,14 @@ async def _release_reservation_deferring_cancellation(
 async def _await_result_deferring_cancellation(awaitable: Awaitable[_T]) -> tuple[_T, bool]:
     """Finish an owned awaitable despite repeated cancellation and report whether cancellation arrived."""
 
-    task = asyncio.ensure_future(awaitable)
-    cancellation_deferred = False
-    with anyio.CancelScope(shield=True):
-        while True:
-            try:
-                return await asyncio.shield(task), cancellation_deferred
-            except asyncio.CancelledError:
-                if task.cancelled():
-                    raise
-                cancellation_deferred = True
-    raise RuntimeError("unreachable shielded cancellation-deferral state")
+    result, cancellation = await _shared_await_result_deferring_cancellation(awaitable)
+    return result, cancellation is not None
 
 
 async def _await_cleanup_deferring_cancellation(awaitable: Awaitable[object]) -> None:
     """Finish a required cleanup operation despite repeated cancellation delivery."""
 
-    await _await_result_deferring_cancellation(awaitable)
+    await _shared_await_cleanup_deferring_cancellation(awaitable)
 
 
 async def _rate_limit_headers_with_reservation_cleanup(

--- a/openspec/changes/consolidate-defer-cancellation-waits/.openspec.yaml
+++ b/openspec/changes/consolidate-defer-cancellation-waits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/consolidate-defer-cancellation-waits/proposal.md
+++ b/openspec/changes/consolidate-defer-cancellation-waits/proposal.md
@@ -1,0 +1,55 @@
+# Consolidate defer-cancellation waits into the canonical helper
+
+## Why
+
+Six hand-rolled copies of the defer-cancellation wait loop drifted apart
+until the one copy without the busy-spin guard livelocked production
+(2026-08-30, #1968). #1955 moved the hardened http-bridge/retry copy into
+`app/core/utils/shared_future.py`; this change routes the remaining copies
+(proxy api, model-sources forwarding, websocket helpers, db session
+`_shielded`) and the inline `api_key_usage` shield loops through it, so a
+divergent copy cannot be reintroduced silently. CodeRabbit review of #1993
+also flagged that the `command_timeout` requirement overpromised an
+unconditional lock-release bound: asyncpg's post-timeout cancellation
+handshake itself talks to the server, so a fully blackholed peer can outlive
+the bound — the requirement is qualified accordingly.
+
+## What Changes
+
+- Route every defer-cancellation wait through the canonical shared-future
+  helper: alias imports where the shape matches (websocket helpers),
+  two-line adapters where callers consume a bool marker or re-raise
+  (proxy api, forwarding, db session `_shielded`), and
+  `wait_on_shared_future` inside the site-specific `api_key_usage` loops.
+- Surface the deferred-cancellation marker uniformly: the api/forwarding/db
+  shapes now report a level-cancelled scope (previously silently suppressed
+  until the caller's next checkpoint) exactly as the canonical helper does.
+- Qualify the `database-backends` statement-bound requirement: best-effort
+  against a blackholed peer; lock discipline stays the primary defense.
+- Pin the alias imports to the canonical implementation with an
+  identity-equality regression test.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: defer-cancellation waits share the canonical
+  implementation; the deferred-cancellation marker surfaces through every
+  marker shape.
+- `database-backends`: qualify the `command_timeout` lock-release claim as
+  best-effort against a blackholed peer; lock discipline is not relaxed.
+
+## Impact
+
+- No API or contract changes. Cleanup ownership semantics unchanged: owned
+  tasks are never cancelled by waiters; owned-task cancellation and
+  exceptions propagate unchanged.
+- Level cancellation during api/forwarding/db defer waits now surfaces as
+  the marker after cleanup (deterministic re-raise point) instead of at the
+  caller's next checkpoint — same eventual outcome, strictly harder to
+  mis-handle.
+- Net negative line count; no new settings.

--- a/openspec/changes/consolidate-defer-cancellation-waits/specs/database-backends/spec.md
+++ b/openspec/changes/consolidate-defer-cancellation-waits/specs/database-backends/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: PostgreSQL engines validate and recycle pooled connections
+
+When `database_url` resolves to a PostgreSQL backend, the application MUST configure each async engine — both the request-path `engine` and the optional background-task `_background_engine` — with `pool_pre_ping=True` and a finite `pool_recycle` window. This is required so the application detects connections that the PostgreSQL server has silently closed (idle timeout, restart, network reset) before the first real query is dispatched on them, and so connections are cycled before they reach any reasonable upstream keep-alive boundary. The recycle window is the fixed 1800-second application constant in `app/db/session.py`.
+
+Each PostgreSQL statement MUST additionally be bounded by the fixed asyncpg `command_timeout` application constant in `app/db/session.py`, so a query stalled on a half-dead connection surfaces as an error within the bound instead of awaiting indefinitely — pre-ping only protects the first statement after checkout, not a connection that dies mid-statement. This bound covers the dominant stall (a dispatched statement whose response never arrives); asyncpg's timeout handling then cancels the statement and raises to the caller, releasing whatever application lock the caller held. The bound is best-effort against a fully blackholed peer: asyncpg's post-timeout cancellation handshake itself talks to the server, so lock-discipline requirements (resolving settings/DB inputs before acquiring application locks) remain the primary defense and MUST NOT be relaxed on the strength of this bound. Alembic migrations run on their own synchronous engine and are not subject to this bound.
+
+#### Scenario: Stale connections are rejected before checkout
+
+- **WHEN** a pooled connection has been closed by the server while sitting idle
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy issues a pre-ping (`SELECT 1`), detects the dead connection, and transparently replaces it
+- **AND** the application returns `200` (or the real business-level result), not `500 server_error` with `asyncpg.InterfaceError: connection is closed`
+
+#### Scenario: Pool recycle bounds connection age
+
+- **WHEN** a pooled connection has been open longer than the fixed 1800-second recycle window
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy discards and replaces the connection before the next query
+
+#### Scenario: Mid-statement connection death cannot wedge its caller
+
+- **WHEN** a statement's connection dies after dispatch (network partition, half-dead peer) and no response arrives, while the server remains reachable for the cancellation handshake
+- **THEN** asyncpg cancels the statement and raises within the fixed `command_timeout` bound
+- **AND** any application lock held by the caller is released when the error propagates
+
+#### Scenario: The statement bound does not license DB awaits under application locks
+
+- **GIVEN** a code path that would await a settings or database read while holding an application lock
+- **WHEN** the path is reviewed against the lock-discipline requirements
+- **THEN** the `command_timeout` bound is not accepted as a substitute for resolving the read before acquiring the lock
+
+#### Scenario: SQLite backends are not affected
+
+- **WHEN** `database_url` resolves to a SQLite backend (file or `:memory:`)
+- **THEN** neither `pool_pre_ping`, `pool_recycle`, nor `command_timeout` is configured on the engine
+- **AND** existing SQLite-specific tuning (PRAGMAs, `busy_timeout`) is unchanged

--- a/openspec/changes/consolidate-defer-cancellation-waits/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/consolidate-defer-cancellation-waits/specs/proxy-admission-control/spec.md
@@ -1,0 +1,85 @@
+## MODIFIED Requirements
+
+### Requirement: Admission waits on shared futures scale O(1) per waiter
+
+When multiple requests wait on one shared future (an inflight bridge session creation, a capacity slot, a token-refresh singleflight, or a usage-refresh singleflight), the system MUST use the established shared-future fan-out wait mechanism so attaching a waiter, a waiter timing out, and a waiter being cancelled each perform O(1) work on the shared future. The shared future MUST carry a constant number of done callbacks regardless of waiter count, and the wait mechanism itself MUST NOT cancel or otherwise mutate the shared future or the work it represents when a waiter times out or is cancelled. Admission handlers MAY still settle the shared future explicitly after a waiter's timeout (the http-bridge timeout handler fails and unregisters the inflight future so piled-up waiters converge on one overload outcome); that settlement is an admission-contract decision, not a side effect of waiting. The shared future's result, exception, or cancellation MUST propagate to every waiter with the same semantics as `asyncio.wait_for(asyncio.shield(shared), timeout)`.
+
+The same bounded-callback contract applies to waits that re-attach to one owned task repeatedly: defer-cancellation waits on owned cleanup tasks, repeated timed waits such as SSE keepalive ticks on a pending chunk task, and bounded teardown drains. A defer-cancellation wait MUST shield itself from level-cancelled scopes so re-delivered cancellation cannot busy-spin the wait loop, MUST keep the owned task's done-callback count bounded by a constant regardless of how many times the waiter is cancelled or times out, MUST NOT cancel the owned task, MUST defer the caller's cancellation until the owned task finishes and then surface it, and MUST propagate the owned task's cancellation and exceptions unchanged.
+
+Every defer-cancellation wait MUST route through the one canonical shared-future helper (or, where site-specific control flow forces an inline loop, wait through the shared-future fan-out mechanism inside that loop) rather than a hand-rolled `asyncio.shield` retry. The deferred-cancellation surfacing above applies uniformly: a caller consuming a boolean or exception marker from any defer-cancellation wait MUST receive the marker for a level-cancelled scope as well as for edge task cancellation, so cleanup-then-cancel sequencing does not depend on which copy of the wait a call site reached.
+
+#### Scenario: Waiter pile-up keeps the shared future's callback list constant
+
+- **WHEN** many requests wait on the same inflight bridge-session future
+- **THEN** the shared future carries a constant number of done callbacks
+- **AND** the callback count does not grow with the number of waiters
+
+#### Scenario: Mass timeout does not degrade the event loop
+
+- **GIVEN** waiters piled onto a shared future that has not resolved within
+  the admission wait timeout
+- **WHEN** the waiters time out together
+- **THEN** each timeout detaches in O(1) without scanning the shared future's
+  callback list
+- **AND** the surviving admission contract (local-overload `429` with the
+  capacity error code) is unchanged
+
+#### Scenario: Client-disconnect storm leaves the owner's creation running
+
+- **WHEN** every waiter on an inflight session future is cancelled by client
+  disconnects
+- **THEN** the shared future stays pending and the owner's session creation
+  continues
+- **AND** no per-waiter callbacks remain attached to the shared future
+
+#### Scenario: Cancelled usage-refresh waiters leave shared refresh running
+
+- **GIVEN** many callers are waiting on one in-flight usage refresh
+- **WHEN** all but one caller are cancelled
+- **THEN** the cancelled callers detach without adding or removing per-waiter
+  callbacks on the shared refresh task
+- **AND** the shared refresh continues to completion for the remaining caller
+
+#### Scenario: Non-joining usage refresh starts after its predecessor
+
+- **GIVEN** a usage refresh is already in flight for an account
+- **WHEN** another caller requests a non-joining refresh for that account
+- **THEN** it waits without cancelling or mutating the in-flight refresh
+- **AND** it starts a successor refresh only after the in-flight refresh has
+  finished
+
+#### Scenario: Level-cancelled scope cannot spin a defer-cancellation wait
+
+- **GIVEN** a cleanup task owned by a defer-cancellation wait is still running
+- **WHEN** the waiter's scope is level-cancelled (client disconnect) while the
+  cleanup task remains pending
+- **THEN** the wait loop does not busy-spin on re-delivered cancellation
+- **AND** the cleanup task's done-callback count stays bounded by a constant
+- **AND** the cleanup task runs to completion before the caller's cancellation
+  is surfaced
+
+#### Scenario: Keepalive ticks leave the pending chunk task's callbacks bounded
+
+- **GIVEN** an SSE stream whose upstream produces no chunk for many keepalive
+  intervals
+- **WHEN** each keepalive tick's timed wait on the pending chunk task times out
+- **THEN** keepalive frames are emitted and the pending chunk task is not
+  cancelled
+- **AND** the pending chunk task's done-callback count does not grow with the
+  number of elapsed ticks
+
+#### Scenario: Every defer-cancellation wait shares the canonical implementation
+
+- **WHEN** any module performs a defer-cancellation wait on an owned task
+- **THEN** the wait routes through the canonical shared-future helper (or the
+  shared-future fan-out mechanism inside a site-specific loop)
+- **AND** no hand-rolled `asyncio.shield` retry loop remains
+
+#### Scenario: Level cancellation surfaces through every marker shape
+
+- **GIVEN** a caller in a level-cancelled scope awaiting an owned cleanup via
+  a defer-cancellation wait that reports a boolean or exception marker
+- **WHEN** the owned cleanup completes
+- **THEN** the marker reports the deferred cancellation
+- **AND** the caller can re-raise it deterministically after cleanup instead
+  of being interrupted at an arbitrary later checkpoint

--- a/openspec/changes/consolidate-defer-cancellation-waits/tasks.md
+++ b/openspec/changes/consolidate-defer-cancellation-waits/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## 1. Consolidation
+
+- [x] 1.1 Add `_await_result_deferring_cancellation` / `_await_cleanup_deferring_cancellation` wrappers next to the canonical `_await_task_deferring_cancellation` in `app/core/utils/shared_future.py`.
+- [x] 1.2 Route the remaining copies through them: websocket helpers (alias import), proxy api and model-sources forwarding (bool-marker adapters), db session `_shielded` (re-raise adapter).
+- [x] 1.3 Convert the inline `api_key_usage` shield loops (deferred keyed-health drain, fallback release, ordering-sensitive settle wait) to `wait_on_shared_future`, preserving their site-specific control flow.
+
+## 2. Spec Qualification
+
+- [x] 2.1 Qualify the `database-backends` `command_timeout` requirement: best-effort against a blackholed peer (asyncpg's cancellation handshake talks to the server); lock discipline remains the primary defense.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Identity-equality test pinning the alias imports to the canonical implementation.
+- [x] 3.2 Marker test: the api/forwarding bool adapters report a level-cancelled scope after cleanup completes.
+- [x] 3.3 Existing defer-leak, idle-leases, shared-future, db-session, forwarding, and websocket suites stay green.
+
+## 4. Verification
+
+- [x] 4.1 ruff format/check + ty on all touched files; strict OpenSpec validation.

--- a/tests/unit/test_defer_cancellation_shield_leak.py
+++ b/tests/unit/test_defer_cancellation_shield_leak.py
@@ -276,3 +276,31 @@ async def test_keyed_health_drain_keeps_apply_task_callbacks_bounded():
     release.set()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(waiter, timeout=1)
+
+
+async def test_keyed_health_drain_surfaces_level_cancellation_after_cleanup():
+    """The drain's shield blocks level cancellation; the post-shield probe
+    must still re-raise it once the queue empties (uniform marker contract)."""
+
+    from types import SimpleNamespace
+    from typing import Any, cast
+
+    from app.modules.proxy._service import api_key_usage as aku
+
+    async def quick_penalty(*_args: object) -> None:
+        await asyncio.sleep(0)
+
+    penalty = SimpleNamespace(account=SimpleNamespace(id="acc"), error=RuntimeError("x"), code="c")
+    request_state = SimpleNamespace(deferred_keyed_stream_health=[penalty])
+    fake_self = SimpleNamespace(_handle_stream_error=quick_penalty)
+
+    async def run_in_cancelled_scope() -> None:
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await aku._ApiKeyUsageMixin._drain_deferred_keyed_stream_health(
+                    cast(Any, fake_self), cast(Any, request_state)
+                )
+
+    await asyncio.wait_for(asyncio.create_task(run_in_cancelled_scope()), timeout=1)
+    assert request_state.deferred_keyed_stream_health == []

--- a/tests/unit/test_defer_cancellation_shield_leak.py
+++ b/tests/unit/test_defer_cancellation_shield_leak.py
@@ -189,3 +189,90 @@ async def test_shielded_bounded_returns_none_when_teardown_finishes():
         await asyncio.sleep(0)
 
     assert await _shielded_bounded(quick_teardown(), timeout=1) is None
+
+
+async def test_defer_cancellation_helpers_share_the_canonical_implementation():
+    """The 2026-08-30 livelock happened because one of six hand-rolled copies
+    of the defer-cancellation loop missed the busy-spin guard. The alias
+    imports must stay identity-equal to the canonical helpers so a new
+    divergent copy cannot be reintroduced silently."""
+
+    from app.core.utils import shared_future
+    from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers
+    from app.modules.proxy._service.streaming import retry as streaming_retry
+    from app.modules.proxy._service.websocket import helpers as websocket_helpers
+
+    assert http_bridge_helpers._await_task_deferring_cancellation is shared_future._await_task_deferring_cancellation
+    assert streaming_retry._await_task_deferring_cancellation is shared_future._await_task_deferring_cancellation
+    assert (
+        websocket_helpers._await_cleanup_deferring_cancellation is shared_future._await_cleanup_deferring_cancellation
+    )
+
+
+async def test_api_and_forwarding_adapters_surface_the_level_cancellation_marker():
+    """The bool-shaped adapters must report the shield-blocked level
+    cancellation (previously suppressed until the caller's next checkpoint)."""
+
+    from app.modules.model_sources import forwarding
+    from app.modules.proxy import api as proxy_api
+
+    async def cleanup() -> str:
+        await asyncio.sleep(0)
+        return "settled"
+
+    async def run_in_cancelled_scope() -> tuple[tuple[str, bool], bool]:
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            api_result = await proxy_api._await_result_deferring_cancellation(cleanup())
+            forwarding_deferred = await forwarding._await_result_deferring_cancellation(cleanup())
+            return api_result, forwarding_deferred
+        raise AssertionError("cancelled scope must not suppress the adapters' return")
+
+    task = asyncio.create_task(run_in_cancelled_scope())
+    (result, api_deferred), forwarding_deferred = await asyncio.wait_for(task, timeout=1)
+    assert result == "settled"
+    assert api_deferred is True
+    assert forwarding_deferred is True
+
+
+async def test_keyed_health_drain_keeps_apply_task_callbacks_bounded():
+    """The inline api_key_usage drain loop must wait leak-free: repeated
+    edge cancels during a slow penalty write may not grow the owned task's
+    callback list (CodeRabbit finding on #1993)."""
+
+    from types import SimpleNamespace
+    from typing import Any, cast
+
+    from app.modules.proxy._service import api_key_usage as aku
+
+    release = asyncio.Event()
+    apply_task_holder: dict[str, asyncio.Task[None] | None] = {"task": None}
+
+    async def slow_penalty(*_args: object) -> None:
+        apply_task_holder["task"] = cast("asyncio.Task[None] | None", asyncio.current_task())
+        await release.wait()
+
+    penalty = SimpleNamespace(account=SimpleNamespace(id="acc"), error=RuntimeError("x"), code="c")
+    request_state = SimpleNamespace(deferred_keyed_stream_health=[penalty])
+    fake_self = SimpleNamespace(_handle_stream_error=slow_penalty)
+
+    waiter = asyncio.create_task(
+        aku._ApiKeyUsageMixin._drain_deferred_keyed_stream_health(cast(Any, fake_self), cast(Any, request_state))
+    )
+    while apply_task_holder["task"] is None:
+        await asyncio.sleep(0)
+
+    for _ in range(50):
+        waiter.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    apply_task = apply_task_holder["task"]
+    assert apply_task is not None
+    assert len(getattr(apply_task, "_callbacks", None) or []) <= 3
+
+    # The drain finishes the claimed penalty, then re-raises the deferred
+    # caller cancellation.
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(waiter, timeout=1)


### PR DESCRIPTION
Follow-up quality refactor from the 2026-08-30 incident (#1968, fixed by #1969/#1972). Rebuilt on top of #1955, which already moved the hardened http-bridge/retry copy into `shared_future.py` — this PR finishes the consolidation and addresses both CodeRabbit findings from #1993.

## Why

Six hand-rolled copies of the defer-cancellation wait loop drifted apart until the one copy without the busy-spin guard livelocked production for the third time. #1955 consolidated two of them; the rest (proxy api ×2, model-sources forwarding ×2, websocket helpers, db session `_shielded`) and the inline `api_key_usage` shield loops still hand-roll `asyncio.shield` retries. Consolidation is how the next copy can't be pasted without the guard again.

## What

- `shared_future.py` gains `_await_result_deferring_cancellation` / `_await_cleanup_deferring_cancellation` wrappers next to #1955's canonical `_await_task_deferring_cancellation`.
- Remaining copies route through them: **alias import** (websocket helpers — exact shape match), **two-line adapters** (proxy api, forwarding — bool marker; db session `_shielded` — re-raise).
- The inline `api_key_usage` loops (deferred keyed-health drain, fallback release, ordering-sensitive settle wait) keep their site-specific control flow (penalty re-queue, swallow-all settle) but wait through `wait_on_shared_future` — the leak-free wait — per the second CodeRabbit finding on #1993.
- **OpenSpec** `consolidate-defer-cancellation-waits` (strict-valid):
  - `proxy-admission-control`: every defer-cancellation wait shares the canonical implementation; the deferred-cancellation marker surfaces through every marker shape.
  - `database-backends`: qualifies the `command_timeout` lock-release claim as **best-effort against a blackholed peer** (asyncpg's post-timeout cancellation handshake itself talks to the server) — lock discipline stays the primary defense and is not relaxed. This resolves the first CodeRabbit finding on #1993.

## Behavior deltas (all strictly hardening)

- api/forwarding/db shapes gain the leak-free wait (previously raw `asyncio.shield`) and now surface the level-cancellation marker their docstrings promised — previously a level cancel was silently suppressed until the caller's next checkpoint; same eventual outcome, now deterministic (the semantics #1969's review required for the http-bridge copy).
- `api_key_usage` loops stop growing the owned task's callback list under repeated cancels (cancellation-storm regression test: 50 cancels → callbacks ≤ 3).

## Regression coverage

- Identity-equality test pins the alias imports to the canonical implementation (a divergent copy cannot reappear silently).
- Marker test: api/forwarding bool adapters report a level-cancelled scope after cleanup completes.
- Cancellation-storm test bounds the keyed-health drain loop's callback growth and verifies the claimed penalty completes before the deferred cancellation re-raises.

## Verification

- `uv run pytest` — defer-leak file (10), idle-leases + shared-future + db-session + forwarding (144), proxy_utils `-k "cleanup or defer or shield or cancel or keyed_stream or settle"` (84) — all green
- `uv run ruff format --check` / `ruff check` / `ty check` on all touched files — clean
- `openspec validate consolidate-defer-cancellation-waits --strict` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when requests, streams, or background operations are cancelled during cleanup.
  * Prevented cancellation handling from causing busy loops or excessive task callbacks.
  * Ensured deferred cancellations are consistently surfaced after required work completes.
  * Improved connection and resource handling across proxy, websocket, database, and usage-management operations.
  * Improved PostgreSQL connection health by detecting stale connections, recycling aged connections, and enforcing statement time limits.

* **Tests**
  * Added regression coverage for cancellation propagation, cleanup behavior, connection handling, and bounded task callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->