### PR TITLE
fix(logging): redact secrets in exception tracebacks

### DIFF
--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -7,6 +7,7 @@ import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
+from types import TracebackType
 from typing import cast
 
 from fastapi import Request
@@ -16,27 +17,53 @@ from uvicorn.logging import AccessFormatter, DefaultFormatter
 from app.core.types import JsonValue
 from app.core.utils.request_id import get_request_id
 
+_LOG_REDACTION = "[REDACTED]"
+# Bounded by whitespace and structural delimiters rather than by the token68
+# alphabet so a malformed credential cannot leave a glued suffix like
+# `abc?secret`, while a closing quote or bracket after a token is kept.
+_BEARER_CREDENTIAL_CHARACTER = r"""[^\s,&;"'\\)\]}]"""
 _SENSITIVE_LOG_VALUE_PATTERNS = (
     re.compile(r"(?i)(password|passwd|pwd|token|secret|api[_-]?key)(\s*[=:]\s*)([^\s,&]+)"),
-    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
+    # An earlier marker is consumed whole so re-formatting is idempotent.
+    re.compile(
+        rf"(?i)(bearer\s+)(?:{re.escape(_LOG_REDACTION)}{_BEARER_CREDENTIAL_CHARACTER}*|{_BEARER_CREDENTIAL_CHARACTER}+)"
+    ),
     re.compile(r"(?i)(authorization\s*[=:]\s*)(?!\s*bearer\b)([^,&]+)"),
 )
+# A value cut off by the end of its line (traceback lines are redacted one at a
+# time) is redacted through that line end, including a dangling escape.
 _JSON_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
     r'(?i)("(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)"\s*:\s*")'
-    r'(?:\\.|[^"\\])*(")'
+    r'(?:\\.|[^"\\])*\\?("|$)'
 )
-_LOG_REDACTION = "[REDACTED]"
+# Every boundary str.splitlines() honors, so per-line redaction never spans one.
+_LINE_TERMINATORS = "\r\n\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+
+type _ExcInfo = tuple[type[BaseException], BaseException, TracebackType | None] | tuple[None, None, None]
 
 
 def _redact_log_value(value: str | None) -> str | None:
     collapsed = _collapse_log_value(value)
     if collapsed is None:
         return None
-    redacted = collapsed
-    redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, redacted)
+    return _redact_sensitive_log_line(collapsed)
+
+
+def _redact_sensitive_log_line(line: str) -> str:
+    redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, line)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[0].sub(_redact_keyed_secret, redacted)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[1].sub(_redact_bearer_token, redacted)
     return _SENSITIVE_LOG_VALUE_PATTERNS[2].sub(_redact_authorization_value, redacted)
+
+
+def _redact_traceback_text(text: str) -> str:
+    # Apply the one-line policy to each line on its own so no pattern can
+    # consume a line terminator; frames and the exception line stay intact.
+    parts: list[str] = []
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip(_LINE_TERMINATORS)
+        parts.append(_redact_sensitive_log_line(body) + line[len(body) :])
+    return "".join(parts)
 
 
 def _redact_keyed_secret(match: re.Match[str]) -> str:
@@ -62,6 +89,21 @@ def _utc_converter(seconds: float | None) -> time.struct_time:
 class UtcDefaultFormatter(DefaultFormatter):
     converter: Callable[[float | None], time.struct_time] = staticmethod(_utc_converter)
 
+    def format(self, record: logging.LogRecord) -> str:
+        # logging.Formatter.format() caches the traceback on the shared record as
+        # exc_text and appends another formatter's cache verbatim. Format a copy
+        # so this formatter neither emits a cached unredacted traceback nor
+        # changes what other handlers see.
+        record = copy.copy(record)
+        if record.exc_info:
+            record.exc_text = None
+        elif record.exc_text:
+            record.exc_text = _redact_traceback_text(record.exc_text)
+        return super().format(record)
+
+    def formatException(self, ei: _ExcInfo) -> str:
+        return _redact_traceback_text(super().formatException(ei))
+
 
 class UtcAccessFormatter(AccessFormatter):
     converter: Callable[[float | None], time.struct_time] = staticmethod(_utc_converter)
