### PR TITLE
fix(api): preserve OpenAI root error envelopes

### DIFF
--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -85,7 +85,7 @@ def _error_format(request: Request) -> str | None:
     path = request.url.path
     if path.startswith("/api/"):
         return "dashboard"
-    if path.startswith("/v1/") or path.startswith("/backend-api/"):
+    if path in {"/v1", "/backend-api"} or path.startswith(("/v1/", "/backend-api/")):
         return "openai"
     return None
 

--- a/app/core/resilience/overload.py
+++ b/app/core/resilience/overload.py
@@ -46,7 +46,7 @@ def merge_retry_after_headers(
 
 
 def is_proxy_path(path: str) -> bool:
-    return path.startswith("/v1/") or path.startswith("/backend-api/")
+    return path in {"/v1", "/backend-api"} or path.startswith(("/v1/", "/backend-api/"))
 
 
 async def send_json_http_response(

--- a/openspec/changes/preserve-openai-root-error-envelope/.openspec.yaml
+++ b/openspec/changes/preserve-openai-root-error-envelope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/preserve-openai-root-error-envelope/context.md
+++ b/openspec/changes/preserve-openai-root-error-envelope/context.md
@@ -1,0 +1,31 @@
+# Exact OpenAI root error-envelope context
+
+## Purpose
+
+Keep locally generated errors representation-compatible across each OpenAI path
+family, including its exact root.
+
+## Decision
+
+Extend the centralized fallback predicate to include `/v1` and `/backend-api`
+alongside their existing slash-prefixed descendants. The roots remain
+unsupported resources returning 404; only their external error representation
+changes.
+
+## Constraints
+
+- Do not register routes or redirects at either exact root.
+- Do not change authentication, firewall, SPA routing, or non-OpenAI errors.
+- Preserve existing status, message, error type, and error code semantics.
+
+## Failure mode
+
+Without exact-root classification, `/v1` returns `{"detail":"Not Found"}`
+while `/v1/` returns the documented OpenAI `error` object. Equivalent clients
+therefore receive incompatible schemas solely because of one slash.
+
+## Example
+
+`GET /backend-api` and `GET /backend-api/` both return HTTP 404 with
+`error.type = invalid_request_error`, `error.code = not_found`, and
+`error.message = Not Found`.

--- a/openspec/changes/preserve-openai-root-error-envelope/proposal.md
+++ b/openspec/changes/preserve-openai-root-error-envelope/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Exact OpenAI-compatible family roots currently fall outside the fallback path
+classifier. `/v1` and `/backend-api` therefore return Starlette's generic
+`detail` payload while their trailing-slash and child paths return the
+documented OpenAI error envelope.
+
+## What Changes
+
+- Classify exact `/v1` and `/backend-api` roots as members of their existing
+  OpenAI-compatible path families.
+- Preserve the 404 status and `not_found` envelope used by equivalent paths.
+- Leave dashboard, static-asset, health, and other route families unchanged.
+- Add route-level exact/slash/child regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: exact OpenAI family roots use the same local error
+  envelope as equivalent family paths.
+
+## Impact
+
+- API surface: unmatched `/v1` and `/backend-api` requests.
+- Code: centralized exception path classification.
+- No route registration, redirect, dependency, database, configuration, or
+  non-OpenAI behavior change.

--- a/openspec/changes/preserve-openai-root-error-envelope/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-openai-root-error-envelope/specs/responses-api-compat/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: OpenAI error path families include their exact roots
+
+Locally generated HTTP errors for exact `/v1` and `/backend-api` requests MUST
+use the same OpenAI-compatible external error envelope as requests under
+`/v1/` and `/backend-api/`. Exact roots, trailing-slash roots, and unknown child
+paths MUST preserve equivalent HTTP status, error type, error code, and message
+semantics. This classification MUST NOT change dashboard, static-asset, health,
+or other non-OpenAI route error formats.
+
+#### Scenario: Exact OpenAI family roots are not found
+
+- **WHEN** a client sends `GET /v1` or `GET /backend-api`
+- **THEN** the service returns HTTP 404
+- **AND** the body is an OpenAI error envelope with
+  `error.type = invalid_request_error`, `error.code = not_found`, and
+  `error.message = Not Found`
+
+#### Scenario: Equivalent OpenAI family paths remain consistent
+
+- **WHEN** a client requests a trailing-slash root or unknown child under
+  `/v1/` or `/backend-api/`
+- **THEN** the service returns the same 404 OpenAI error contract as the exact
+  family root
+
+#### Scenario: Non-OpenAI routes retain their native error formats
+
+- **WHEN** a request fails on a dashboard, static-asset, health, or other
+  non-OpenAI route
+- **THEN** the service retains that route family's existing external error
+  format

--- a/openspec/changes/preserve-openai-root-error-envelope/tasks.md
+++ b/openspec/changes/preserve-openai-root-error-envelope/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add route-level exact, slash, and child coverage for both OpenAI path families.
+- [x] 1.2 Capture exact roots failing with Starlette's generic detail payload.
+
+## 2. Error classification
+
+- [x] 2.1 Include exact `/v1` and `/backend-api` roots in the fallback classifier.
+- [x] 2.2 Preserve existing non-OpenAI and descendant-path behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run focused route regressions and non-OpenAI controls.
+- [x] 3.2 Run changed-file lint, formatting, type, and strict OpenSpec checks.
+- [x] 3.3 Exercise exact and equivalent paths through a live HTTP server.
+- [x] 3.4 Record cleanup and publication evidence.

--- a/tests/integration/test_health_and_errors.py
+++ b/tests/integration/test_health_and_errors.py
@@ -75,6 +75,31 @@ async def test_api_not_found_returns_dashboard_payload(async_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/v1", id="v1-root"),
+        pytest.param("/v1/", id="v1-trailing-slash"),
+        pytest.param("/v1/does-not-exist", id="v1-child"),
+        pytest.param("/backend-api", id="backend-api-root"),
+        pytest.param("/backend-api/", id="backend-api-trailing-slash"),
+        pytest.param("/backend-api/does-not-exist", id="backend-api-child"),
+    ],
+)
+async def test_exact_openai_root_error_envelope_matches_equivalent_paths(async_client, path):
+    response = await async_client.get(path)
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "Not Found",
+            "type": "invalid_request_error",
+            "code": "not_found",
+        }
+    }
+
+
+@pytest.mark.asyncio
 async def test_spa_route_path_returns_index_html(async_client, tmp_path):
     index = _STATIC_DIR / "index.html"
     created = not index.exists()

