### PR TITLE
fix(proxy): preserve warmup usage on cancellation

### DIFF
--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -15,6 +15,7 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import ResponsesRequest
+from app.core.utils.shared_future import _await_cleanup_deferring_cancellation
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus, QuotaPlannerDecision
 from app.modules.accounts.repository import AccountsRepository
@@ -246,6 +247,7 @@ class QuotaWarmupService:
                 )
 
         started = time.monotonic()
+        reservation_finalized = False
         try:
             usage = await self._send_warmup_probe(
                 account=account,
@@ -253,13 +255,18 @@ class QuotaWarmupService:
                 request_id=request_id,
             )
             if reservation_id is not None:
-                await self._api_keys.finalize_usage_reservation(
-                    reservation_id,
-                    model=resolved_model,
-                    input_tokens=usage.input_tokens,
-                    output_tokens=usage.output_tokens,
-                    cached_input_tokens=usage.cached_input_tokens,
+                settlement_cancellation = await _await_cleanup_deferring_cancellation(
+                    self._api_keys.finalize_usage_reservation(
+                        reservation_id,
+                        model=resolved_model,
+                        input_tokens=usage.input_tokens,
+                        output_tokens=usage.output_tokens,
+                        cached_input_tokens=usage.cached_input_tokens,
+                    )
                 )
+                reservation_finalized = True
+                if settlement_cancellation is not None:
+                    raise settlement_cancellation
             await self._request_logs.add_log(
                 account_id=account_id,
                 api_key_id=api_key_id,
@@ -298,7 +305,7 @@ class QuotaWarmupService:
                 request_id=request_id,
             )
         except asyncio.CancelledError:
-            if reservation_id is not None:
+            if reservation_id is not None and not reservation_finalized:
                 await self._api_keys.fail_usage_reservation(
                     reservation_id,
                     model=resolved_model,

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/.openspec.yaml
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/context.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/context.md
@@ -1,0 +1,26 @@
+# Warmup usage cancellation context
+
+## Purpose
+
+Warmup accounting must reflect upstream work that already completed. A caller
+disconnect may stop later bookkeeping, but it must not erase exact token usage.
+
+## Decision
+
+Before the probe returns, cancellation continues to fail an owned reservation
+with zero usage. After the probe returns, reservation finalization owns the
+measured usage. Cancellation is deferred only until finalization completes and
+then propagates before logging, warmup-effect refresh, or decision completion.
+
+## Constraints
+
+- Do not shield the probe or later bookkeeping.
+- Do not change reservation admission, claim leases, scheduler policy, or
+  stale-claim recovery.
+- Reuse the canonical deferred-cancellation helper.
+
+## Example
+
+If the probe returns 7 input, 3 output, and 2 cached input tokens, cancellation
+while finalization is blocked produces exactly one finalized 7/3/2 settlement,
+no failed 0/0/0 settlement, no success log, and no executed decision update.

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/design.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/design.md
@@ -1,0 +1,23 @@
+## Context
+
+`QuotaWarmupService.warm_now` directly awaits reservation finalization inside a
+broad cancellation handler. Cancellation of that await reaches the fallback
+that fails the reservation with literal zero counts.
+
+## Decision
+
+Await finalization through `_await_cleanup_deferring_cancellation`. Set a
+positive `reservation_finalized` marker only after the helper returns normally.
+If it reports deferred cancellation, raise it after setting the marker. The
+existing cancellation handler applies zero-usage failure only while the marker
+is false.
+
+Request logging, warmup-effect refresh, and decision completion remain outside
+the owned settlement boundary.
+
+## Risks
+
+- Cancellation waits for the existing settlement operation; this is required
+  ownership, not a retry or timeout policy.
+- The durable decision remains `executing` and uses existing reconciliation.
+- Finalizer exceptions retain the current failure path.

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/proposal.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+A quota warmup can finish its upstream probe and receive exact token usage, but
+caller cancellation during API-key reservation finalization currently replaces
+that measured usage with a failed zero-token settlement.
+
+## What Changes
+
+- Finish owned warmup reservation finalization before propagating cancellation
+  once the probe has returned exact usage.
+- Preserve zero-usage failure when cancellation occurs before successful
+  finalization.
+- Keep request logging and decision completion outside the deferred boundary.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `quota-phase-planner`: preserve measured warmup usage during cancellation.
+
+## Impact
+
+- Shared quota warmup service and one integration regression.
+- No setting, dependency, route, migration, reservation, or scheduler policy.

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/proposal.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/proposal.md
@@ -8,8 +8,9 @@ that measured usage with a failed zero-token settlement.
 
 - Finish owned warmup reservation finalization before propagating cancellation
   once the probe has returned exact usage.
-- Preserve zero-usage failure when cancellation occurs before successful
-  finalization.
+- Preserve zero-usage failure only when cancellation occurs before the probe
+  returns measured usage. Cancellation during finalization preserves measured
+  usage.
 - Keep request logging and decision completion outside the deferred boundary.
 
 ## Capabilities

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/specs/quota-phase-planner/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Warmup cancellation preserves measured API-key usage
+
+When a warmup probe has returned exact token usage for an owned API-key reservation, warmup execution SHALL finish reservation finalization with those measured counts before propagating caller cancellation. It MUST NOT replace a completed probe's known usage with a zero-usage failure settlement.
+
+Cancellation before the warmup probe returns measured usage SHALL continue to
+fail the owned reservation with zero usage. Deferred cancellation during
+finalization of already measured usage MUST propagate before request logging,
+warmup-effect recording, or decision completion.
+
+#### Scenario: Cancellation during finalization preserves measured usage
+
+- **GIVEN** a warmup probe returns 7 input, 3 output, and 2 cached input tokens
+- **AND** reservation finalization has started with those counts
+- **WHEN** caller cancellation arrives before finalization returns
+- **THEN** finalization completes exactly once with 7/3/2
+- **AND** no failed zero-usage settlement is applied
+- **AND** cancellation propagates after finalization
+- **AND** no success log or executed decision status is written
+
+#### Scenario: Cancellation before usage remains a zero-usage failure
+
+- **GIVEN** an API-key reservation exists for a warmup
+- **WHEN** cancellation arrives before the probe returns usage
+- **THEN** the reservation is failed with zero token counts
+- **AND** caller cancellation propagates

--- a/openspec/changes/preserve-warmup-usage-on-cancellation/tasks.md
+++ b/openspec/changes/preserve-warmup-usage-on-cancellation/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract
+
+- [x] 1.1 Define the measured-usage cancellation boundary and non-goals.
+- [x] 1.2 Add the quota-phase-planner cancellation settlement requirement.
+
+## 2. Regression and implementation
+
+- [x] 2.1 Add an event-gated integration regression.
+- [x] 2.2 Capture zero-usage replacement before production code.
+- [x] 2.3 Defer cancellation only around reservation finalization.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/adjacent tests, quality checks, OpenSpec, and QA.
+- [x] 3.2 Record cleanup and publication evidence.

--- a/tests/integration/test_quota_warmup_cancellation.py
+++ b/tests/integration/test_quota_warmup_cancellation.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, RequestLog
+from app.db.session import SessionLocal
+from app.modules.api_keys.service import ApiKeyRequestUsageBudget
+from app.modules.quota_planner.logic import PlannerSettings
+from app.modules.quota_planner.repository import QuotaPlannerRepository
+from app.modules.quota_planner.warmup import QuotaWarmupService, WarmupUsage
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_cancelled_warmup_settles_known_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    db_setup: bool,
+) -> None:
+    del db_setup
+    finalization_started = asyncio.Event()
+    allow_finalization = asyncio.Event()
+    settlements: list[tuple[str, str, str, int | None, int | None, int | None]] = []
+
+    class FakeApiKeys:
+        async def enforce_limits_for_request(
+            self,
+            api_key_id: str,
+            *,
+            request_model: str,
+            request_usage_budget: ApiKeyRequestUsageBudget,
+        ) -> SimpleNamespace:
+            del api_key_id, request_model, request_usage_budget
+            return SimpleNamespace(reservation_id="reservation-known-usage")
+
+        async def finalize_usage_reservation(
+            self,
+            reservation_id: str,
+            *,
+            model: str,
+            input_tokens: int,
+            output_tokens: int,
+            cached_input_tokens: int = 0,
+            service_tier: str | None = None,
+            cost_microdollars: int | None = None,
+        ) -> None:
+            del service_tier, cost_microdollars
+            finalization_started.set()
+            await allow_finalization.wait()
+            settlements.append(
+                (
+                    "finalized",
+                    reservation_id,
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    cached_input_tokens,
+                )
+            )
+
+        async def fail_usage_reservation(
+            self,
+            reservation_id: str,
+            *,
+            model: str,
+            input_tokens: int | None = None,
+            output_tokens: int | None = None,
+            cached_input_tokens: int | None = None,
+            service_tier: str | None = None,
+        ) -> None:
+            del service_tier
+            settlements.append(
+                (
+                    "failed",
+                    reservation_id,
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    cached_input_tokens,
+                )
+            )
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        account = Account(
+            id="acc-warm-cancel-known-usage",
+            email="warm-cancel-known-usage@example.test",
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        )
+        session.add(account)
+        repo = QuotaPlannerRepository(session)
+        await repo.upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                allow_synthetic_traffic=True,
+                dry_run=False,
+                max_warmup_credits_per_day=1.0,
+                warmup_model_preference="gpt-5.4-mini",
+            )
+        )
+        await repo.add_window_observation(
+            account_id=account.id,
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="cancel-during-known-usage-settlement",
+            account_id=account.id,
+            scheduled_at=utcnow(),
+            score=3.0,
+            reason="operator_review",
+            status="planned",
+        )
+        service = QuotaWarmupService(session)
+
+        async def fake_send(
+            self: QuotaWarmupService,
+            *,
+            account: Account,
+            model: str,
+            request_id: str,
+        ) -> WarmupUsage:
+            del self, account, model, request_id
+            return WarmupUsage(
+                input_tokens=7,
+                output_tokens=3,
+                cached_input_tokens=2,
+                reasoning_tokens=1,
+            )
+
+        monkeypatch.setattr(service, "_api_keys", FakeApiKeys())
+        monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+
+        task = asyncio.create_task(
+            service.warm_now(
+                account_id=account.id,
+                model="gpt-5.4-mini",
+                api_key_id="api-key-known-usage",
+                force_probe=True,
+                decision_id=decision.id,
+            )
+        )
+        await asyncio.wait_for(finalization_started.wait(), timeout=1)
+        task.cancel("shutdown")
+        allow_finalization.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+
+        assert settlements == [
+            (
+                "finalized",
+                "reservation-known-usage",
+                "gpt-5.4-mini",
+                7,
+                3,
+                2,
+            )
+        ]
+        refreshed = await repo.get_decision_fresh(decision.id)
+        assert refreshed is not None
+        assert refreshed.status == "executing"
+        request_logs = (
+            await session.scalars(select(RequestLog).where(RequestLog.request_id == f"quota-warmup-{decision.id}"))
+        ).all()
+        assert request_logs == []


