### PR TITLE
fix(oauth): stop callback query secrets from reaching logs

### DIFF
--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -296,7 +296,7 @@ class OAuthCallbackServer:
     async def start(self) -> None:
         app = web.Application()
         app.router.add_get("/auth/callback", self._handler)
-        self._runner = web.AppRunner(app)
+        self._runner = web.AppRunner(app, access_log=None)
         await self._runner.setup()
         self._site = web.TCPSite(self._runner, self._host, self._port)
         await self._site.start()

--- a/openspec/changes/omit-oauth-callback-query-logs/.openspec.yaml
+++ b/openspec/changes/omit-oauth-callback-query-logs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/omit-oauth-callback-query-logs/context.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/context.md
@@ -1,0 +1,15 @@
+# OAuth callback privacy context
+
+## Purpose
+
+The browser OAuth redirect carries two temporary secrets in its query: a single-use authorization code and an anti-CSRF state token. The callback listener is local, but its stderr/stdout can still be collected by containers, supervisors, or developer tooling, so loopback transport does not make those values safe to record.
+
+## Decision
+
+Suppress the callback-only runner's generic access record before it is created. This boundary control is intentionally preferred over formatter redaction: formatters should never receive the raw callback target, and text and JSON modes inherit the same guarantee.
+
+## Constraints
+
+- The callback stays on the same path and invokes the same handler.
+- OAuth exchange, state validation, response HTML, and callback-server lifecycle remain unchanged.
+- Global application and proxy access logging remain unchanged.

--- a/openspec/changes/omit-oauth-callback-query-logs/design.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`OAuthCallbackServer` binds a loopback-only `aiohttp` application for `/auth/callback`. Its `web.AppRunner` currently uses aiohttp's default access logger, whose request target includes the complete query string. OAuth providers place the short-lived authorization code and anti-CSRF state token in that query, so the generic access record crosses a secret-bearing boundary before the existing text or JSON formatter runs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep authorization-code and state values out of every callback access-log sink.
+- Preserve the real callback request route, handler result, and server lifecycle.
+- Prove the boundary with a real loopback callback request.
+
+**Non-Goals:**
+
+- Changing global aiohttp, Uvicorn, or application logging policy.
+- Redacting arbitrary URLs after they have entered a log record.
+- Changing OAuth exchange, state validation, or browser response behavior.
+
+## Decisions
+
+### Disable access logging on the callback-only runner
+
+Construct the callback runner with `access_log=None`. This prevents the secret-bearing raw request target from entering logging at all and is the narrowest control available at the boundary.
+
+A callback-specific access logger that reconstructs method, fixed path, and status was rejected. It would preserve low-value loopback traffic metadata while adding a second formatter and a future route for query text to regress into logs. Global URL redaction was rejected because it broadens scope and still accepts secrets into the logging pipeline before redaction.
+
+### Exercise the real server seam
+
+The regression starts `OAuthCallbackServer` on an ephemeral loopback port, sends a callback containing distinct code and state sentinels, and asserts both successful handler behavior and absence from captured `aiohttp.access` records. Formatter-specific text and JSON behavior is covered by real-surface QA because the product fix must prevent record creation independent of output formatting.
+
+## Risks / Trade-offs
+
+- [Loss of one generic callback access record] -> Existing OAuth outcome handling remains authoritative; no operator contract requires raw loopback request access records.

--- a/openspec/changes/omit-oauth-callback-query-logs/proposal.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The loopback OAuth callback server's default access logger records the complete request target, exposing temporary authorization codes and anti-CSRF state tokens in both supported log formats. The callback must remain functional without sending credential-bearing query text to log sinks.
+
+## What Changes
+
+- Prevent the callback-only server from emitting raw HTTP access records.
+- Preserve callback routing, response status, and OAuth completion behavior.
+- Add a real-server regression covering authorization-code and state sentinels.
+
+## Capabilities
+
+### New Capabilities
+
+- `oauth-callback-privacy`: Defines credential-safe logging behavior for the loopback OAuth callback boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the callback-only `aiohttp` runner in `app/modules/oauth/service.py` and its integration coverage.
+- Removes one generic callback access record; existing application-level OAuth outcome logs remain unchanged.

--- a/openspec/changes/omit-oauth-callback-query-logs/specs/oauth-callback-privacy/spec.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/specs/oauth-callback-privacy/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: OAuth callback query credentials stay out of logs
+
+The loopback OAuth callback server MUST NOT emit authorization codes, state tokens, or the raw callback query string to access-log or application-log sinks. It MUST preserve callback routing and handler responses when access logging is suppressed.
+
+#### Scenario: Successful callback omits query credentials
+
+- **GIVEN** the real loopback callback server is running
+- **WHEN** a client requests `/auth/callback` with authorization-code and state query values
+- **THEN** the callback handler response is returned unchanged
+- **AND** neither query value is emitted to text or JSON logs
+
+#### Scenario: Access suppression is callback-local
+
+- **WHEN** the loopback OAuth callback server suppresses its access record
+- **THEN** global application and proxy access-logging configuration remains unchanged

--- a/openspec/changes/omit-oauth-callback-query-logs/specs/oauth-callback-privacy/spec.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/specs/oauth-callback-privacy/spec.md
@@ -2,14 +2,18 @@
 
 ### Requirement: OAuth callback query credentials stay out of logs
 
-The loopback OAuth callback server MUST NOT emit authorization codes, state tokens, or the raw callback query string to access-log or application-log sinks. It MUST preserve callback routing and handler responses when access logging is suppressed.
+The loopback OAuth callback server MUST NOT emit authorization codes, state
+tokens, or the raw callback query string through its generic access log. It
+MUST preserve callback routing and handler responses when access logging is
+suppressed.
 
 #### Scenario: Successful callback omits query credentials
 
 - **GIVEN** the real loopback callback server is running
 - **WHEN** a client requests `/auth/callback` with authorization-code and state query values
 - **THEN** the callback handler response is returned unchanged