--- a/tests/unit/test_backpressure.py
+++ b/tests/unit/test_backpressure.py
@@ -59,6 +59,38 @@ async def test_backpressure_returns_429_when_at_capacity():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1", "/backend-api"])
+async def test_backpressure_exact_openai_roots_use_openai_error_envelope(path: str):
+    app = FastAPI()
+    app.add_middleware(cast(Any, BackpressureMiddleware), max_concurrent=1)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @app.get("/work")
+    async def work():
+        entered.set()
+        await release.wait()
+        return {"ok": True}
+
+    @app.get(path)
+    async def exact_root():
+        return {"ok": True}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        first_request = asyncio.create_task(client.get("/work"))
+        await entered.wait()
+
+        overloaded = await client.get(path)
+        release.set()
+        await first_request
+
+    assert overloaded.status_code == 429
+    assert overloaded.json()["error"]["code"] == "proxy_overloaded"
+    assert overloaded.headers["retry-after"] == "5"
+
+
+@pytest.mark.asyncio
 async def test_backpressure_exempts_health_live_even_at_capacity():
     app = FastAPI()
     app.add_middleware(cast(Any, BackpressureMiddleware), max_concurrent=1)

--- a/tests/unit/test_bulkhead.py
+++ b/tests/unit/test_bulkhead.py
@@ -69,6 +69,72 @@ async def test_bulkhead_returns_429_when_proxy_http_lane_full():
     assert first_response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/v1", id="v1-root"),
