### PR TITLE
fix(proxy): settle accepted background JSON

### DIFF
--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -410,6 +410,24 @@ def _facade() -> Any:
     return sys.modules["app.modules.proxy.service"]
 
 
+def _is_background_json_ack(
+    stream: bool | None,
+    event_payload: dict[str, JsonValue] | None,
+    event_type: str | None,
+) -> bool:
+    if stream is not False or event_type not in {"response.queued", "response.in_progress"}:
+        return False
+    response = event_payload.get("response") if event_payload is not None else None
+    return (
+        isinstance(response, dict)
+        and response.get("object") == "response"
+        and isinstance(response.get("id"), str)
+        and bool(response["id"])
+        and response.get("status") == event_type.removeprefix("response.")
+        and response.get("output") == []
+    )
+
+
 def _stream_iterator_after_capacity_admission(
     stream: AsyncIterator[str],
 ) -> AsyncIterator[str]:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -424,6 +424,7 @@ def _canonical_background_ack_response_id(
         and response.get("object") == "response"
         and isinstance(response_id, str)
         and bool(response_id)
+        and response_id == response_id.strip()
         and response.get("status") == event_type.removeprefix("response.")
         and response.get("output") == []
     ):

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -54,7 +54,8 @@ from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
 from app.core.openai.models import OpenAIError, OpenAIEvent
-from app.core.openai.parsing import parse_sse_event
+from app.core.openai.parsing import classify_event_type, parse_sse_event
+from app.core.openai.requests import ResponsesRequest
 from app.core.resilience.network_recovery import (
     PROCESS_NETWORK_UNAVAILABLE_CODE,
 )
@@ -436,6 +437,24 @@ def _is_background_json_ack(
     event_type: str | None,
 ) -> bool:
     return stream is False and _canonical_background_ack_response_id(event_payload, event_type) is not None