@@ -70,6 +112,9 @@ class UtcAccessFormatter(AccessFormatter):
 class JsonFormatter(logging.Formatter):
     def __init__(self) -> None:
         super().__init__()
+
+    def formatException(self, ei: _ExcInfo) -> str:
+        return _redact_traceback_text(super().formatException(ei))
 
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {

--- a/openspec/changes/redact-exception-traceback-secrets/context.md
+++ b/openspec/changes/redact-exception-traceback-secrets/context.md
@@ -1,0 +1,54 @@
+# Exception traceback redaction context
+
+## Purpose and scope
+
+The runtime logging module already recognizes keyed credentials, JSON credential fields, Bearer tokens, and non-Bearer authorization values in ordinary error fields. This change closes the remaining serializer path where `logging.Formatter.formatException()` copied an exception message into traceback output without those replacements.
+
+The scope is the two default exception formatter families used by text and JSON application logs. Access logs and public exception responses are unchanged.
+
+## Decision
+
+Format the traceback first, then apply the same pattern substitutions used for ordinary log values to each traceback line independently. The ordinary one-line whitespace collapse is not applied to tracebacks.
+
+Per-line application is what preserves diagnostic structure: no pattern can consume a line terminator, so frame locations, chained-exception separators, and the exception type line stay byte-identical unless that specific line contains a recognized secret. The set of line terminators is the one `str.splitlines()` honors, which includes `\r\n`, `\v`, `\f`, `\x1c`–`\x1e`, `\x85`, `\u2028`, and `\u2029`.
+
+`UtcDefaultFormatter` also overrides `format()` because `logging.Formatter.format()` appends `record.exc_text` verbatim when another handler's formatter already cached a traceback on the shared record. The override always formats a shallow copy of the record, so this formatter neither emits another formatter's cached traceback nor writes its own cache or `message` onto the record other handlers see.
+
+## Constraints
+
+- Do not reconstruct exceptions or mutate traceback objects.
+- Do not introduce a separate list of secret patterns or a credential grammar; the ordinary-field policy is the single source of truth for what counts as a secret and where a value ends.
+- Keep existing one-line normalization for ordinary structured error fields. The two pattern changes apply to ordinary fields as well and only add redaction: an unterminated JSON-style value redacts through the end of its line, and a Bearer credential is bounded by whitespace or a structural delimiter (`,`, `&`, `;`, quotes, backslash, closing brackets) instead of by the token68 alphabet, so a malformed credential such as `Bearer user:<secret>` cannot leave a glued suffix while a closing quote or bracket after a valid token is kept.
+
+## Failure modes and rejected alternatives
+
+- Applying `_redact_log_value()` directly would collapse traceback whitespace and destroy stack structure.
+- Applying the ordinary patterns to the whole traceback text lets value classes such as `[^,&]+` run across line terminators and swallow following frames.
+- Matching JSON-style values across lines is unsafe: an unterminated value in an exception message would be closed by the first `"` in a later `File "..."` frame line and erase those frames. A value cut off by the end of its line is therefore redacted through that line end only.
+- Parsing HTTP `Authorization` grammar to preserve same-line context after a credential while failing closed on malformed values was attempted and abandoned: the two goals are undecidable for arbitrary text, and each added rule surfaced a new boundary case.
+
+## Known limits (pre-existing policy, unchanged here)
+
+The ordinary-field patterns stop authorization values at `,` and `&`, only recognize `authorization` when it is directly followed by `=` or `:`, and stop Bearer and keyed values at whitespace. Inputs such as `Digest username="a,b", response="<secret>"`, `{'authorization': 'Basic <secret>'}`, or `Bearer abc <secret>` therefore keep part of the credential in ordinary error fields on `main` today and behave identically in tracebacks after this change. A whitespace-separated tail is indistinguishable from diagnostic prose such as `Bearer abc retrying upstream request`, and the quoted-key and quoted-comma forms belong to schemes and serializations this proxy does not emit. Hardening those boundaries is a separate policy change to the shared patterns.
+
+## Example
+
+Input traceback excerpt:
+
+```text
+Traceback (most recent call last):
+  File "app/modules/proxy/service.py", line 42, in forward
+    raise UpstreamError(message)
+UpstreamError: authorization=Basic dXNlcjpwYXNz
+status=failed
+```
+
+Serialized text and JSON traceback fields retain every line and frame:
+
+```text
+Traceback (most recent call last):
+  File "app/modules/proxy/service.py", line 42, in forward
+    raise UpstreamError(message)
+UpstreamError: authorization=[REDACTED]
+status=failed
+```

--- a/openspec/changes/redact-exception-traceback-secrets/proposal.md
+++ b/openspec/changes/redact-exception-traceback-secrets/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exception messages are redacted when copied into ordinary log fields, but the same message is serialized again inside exception tracebacks without the shipped secret-redaction policy. A credential included in an exception can therefore reach operator text and JSON log sinks even though the structured message is safe.
+
+## What Changes
+
+- Apply the existing log-secret patterns to exception traceback text in both shipped application formatter families, one traceback line at a time so no pattern can consume a line terminator.
+- Redact a traceback cached on a shared `LogRecord` by another formatter instead of appending it verbatim.
+- Treat a recognized JSON-style secret value with no closing quote as extending to the end of its line, and bound Bearer credentials by whitespace or a structural delimiter (`,`, `&`, `;`, quotes, backslash, closing brackets) instead of the token68 alphabet; both shared-pattern changes apply to tracebacks and ordinary fields alike and only add redaction.
+- Keep the one-line normalization for ordinary structured error fields unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-log-redaction`: Defines privacy and diagnostic-structure requirements for runtime exception logging.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/core/runtime_logging.py`: `UtcDefaultFormatter` and `JsonFormatter` redact formatted exception text; ordinary field redaction reuses the same per-line policy.
+- `tests/unit/test_structured_logging.py`: formatter-level regression coverage for both formatters.
+- No settings, migrations, dashboard, or README changes.

--- a/openspec/changes/redact-exception-traceback-secrets/specs/runtime-log-redaction/spec.md
+++ b/openspec/changes/redact-exception-traceback-secrets/specs/runtime-log-redaction/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Runtime exception tracebacks redact recognized secrets
+
+The runtime logging system MUST apply the existing sensitive-log-value patterns
+to exception traceback text emitted by the shipped text and JSON application
+formatters.
+
+#### Scenario: Recognized secrets appear in an exception message
+
+- **WHEN** an exception message contains a recognized keyed secret, Bearer
+  token, or JSON-style secret field
+- **THEN** the text formatter MUST replace each secret value with `[REDACTED]`
+- **AND** the JSON formatter MUST replace the same secret values with `[REDACTED]`
+- **AND** neither serialized log entry may contain the original secret values
+
+#### Scenario: A credential contains delimiters before a later field
+
+- **WHEN** an exception message contains `authorization=Basic user:<secret>, status=ok`,
+  `authorization=Bearer user:<secret>, status=ok`, or
+  `authorization=Digest username=public; response=<secret>, status=ok`
+- **THEN** both shipped formatters MUST omit the secret
+- **AND** `status=ok` MUST remain present
+
+#### Scenario: A JSON-style secret value is cut off by the end of its line
+
+- **WHEN** a recognized JSON-style secret field has no closing quote before the
+  end of its traceback line
+- **THEN** both shipped formatters MUST redact the value through that line end,
+  including a trailing backslash
+- **AND** the following traceback lines MUST remain unchanged
+
+### Requirement: Traceback redaction is scoped to single lines
+
+The runtime logging system MUST redact traceback text one line at a time so
+that no sensitive-value pattern consumes a line terminator.
+
+#### Scenario: Redacted traceback keeps its structure
+
+- **WHEN** a recognized secret is redacted from an exception traceback
+- **THEN** the serialized traceback MUST contain the same number of lines as the
+  unredacted traceback
+- **AND** every line that contains no recognized secret MUST be unchanged,
+  including frame locations, source lines, chained-exception separators, and
+  the exception type line
+
+#### Scenario: A sensitive value is followed by a line terminator
+
+- **WHEN** an exception message places a recognized secret before any line
+  terminator honored by `str.splitlines()`, including `\r\n`, `\u2028`, and
+  `\u2029`, followed by non-sensitive text
+- **THEN** both shipped formatters MUST omit the secret
+- **AND** they MUST retain the line terminator and the following non-sensitive
+  text
+
+### Requirement: Cached traceback text is redacted
+
+The text application formatter MUST NOT append an unredacted traceback that
+another formatter cached on a shared `LogRecord`.
+
+#### Scenario: Another formatter already cached the traceback
+
+- **WHEN** a record with `exc_info` already carries unredacted `exc_text` from
+  another formatter
+- **THEN** the text formatter MUST emit a redacted traceback
+- **AND** it MUST NOT write to the shared record, so the cached `exc_text`
+  stays unchanged for other handlers
+
+#### Scenario: A record carries only cached traceback text
+
+- **WHEN** a record has `exc_text` but no `exc_info`
+- **THEN** the text formatter MUST emit that text with recognized secrets
+  redacted
+
+### Requirement: Ordinary log-value redaction is preserved
+
+The runtime logging system MUST preserve the existing one-line normalization
+for ordinary structured error fields and MUST continue to redact every value
+the existing patterns redacted. The only pattern changes are that a recognized
+JSON-style secret value with no closing quote is redacted through the end of
+the field, and that a Bearer credential extends to the next whitespace or
+structural delimiter (`,`, `&`, `;`, quotes, backslash, closing brackets)
+rather than to the first character outside the token68 alphabet.
+
+#### Scenario: Ordinary structured field contains multiline whitespace
+
+- **WHEN** an ordinary error field is passed through the existing log-value
+  redaction entry point
+- **THEN** the field MUST remain normalized to one line
+- **AND** recognized secret values MUST remain redacted
+
+#### Scenario: Ordinary structured field contains an unterminated JSON-style secret
+
+- **WHEN** an ordinary error field contains a recognized JSON-style secret
+  field whose value has no closing quote
+- **THEN** the value MUST be redacted through the end of the field
+
+#### Scenario: Ordinary structured field contains a malformed Bearer credential
+
+- **WHEN** an ordinary error field contains `Bearer` followed by a credential
+  that contains characters outside the token68 alphabet, such as `user:<secret>`
+- **THEN** the whole credential up to the next whitespace or structural
+  delimiter MUST be replaced with `[REDACTED]`
+- **AND** fields after that delimiter MUST remain present
+- **AND** a closing quote or bracket directly after a valid token MUST be kept

--- a/openspec/changes/redact-exception-traceback-secrets/tasks.md
+++ b/openspec/changes/redact-exception-traceback-secrets/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specification
+
+- [x] 1.1 Define traceback privacy and line-scoped structure requirements.
+- [x] 1.2 Record the per-line decision, rejected alternatives, and known pre-existing policy limits in `context.md`.
+
+## 2. Regression proof
+
+- [x] 2.1 Add failing text and JSON formatter coverage for secret-bearing tracebacks.
+- [x] 2.2 Add failing coverage for line-terminator boundaries, chained exceptions, JSON values cut by a line end, and cached `exc_text`.
+- [x] 2.3 Capture the targeted RED output before production edits.
+
+## 3. Implementation
+
+- [x] 3.1 Reuse the shipped secret patterns per traceback line without collapsing whitespace.
+- [x] 3.2 Redact `formatException()` output in the text and JSON application formatters.
+- [x] 3.3 Redact or regenerate traceback text cached on a shared record without mutating it.
+
+## 4. Verification
+
+- [x] 4.1 Capture the targeted GREEN output.
+- [x] 4.2 Run Ruff, Ruff format, ty, and the logging, CLI, and OTel unit tests.
+- [x] 4.3 Validate this OpenSpec change strictly.
+- [x] 4.4 Run real handler QA for text and JSON outputs.

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 
 import pytest
 
@@ -269,3 +270,207 @@ def test_build_log_config_exposes_app_loggers_via_root_handler(monkeypatch):
     assert root_logger.get("handlers") == ["default"]
     assert root_logger.get("level") == "INFO"
     get_settings.cache_clear()
+
+
+def test_redact_log_value_keeps_one_line_normalization():
+    value = "token=abc123\n  status=failed"
+
+    assert _redact_log_value(value) == "token=[REDACTED] status=failed"
+
+
+def test_redact_log_value_redacts_unterminated_json_secret_through_field_end():
+    value = 'provider error {"api_key":"sk-QA_TRUNCATED'
+
+    assert _redact_log_value(value) == 'provider error {"api_key":"[REDACTED]'
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("authorization=Bearer user:QA_SECRET, status=ok", "authorization=Bearer [REDACTED], status=ok"),
+        ("Bearer abc?QA_SECRET&status=ok", "Bearer [REDACTED]&status=ok"),
+        ('{"message":"Bearer QA_SECRET","status":"ok"}', '{"message":"Bearer [REDACTED]","status":"ok"}'),
+        ("(Bearer QA_SECRET); retrying", "(Bearer [REDACTED]); retrying"),
+        ("Bearer [REDACTED]QA_SECRET", "Bearer [REDACTED]"),
+    ],
+)
+def test_redact_log_value_bounds_bearer_credentials_at_structural_delimiters(value, expected):
+    assert _redact_log_value(value) == expected
+    assert _redact_log_value(expected) == expected
+
+
+@pytest.fixture(params=["text", "json"])
+def exception_formatter(request, text_formatter, json_formatter):
+    return text_formatter if request.param == "text" else json_formatter
+
+
+def _exception_record(exc_info) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test.module",
+        level=logging.ERROR,
+        pathname="test.py",
+        lineno=42,
+        msg="Error occurred",
+        args=(),
+        exc_info=exc_info,
+    )
+
+
+def _exception_text(formatter: logging.Formatter, record: logging.LogRecord) -> str:
+    output = formatter.format(record)
+    if isinstance(formatter, JsonFormatter):
+        return json.loads(output)["exception"]
+    return output.split("\n", 1)[1]
+
+
+def _formatted_traceback(formatter: logging.Formatter, message: str) -> str:
+    try:
+        raise ValueError(message)
+    except ValueError:
+        record = _exception_record(sys.exc_info())
+    return _exception_text(formatter, record)
+
+
+def _assert_only_secret_lines_changed(redacted_text: str, plain_text: str) -> None:
+    redacted_lines = redacted_text.splitlines(keepends=True)
+    plain_lines = plain_text.splitlines(keepends=True)
+    assert len(redacted_lines) == len(plain_lines)
+    for redacted, plain in zip(redacted_lines, plain_lines, strict=True):
+        if "QA_" in plain:
+            assert "QA_" not in redacted
+            assert "[REDACTED]" in redacted
+            assert redacted.endswith(plain[len(plain.splitlines()[0]) :])
+        else:
+            assert redacted == plain
+
+
+def test_exception_traceback_redacts_recognized_secrets(exception_formatter):
+    message = 'api_key=sk-QA_KEY Authorization: Bearer QA_BEARER body={"token":"QA_JSON"}'
+
+    output = _formatted_traceback(exception_formatter, message)
+
+    for secret in ("sk-QA_KEY", "QA_BEARER", "QA_JSON"):
+        assert secret not in output
+    assert 'ValueError: api_key=[REDACTED] Authorization: Bearer [REDACTED] body={"token":"[REDACTED]"}' in output
+    assert output.startswith("Traceback (most recent call last):\n  File ")
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ("authorization=Basic user:QA_SECRET, status=ok", "authorization=[REDACTED], status=ok"),
+        ("authorization=Bearer user:QA_SECRET, status=ok", "authorization=Bearer [REDACTED], status=ok"),
+        ("authorization=Bearer abc?QA_SECRET&status=ok", "authorization=Bearer [REDACTED]&status=ok"),
+        (
+            "authorization=Digest username=public; response=QA_SECRET, status=ok",
+            "authorization=[REDACTED], status=ok",
+        ),
+    ],
+)
+def test_exception_traceback_redacts_delimited_credentials_and_keeps_later_fields(
+    exception_formatter, message, expected
+):
+    output = _formatted_traceback(exception_formatter, message)
+
+    assert "QA_SECRET" not in output
+    assert f"ValueError: {expected}" in output
+    assert _redact_log_value(expected) == expected
+
+
+@pytest.mark.parametrize(
+    "terminator", ["\n", "\r\n", "\r", "\v", "\f", "\x1c", "\x1d", "\x1e", "\x85", "\u2028", "\u2029"]
+)
+def test_exception_traceback_redaction_stops_at_line_ends(exception_formatter, terminator):
+    message = f"authorization=Basic QA_SECRET{terminator}status=failed{terminator}api_key=QA_KEY"
+
+    output = _formatted_traceback(exception_formatter, message)
+
+    assert "QA_SECRET" not in output
+    assert "QA_KEY" not in output
+    assert f"authorization=[REDACTED]{terminator}status=failed{terminator}api_key=[REDACTED]" in output
+
+
+def test_exception_traceback_redaction_keeps_chained_exception_structure(exception_formatter):
+    try:
+        try:
+            raise KeyError("password=QA_CAUSE")
+        except KeyError as error:
+            raise ValueError("token=QA_EFFECT") from error
+    except ValueError:
+        exc_info = sys.exc_info()
+    plain_text = logging.Formatter().formatException(exc_info)
+
+    redacted_text = _exception_text(exception_formatter, _exception_record(exc_info))
+
+    assert "\nThe above exception was the direct cause of the following exception:\n" in redacted_text
+    _assert_only_secret_lines_changed(redacted_text, plain_text)
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ('{"authorization":"QA_SECRET\nsafe diagnostic line"}', '{"authorization":"[REDACTED]\nsafe diagnostic line"}'),
+        ('{"token":"QA_SECRET\\\nsafe diagnostic line"}', '{"token":"[REDACTED]\nsafe diagnostic line"}'),
+    ],
+)
+def test_exception_traceback_redacts_json_value_cut_by_line_end(exception_formatter, message, expected):
+    output = _formatted_traceback(exception_formatter, message)
+
+    assert "QA_SECRET" not in output
+    assert expected in output
+
+
+def test_exception_traceback_unterminated_json_value_keeps_following_frames(exception_formatter):
+    try:
+        try:
+            raise KeyError('{"token":"QA_SECRET')
+        except KeyError as error:
+            raise ValueError("wrapped") from error
+    except ValueError:
+        exc_info = sys.exc_info()
+    plain_text = logging.Formatter().formatException(exc_info)
+
+    redacted_text = _exception_text(exception_formatter, _exception_record(exc_info))
+
+    assert '\nKeyError: \'{"token":"[REDACTED]\n' in redacted_text
+    _assert_only_secret_lines_changed(redacted_text, plain_text)
+
+
+def test_text_formatter_redacts_traceback_cached_by_another_formatter(text_formatter):
+    try:
+        raise ValueError("api_key=QA_CACHED")
+    except ValueError:
+        record = _exception_record(sys.exc_info())
+    plain_output = logging.Formatter().format(record)
+    assert "QA_CACHED" in plain_output
+    assert record.exc_text is not None and "QA_CACHED" in record.exc_text
+
+    output = text_formatter.format(record)
+
+    assert "QA_CACHED" not in output
+    assert "api_key=[REDACTED]" in output
+    assert "QA_CACHED" in record.exc_text
+
+
+def test_text_formatter_does_not_cache_traceback_on_shared_record(text_formatter):
+    try:
+        raise ValueError("api_key=QA_FRESH")
+    except ValueError:
+        record = _exception_record(sys.exc_info())
+
+    output = text_formatter.format(record)
+
+    assert "api_key=[REDACTED]" in output
+    assert record.exc_text is None
+
+
+def test_text_formatter_redacts_cached_traceback_without_exc_info(text_formatter):
+    record = _exception_record(None)
+    record.exc_text = 'Traceback (most recent call last):\n  File "x.py", line 1, in f\nValueError: token=QA_CACHED\n'
+
+    output = text_formatter.format(record)
+
+    assert "QA_CACHED" not in output
+    assert output.endswith(
+        '\nTraceback (most recent call last):\n  File "x.py", line 1, in f\nValueError: token=[REDACTED]\n'
+    )


