### PR TITLE
fix(proxy): release reset-credit claims on cancellation

### DIFF
--- a/app/modules/rate_limit_reset_credits/api.py
+++ b/app/modules/rate_limit_reset_credits/api.py
@@ -41,6 +41,7 @@ from app.core.exceptions import (
     DashboardServiceUnavailableError,
 )
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
+from app.core.utils.shared_future import _await_cleanup_deferring_cancellation
 from app.db.models import Account, AccountStatus
 from app.dependencies import AccountsContext, get_accounts_context
 from app.modules.accounts.auth_manager import AuthManager
@@ -280,10 +281,16 @@ async def serialize_reset_credit_redeem(
             try:
                 yield
             finally:
-                heartbeat.cancel()
-                with suppress(asyncio.CancelledError):
-                    await heartbeat
-                await release_redeem_claim(account_id, holder_id)
+
+                async def cleanup_redeem_claim() -> None:
+                    heartbeat.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await heartbeat
+                    await release_redeem_claim(account_id, holder_id)
+
+                cancellation = await _await_cleanup_deferring_cancellation(cleanup_redeem_claim())
+                if cancellation is not None:
+                    raise cancellation
             return
 
     # Direct callers without a DB session keep the in-process lock.

--- a/openspec/changes/fix-reset-credit-claim-cancellation/.openspec.yaml
+++ b/openspec/changes/fix-reset-credit-claim-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/fix-reset-credit-claim-cancellation/context.md
+++ b/openspec/changes/fix-reset-credit-claim-cancellation/context.md
@@ -1,0 +1,28 @@
+# Cancellation-safe reset-credit claim release
+
+## Purpose
+
+Lease expiry is crash recovery, not the normal release mechanism for a live
+process that receives request cancellation.
+
+## Decision
+
+Heartbeat cancellation/drain and the existing holder-fenced release form one
+owned cleanup coroutine. The canonical defer-cancellation helper runs that
+coroutine to completion and then surfaces the captured cancellation.
+
+Cleanup order remains heartbeat cancel, heartbeat drain, claim release, then
+deferred cancellation propagation.
+
+## Constraints
+
+- Do not shield or extend the redemption body.
+- Do not alter acquisition, holder fencing, lease duration, renewal, or timeout.
+- Do not change PostgreSQL or session-less locking.
+- Preserve the existing logged lease-expiry fallback for genuine DB errors.
+
+## Example
+
+Cancellation enters cleanup, then cancellation is delivered again while the
+SQLite delete is suspended. Release commits first, cancellation propagates
+second, and a successor acquires immediately instead of waiting 30 seconds.

--- a/openspec/changes/fix-reset-credit-claim-cancellation/proposal.md
+++ b/openspec/changes/fix-reset-credit-claim-cancellation/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+SQLite reset-credit redemption uses a durable per-account claim. If
+cancellation is delivered again while holder-fenced release is suspended, the
+operation terminates without releasing the row and healthy contenders wait for
+lease expiry.
+
+## What Changes
+
+- Own heartbeat shutdown and holder-fenced release as one cleanup operation.
+- Defer repeated caller cancellation until cleanup finishes.
+- Add an event-gated repeated-cancellation regression.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `rate-limit-reset-credits`: live SQLite claims become immediately reclaimable
+  after cancellation.
+
+## Impact
+
+- Shared dashboard and `/v1/reset-credit` serialization context.
+- No migration, setting, API shape, lease timing, PostgreSQL, or in-process
+  locking change.

--- a/openspec/changes/fix-reset-credit-claim-cancellation/specs/rate-limit-reset-credits/spec.md
+++ b/openspec/changes/fix-reset-credit-claim-cancellation/specs/rate-limit-reset-credits/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: SQLite redeem-claim cleanup survives repeated cancellation
+
+After a process acquires the SQLite reset-credit redeem claim, the system MUST
+treat heartbeat cancellation and drain followed by holder-fenced claim release
+as one owned cleanup operation. Repeated caller cancellation while cleanup is
+suspended MUST NOT interrupt that operation. Deferred cancellation MUST surface
+only after heartbeat shutdown and release finish. Lease expiry MUST remain the
+crash or release-error backstop, not routine live-process cancellation cleanup.
+
+#### Scenario: Repeated cancellation cannot strand a live SQLite claim
+
+- **GIVEN** a SQLite redemption holds a durable claim with a heartbeat
+- **WHEN** the body is cancelled and cancellation is delivered again after
+  claim release starts
+- **THEN** the heartbeat is cancelled and drained
+- **AND** holder-fenced release finishes before cancellation surfaces
+- **AND** a successor can acquire immediately without waiting for lease expiry

--- a/openspec/changes/fix-reset-credit-claim-cancellation/tasks.md
+++ b/openspec/changes/fix-reset-credit-claim-cancellation/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Define cancellation-safe SQLite claim cleanup.
+
+## 2. Regression
+
+- [x] 2.1 Add an event-gated repeated-cancellation regression.
+- [x] 2.2 Capture release interruption before production code.
+
+## 3. Implementation
+
+- [x] 3.1 Own heartbeat drain and holder-fenced release through deferred cancellation.
+
+## 4. Verification
+
+- [x] 4.1 Run focused/broader tests, quality checks, OpenSpec, and SQLite QA.
+- [x] 4.2 Record cleanup and publication evidence.

--- a/tests/integration/test_v1_reset_credit.py
+++ b/tests/integration/test_v1_reset_credit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from contextlib import asynccontextmanager
@@ -580,6 +581,110 @@ async def test_v1_reset_credit_post_claim_contention_returns_openai_envelope(
     assert error["code"] == "invalid_request_error"
     assert "already in progress" in error["message"]
     consume_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_v1_reset_credit_post_repeated_cancellation_releases_real_sqlite_claim(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.modules.rate_limit_reset_credits import api as reset_credits_api
+    from app.modules.rate_limit_reset_credits.redeem_coordination import (
+        release_redeem_claim,
+        try_acquire_redeem_claim,
+    )
+
+    await _enable_api_key_auth(async_client)
+    account_id = await _import_account(
+        async_client,
+        "acc-reset-cancel-release",
+        "cancel-release@example.com",
+    )
+    _, key = await _create_api_key(async_client, name="reset-credit-cancel-release")
+
+    credit = ResetCreditItem(
+        id="credit-cancel-release",
+        status="available",
+        expires_at=datetime(2031, 4, 4, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        "app.modules.proxy.api.fetch_reset_credits",
+        AsyncMock(return_value=_upstream_available([credit])),
+    )
+
+    consume_started = asyncio.Event()
+    consume_allowed = asyncio.Event()
+    release_started = asyncio.Event()
+    release_allowed = asyncio.Event()
+
+    async def blocked_consume(*args, **kwargs):
+        del args, kwargs
+        consume_started.set()
+        await consume_allowed.wait()
+        raise AssertionError("cancelled redeem must not resume upstream consumption")
+
+    monkeypatch.setattr("app.modules.proxy.api.consume_reset_credit", blocked_consume)
+
+    real_release_redeem_claim = reset_credits_api.release_redeem_claim
+    original_holder_id: str | None = None
+
+    async def observed_real_release(account_id_arg: str, holder_id: str) -> None:
+        nonlocal original_holder_id
+        assert account_id_arg == account_id
+        original_holder_id = holder_id
+        release_started.set()
+        await release_allowed.wait()
+        await real_release_redeem_claim(account_id_arg, holder_id)
+
+    monkeypatch.setattr(
+        reset_credits_api,
+        "release_redeem_claim",
+        observed_real_release,
+    )
+
+    successor_holder = "successor-after-cancellation"
+    successor_acquired = False
+    request_task = asyncio.create_task(
+        async_client.post(
+            "/v1/reset-credit",
+            headers={"Authorization": f"Bearer {key}"},
+            json={
+                "account_id": account_id,
+                "redeem_id": credit.id,
+            },
+        )
+    )
+
+    try:
+        await asyncio.wait_for(consume_started.wait(), timeout=5)
+
+        assert await try_acquire_redeem_claim(account_id, successor_holder) is False
+
+        request_task.cancel("redeem-body-cancelled")
+        await asyncio.wait_for(release_started.wait(), timeout=5)
+
+        request_task.cancel("release-cancelled")
+        release_allowed.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(request_task, timeout=5)
+
+        successor_acquired = await try_acquire_redeem_claim(
+            account_id,
+            successor_holder,
+        )
+        assert successor_acquired is True
+    finally:
+        consume_allowed.set()
+        release_allowed.set()
+        if not request_task.done():
+            request_task.cancel()
+        await asyncio.gather(request_task, return_exceptions=True)
+
+        if original_holder_id is not None:
+            await real_release_redeem_claim(account_id, original_holder_id)
+        if successor_acquired:
+            await release_redeem_claim(account_id, successor_holder)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rate_limit_reset_credits_api.py
+++ b/tests/unit/test_rate_limit_reset_credits_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1123,6 +1124,69 @@ async def test_serialize_reset_credit_redeem_renews_sqlite_claim_while_held(
         events.append("locked")
 
     assert events == ["acquire", "heartbeat-start", "locked", "heartbeat-cancelled", "release"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_releases_reset_credit_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    heartbeat_started = asyncio.Event()
+    body_started = asyncio.Event()
+    release_started = asyncio.Event()
+    release_allowed = asyncio.Event()
+
+    async def fake_acquire(account_id: str, holder_id: str) -> None:
+        events.append("claim-acquired")
+
+    async def fake_heartbeat(account_id: str, holder_id: str) -> None:
+        heartbeat_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            events.append("heartbeat-stopped")
+            raise
+
+    async def fake_release(account_id: str, holder_id: str) -> None:
+        release_started.set()
+        await release_allowed.wait()
+        events.append("claim-released")
+
+    monkeypatch.setattr(reset_credits_api, "acquire_redeem_claim", fake_acquire)
+    monkeypatch.setattr(reset_credits_api, "renew_redeem_claim_periodically", fake_heartbeat)
+    monkeypatch.setattr(reset_credits_api, "release_redeem_claim", fake_release)
+
+    async def hold_claim() -> None:
+        async with serialize_reset_credit_redeem("acc_1", session=cast(Any, _FakeSqliteSession())):
+            await heartbeat_started.wait()
+            body_started.set()
+            await asyncio.Event().wait()
+
+    holder = asyncio.create_task(hold_claim())
+    try:
+        await asyncio.wait_for(body_started.wait(), timeout=5)
+
+        holder.cancel("redeem-body-cancelled")
+        await asyncio.wait_for(release_started.wait(), timeout=5)
+        holder.cancel("release-cancelled")
+        asyncio.get_running_loop().call_soon(release_allowed.set)
+
+        with pytest.raises(asyncio.CancelledError):
+            await holder
+        events.append("cancellation-propagated")
+
+        assert events == [
+            "claim-acquired",
+            "heartbeat-stopped",
+            "claim-released",
+            "cancellation-propagated",
+        ]
+    finally:
+        release_allowed.set()
+        if not holder.done():
+            holder.cancel()
+            with suppress(asyncio.CancelledError):
+                await holder
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- own SQLite reset-credit heartbeat drain and holder-fenced release as one cleanup operation
- defer repeated caller cancellation until durable claim release finishes
- preserve existing lease-expiry fallback and PostgreSQL/session-less behavior

## OpenSpec

- `openspec/changes/fix-reset-credit-claim-cancellation/`
- strict change validation passes

## Regression evidence

- RED: repeated cancellation propagated before `claim-released`
- GREEN: release completes before cancellation propagation
- event-owned regression uses exact state transitions, not sleeps or polling

## Verification

- focused repeated-cancellation regression — 1 passed
- full reset-credit unit file — 57 passed
- replica-safety and `/v1/reset-credit` integration controls — 36 passed
- Ruff, formatting, direct `ty check`, strict OpenSpec validation, and diff check
- Oracle pre-commit lifecycle/DB review — PASS

The worktree LSP daemon did not load third-party dependencies; direct worktree
`ty check` completed cleanly.

## Manual QA

The real SQLite engine, durable claim row, heartbeat, serialization context,
holder-fenced release, and successor acquisition produced:

```text
PASS claim_released_before_cancellation=True immediately_claimable=True
```

The temporary SQLite directory, driver, and environment were removed.

## Scope and independence

- based directly on `upstream/main`
- no dependency on another pull request
- no migration, lease timing, holder fencing, API shape, setting, PostgreSQL, or in-process lock change
- no matching active issue, PR, or OpenSpec owner found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite reset-credit redemption cleanup when requests are cancelled repeatedly.
  * Active claims are now released before cancellation is reported, allowing immediate retries instead of waiting for lease expiry.

* **Tests**
  * Added regression coverage for interrupted redemption cleanup and claim recovery.

* **Documentation**
  * Added specifications and implementation guidance for cancellation-safe reset-credit claim handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->