### PR DESCRIPTION
## Summary

- finish API-key reservation finalization with measured warmup usage before propagating cancellation
- preserve the existing zero-usage failure path when cancellation arrives before the probe returns usage
- keep request logging, effect refresh, and decision completion outside the deferred boundary

## OpenSpec

- `openspec/changes/preserve-warmup-usage-on-cancellation/`
- strict change and owning-capability validation pass

## Regression evidence

- RED: cancellation during finalization replaced known 7/3/2 usage with failed 0/0/0
- GREEN: finalization records 7/3/2 exactly once, cancellation propagates afterwards, and no success log/decision completion occurs

## Verification

- focused known-usage regression — 1 passed
- cancellation boundary/helper controls — 13 passed
- quota planner and atomic claim integration domain — 35 passed
- Ruff, formatting, direct `ty check`, OpenSpec, package build, and diff check
- Oracle pre-commit review approved after the zero-usage contract was narrowed to pre-probe cancellation

The worktree LSP daemon did not load third-party dependencies; direct worktree
`ty check` completed cleanly.

## Manual QA

The actual `QuotaWarmupService.warm_now` boundary produced:

```text
PASS settlements=[('finalized', 7, 3, 2)] logs=[] decision_updates=[] pending=0 cancellation=propagated
```

The QA driver, dedicated environment, and build output were removed.

## Scope and independence

- based directly on `upstream/main`
- no dependency on another pull request
- no reservation admission, scheduler, claim lease, logging, migration, setting, or route change
- no matching issue or pull request found in the bounded overlap pass

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Warmup cancellations now preserve measured token usage when finalizing quota reservations.
  - Cancellations before usage is measured continue to settle reservations with zero usage.
  - Prevented cancelled warmups from recording success, refreshing effects, completing decisions, or creating request logs.
  - Ensured quota accounting remains accurate even when cancellation occurs during finalization.

- **Tests**
  - Added integration coverage for cancellation during warmup usage settlement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->