### PR DESCRIPTION
## Summary

- apply the existing sensitive-log-value patterns to exception tracebacks in both shipped application formatters (`UtcDefaultFormatter`, `JsonFormatter`), one traceback line at a time so no pattern can consume a line terminator
- always format a shallow copy of the record in `UtcDefaultFormatter`, so a traceback another formatter cached on the shared `LogRecord` (`record.exc_text`) is regenerated redacted and this formatter never writes its own cache onto the record other handlers see
- keep one-line normalization for ordinary error fields unchanged; two shared-pattern changes only add redaction: an unterminated JSON-style value redacts through the end of its line, and Bearer credentials are bounded by whitespace or a structural delimiter (`,` `&` `;` quotes, backslash, closing brackets) instead of the token68 alphabet, so `Bearer user:<secret>` cannot leave a glued suffix while `"Bearer <token>"` keeps its closing quote; re-formatting is idempotent

## Why this head replaces the earlier ones

Earlier heads on this PR tried to preserve same-line diagnostic context after a credential while failing closed on malformed values, which required an HTTP `Authorization` grammar. Every review round surfaced a new boundary case because the two goals are undecidable for arbitrary text. This head drops the grammar and applies the existing ordinary-field policy per line; the diff is ~40 product lines instead of ~900. Rationale and rejected alternatives are recorded in the change `context.md`.