+
+
+def _settle_background_ack(
+    settlement: _StreamSettlement,
+    payload: ResponsesRequest,
+    event_payload: dict[str, JsonValue] | None,
+    response_id: str,
+) -> tuple[bool, str]:
+    """Treat a canonical background acknowledgement as the terminal event of a `stream: false` request."""
+    ack_response_id = (
+        _canonical_background_ack_response_id(event_payload, classify_event_type(event_payload))
+        if payload.stream is False
+        else None
+    )
+    if ack_response_id is None:
+        return False, response_id
+    settlement.response_id = ack_response_id
+    return True, ack_response_id
 
 
 def _stream_iterator_after_capacity_admission(

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -410,22 +410,32 @@ def _facade() -> Any:
     return sys.modules["app.modules.proxy.service"]
 
 
+def _canonical_background_ack_response_id(
+    event_payload: dict[str, JsonValue] | None,
+    event_type: str | None,
+) -> str | None:
+    if event_type not in {"response.queued", "response.in_progress"}:
+        return None
+    response = event_payload.get("response") if event_payload is not None else None
+    response_id = response.get("id") if isinstance(response, dict) else None
+    if not (
+        isinstance(response, dict)
+        and response.get("object") == "response"
+        and isinstance(response_id, str)
+        and bool(response_id)
+        and response.get("status") == event_type.removeprefix("response.")
+        and response.get("output") == []
+    ):
+        return None
+    return response_id
+
+
 def _is_background_json_ack(
     stream: bool | None,
     event_payload: dict[str, JsonValue] | None,
     event_type: str | None,
 ) -> bool:
-    if stream is not False or event_type not in {"response.queued", "response.in_progress"}:
-        return False
-    response = event_payload.get("response") if event_payload is not None else None
-    return (
-        isinstance(response, dict)
-        and response.get("object") == "response"
-        and isinstance(response.get("id"), str)
-        and bool(response["id"])
-        and response.get("status") == event_type.removeprefix("response.")
-        and response.get("output") == []
-    )
+    return stream is False and _canonical_background_ack_response_id(event_payload, event_type) is not None
 
 
 def _stream_iterator_after_capacity_admission(

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -53,7 +53,7 @@ from app.core.errors import (
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
-from app.core.openai.models import OpenAIError, OpenAIEvent
+from app.core.openai.models import OpenAIError, OpenAIEvent, OpenAIResponsePayload
 from app.core.openai.parsing import classify_event_type, parse_sse_event
 from app.core.openai.requests import ResponsesRequest
 from app.core.resilience.network_recovery import (
@@ -428,6 +428,14 @@ def _canonical_background_ack_response_id(
         and response.get("status") == event_type.removeprefix("response.")
         and response.get("output") == []
     ):
+        return None
+    # The relayed payload model drops known submodels that fail validation
+    # instead of raising, so a malformed `usage` or `error` would otherwise be
+    # discarded silently on a response classified as successful.
+    payload = OpenAIResponsePayload.model_validate(response)
+    if (response.get("usage") is None) != (payload.usage is None):
+        return None
+    if (response.get("error") is None) != (payload.error is None):
         return None
     return response_id
 

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -53,7 +53,7 @@ from app.core.errors import (
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
-from app.core.openai.models import OpenAIError, OpenAIEvent, OpenAIResponsePayload
+from app.core.openai.models import OpenAIError, OpenAIEvent, OpenAIResponsePayload, ResponseUsage
 from app.core.openai.parsing import classify_event_type, parse_sse_event
 from app.core.openai.requests import ResponsesRequest
 from app.core.resilience.network_recovery import (
@@ -411,10 +411,10 @@ def _facade() -> Any:
     return sys.modules["app.modules.proxy.service"]
 
 
-def _canonical_background_ack_response_id(
+def _canonical_background_ack(
     event_payload: dict[str, JsonValue] | None,
     event_type: str | None,
-) -> str | None:
+) -> tuple[str, OpenAIResponsePayload] | None:
     if event_type not in {"response.queued", "response.in_progress"}:
         return None
     response = event_payload.get("response") if event_payload is not None else None
@@ -437,7 +437,15 @@ def _canonical_background_ack_response_id(
         return None
     if (response.get("error") is None) != (payload.error is None):
         return None
-    return response_id
+    return response_id, payload
+
+
+def _canonical_background_ack_response_id(
+    event_payload: dict[str, JsonValue] | None,
+    event_type: str | None,
+) -> str | None:
+    canonical_ack = _canonical_background_ack(event_payload, event_type)
+    return canonical_ack[0] if canonical_ack is not None else None
 
 
 def _is_background_json_ack(
@@ -453,17 +461,18 @@ def _settle_background_ack(
     payload: ResponsesRequest,
     event_payload: dict[str, JsonValue] | None,
     response_id: str,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, ResponseUsage | None]:
     """Treat a canonical background acknowledgement as the terminal event of a `stream: false` request."""
-    ack_response_id = (
-        _canonical_background_ack_response_id(event_payload, classify_event_type(event_payload))
+    canonical_ack = (
+        _canonical_background_ack(event_payload, classify_event_type(event_payload))
         if payload.stream is False
         else None
     )
-    if ack_response_id is None:
-        return False, response_id
+    if canonical_ack is None:
+        return False, response_id, None
+    ack_response_id, ack_payload = canonical_ack
     settlement.response_id = ack_response_id
-    return True, ack_response_id
+    return True, ack_response_id, ack_payload.usage
 
 
 def _stream_iterator_after_capacity_admission(

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -279,7 +279,6 @@ from app.modules.proxy._service.streaming.helpers import (
     _openai_error_fields,
     _raw_stream_error_code_or_upstream,
     _rewrite_malformed_stream_error_event,
-    _settle_background_ack,
     _stream_transport_failure_event_or_raise,
 )
 from app.modules.proxy._service.streaming.helpers import _raw_stream_error_fields as _raw_error_fields
@@ -289,6 +288,7 @@ from app.modules.proxy._service.streaming.helpers import (
 from app.modules.proxy._service.streaming.helpers import (
     _select_account_with_budget_for_stream as _select_account_with_budget_for_stream_helper,
 )
+from app.modules.proxy._service.streaming.helpers import _settle_background_ack as _settle_bg_ack
 from app.modules.proxy._service.streaming.protocol import _StreamingServiceProtocol
 from app.modules.proxy._service.streaming.retry import _StreamingRetryMixin
 from app.modules.proxy._service.support import (
@@ -633,7 +633,7 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
-            terminal_event_seen, response_id = _settle_background_ack(settlement, payload, first_payload, response_id)
+            terminal_event_seen, response_id, usage = _settle_bg_ack(settlement, payload, first_payload, response_id)
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -632,17 +632,7 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
-            response = first_payload.get("response") if first_payload is not None else None
-            terminal_event_seen = (
-                payload.stream is False
-                and event_type in {"response.queued", "response.in_progress"}
-                and isinstance(response, dict)
-                and response.get("object") == "response"
-                and isinstance(response.get("id"), str)
-                and bool(response["id"])
-                and response.get("status") == event_type.removeprefix("response.")
-                and response.get("output") == []
-            )
+            terminal_event_seen = _facade()._is_background_json_ack(payload.stream, first_payload, event_type)
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -622,7 +622,6 @@ class _StreamingMixin(_StreamingRetryMixin):
             first_payload = parse_sse_data_json(first)
             event_type = classify_event_type(first_payload)
             event = parse_sse_event_payload(first_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
-            terminal_event_seen = False
             preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
             malformed_error_rewrite = _rewrite_malformed_stream_error_event(
                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
@@ -633,6 +632,17 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
+            response = first_payload.get("response") if first_payload is not None else None
+            terminal_event_seen = (
+                payload.stream is False
+                and event_type in {"response.queued", "response.in_progress"}
+                and isinstance(response, dict)
+                and response.get("object") == "response"
+                and isinstance(response.get("id"), str)
+                and bool(response["id"])
+                and response.get("status") == event_type.removeprefix("response.")
+                and response.get("output") == []
+            )
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -279,6 +279,7 @@ from app.modules.proxy._service.streaming.helpers import (
     _openai_error_fields,
     _raw_stream_error_code_or_upstream,
     _rewrite_malformed_stream_error_event,
+    _settle_background_ack,
     _stream_transport_failure_event_or_raise,
 )
 from app.modules.proxy._service.streaming.helpers import _raw_stream_error_fields as _raw_error_fields
@@ -632,15 +633,7 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
-            ack_response_id = (
-                _facade()._canonical_background_ack_response_id(first_payload, event_type)
-                if payload.stream is False
-                else None
-            )
-            terminal_event_seen = ack_response_id is not None
-            if ack_response_id is not None:
-                response_id = ack_response_id
-                settlement.response_id = ack_response_id
+            terminal_event_seen, response_id = _settle_background_ack(settlement, payload, first_payload, response_id)
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -632,7 +632,15 @@ class _StreamingMixin(_StreamingRetryMixin):
             )
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
-            terminal_event_seen = _facade()._is_background_json_ack(payload.stream, first_payload, event_type)
+            ack_response_id = (
+                _facade()._canonical_background_ack_response_id(first_payload, event_type)
+                if payload.stream is False
+                else None
+            )
+            terminal_event_seen = ack_response_id is not None
+            if ack_response_id is not None:
+                response_id = ack_response_id
+                settlement.response_id = ack_response_id
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -8708,18 +8708,18 @@ async def _collect_responses_payload(
                 else:
                     parsed = None
                 if parsed is not None:
-                    if event_type in ("response.queued", "response.in_progress"):
-                        if isinstance(parsed, OpenAIResponsePayload) and proxy_service_module._is_background_json_ack(
-                            False,
-                            payload,
-                            event_type,
-                        ):
-                            nonterminal_result = parsed
-                        else:
-                            contract_violation_kind = contract_violation_kind or "invalid_json"
-                    else:
+                    if event_type not in ("response.queued", "response.in_progress"):
                         terminal_result = parsed
-                    continue
+                        continue
+                    if isinstance(parsed, OpenAIResponsePayload) and proxy_service_module._is_background_json_ack(
+                        False,
+                        payload,
+                        event_type,
+                    ):
+                        nonterminal_result = parsed
+                        continue
+            # A queued/in-progress object that is not a canonical acknowledgement
+            # is a contract violation and terminal, like an unparsable response.
             error_kind = contract_violation_kind or "invalid_json"
             terminal_result = _public_contract_error_envelope(
                 error_kind,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6591,6 +6591,7 @@ async def _collect_responses(
         if downstream_turn_state is not None
         else {}
     )
+    upstream_stream_false = preserve_upstream_stream_mode and payload.stream is False
     if not preserve_upstream_stream_mode:
         payload.stream = True
     if prefer_http_bridge:
@@ -6633,6 +6634,7 @@ async def _collect_responses(
         response_payload = await _collect_responses_payload(
             stream,
             captured_turn_state_headers=captured_turn_state_headers,
+            upstream_stream_false=upstream_stream_false,
         )
     except asyncio.CancelledError:
         if _responses_origin_may_release_reservation(
@@ -8664,6 +8666,7 @@ async def _collect_responses_payload(
     stream: AsyncIterator[str],
     *,
     captured_turn_state_headers: dict[str, str] | None = None,
+    upstream_stream_false: bool = False,
 ) -> OpenAIResponseResult:
     output_items: dict[int, dict[str, JsonValue]] = {}
     terminal_result: OpenAIResponseResult | None = None
@@ -8711,6 +8714,10 @@ async def _collect_responses_payload(
                     if event_type not in ("response.queued", "response.in_progress"):
                         terminal_result = parsed
                         continue
+                    if not upstream_stream_false:
+                        if isinstance(parsed, OpenAIResponsePayload):
+                            nonterminal_result = parsed
+                        continue
                     if isinstance(parsed, OpenAIResponsePayload) and proxy_service_module._is_background_json_ack(
                         False,
                         payload,
@@ -8718,8 +8725,9 @@ async def _collect_responses_payload(
                     ):
                         nonterminal_result = parsed
                         continue
-            # A queued/in-progress object that is not a canonical acknowledgement
-            # is a contract violation and terminal, like an unparsable response.
+            # Unparsable queued/in-progress payloads are always contract violations.
+            # Parseable but noncanonical acknowledgements reach this branch only for
+            # the single-object stream:false HTTP JSON exchange.
             error_kind = contract_violation_kind or "invalid_json"
             terminal_result = _public_contract_error_envelope(
                 error_kind,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -8709,8 +8709,14 @@ async def _collect_responses_payload(
                     parsed = None
                 if parsed is not None:
                     if event_type in ("response.queued", "response.in_progress"):
-                        if isinstance(parsed, OpenAIResponsePayload):
+                        if isinstance(parsed, OpenAIResponsePayload) and proxy_service_module._is_background_json_ack(
+                            False,
+                            payload,
+                            event_type,
+                        ):
                             nonterminal_result = parsed
+                        else:
+                            contract_violation_kind = contract_violation_kind or "invalid_json"
                     else:
                         terminal_result = parsed
                     continue

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -521,6 +521,7 @@ from app.modules.proxy._service.streaming.helpers import (
 from app.modules.proxy._service.streaming.helpers import (
     _is_account_neutral_transport_drop as _is_account_neutral_transport_drop,
 )
+from app.modules.proxy._service.streaming.helpers import _is_background_json_ack as _is_background_json_ack
 from app.modules.proxy._service.streaming.helpers import (
     _push_stream_attempt_timeout_overrides as _push_stream_attempt_timeout_overrides,
 )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -516,9 +516,6 @@ from app.modules.proxy._service.streaming.helpers import (
     _call_stream_with_supported_optional_kwargs as _call_stream_with_supported_optional_kwargs,
 )
 from app.modules.proxy._service.streaming.helpers import (
-    _canonical_background_ack_response_id as _canonical_background_ack_response_id,
-)
-from app.modules.proxy._service.streaming.helpers import (
     _classify_upstream_close as _classify_upstream_close,
 )
 from app.modules.proxy._service.streaming.helpers import (

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -516,6 +516,9 @@ from app.modules.proxy._service.streaming.helpers import (
     _call_stream_with_supported_optional_kwargs as _call_stream_with_supported_optional_kwargs,
 )
 from app.modules.proxy._service.streaming.helpers import (
+    _canonical_background_ack_response_id as _canonical_background_ack_response_id,
+)
+from app.modules.proxy._service.streaming.helpers import (
     _classify_upstream_close as _classify_upstream_close,
 )
 from app.modules.proxy._service.streaming.helpers import (

--- a/openspec/changes/classify-background-json-completion/.openspec.yaml
+++ b/openspec/changes/classify-background-json-completion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/classify-background-json-completion/context.md
+++ b/openspec/changes/classify-background-json-completion/context.md
@@ -1,0 +1,33 @@
+# Background JSON completion context
+
+## Purpose
+
+Distinguish completion of a non-streaming HTTP exchange from completion of the
+background Responses job represented by its JSON body.
+
+## Decision
+
+For a request whose upstream `stream` value is exactly `false`, one fully read
+canonical background acknowledgement completes the transport and settles
+successfully. The acknowledgement has `object: "response"`, a non-empty `id`, a
+queued/in-progress status matching its event type, and an empty `output` list.
+The object is returned unchanged. The event names remain nonterminal for SSE
+streams.
+
+## Constraints
+
+- Do not add polling or wait for background job completion.
+- Do not reinterpret failed, incomplete, malformed, or empty responses.
+- Do not treat partial or malformed queued/in-progress objects as accepted
+  acknowledgements.
+- Do not relax genuine `stream_incomplete` handling for streaming requests.
+- Preserve account selection, reservation, usage, and response shapes.
+
+## Example
+
+A `stream: false` request receives HTTP 200 JSON with
+`{"object":"response","id":"resp_1","status":"queued","output":[]}`. The client
+receives that object, the request log records success, and account health
+records success. A malformed object with non-object output items and a
+`stream: true` SSE connection that disconnects after `response.queued` both
+retain error settlement.

--- a/openspec/changes/classify-background-json-completion/context.md
+++ b/openspec/changes/classify-background-json-completion/context.md
@@ -27,7 +27,8 @@ streams.
 
 A `stream: false` request receives HTTP 200 JSON with
 `{"object":"response","id":"resp_1","status":"queued","output":[]}`. The client
-receives that object, the request log records success, and account health
-records success. A malformed object with non-object output items and a
-`stream: true` SSE connection that disconnects after `response.queued` both
-retain error settlement.
+receives that object, the request log records success keyed by `resp_1`, and
+account health records success. A queued object that omits `object` or a
+non-empty `id` returns the same external contract error as other malformed
+acknowledgements, and a `stream: true` SSE connection that disconnects after
+`response.queued` retains error settlement.

--- a/openspec/changes/classify-background-json-completion/proposal.md
+++ b/openspec/changes/classify-background-json-completion/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`POST /backend-api/codex/responses` preserves `stream: false` and returns an
+accepted background Response whose status is `queued` or `in_progress`. Stream
+settlement nevertheless expects a terminal SSE event and records
+`stream_incomplete`, penalizing a healthy account after a successful HTTP JSON
+exchange.
+
+## What Changes
+
+- Treat a canonical queued/in-progress background acknowledgement from
+  `stream: false` as transport-complete for settlement.
+- Record successful request-log and account-health outcomes.
+- Preserve nonterminal EOF failure for actual streaming requests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: accepted background JSON completes its HTTP transport
+  without making the same lifecycle event terminal for SSE.
+
+## Impact
+
+- HTTP Responses settlement classification only.
+- No setting, schema, polling, response shape, or global event classification.

--- a/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
@@ -12,7 +12,8 @@ the `/v1/responses` subscription compatibility path, which MAY aggregate an
 upstream stream when required by the configured ChatGPT Codex backend.
 
 When the completed HTTP exchange returns a canonical background acknowledgement
-with `object = response`, a non-empty response ID, status `queued` or
+with `object = response`, a non-empty response ID without surrounding
+whitespace, status `queued` or
 `in_progress` matching the event type, and `output = []`, the proxy MUST treat
 the transport as successful: the request log MUST use `status=success` without
 `stream_incomplete`, account health MUST take the successful-request path, and
@@ -42,7 +43,7 @@ streams.
 - **GIVEN** a backend Responses request has `stream: false`
 - **AND** upstream returns one valid Response object with status `queued` or
   `in_progress`
-- **AND** the object has a non-empty ID and an empty output list
+- **AND** the object has a non-empty, unpadded ID and an empty output list
 - **WHEN** codex-lb finishes reading that HTTP response
 - **THEN** the Response object is returned unchanged
 - **AND** the request log records success without `stream_incomplete`

--- a/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
@@ -23,6 +23,7 @@ streams.
 - **WHEN** codex-lb finishes reading that HTTP response
 - **THEN** the Response object is returned unchanged
 - **AND** the request log records success without `stream_incomplete`
+- **AND** the request log stores the returned response ID for later owner lookup
 - **AND** account health records success without an error penalty
 
 #### Scenario: Malformed background object retains error settlement

--- a/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
@@ -2,7 +2,14 @@
 
 ### Requirement: Backend non-streaming Responses preserve HTTP JSON transport
 
-When `POST /backend-api/codex/responses` receives a valid request with `stream: false`, the service MUST preserve that value upstream, MUST use HTTP rather than WebSocket, and MUST return one `application/json` Response object.
+When `POST /backend-api/codex/responses` receives a valid request with
+`stream: false`, the service MUST preserve that value in the upstream request,
+MUST use upstream HTTP rather than WebSocket, and MUST return one
+`application/json` Response object rather than an SSE stream. The service MUST
+retain the existing account selection, error masking, usage settlement, and
+request logging behavior around that request. This requirement does not change
+the `/v1/responses` subscription compatibility path, which MAY aggregate an
+upstream stream when required by the configured ChatGPT Codex backend.
 
 When the completed HTTP exchange returns a canonical background acknowledgement
 with `object = response`, a non-empty response ID, status `queued` or
@@ -13,6 +20,22 @@ the account MUST NOT receive a transient error-health penalty. This transport
 classification MUST NOT make malformed or partial response objects successful
 and MUST NOT make `response.queued` or `response.in_progress` terminal for SSE
 streams.
+
+#### Scenario: Backend stream false stays false upstream
+
+- **GIVEN** a client sends `POST /backend-api/codex/responses` with
+  `stream: false`
+- **WHEN** codex-lb forwards the request to an HTTP-capable upstream
+- **THEN** the upstream request body MUST contain `stream: false`
+- **AND** its request headers MUST advertise `Accept: application/json`
+- **AND** codex-lb MUST NOT open an upstream WebSocket for that request.
+
+#### Scenario: Backend non-streaming response remains JSON downstream
+
+- **GIVEN** the upstream returns a successful single Response JSON object
+- **WHEN** codex-lb completes the backend non-streaming request
+- **THEN** the downstream response MUST have an `application/json` content type
+- **AND** its Response fields MUST preserve the upstream values.
 
 #### Scenario: Accepted background JSON settles successfully
 

--- a/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-background-json-completion/specs/responses-api-compat/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Backend non-streaming Responses preserve HTTP JSON transport
+
+When `POST /backend-api/codex/responses` receives a valid request with `stream: false`, the service MUST preserve that value upstream, MUST use HTTP rather than WebSocket, and MUST return one `application/json` Response object.
+
+When the completed HTTP exchange returns a canonical background acknowledgement
+with `object = response`, a non-empty response ID, status `queued` or
+`in_progress` matching the event type, and `output = []`, the proxy MUST treat
+the transport as successful: the request log MUST use `status=success` without
+`stream_incomplete`, account health MUST take the successful-request path, and
+the account MUST NOT receive a transient error-health penalty. This transport
+classification MUST NOT make malformed or partial response objects successful
+and MUST NOT make `response.queued` or `response.in_progress` terminal for SSE
+streams.
+
+#### Scenario: Accepted background JSON settles successfully
+
+- **GIVEN** a backend Responses request has `stream: false`
+- **AND** upstream returns one valid Response object with status `queued` or
+  `in_progress`
+- **AND** the object has a non-empty ID and an empty output list
+- **WHEN** codex-lb finishes reading that HTTP response
+- **THEN** the Response object is returned unchanged
+- **AND** the request log records success without `stream_incomplete`
+- **AND** account health records success without an error penalty
+
+#### Scenario: Malformed background object retains error settlement
+
+- **GIVEN** a backend non-streaming response reports queued or in-progress
+- **BUT** its response object is missing canonical acknowledgement fields or
+  contains malformed output items
+- **WHEN** codex-lb validates the response
+- **THEN** the external contract error is returned
+- **AND** request-log and account-health settlement MUST remain on the error
+  path
+
+#### Scenario: Streaming progress EOF remains truncated
+
+- **GIVEN** a Responses request uses streaming transport
+- **AND** upstream emits `response.queued` or `response.in_progress`
+- **WHEN** the stream ends before a terminal Responses event
+- **THEN** settlement remains `stream_incomplete`
+- **AND** existing request-log and account-health error handling remains
+  unchanged

--- a/openspec/changes/classify-background-json-completion/tasks.md
+++ b/openspec/changes/classify-background-json-completion/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Define successful accepted-JSON settlement and streaming EOF controls.
+
+## 2. Regression coverage
+
+- [x] 2.1 Add queued/in-progress route cases covering response, logs, and health.
+- [x] 2.2 Capture failing request-log and account-health settlement before code.
+
+## 3. Implementation
+
+- [x] 3.1 Mark accepted single-JSON transport complete only for `stream: false`.
+
+## 4. Verification
+
+- [x] 4.1 Run focused controls, quality checks, OpenSpec validation, and QA.
+- [x] 4.2 Record cleanup and publication evidence.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -3008,6 +3008,8 @@ async def test_background_json_completion_is_not_truncated(
         assert response.json()["status"] == status
         assert request_log_calls[0]["status"] == "success"
         assert request_log_calls[0]["error_code"] is None
+        assert request_log_calls[0]["request_id"] == f"resp_background_json_{status}"
+        assert request_log_calls[0]["archive_request_id"] != request_log_calls[0]["request_id"]
         assert error_account_ids == []
         assert success_account_ids == [expected_account_id]
     else:
@@ -3017,6 +3019,91 @@ async def test_background_json_completion_is_not_truncated(
         assert request_log_calls[0]["error_code"] == "stream_incomplete"
         assert error_account_ids == [expected_account_id]
         assert success_account_ids == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "response_body"),
+    [
+        pytest.param(
+            "queued",
+            {"id": "resp_missing_object", "status": "queued", "output": []},
+            id="missing-object",
+        ),
+        pytest.param(
+            "in_progress",
+            {"id": "", "object": "response", "status": "in_progress", "output": []},
+            id="empty-id",
+        ),
+    ],
+)
+async def test_background_json_malformed_ack_returns_contract_error(
+    async_client,
+    monkeypatch,
+    status: str,
+    response_body: dict[str, JsonValue],
+) -> None:
+    email = f"background-json-malformed-{status}@example.com"
+    raw_account_id = f"acc_background_json_malformed_{status}"
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    request_log_calls: list[dict[str, object]] = []
+    error_account_ids: list[str] = []
+    success_account_ids: list[str] = []
+
+    async def fake_stream(
+        payload: ResponsesRequest,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncIterator[str]:
+        assert payload.stream is False
+        yield proxy_module.format_sse_event(
+            {
+                "type": f"response.{status}",
+                "response": response_body,
+            }
+        )
+
+    async def fake_write_request_log(
+        _self: object,
+        **kwargs: object,
+    ) -> None:
+        request_log_calls.append(dict(kwargs))
+
+    async def fake_record_error(_self: object, account: Account) -> None:
+        error_account_ids.append(account.id)
+
+    async def fake_record_success(_self: object, account: Account) -> None:
+        success_account_ids.append(account.id)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "record_error", fake_record_error)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "record_success", fake_record_success)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": False,
+            "background": True,
+        },
+    )
+
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "invalid_json"
+    assert len(request_log_calls) == 1
+    assert request_log_calls[0]["status"] == "error"
+    assert request_log_calls[0]["error_code"] == "stream_incomplete"
+    assert error_account_ids == [expected_account_id]
+    assert success_account_ids == []
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -3022,6 +3022,134 @@ async def test_background_json_completion_is_not_truncated(
 
 
 @pytest.mark.asyncio
+async def test_background_json_ack_usage_is_finalized(async_client, monkeypatch) -> None:
+    email = "background-json-usage@example.com"
+    raw_account_id = "acc_background_json_usage"
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    reservation = ApiKeyUsageReservationData(
+        reservation_id="resv_background_json_usage",
+        key_id="key_background_json_usage",
+        model="gpt-5.4",
+    )
+    request_log_calls: list[dict[str, object]] = []
+    settle_calls: list[dict[str, object]] = []
+    success_account_ids: list[str] = []
+
+    async def fake_stream(
+        payload: ResponsesRequest,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncIterator[str]:
+        assert payload.stream is False
+        yield proxy_module.format_sse_event(
+            {
+                "type": "response.queued",
+                "response": {
+                    "id": "resp_background_json_usage",
+                    "object": "response",
+                    "status": "queued",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 12,
+                        "output_tokens": 3,
+                        "total_tokens": 15,
+                        "input_tokens_details": {"cached_tokens": 2},
+                        "output_tokens_details": {"reasoning_tokens": 1},
+                    },
+                },
+            }
+        )
+
+    async def fake_enforce_request_limits(*_args: object, **_kwargs: object) -> ApiKeyUsageReservationData:
+        return reservation
+
+    async def fake_write_request_log(
+        _self: object,
+        **kwargs: object,
+    ) -> None:
+        request_log_calls.append(dict(kwargs))
+
+    async def fake_settle_stream_api_key_usage(
+        _self: object,
+        _api_key: object,
+        api_key_reservation: ApiKeyUsageReservationData | None,
+        settlement: proxy_module._StreamSettlement,
+        request_id: str,
+        **kwargs: object,
+    ) -> bool:
+        settle_calls.append(
+            {
+                "reservation": api_key_reservation,
+                "status": settlement.status,
+                "request_id": request_id,
+                "input_tokens": settlement.input_tokens,
+                "output_tokens": settlement.output_tokens,
+                "cached_input_tokens": settlement.cached_input_tokens,
+                "wait_for_settlement": kwargs.get("wait_for_settlement", False),
+            }
+        )
+        return True
+
+    async def fake_record_success(_self: object, account: Account) -> None:
+        success_account_ids.append(account.id)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", fake_enforce_request_limits)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_settle_stream_api_key_usage",
+        fake_settle_stream_api_key_usage,
+    )
+    monkeypatch.setattr(proxy_module.LoadBalancer, "record_success", fake_record_success)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": False,
+            "background": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 3,
+        "total_tokens": 15,
+        "input_tokens_details": {"cached_tokens": 2},
+        "output_tokens_details": {"reasoning_tokens": 1},
+    }
+    assert len(request_log_calls) == 1
+    request_log = request_log_calls[0]
+    assert request_log["status"] == "success"
+    assert request_log["request_id"] == "resp_background_json_usage"
+    assert request_log["input_tokens"] == 12
+    assert request_log["output_tokens"] == 3
+    assert request_log["cached_input_tokens"] == 2
+    assert request_log["reasoning_tokens"] == 1
+    assert settle_calls == [
+        {
+            "reservation": reservation,
+            "status": "success",
+            "request_id": request_log_calls[0]["archive_request_id"],
+            "input_tokens": 12,
+            "output_tokens": 3,
+            "cached_input_tokens": 2,
+            "wait_for_settlement": False,
+        }
+    ]
+    assert success_account_ids == [expected_account_id]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "response_body"),
     [

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from types import SimpleNamespace
 from typing import cast
 
@@ -17,6 +17,7 @@ import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.config.settings import Settings
 from app.core.openai.models import CompactResponsePayload
+from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.time import utcnow
 from app.db.models import Account, DashboardSettings, RequestLog, StickySessionKind
@@ -2924,6 +2925,98 @@ async def test_backend_responses_preserves_non_streaming_json_contract(async_cli
     assert resp.headers["content-type"].startswith("application/json")
     assert resp.json()["id"] == "resp_1"
     assert observed_stream["value"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "output", "accepted"),
+    [
+        pytest.param("queued", [], True, id="queued"),
+        pytest.param("in_progress", [], True, id="in-progress"),
+        pytest.param("queued", ["not-an-object"], False, id="malformed-output"),
+    ],
+)
+async def test_background_json_completion_is_not_truncated(
+    async_client,
+    monkeypatch,
+    status: str,
+    output: list[JsonValue],
+    accepted: bool,
+) -> None:
+    email = f"background-json-{status}@example.com"
+    raw_account_id = f"acc_background_json_{status}"
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    request_log_calls: list[dict[str, object]] = []
+    error_account_ids: list[str] = []
+    success_account_ids: list[str] = []
+
+    async def fake_stream(
+        payload: ResponsesRequest,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncIterator[str]:
+        assert payload.stream is False
+        event_payload: dict[str, JsonValue] = {
+            "type": f"response.{status}",
+            "response": {
+                "id": f"resp_background_json_{status}",
+                "object": "response",
+                "status": status,
+                "output": output,
+            },
+        }
+        yield proxy_module.format_sse_event(event_payload)
+
+    async def fake_write_request_log(
+        _self: object,
+        **kwargs: object,
+    ) -> None:
+        request_log_calls.append(dict(kwargs))
+
+    async def fake_record_error(_self: object, account: Account) -> None:
+        error_account_ids.append(account.id)
+
+    async def fake_record_success(_self: object, account: Account) -> None:
+        success_account_ids.append(account.id)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "record_error", fake_record_error)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "record_success", fake_record_success)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": False,
+            "background": True,
+        },
+    )
+
+    assert response.headers["content-type"].startswith("application/json")
+    assert len(request_log_calls) == 1
+    if accepted:
+        assert response.status_code == 200
+        assert response.json()["id"] == f"resp_background_json_{status}"
+        assert response.json()["status"] == status
+        assert request_log_calls[0]["status"] == "success"
+        assert request_log_calls[0]["error_code"] is None
+        assert error_account_ids == []
+        assert success_account_ids == [expected_account_id]
+    else:
+        assert response.status_code == 502
+        assert response.json()["error"]["code"] == "invalid_output_item"
+        assert request_log_calls[0]["status"] == "error"
+        assert request_log_calls[0]["error_code"] == "stream_incomplete"
+        assert error_account_ids == [expected_account_id]
+        assert success_account_ids == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -37,11 +37,12 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.config.settings import Settings
 from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE, openai_error
-from app.core.openai.models import OpenAIError
+from app.core.openai.models import OpenAIError, OpenAIResponsePayload
 from app.core.openai.requests import ResponsesRequest
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
 from app.db.models import AccountStatus, Base, HttpBridgeSessionState
 from app.modules.proxy import affinity as proxy_affinity
+from app.modules.proxy import api as proxy_api
 from app.modules.proxy import http_bridge_forwarding as http_bridge_forwarding_module
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import support as proxy_support_module
@@ -7502,6 +7503,97 @@ async def test_http_bridge_keepalive_counts_as_first_yield_before_late_response_
     await event_queue.put(None)
     with pytest.raises(StopAsyncIteration):
         await asyncio.wait_for(anext(stream), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_keepalive_remains_nonterminal_for_aggregated_collector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: SimpleNamespace(
+            sse_keepalive_interval_seconds=0.05,
+            stream_idle_timeout_seconds=10.0,
+        ),
+    )
+
+    session = _make_bridge_session(key_value="sid-keepalive-collector")
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-keepalive-collector",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=event_queue,
+        transport="http",
+        response_id="resp_keepalive_collector",
+    )
+    completed_response: dict[str, Any] = {
+        "id": "resp_keepalive_collector",
+        "object": "response",
+        "status": "completed",
+        "output": [],
+    }
+
+    async def fake_submit_http_bridge_request(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del text_data, queue_limit
+        target_session.pending_requests.append(request_state)
+        await event_queue.put(
+            proxy_service.format_sse_event(
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_keepalive_collector", "status": "in_progress"},
+                }
+            )
+        )
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", fake_submit_http_bridge_request)
+
+    async def enqueue_completed() -> None:
+        await asyncio.sleep(1.0)
+        await event_queue.put(
+            proxy_service.format_sse_event({"type": "response.completed", "response": completed_response})
+        )
+        await event_queue.put(None)
+
+    keepalive_count = 0
+
+    async def bridge_stream() -> AsyncIterator[str]:
+        nonlocal keepalive_count
+        async for event in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data="{}",
+            queue_limit=8,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+        ):
+            payload = proxy_service.parse_sse_data_json(event)
+            if payload is not None and payload.get("type") == "response.in_progress":
+                keepalive_count += 1
+            yield event
+
+    async with asyncio.TaskGroup() as task_group:
+        task_group.create_task(enqueue_completed())
+        result = await asyncio.wait_for(
+            proxy_api._collect_responses_payload(bridge_stream()),
+            timeout=3.0,
+        )
+
+    assert keepalive_count > 0
+    assert isinstance(result, OpenAIResponsePayload)
+    assert result.model_dump(mode="json", exclude_none=True) == completed_response
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9405,7 +9405,7 @@ async def test_non_streaming_response_preserves_unfinished_status(status: str) -
     ],
 )
 async def test_collect_responses_payload_rejects_noncanonical_background_ack(
-    response_body: dict[str, object],
+    response_body: dict[str, JsonValue],
 ) -> None:
     async def stream() -> AsyncIterator[str]:
         yield proxy_module.format_sse_event({"type": "response.queued", "response": response_body})
@@ -9421,7 +9421,10 @@ async def test_collect_responses_payload_rejects_noncanonical_background_ack(
 async def test_collect_responses_payload_does_not_treat_in_progress_as_terminal() -> None:
     async def stream() -> AsyncIterator[str]:
         yield proxy_module.format_sse_event(
-            {"type": "response.in_progress", "response": {"id": "resp_background", "status": "in_progress"}}
+            {
+                "type": "response.in_progress",
+                "response": {"id": "resp_background", "object": "response", "status": "in_progress", "output": []},
+            }
         )
         yield proxy_module.format_sse_event(
             {
@@ -9434,6 +9437,47 @@ async def test_collect_responses_payload_does_not_treat_in_progress_as_terminal(
 
     assert isinstance(result, OpenAIResponsePayload)
     assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_type", ["response.queued", "response.in_progress"])
+async def test_collect_responses_payload_malformed_ack_is_terminal_before_completed(event_type: str) -> None:
+    async def stream() -> AsyncIterator[str]:
+        yield proxy_module.format_sse_event(
+            {"type": event_type, "response": {"id": "resp_background", "status": event_type.removeprefix("response.")}}
+        )
+        yield proxy_module.format_sse_event(
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_background", "status": "completed", "output": []},
+            }
+        )
+
+    result = await proxy_api._collect_responses_payload(stream())
+
+    assert not isinstance(result, OpenAIResponsePayload)
+    assert result.error is not None
+    assert result.error.code == "invalid_json"
+
+
+@pytest.mark.asyncio
+async def test_collect_responses_payload_malformed_ack_overrides_earlier_canonical_ack() -> None:
+    async def stream() -> AsyncIterator[str]:
+        yield proxy_module.format_sse_event(
+            {
+                "type": "response.queued",
+                "response": {"id": "resp_background", "object": "response", "status": "queued", "output": []},
+            }
+        )
+        yield proxy_module.format_sse_event(
+            {"type": "response.in_progress", "response": {"id": "resp_background", "status": "in_progress"}}
+        )
+
+    result = await proxy_api._collect_responses_payload(stream())
+
+    assert not isinstance(result, OpenAIResponsePayload)
+    assert result.error is not None
+    assert result.error.code == "invalid_json"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9431,6 +9431,8 @@ async def test_collect_responses_payload_aggregated_bridge_keepalive_yields_comp
     [
         {"id": "resp_background", "status": "queued", "output": []},
         {"id": "", "object": "response", "status": "queued", "output": []},
+        {"id": "   ", "object": "response", "status": "queued", "output": []},
+        {"id": " resp_background ", "object": "response", "status": "queued", "output": []},
     ],
 )
 async def test_collect_responses_payload_rejects_noncanonical_background_ack(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9381,10 +9381,25 @@ def test_stream_startup_error_response_rejects_malformed_retry_after_header() ->
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status", ["queued", "in_progress"])
-async def test_non_streaming_response_preserves_unfinished_status(status: str) -> None:
-    event_block, event_type = proxy_module._non_streaming_response_event(
-        {"id": "resp_background", "object": "response", "status": status, "output": []}
-    )
+@pytest.mark.parametrize(
+    "extra_fields",
+    [
+        {},
+        {"usage": {"input_tokens": 12, "output_tokens": 0, "total_tokens": 12}},
+    ],
+)
+async def test_non_streaming_response_preserves_unfinished_status(
+    status: str,
+    extra_fields: dict[str, JsonValue],
+) -> None:
+    response_body: dict[str, JsonValue] = {
+        "id": "resp_background",
+        "object": "response",
+        "status": status,
+        "output": [],
+        **extra_fields,
+    }
+    event_block, event_type = proxy_module._non_streaming_response_event(response_body)
 
     async def stream() -> AsyncIterator[str]:
         yield event_block
@@ -9394,6 +9409,7 @@ async def test_non_streaming_response_preserves_unfinished_status(status: str) -
     assert event_type == f"response.{status}"
     assert isinstance(result, OpenAIResponsePayload)
     assert result.status == status
+    assert result.model_dump(mode="json", exclude_none=True) == response_body
 
 
 @pytest.mark.asyncio
@@ -9433,6 +9449,14 @@ async def test_collect_responses_payload_aggregated_bridge_keepalive_yields_comp
         {"id": "", "object": "response", "status": "queued", "output": []},
         {"id": "   ", "object": "response", "status": "queued", "output": []},
         {"id": " resp_background ", "object": "response", "status": "queued", "output": []},
+        {
+            "id": "resp_background",
+            "object": "response",
+            "status": "queued",
+            "output": [],
+            "usage": {"input_tokens": "invalid"},
+        },
+        {"id": "resp_background", "object": "response", "status": "queued", "output": [], "error": "boom"},
     ],
 )
 async def test_collect_responses_payload_rejects_noncanonical_background_ack(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9383,7 +9383,7 @@ def test_stream_startup_error_response_rejects_malformed_retry_after_header() ->
 @pytest.mark.parametrize("status", ["queued", "in_progress"])
 async def test_non_streaming_response_preserves_unfinished_status(status: str) -> None:
     event_block, event_type = proxy_module._non_streaming_response_event(
-        {"id": "resp_background", "status": status, "output": []}
+        {"id": "resp_background", "object": "response", "status": status, "output": []}
     )
 
     async def stream() -> AsyncIterator[str]:
@@ -9394,6 +9394,27 @@ async def test_non_streaming_response_preserves_unfinished_status(status: str) -
     assert event_type == f"response.{status}"
     assert isinstance(result, OpenAIResponsePayload)
     assert result.status == status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response_body",
+    [
+        {"id": "resp_background", "status": "queued", "output": []},
+        {"id": "", "object": "response", "status": "queued", "output": []},
+    ],
+)
+async def test_collect_responses_payload_rejects_noncanonical_background_ack(
+    response_body: dict[str, object],
+) -> None:
+    async def stream() -> AsyncIterator[str]:
+        yield proxy_module.format_sse_event({"type": "response.queued", "response": response_body})
+
+    result = await proxy_api._collect_responses_payload(stream())
+
+    assert not isinstance(result, OpenAIResponsePayload)
+    assert result.error is not None
+    assert result.error.code == "invalid_json"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9389,11 +9389,40 @@ async def test_non_streaming_response_preserves_unfinished_status(status: str) -
     async def stream() -> AsyncIterator[str]:
         yield event_block
 
-    result = await proxy_api._collect_responses_payload(stream())
+    result = await proxy_api._collect_responses_payload(stream(), upstream_stream_false=True)
 
     assert event_type == f"response.{status}"
     assert isinstance(result, OpenAIResponsePayload)
     assert result.status == status
+
+
+@pytest.mark.asyncio
+async def test_collect_responses_payload_aggregated_bridge_keepalive_yields_completed_response() -> None:
+    completed_response: dict[str, JsonValue] = {
+        "id": "resp_background",
+        "object": "response",
+        "status": "completed",
+        "output": [],
+    }
+
+    async def stream() -> AsyncIterator[str]:
+        for event in (
+            {
+                "type": "response.created",
+                "response": {"id": "resp_background", "status": "in_progress"},
+            },
+            {
+                "type": "response.in_progress",
+                "response": {"id": "resp_background", "status": "in_progress"},
+            },
+            {"type": "response.completed", "response": completed_response},
+        ):
+            yield proxy_module.format_sse_event(event)
+
+    result = await proxy_api._collect_responses_payload(stream())
+
+    assert isinstance(result, OpenAIResponsePayload)
+    assert result.model_dump(mode="json", exclude_none=True) == completed_response
 
 
 @pytest.mark.asyncio
@@ -9410,7 +9439,7 @@ async def test_collect_responses_payload_rejects_noncanonical_background_ack(
     async def stream() -> AsyncIterator[str]:
         yield proxy_module.format_sse_event({"type": "response.queued", "response": response_body})
 
-    result = await proxy_api._collect_responses_payload(stream())
+    result = await proxy_api._collect_responses_payload(stream(), upstream_stream_false=True)
 
     assert not isinstance(result, OpenAIResponsePayload)
     assert result.error is not None
@@ -9418,12 +9447,12 @@ async def test_collect_responses_payload_rejects_noncanonical_background_ack(
 
 
 @pytest.mark.asyncio
-async def test_collect_responses_payload_does_not_treat_in_progress_as_terminal() -> None:
+async def test_collect_responses_payload_aggregated_in_progress_without_output_is_nonterminal() -> None:
     async def stream() -> AsyncIterator[str]:
         yield proxy_module.format_sse_event(
             {
                 "type": "response.in_progress",
-                "response": {"id": "resp_background", "object": "response", "status": "in_progress", "output": []},
+                "response": {"id": "resp_background", "object": "response", "status": "in_progress"},
             }
         )
         yield proxy_module.format_sse_event(
@@ -9453,7 +9482,7 @@ async def test_collect_responses_payload_malformed_ack_is_terminal_before_comple
             }
         )
 
-    result = await proxy_api._collect_responses_payload(stream())
+    result = await proxy_api._collect_responses_payload(stream(), upstream_stream_false=True)
 
     assert not isinstance(result, OpenAIResponsePayload)
     assert result.error is not None
@@ -9473,7 +9502,7 @@ async def test_collect_responses_payload_malformed_ack_overrides_earlier_canonic
             {"type": "response.in_progress", "response": {"id": "resp_background", "status": "in_progress"}}
         )
 
-    result = await proxy_api._collect_responses_payload(stream())
+    result = await proxy_api._collect_responses_payload(stream(), upstream_stream_false=True)
 
     assert not isinstance(result, OpenAIResponsePayload)
     assert result.error is not None


### PR DESCRIPTION
## Summary

- settle canonical queued/in-progress background acknowledgements as successful completed HTTP JSON exchanges
- keep the returned Response object, request log, and account health consistent
- preserve `stream_incomplete` for streaming EOF and malformed/partial background objects
- return the `invalid_json` contract error for a non-canonical queued/in-progress object on the single-object `stream: false` HTTP JSON exchange only; the aggregated `/v1/responses` SSE path keeps its tolerant nonterminal handling

## Maintainer follow-up (head `b1d76d08`)

`_collect_responses` now derives `upstream_stream_false = preserve_upstream_stream_mode and payload.stream is False` and passes that transport fact into `_collect_responses_payload`. Canonical background-ack rejection is applied only for that single-object `stream: false` HTTP JSON exchange; the aggregated `/v1/responses` SSE path again treats parseable `response.queued`/`response.in_progress` frames as nonterminal, including the HTTP-bridge idle keepalive (`{"type":"response.in_progress","response":{"id":...,"status":"in_progress"}}`, no `object`, no `output`) and an in-progress object that omits only `output`, so a later `response.completed` wins. The confirmed `_settle_background_ack` behavior is unchanged.

The MODIFIED OpenSpec requirement retains the `/v1/responses` aggregation scope sentence and restores the existing `Backend stream false stays false upstream` and `Backend non-streaming response remains JSON downstream` scenarios verbatim.

## OpenSpec

- `openspec/changes/classify-background-json-completion/`
- strict change validation passes with `@fission-ai/openspec@1.11.0` and `@fission-ai/openspec@1.8.0`
- the canonical owning spec retains unrelated pre-existing failures assigned to independent repair work

## Regression evidence

- RED: valid queued/in-progress HTTP JSON returned 200 but request logs recorded `error/stream_incomplete`
- GREEN: valid canonical acknowledgements record success and no health error
- adversarial RED: malformed queued output returned HTTP 502 while settlement incorrectly recorded success
- adversarial GREEN: malformed output keeps error/stream_incomplete settlement

## Verification

- focused route matrix — 3 passed
- streaming EOF controls — 5 passed
- full `tests/integration/test_proxy_responses.py` — 76 passed
- Ruff, formatting, repository `ty check`, strict change validation, and diff check
- Oracle pre-commit review approved after the canonical acknowledgement gate was added

Follow-up head (`46d8af72`, addresses the CodeRabbit precedence finding and the red CI):

- RED on `86791c48` (detached baseline worktree): `tests/unit/test_proxy_utils.py -k "malformed_ack"` — `3 failed`
- GREEN: same selection — `3 passed`; full `tests/unit/test_proxy_utils.py` — `1217 passed`; `tests/integration/test_proxy_responses.py -k "background or queued or in_progress"` — `11 passed`
- `.venv/bin/python scripts/check_proxy_architecture.py` — passes (`service.py` 2600, `streaming/mixin.py` 1100)
- `.venv/bin/ruff check`, `.venv/bin/ruff format --check .`, `.venv/bin/ty check` on the five changed files — clean
- one independent review of the committed diff `86791c48..46d8af72`

The worktree LSP daemon did not load third-party dependencies; direct repository
`ty check` completed cleanly.

Follow-up head (`b1d76d08`, addresses the maintainer's two blockers):

- regression provenance for `test_collect_responses_payload_aggregated_bridge_keepalive_yields_completed_response`: previous PR head `46d8af729` — `1 failed, 1217 deselected in 2.98s`; pristine `upstream/main` (`575c2087`) — `1 passed, 1217 deselected in 2.63s`; this head — `1 passed, 1217 deselected in 0.30s`
- `set -o pipefail; .venv/bin/python -m pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py -q -p no:cacheprovider` — `2167 passed in 47.32s`
- `set -o pipefail; .venv/bin/ruff check app/modules/proxy/api.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py` — `All checks passed!`
- `set -o pipefail; .venv/bin/ruff format --check app/modules/proxy/api.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py` — `3 files already formatted`
- `set -o pipefail; .venv/bin/ty check app/modules/proxy/api.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py` — `All checks passed!`
- `set -o pipefail; npx -y @fission-ai/openspec@1.11.0 validate classify-background-json-completion --strict` — `Change 'classify-background-json-completion' is valid`
- `set -o pipefail; npx -y @fission-ai/openspec@1.8.0 validate classify-background-json-completion --strict` — `Change 'classify-background-json-completion' is valid`
- one independent review of the committed diff `46d8af72..b1d76d08`

## Manual QA

The actual `ProxyService._stream_once` settlement path produced:

```text
queued stream=false output_items=0 log=success error_code=None health_error=False
in_progress stream=false output_items=0 log=success error_code=None health_error=False
in_progress stream=true output_items=0 log=error error_code=stream_incomplete health_error=True
queued stream=false output_items=1 log=error error_code=stream_incomplete health_error=True
PASS
```

The temporary driver/environment were removed.

## Scope and independence

- based directly on `upstream/main`
- no dependency on open PR #1989 or another new pull request
- no polling, response-shape, event-name, reservation, setting, or schema changes
- no matching active issue or competing PR found

No existing issue is claimed by this independently discovered defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Background, non-streaming Responses requests now return complete JSON acknowledgements instead of being truncated.
  - Valid `queued` and `in_progress` responses are recorded as successfully completed with the response ID.
  - Malformed or incomplete acknowledgements now return clear errors instead of being accepted.
  - Streaming lifecycle events remain nonterminal, preserving existing streaming behavior.

- **Documentation**
  - Added specifications and implementation notes describing background JSON completion handling and supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