-- **AND** neither query value is emitted to text or JSON logs
+- **AND** neither query value is emitted by the callback access logger under
+  text or JSON logging configuration
 
 #### Scenario: Access suppression is callback-local
 

--- a/openspec/changes/omit-oauth-callback-query-logs/tasks.md
+++ b/openspec/changes/omit-oauth-callback-query-logs/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression
+
+- [x] 1.1 Add a real `OAuthCallbackServer` integration test with distinct authorization-code and state sentinels.
+- [x] 1.2 Run the focused test against the default runner and capture the intended secret-absence assertion failing.
+
+## 2. Callback boundary
+
+- [x] 2.1 Suppress access logging on the callback-only `aiohttp` runner without changing global logging.
+- [x] 2.2 Re-run the same focused integration proof to green while preserving successful callback behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run changed-file diagnostics, focused OAuth tests, lint, type checks, and the appropriate package build.
+- [x] 3.2 Validate and verify the scoped OpenSpec change strictly.
+- [x] 3.3 Run the real callback server under text and JSON logging and prove both sentinels stay absent.

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from aiohttp import ClientSession, web
 from fastapi.responses import JSONResponse
 
 import app.modules.oauth.service as oauth_module
@@ -1133,6 +1134,36 @@ async def test_only_expired_pending_browser_flow_no_longer_keeps_callback_server
         assert not oauth_module._OAUTH_STORE.has_pending_browser_flows_locked()
         assert oauth_module._OAUTH_STORE._flows == {}
         assert oauth_module._OAUTH_STORE.state.status == "idle"
+
+
+@pytest.mark.asyncio
+async def test_callback_access_log_omits_code_and_state(caplog, unused_tcp_port):
+    code_secret = "CALLBACK_CODE_SECRET"
+    state_secret = "CALLBACK_STATE_SECRET"
+
+    async def handler(request: web.Request) -> web.StreamResponse:
+        assert request.query["code"] == code_secret
+        assert request.query["state"] == state_secret
+        return web.Response(text="callback accepted")
+
+    caplog.set_level(logging.INFO, logger="aiohttp.access")
+    server = oauth_module.OAuthCallbackServer(handler, port=unused_tcp_port)
+    await server.start()
+    try:
+        async with ClientSession() as client:
+            async with client.get(
+                f"http://127.0.0.1:{unused_tcp_port}/auth/callback",
+                params={"code": code_secret, "state": state_secret},
+            ) as response:
+                status = response.status
+                body = await response.text()
+    finally:
+        await server.stop()
+
+    assert status == 200
+    assert body == "callback accepted"
+    assert code_secret not in caplog.text
+    assert state_secret not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stops the loopback OAuth callback server from sending authorization-code and state query values to access-log sinks, while preserving the callback route and handler response.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] **Breaking change**

Linked issue: None — independently discovered; the bounded upstream issue/PR search found no matching owner or prerequisite.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches an OAuth flow and preserves callback behavior

Change directory: `openspec/changes/omit-oauth-callback-query-logs/`

## Changes

- Disable access logging only on the callback-specific aiohttp runner, before the raw query target enters logging.
- Add a real loopback-server regression that preserves the successful status/body and proves both query secrets are absent.
- Document the normative privacy boundary, design trade-off, and completed verification in OpenSpec.

## Simplicity

- [x] Works with zero configuration and changes no default outside the callback listener
- [x] Adds no setting, dependency, setup step, README section, `.env.example` entry, or dashboard navigation

## Test plan

```text
uv run pytest -q tests/integration/test_oauth_flow.py -k callback_access_log_omits_code_and_state
# 1 passed, 58 deselected

uv run pytest -q tests/integration/test_oauth_flow.py
# 59 passed

uv run ruff check app/modules/oauth/service.py tests/integration/test_oauth_flow.py
uv run ruff format --check app/modules/oauth/service.py tests/integration/test_oauth_flow.py
uv run ty check app/modules/oauth/service.py tests/integration/test_oauth_flow.py
uv build
openspec validate omit-oauth-callback-query-logs --type change --strict --no-interactive
```

The focused regression was captured failing first because `aiohttp.access` contained the complete callback query, then passed unchanged after callback-local access suppression.

## Real-server QA

The real callback server was exercised once under each shipped log formatter:

- text: callback returned HTTP 200; authorization-code and state sentinels absent
- JSON: callback returned HTTP 200; valid JSON log output; both sentinels absent
- the QA process exited cleanly and left no listener/process behind

## Related work and intentionally unrun checks

- One bounded issue query returned no match.
- One bounded PR query returned only unrelated draft PR #1183; this PR has no dependency on it.
- Full local CI was intentionally not run; the OAuth integration seam, changed-file lint/type checks, package build, strict scoped OpenSpec validation, and real text/JSON callback QA cover this focused change. Required GitHub CI remains authoritative.
- GitGuardian is PR-only evidence and was not reproduced locally.

## Checklist

- [x] Conventional Commit title
- [x] Added regression coverage at the externally failing callback seam
- [x] Strict OpenSpec validation passes and scoped verification is complete
- [x] Simplicity gates reviewed
- [x] `CHANGELOG.md` is untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth callback requests no longer expose authorization codes or state tokens in access logs.
  * OAuth callback handling and responses remain unchanged.
  * Global application and proxy access logging behavior is preserved.

* **Tests**
  * Added integration coverage confirming sensitive callback parameters are omitted from logs while successful OAuth responses continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->