## OpenSpec

- `openspec/changes/redact-exception-traceback-secrets/`
- `openspec validate redact-exception-traceback-secrets --strict` — valid

## Verification

- RED (tests against the `upstream/main` module): `.venv/bin/python -m pytest -q tests/unit/test_structured_logging.py` — `47 failed, 19 passed`
- GREEN: same command — `66 passed`; with `tests/unit/test_cli.py tests/unit/test_otel.py` — `150 passed`
- `.venv/bin/ruff check` / `.venv/bin/ruff format --check` on changed files — clean
- `.venv/bin/ty check app/core/runtime_logging.py tests/unit/test_structured_logging.py` — clean
- Real handler QA: `logging.config.dictConfig(build_log_config())` for `text` and `json`, with a non-redacting `logging.Formatter` handler formatting first (populating `exc_text`), logging a chained exception carrying `{"token":"<secret>` and `authorization=Bearer user:<secret>, status=502\nretrying`. Both shipped outputs omit the secrets and keep every frame line, the chained-exception separator, `status=502`, and the `retrying` line.
- Not run locally: the full test suite and the Helm/migration/PostgreSQL jobs (covered by required CI)

## Known pre-existing policy gaps (not introduced here)

These leak part of the credential in ordinary error fields on `main` today through `log_error_response` and behave identically in tracebacks after this change: comma inside a quoted Digest parameter (`Digest username="a,b", response="<secret>"`), quoted keys (`{'authorization': 'Basic <secret>'}`, `{"authorization": Basic <secret>}`), and whitespace-separated tails (`Bearer abc <secret>`, indistinguishable from `Bearer abc retrying upstream request`). Hardening those boundaries is a separate policy change to the shared patterns and is out of scope for this fix; tracked in #2028, see `context.md` "Known limits".

## Scope and independence

- based directly on current `upstream/main`
- no dependency on another pull request
- no new settings, navigation, README section, or compatibility shim
- overlap pass: `gh search issues|prs --repo Soju06/codex-lb --state open` for `traceback redact` and `formatException` returned no open issue and only this PR

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sensitive credentials are now redacted from exception tracebacks in both text and JSON logs.
  - Redaction handles API keys, bearer credentials, JSON-formatted secrets, malformed values, and multiline tracebacks.
  - Traceback structure, line breaks, frame details, and non-sensitive content are preserved.
  - Cached traceback data is protected without altering shared log records.
  - Improved handling of authorization values and existing redaction markers.

- **Tests**
  - Added comprehensive coverage for credential formats, line terminators, chained exceptions, and text/JSON logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
