### PR TITLE
fix(auth): reject duplicate trusted identity fields

### DIFF
--- a/app/core/auth/dashboard_mode.py
+++ b/app/core/auth/dashboard_mode.py
@@ -101,11 +101,11 @@ def _get_trusted_header_auth(request: Request) -> DashboardRequestAuth | None:
     if not _is_trusted_proxy_source(client_host, _trusted_proxy_networks()):
         return None
 
-    raw_actor = request.headers.get(settings.dashboard_auth_proxy_header)
-    if raw_actor is None:
+    raw_actors = request.headers.getlist(settings.dashboard_auth_proxy_header)
+    if len(raw_actors) != 1:
         return None
 
-    actor = raw_actor.strip()
+    actor = raw_actors[0].strip()
     if not actor:
         return None
     return DashboardRequestAuth(mode=DashboardAuthMode.TRUSTED_HEADER, actor=actor)

--- a/openspec/changes/reject-duplicate-trusted-identities/.openspec.yaml
+++ b/openspec/changes/reject-duplicate-trusted-identities/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/reject-duplicate-trusted-identities/context.md
+++ b/openspec/changes/reject-duplicate-trusted-identities/context.md
@@ -1,0 +1,15 @@
+## Purpose
+
+Trusted-header authentication is safe only when the configured identity field is unambiguous. HTTP permits repeated fields, and append-style reverse proxies can retain a client-supplied occurrence while adding the authenticated identity.
+
+## Decision
+
+The trusted identity parser accepts exactly one configured-header occurrence from a trusted raw peer. Zero fields, a blank singleton, or two or more fields produce no trusted-header identity. Duplicate values are not deduplicated because accepting them would make proxy normalization assumptions part of the application's authentication boundary.
+
+## Failure mode and response
+
+An ambiguous request follows the existing missing-proxy-identity path. Protected dashboard APIs return HTTP 401 with error code `proxy_auth_required`, and no trusted-header admin principal or actor is created. A valid password-authenticated fallback session remains governed by its existing contract.
+
+## Example
+
+A proxy receives `Remote-User: attacker@example.com` and appends `Remote-User: alice@example.com`. The application rejects the request instead of selecting either value. A single `Remote-User: alice@example.com` field continues to authenticate Alice.

--- a/openspec/changes/reject-duplicate-trusted-identities/design.md
+++ b/openspec/changes/reject-duplicate-trusted-identities/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Trusted-header dashboard authentication trusts a configured identity field only from an allowlisted raw proxy peer. The middleware strips that field from untrusted peers but deliberately preserves every occurrence from trusted peers. The parser then uses singular Starlette header lookup, so repeated fields are reduced by order before the application establishes an admin actor.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Parse trusted identity cardinality before selecting an actor value.
+- Reject every duplicate configuration-header occurrence, including equal and blank-plus-nonblank pairs.
+- Preserve singleton authentication and the documented `proxy_auth_required` envelope for absent or invalid proxy identity.
+- Prove behavior through the protected dashboard API boundary.
+
+**Non-Goals:**
+
+- Changing trusted proxy source classification or middleware ordering.
+- Silently deduplicating values or splitting comma-delimited identity content.
+- Changing password fallback behavior, roles, settings, or response schemas.
+
+## Decisions
+
+### Enforce cardinality in the trusted identity parser
+
+Read all occurrences with Starlette's case-insensitive `getlist` interface and construct a trusted-header identity only when the list contains exactly one field whose trimmed value is non-empty. This is the narrow point where trusted transport evidence becomes an authenticated actor.
+
+Rejecting in the sanitizer middleware was not selected because that middleware owns raw-peer provenance and scrubbing, not dashboard rejection semantics. Deduplicating equal values was rejected because repeated authentication evidence remains ambiguous and can hide a misconfigured append-style proxy.
+
+### Reuse the existing missing-identity rejection path
+
+The parser returns no trusted identity for duplicate fields. Protected dashboard dependencies then emit HTTP 401 with error code `proxy_auth_required`, exactly as they do for a missing or blank identity. No new public error type or configuration is needed.
+
+## Risks / Trade-offs
+
+- [Risk] A proxy that intentionally emits repeated equal identity fields will begin failing closed. → Document the singleton contract and preserve the existing response envelope so the misconfiguration is diagnosable.
+- [Risk] A future parser bypass could reintroduce first-value selection. → Keep the regression at the protected route boundary, where an authenticated principal would be observable.
+- [Trade-off] The response does not distinguish duplicate from missing identity. → Reusing the established envelope avoids exposing parser details and keeps this fix contract-compatible.