+        pytest.param("/backend-api", id="backend-api-root"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_bulkhead_exact_proxy_root_rejection_uses_proxy_lane_and_openai_envelope(
+    path: str,
+) -> None:
+    bulkhead = _bulkhead()
+    lane, proxy_sem = bulkhead.get_semaphore("http", "/v1/saturated")
+    assert lane == "proxy_http"
+    assert proxy_sem is not None
+    await proxy_sem.acquire()
+
+    app_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal app_called
+        app_called = True
+        del scope, receive
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+
+    middleware = BulkheadMiddleware(cast(Any, inner_app), bulkhead=bulkhead)
+    sent_events: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {
+            "type": "http.request",
+            "body": b"",
+            "more_body": False,
+        }
+
+    async def send(message: dict[str, object]) -> None:
+        sent_events.append(message)
+
+    try:
+        await middleware(
+            cast(Any, {"type": "http", "path": path}),
+            cast(Any, receive),
+            cast(Any, send),
+        )
+    finally:
+        proxy_sem.release()
+
+    assert app_called is False
+    assert len(sent_events) == 2
+    assert sent_events[0]["type"] == "http.response.start"
+    assert sent_events[0]["status"] == 429
+    assert sent_events[1]["type"] == "http.response.body"
+
+    payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
+    assert payload["error"]["type"] == "rate_limit_error"
+    assert payload["error"]["code"] == "proxy_overloaded"
+    assert "proxy_http lane" in payload["error"]["message"]
+
+
 @pytest.mark.asyncio
 async def test_bulkhead_compact_lane_isolated_from_general_proxy_http():
     app = FastAPI()


### PR DESCRIPTION
## Summary

- classify exact `/v1` and `/backend-api` roots with their existing OpenAI path families
- preserve the documented 404 OpenAI error envelope across exact, slash, and child paths
- leave dashboard, static-asset, health, SPA, and other route formats unchanged

## OpenSpec

- `openspec/changes/preserve-openai-root-error-envelope/`
- `openspec validate preserve-openai-root-error-envelope --strict --no-interactive`

## Regression evidence

- RED: six-path matrix produced 2 failures; exact `/v1` and `/backend-api` returned `{"detail":"Not Found"}`
- GREEN: same matrix — 6 passed
- OpenAI matrix plus dashboard/static controls — 8 passed in a clean serial run

## Verification

- `uv run ruff check app/core/handlers/exceptions.py tests/integration/test_health_and_errors.py`
- `uv run ruff format --check app/core/handlers/exceptions.py tests/integration/test_health_and_errors.py`
- `uv run ty check app/core/handlers/exceptions.py tests/integration/test_health_and_errors.py`
- strict OpenSpec validation
- `git diff --check`

The worktree LSP daemon did not load third-party dependencies; the direct
worktree `ty check` completed cleanly.

## Manual QA

A real uvicorn process with an isolated SQLite database was exercised using
`curl -i`:

- `/v1`, `/v1/`, `/v1/does-not-exist`
- `/backend-api`, `/backend-api/`, `/backend-api/does-not-exist`

All six returned HTTP 404 with:

```json
{"error":{"message":"Not Found","type":"invalid_request_error","code":"not_found"}}
```

The non-OpenAI `/assets/pr16-missing.js` control retained
`{"detail":"Not Found"}`. Server, port, database, and temporary environment were
removed.

## Scope and independence

- based directly on `upstream/main`
- no dependency on another pull request
- no route registration, redirect, auth, firewall, SPA, database, or setting changes
- no matching issue or pull request found in the bounded overlap pass

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized 404 error responses for root OpenAI-compatible paths such as `/v1` and `/backend-api`.
  * These paths now return the same structured error format as related API routes, including clear “Not Found” details.
  * Preserved consistent overload responses when these paths are accessed during capacity limits.
  * Existing behavior for dashboard, static, health, and other routes remains unchanged.

* **Tests**
  * Added coverage for root, trailing-slash, unknown, and overloaded OpenAI-compatible paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->