--- a/openspec/changes/reject-duplicate-trusted-identities/proposal.md
+++ b/openspec/changes/reject-duplicate-trusted-identities/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Trusted-header dashboard authentication currently selects the first configured identity field when a trusted proxy forwards duplicates. An append-style proxy can therefore preserve an attacker-supplied value and let field order determine the authenticated admin actor.
+
+## What Changes
+
+- Require exactly one configured trusted identity field before creating a trusted-header dashboard principal.
+- Treat duplicate identity fields as ambiguous even when their values match or only one value is non-empty.
+- Return the existing `proxy_auth_required` rejection envelope without producing an authenticated identity.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-auth`: Define fail-closed cardinality for trusted-header dashboard identities.
+
+## Impact
+
+Affected areas are trusted-header identity parsing, the dashboard authentication boundary, focused integration coverage, and the admin-auth contract. Proxy trust configuration, password fallback sessions, untrusted-peer scrubbing, and identity normalization remain unchanged.

--- a/openspec/changes/reject-duplicate-trusted-identities/specs/admin-auth/spec.md
+++ b/openspec/changes/reject-duplicate-trusted-identities/specs/admin-auth/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Trusted-header identity evidence is singular
+
+The system MUST create a trusted-header dashboard principal only when a trusted raw proxy peer supplies exactly one occurrence of the configured identity field and its trimmed value is non-empty. The system MUST treat two or more occurrences as ambiguous regardless of field-name casing, field order, value equality, or whether another occurrence is empty. Ambiguous identity evidence MUST NOT produce an authenticated principal or actor.
+
+#### Scenario: Duplicate trusted identity fields are rejected
+
+- **WHEN** a trusted raw proxy peer sends two or more occurrences of the configured dashboard identity field
+- **THEN** a protected dashboard request returns HTTP 401 with error code `proxy_auth_required`
+- **AND** no trusted-header principal or actor is produced
+
+#### Scenario: One non-empty trusted identity field authenticates
+
+- **WHEN** a trusted raw proxy peer sends exactly one configured dashboard identity field with a non-empty trimmed value
+- **THEN** the system authenticates an admin principal with that trimmed value as the actor

--- a/openspec/changes/reject-duplicate-trusted-identities/tasks.md
+++ b/openspec/changes/reject-duplicate-trusted-identities/tasks.md
@@ -1,0 +1,8 @@
+## 1. Trusted identity parsing
+
+- [x] 1.1 Add an adversarial route-level regression proving duplicate configured identity fields return `proxy_auth_required` and do not authenticate either actor.
+- [x] 1.2 Require exactly one non-empty configured identity occurrence while preserving valid singleton behavior.
+
+## 2. Verification
+
+- [x] 2.1 Run focused RED/GREEN proof, affected auth tests, changed-file diagnostics, strict OpenSpec validation, and real-boundary QA.

--- a/tests/integration/test_trusted_header_identity.py
+++ b/tests/integration/test_trusted_header_identity.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.auth.dashboard_mode import DashboardAuthMode
+from app.core.config.settings import get_settings
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [("Remote-User", "attacker@example.com"), ("Remote-User", "alice@example.com")],
+        [("Remote-User", "alice@example.com"), ("Remote-User", "attacker@example.com")],
+        [("Remote-User", "alice@example.com"), ("Remote-User", "alice@example.com")],
+        [("remote-user", "alice@example.com"), ("Remote-User", "")],
+    ],
+    ids=["attacker-first", "attacker-last", "equal-values", "empty-and-mixed-case"],
+)
+@pytest.mark.asyncio
+async def test_duplicate_trusted_identity_is_rejected(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    headers: list[tuple[str, str]],
+) -> None:
+    # Given trusted-header auth behind an allowlisted raw proxy peer
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_AUTH_MODE", DashboardAuthMode.TRUSTED_HEADER)
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS", "true")
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER", "Remote-User")
+    get_settings.cache_clear()
+
+    # When the peer forwards ambiguous identity evidence
+    response = await async_client.get("/api/settings", headers=headers)
+
+    # Then neither value authenticates an admin principal
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "proxy_auth_required"


### PR DESCRIPTION
## Summary

Reject repeated trusted-header dashboard identity fields instead of allowing field order to choose the authenticated admin actor. The parser now fails closed on ambiguous identity evidence while preserving valid singleton and password-fallback behavior.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: None; the bounded related-work search found no issue owning trusted identity cardinality.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/reject-duplicate-trusted-identities/`

The observable authentication contract requires exactly one non-empty configured identity occurrence from a trusted raw proxy peer. Repeated equal, reordered, mixed-case, and blank-plus-nonblank fields all use the existing `proxy_auth_required` rejection envelope and produce no authenticated identity.

## Changes

- Parse all configured trusted identity field occurrences before selecting an actor.
- Accept only cardinality one and retain existing trimming/blank handling.
- Add route-level adversarial regression coverage for attacker-first, attacker-last, equal-value, and mixed-case duplicate inputs.

## Related work

Nearby raw-peer provenance and client-IP consensus changes do not validate trusted identity cardinality and still use singular identity lookup. This PR is independent, has no prerequisite, and can merge in any order.

## Test plan

```text
uv run pytest -q tests -k duplicate_trusted_identity_is_rejected
# 4 passed, 9822 deselected

uv run pytest -q tests/integration/test_auth_middleware.py tests/unit/test_dashboard_auth_dependencies.py -k 'trusted_header or proxy_header'
# 9 passed, 27 deselected

uv run ruff check app/core/auth/dashboard_mode.py tests/integration/test_trusted_header_identity.py
uv run ruff format --check app/core/auth/dashboard_mode.py tests/integration/test_trusted_header_identity.py
uv run ty check app/core/auth/dashboard_mode.py tests/integration/test_trusted_header_identity.py
openspec validate reject-duplicate-trusted-identities --strict
uv build
```

Changed-file LSP diagnostics were clean. A full repository local gate additionally passed frontend tests/build, Python lint/format/type checks, Rust fmt/clippy/tests, and native release build before stopping at the locally unavailable `cargo-deny`; no product check failed, and GitHub CI remains authoritative for that audit.

## Real-boundary QA

A real application lifespan received two differently cased `Remote-User` fields through ASGI. `GET /api/settings` returned HTTP 401 with `proxy_auth_required`, and `GET /api/dashboard-auth/session` reported `authenticated=false`.

## Simplicity

No setting, setup step, README section, environment example, dashboard navigation item, schema, or default changed.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Added tests covering the change.
- [x] Ran the relevant repository checks and recorded the only unavailable local tool above.
- [x] Strict OpenSpec change validation passes and implementation verification is clean.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trusted-header dashboard authentication now rejects requests containing duplicate or ambiguous identity headers.
  * Such requests return the existing `401 proxy_auth_required` response and do not create an authenticated identity.
  * Valid requests with exactly one non-empty identity header continue to authenticate successfully.

* **Tests**
  * Added coverage for duplicate, repeated, mixed-case, and blank identity headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->