### PR TITLE
fix(dashboard): recover from overview load errors

### DIFF
--- a/frontend/src/__integration__/dashboard-overview-error.test.tsx
+++ b/frontend/src/__integration__/dashboard-overview-error.test.tsx
@@ -86,4 +86,151 @@ describe("dashboard overview error integration", () => {
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
     expect(overviewCalls).toBeGreaterThan(2);
   });
+
+  it("does not carry an unresolved Retry into a new timeframe", async () => {
+    const user = userEvent.setup({ delay: null });
+    let retryPreviousTimeframe = false;
+    let signalPreviousRetry = () => {};
+    const previousRetryStarted = new Promise<void>((resolve) => {
+      signalPreviousRetry = resolve;
+    });
+    let releasePreviousRetry = () => {};
+    const previousRetryGate = new Promise<void>((resolve) => {
+      releasePreviousRetry = resolve;
+    });
+    let signalNextTimeframeRequest = () => {};
+    const nextTimeframeRequestStarted = new Promise<void>((resolve) => {
+      signalNextTimeframeRequest = resolve;
+    });
+    let releaseNextTimeframeRequest = () => {};
+    const nextTimeframeRequestGate = new Promise<void>((resolve) => {
+      releaseNextTimeframeRequest = resolve;
+    });
+
+    server.use(
+      http.get("/api/dashboard/overview", async ({ request }) => {
+        const timeframe = new URL(request.url).searchParams.get("timeframe");
+        if (timeframe === "30d") {
+          signalNextTimeframeRequest();
+          await nextTimeframeRequestGate;
+          return HttpResponse.json(
+            createDashboardOverview({
+              accounts: [
+                createAccountSummary({
+                  accountId: "acc_thirty_day",
+                  chatgptAccountId: "chatgpt_acc_thirty_day",
+                  displayName: "Thirty Day Overview Account",
+                  email: "thirty-day@example.com",
+                }),
+              ],
+            }),
+          );
+        }
+        if (!retryPreviousTimeframe) {
+          return HttpResponse.json(
+            { error: { code: "forced_outage", message: OUTAGE } },
+            { status: 503 },
+          );
+        }
+        signalPreviousRetry();
+        await previousRetryGate;
+        return HttpResponse.json(createDashboardOverview());
+      }),
+    );
+
+    window.history.pushState({}, "", "/dashboard");
+    const { container, queryClient } = renderWithProviders(<App />);
+
+    expect(await screen.findByText(OUTAGE)).toBeInTheDocument();
+    retryPreviousTimeframe = true;
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await previousRetryStarted;
+
+    await user.click(screen.getByRole("combobox", { name: /timeframe/i }));
+    await user.click(screen.getByRole("option", { name: "30d" }));
+    await nextTimeframeRequestStarted;
+
+    expect(screen.queryByText(OUTAGE)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+
+    const previousRetrySettled = new Promise<void>((resolve) => {
+      const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+        const queryKey = event.query.queryKey;
+        if (
+          queryKey[0] === "dashboard" &&
+          queryKey[1] === "overview" &&
+          queryKey[2] === "7d" &&
+          event.query.state.fetchStatus === "idle"
+        ) {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+    releasePreviousRetry();
+    await previousRetrySettled;
+    expect(screen.queryByText(OUTAGE)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+
+    releaseNextTimeframeRequest();
+    expect((await screen.findAllByText("Thirty Day Overview Account")).length).toBeGreaterThan(0);
+  });
+
+  it("retains terminal no-data error during an invalidation refetch", async () => {
+    const user = userEvent.setup({ delay: null });
+    let recoverOnRefresh = false;
+    let signalRefresh = () => {};
+    const refreshStarted = new Promise<void>((resolve) => {
+      signalRefresh = resolve;
+    });
+    let releaseRefresh = () => {};
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+
+    server.use(
+      http.get("/api/dashboard/overview", async () => {
+        if (!recoverOnRefresh) {
+          return HttpResponse.json(
+            { error: { code: "forced_outage", message: OUTAGE } },
+            { status: 503 },
+          );
+        }
+        signalRefresh();
+        await refreshGate;
+        return HttpResponse.json(
+          createDashboardOverview({
+            accounts: [
+              createAccountSummary({
+                accountId: "acc_refreshed",
+                chatgptAccountId: "chatgpt_acc_refreshed",
+                displayName: RECOVERED,
+                email: "refreshed@example.com",
+              }),
+            ],
+          }),
+        );
+      }),
+    );
+
+    window.history.pushState({}, "", "/dashboard");
+    const { container } = renderWithProviders(<App />);
+
+    expect(await screen.findByText(OUTAGE)).toBeInTheDocument();
+    recoverOnRefresh = true;
+    await user.click(screen.getByRole("button", { name: "Refresh dashboard" }));
+    await refreshStarted;
+
+    const alert = screen.getByRole("alert");
+    const terminalState = alert.parentElement ?? alert;
+    const retry = within(terminalState).getByRole("button", { name: "Retry" });
+    expect(alert).toHaveTextContent(OUTAGE);
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+    expect(retry).toBeDisabled();
+    expect(retry).toHaveAttribute("aria-busy", "true");
+
+    releaseRefresh();
+    expect((await screen.findAllByText(RECOVERED)).length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/__integration__/dashboard-overview-error.test.tsx
+++ b/frontend/src/__integration__/dashboard-overview-error.test.tsx
@@ -115,6 +115,12 @@ describe("dashboard overview error integration", () => {
           await nextTimeframeRequestGate;
           return HttpResponse.json(
             createDashboardOverview({
+              timeframe: {
+                key: "30d",
+                windowMinutes: 43_200,
+                bucketSeconds: 86_400,
+                bucketCount: 30,
+              },
               accounts: [
                 createAccountSummary({
                   accountId: "acc_thirty_day",

--- a/frontend/src/__integration__/dashboard-overview-error.test.tsx
+++ b/frontend/src/__integration__/dashboard-overview-error.test.tsx
@@ -1,0 +1,89 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+
+import App from "@/App";
+import {
+  createAccountSummary,
+  createDashboardOverview,
+} from "@/test/mocks/factories";
+import { server } from "@/test/mocks/server";
+import { renderWithProviders } from "@/test/utils";
+
+const OUTAGE = "forced overview outage";
+const RECOVERED = "Recovered Overview Account";
+
+afterEach(() => {
+  window.history.pushState({}, "", "/");
+});
+
+describe("dashboard overview error integration", () => {
+  it("replaces terminal failure with announced Retry and recovers in place", async () => {
+    const user = userEvent.setup({ delay: null });
+    let overviewCalls = 0;
+    let overviewAvailable = false;
+    let signalRetry = () => {};
+    const retryRequest = new Promise<void>((resolve) => {
+      signalRetry = resolve;
+    });
+    let releaseRecovery = () => {};
+    const recoveryGate = new Promise<void>((resolve) => {
+      releaseRecovery = resolve;
+    });
+
+    server.use(
+      http.get("/api/dashboard/overview", async () => {
+        overviewCalls += 1;
+        if (!overviewAvailable) {
+          return HttpResponse.json(
+            { error: { code: "forced_outage", message: OUTAGE } },
+            { status: 503 },
+          );
+        }
+        signalRetry();
+        await recoveryGate;
+        return HttpResponse.json(
+          createDashboardOverview({
+            accounts: [
+              createAccountSummary({
+                accountId: "acc_recovered_overview",
+                chatgptAccountId: "chatgpt_acc_recovered_overview",
+                displayName: RECOVERED,
+                email: "recovered-overview@example.com",
+              }),
+            ],
+          }),
+        );
+      }),
+    );
+
+    window.history.pushState({}, "", "/dashboard");
+    const { container } = renderWithProviders(<App />);
+
+    expect(await screen.findByText(OUTAGE)).toBeInTheDocument();
+    await waitFor(() => expect(overviewCalls).toBeGreaterThan(1));
+
+    const alert = screen.getByRole("alert");
+    const terminalState = alert.parentElement ?? alert;
+    const retry = within(terminalState).getByRole("button");
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(screen.getByRole("main")).toBeInTheDocument();
+
+    overviewAvailable = true;
+    retry.focus();
+    await user.keyboard("{Enter}");
+    await retryRequest;
+
+    await waitFor(() => expect(retry).toBeDisabled());
+    expect(retry).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent(OUTAGE);
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+
+    releaseRecovery();
+    expect(await screen.findByText(RECOVERED)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(overviewCalls).toBeGreaterThan(2);
+  });
+});

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -57,6 +57,11 @@ import { usePrivacyStore } from "@/hooks/use-privacy";
 
 const MODEL_OPTION_DELIMITER = ":::";
 
+type RetainedDashboardLoadError = {
+  timeframe: OverviewTimeframe;
+  message: string;
+};
+
 export function DashboardPage() {
   const { t, i18n } = useTranslation();
   const {
@@ -106,7 +111,10 @@ export function DashboardPage() {
   const dashboardTimeframe =
     dashboardView === "conversations" ? conversationTimeframe : overviewTimeframe;
   const dashboardQuery = useDashboard(dashboardTimeframe);
-  const [initialOverviewRetryError, setInitialOverviewRetryError] = useState<string | null>(null);
+  const [retainedDashboardLoadError, setRetainedDashboardLoadError] =
+    useState<RetainedDashboardLoadError | null>(null);
+  const [overviewRetryTimeframe, setOverviewRetryTimeframe] =
+    useState<OverviewTimeframe | null>(null);
   const projectionsQuery = useDashboardProjections(Boolean(dashboardQuery.data));
   const conversationsState = useConversations({
     enabled: isAdmin && dashboardView === "conversations",
@@ -354,8 +362,29 @@ export function DashboardPage() {
   );
 
   const dashboardLoadError = getErrorMessageOrNull(dashboardQuery.error);
-  const displayedDashboardLoadError = dashboardLoadError ?? initialOverviewRetryError;
-  const overviewRetryBusy = dashboardQuery.isFetching || initialOverviewRetryError !== null;
+  if (
+    retainedDashboardLoadError !== null &&
+    (overview || retainedDashboardLoadError.timeframe !== dashboardTimeframe)
+  ) {
+    setRetainedDashboardLoadError(null);
+  } else if (
+    !overview &&
+    dashboardLoadError !== null &&
+    (retainedDashboardLoadError === null ||
+      retainedDashboardLoadError.message !== dashboardLoadError)
+  ) {
+    setRetainedDashboardLoadError({
+      timeframe: dashboardTimeframe,
+      message: dashboardLoadError,
+    });
+  }
+  const displayedDashboardLoadError =
+    dashboardLoadError ??
+    (retainedDashboardLoadError?.timeframe === dashboardTimeframe
+      ? retainedDashboardLoadError.message
+      : null);
+  const overviewRetryBusy =
+    dashboardQuery.isFetching || overviewRetryTimeframe === dashboardTimeframe;
   const errorMessage =
     (overview ? dashboardLoadError : null) ||
     (dashboardView === "request-logs" && optionsQuery.error instanceof Error && optionsQuery.error.message) ||
@@ -415,9 +444,16 @@ export function DashboardPage() {
             aria-busy={overviewRetryBusy}
             disabled={overviewRetryBusy}
             onClick={() => {
-              setInitialOverviewRetryError(displayedDashboardLoadError ?? "Request failed");
+              const retryTimeframe = dashboardTimeframe;
+              setRetainedDashboardLoadError({
+                timeframe: retryTimeframe,
+                message: displayedDashboardLoadError ?? "Request failed",
+              });
+              setOverviewRetryTimeframe(retryTimeframe);
               void dashboardQuery.refetch().finally(() => {
-                setInitialOverviewRetryError(null);
+                setOverviewRetryTimeframe((current) =>
+                  current === retryTimeframe ? null : current,
+                );
               });
             }}
           >

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
@@ -51,6 +51,7 @@ import {
 import { useDashboardPreferencesStore } from "@/hooks/use-dashboard-preferences";
 import { useThemeStore } from "@/hooks/use-theme";
 import { REQUEST_STATUS_LABELS } from "@/utils/constants";
+import { getErrorMessageOrNull } from "@/utils/errors";
 import { formatModelLabel, formatCurrency, formatSlug } from "@/utils/formatters";
 import { usePrivacyStore } from "@/hooks/use-privacy";
 
@@ -105,6 +106,7 @@ export function DashboardPage() {
   const dashboardTimeframe =
     dashboardView === "conversations" ? conversationTimeframe : overviewTimeframe;
   const dashboardQuery = useDashboard(dashboardTimeframe);
+  const [initialOverviewRetryError, setInitialOverviewRetryError] = useState<string | null>(null);
   const projectionsQuery = useDashboardProjections(Boolean(dashboardQuery.data));
   const conversationsState = useConversations({
     enabled: isAdmin && dashboardView === "conversations",
@@ -351,8 +353,11 @@ export function DashboardPage() {
     [optionsQuery.data?.statuses, t],
   );
 
+  const dashboardLoadError = getErrorMessageOrNull(dashboardQuery.error);
+  const displayedDashboardLoadError = dashboardLoadError ?? initialOverviewRetryError;
+  const overviewRetryBusy = dashboardQuery.isFetching || initialOverviewRetryError !== null;
   const errorMessage =
-    (dashboardQuery.error instanceof Error && dashboardQuery.error.message) ||
+    (overview ? dashboardLoadError : null) ||
     (dashboardView === "request-logs" && optionsQuery.error instanceof Error && optionsQuery.error.message) ||
     null;
 
@@ -394,8 +399,29 @@ export function DashboardPage() {
 
       {errorMessage ? <AlertMessage variant="error">{errorMessage}</AlertMessage> : null}
 
-      {!view ? (
+      {dashboardQuery.isPending && !view && initialOverviewRetryError === null ? (
         <DashboardSkeleton />
+      ) : !view ? (
+        <div className="space-y-3 rounded-xl border bg-card p-4">
+          <div role="alert">
+            <AlertMessage variant="error">{displayedDashboardLoadError ?? "Request failed"}</AlertMessage>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-busy={overviewRetryBusy}
+            disabled={overviewRetryBusy}
+            onClick={() => {
+              setInitialOverviewRetryError(displayedDashboardLoadError ?? "Request failed");
+              void dashboardQuery.refetch().finally(() => {
+                setInitialOverviewRetryError(null);
+              });
+            }}
+          >
+            {t("common.actions.retry")}
+          </Button>
+        </div>
       ) : (
         <>
           <StatsGrid stats={view.stats} />

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -399,7 +399,9 @@ export function DashboardPage() {
 
       {errorMessage ? <AlertMessage variant="error">{errorMessage}</AlertMessage> : null}
 
-      {dashboardQuery.isPending && !view && initialOverviewRetryError === null ? (
+      {(dashboardQuery.isPending || dashboardQuery.isFetching) &&
+      !view &&
+      displayedDashboardLoadError === null ? (
         <DashboardSkeleton />
       ) : !view ? (
         <div className="space-y-3 rounded-xl border bg-card p-4">

--- a/openspec/changes/fix-dashboard-overview-error/.openspec.yaml
+++ b/openspec/changes/fix-dashboard-overview-error/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/fix-dashboard-overview-error/context.md
+++ b/openspec/changes/fix-dashboard-overview-error/context.md
@@ -1,0 +1,26 @@
+# Dashboard overview terminal-error context
+
+## Purpose
+
+Separate an initial pending query from a terminal failure that has no overview
+data, while retaining healthy shell and cached-data behavior.
+
+## Decision
+
+Pending no-data state keeps the existing skeleton. Terminal no-data state uses
+the existing alert and button primitives. Presentation state retains the error
+while TanStack Query clears its error during refetch, then clears after the
+request settles.
+
+## Constraints
+
+- Retry only the overview query.
+- Do not change retry count, query key, API, shell, or global alert behavior.
+- Cached overview content remains visible on later refetch errors.
+- No timing waits or polling in tests.
+
+## Example
+
+The overview endpoint exhausts retries with HTTP 503. The shell remains, the
+skeleton disappears, an alert and Retry appear, Retry becomes busy during the
+single refetch, and recovered overview content replaces the error.

--- a/openspec/changes/fix-dashboard-overview-error/proposal.md
+++ b/openspec/changes/fix-dashboard-overview-error/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+After the first dashboard overview request reaches terminal failure, the page
+shows the endpoint message but keeps its page-wide skeleton. The operator gets
+neither an announced terminal state nor an in-page recovery action.
+
+## What Changes
+
+- Distinguish pending initial load from terminal no-data failure.
+- Replace the terminal skeleton with an announced error and keyboard Retry.
+- Keep that error visible while Retry is in flight and recover in place.
+- Preserve shell, query key/retry policy, and cached-overview behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: terminal dashboard overview failures become
+  actionable and announced.
+
+## Impact
+
+- Dashboard page state and one App-route integration regression.
+- No API, schema, query key, locale, dependency, backend, or navigation change.

--- a/openspec/changes/fix-dashboard-overview-error/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-dashboard-overview-error/specs/frontend-architecture/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard overview and request-log listing fail independently
+
+The Dashboard SHALL gate overview-backed content only on dashboard overview
+availability. While the initial overview request is pending with no data, it
+SHALL render the existing page-wide skeleton. When that request reaches a
+terminal error with no data, it MUST NOT render the skeleton; it MUST preserve
+the shell, MUST announce the error, and MUST expose a keyboard-operable Retry.
+
+Retry SHALL refetch only the overview query. The terminal error SHALL remain
+rendered and Retry SHALL remain disabled with a busy state while that no-data
+refetch is in flight. Successful refetch SHALL replace the error with overview
+content. Cached overview data SHALL remain visible on later refetch errors.
+
+#### Scenario: Terminal overview failure replaces the skeleton
+
+- **GIVEN** no overview data is available
+- **WHEN** the overview query reaches terminal error
+- **THEN** shell landmarks remain mounted
+- **AND** the loading skeleton is removed
+- **AND** an alert and keyboard-operable Retry are rendered
+
+#### Scenario: Retry remains visible while fetching
+
+- **GIVEN** the terminal no-data error is rendered
+- **WHEN** the operator activates Retry
+- **THEN** only the overview query refetches
+- **AND** the error remains visible
+- **AND** Retry is disabled and exposes a busy state
+
+#### Scenario: Retry recovers in place
+
+- **WHEN** the endpoint succeeds after Retry
+- **THEN** overview content replaces the error without a full page reload
+
+#### Scenario: Cached overview survives later failure
+
+- **GIVEN** overview content already exists
+- **WHEN** a later refetch fails
+- **THEN** the content remains visible without a page-wide skeleton

--- a/openspec/changes/fix-dashboard-overview-error/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-dashboard-overview-error/specs/frontend-architecture/spec.md
@@ -2,16 +2,49 @@
 
 ### Requirement: Dashboard overview and request-log listing fail independently
 
-The Dashboard SHALL gate overview-backed content only on dashboard overview
-availability. While the initial overview request is pending with no data, it
-SHALL render the existing page-wide skeleton. When that request reaches a
-terminal error with no data, it MUST NOT render the skeleton; it MUST preserve
-the shell, MUST announce the error, and MUST expose a keyboard-operable Retry.
+The Dashboard SHALL gate overview-backed statistics, quota, projections, and account controls only on dashboard overview availability. The Request Logs section SHALL own the initial loading, terminal error, and ready states of its listing query without hiding healthy overview-backed content.
+
+When the initial request-log listing reaches a terminal error, the Request Logs section MUST remain visible, MUST render the listing error inside that section, MUST announce that error through an alert semantic local to the section, and MUST expose a keyboard-operable, accessibly named Retry action. Activating Retry MUST refetch only the request-log listing query and MUST NOT refetch or hide healthy overview-backed content.
+
+While the initial overview request is pending with no data, the Dashboard SHALL
+render the existing page-wide skeleton. When that request reaches a terminal
+error with no data, it MUST NOT render the skeleton; it MUST preserve the shell,
+MUST announce the error, and MUST expose a keyboard-operable Retry.
 
 Retry SHALL refetch only the overview query. The terminal error SHALL remain
 rendered and Retry SHALL remain disabled with a busy state while that no-data
 refetch is in flight. Successful refetch SHALL replace the error with overview
 content. Cached overview data SHALL remain visible on later refetch errors.
+
+#### Scenario: Initial request-log failure preserves healthy overview
+
+- **GIVEN** dashboard overview, projections, and request-log filter options load successfully
+- **WHEN** the initial request-log listing reaches a terminal error
+- **THEN** overview statistics, quota, and account content remain rendered
+- **AND** the page-wide Dashboard loading skeleton is not rendered
+- **AND** the Request Logs section contains and announces the listing error and exposes a Retry action
+
+#### Scenario: Request-log retry recovers independently
+
+- **GIVEN** healthy overview-backed content is rendered and the initial request-log listing has failed
+- **WHEN** the listing endpoint recovers and the operator activates Retry
+- **THEN** only the request-log listing query is refetched
+- **AND** healthy overview-backed content remains visible throughout recovery
+- **AND** the recovered request-log rows render in the Request Logs section
+
+#### Scenario: Request logs load inside their section
+
+- **GIVEN** dashboard overview data is available
+- **WHEN** the initial request-log listing is still pending
+- **THEN** overview-backed content is rendered
+- **AND** the Request Logs section renders its own loading state
+- **AND** the page-wide Dashboard loading skeleton is not rendered
+
+#### Scenario: Initial overview loading keeps the existing page skeleton
+
+- **WHEN** the dashboard overview is not yet available
+- **THEN** the Dashboard renders its existing page-wide loading skeleton
+- **AND** it does not render overview-backed content prematurely
 
 #### Scenario: Terminal overview failure replaces the skeleton
 

--- a/openspec/changes/fix-dashboard-overview-error/tasks.md
+++ b/openspec/changes/fix-dashboard-overview-error/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define terminal no-data and retry behavior.
+- [x] 1.2 Add an App-route terminal-error regression.
+- [x] 1.3 Capture the unannounced skeleton/no-retry RED.
+
+## 2. Implementation
+
+- [x] 2.1 Split initial pending from terminal no-data state.
+- [x] 2.2 Add alert, keyboard Retry, retained error, and busy semantics.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/broader tests, lint, typecheck, build, and OpenSpec.
+- [x] 3.2 Run real-browser error/retry/recovery QA with screenshots.
+- [x] 3.3 Record cleanup and publication evidence.


### PR DESCRIPTION
## Summary

- distinguish initial overview loading from terminal no-data failure
- replace the terminal skeleton with an announced error and keyboard Retry
- retain the error and disabled busy Retry during refetch, then recover in place

## OpenSpec

- `openspec/changes/fix-dashboard-overview-error/`
- the MODIFIED requirement block carries the current requirement text (including both Request Logs paragraphs) and all four existing scenarios alongside the four new overview scenarios
- `set -o pipefail; npx -y @fission-ai/openspec@1.11.0 validate fix-dashboard-overview-error --strict` — `Change 'fix-dashboard-overview-error' is valid`
- `set -o pipefail; npx -y @fission-ai/openspec@1.8.0 validate fix-dashboard-overview-error --strict` — `Change 'fix-dashboard-overview-error' is valid`

## Regression evidence

- RED: terminal outage rendered no alert and exposed no actionable Retry
- GREEN: announced error, no skeleton, retained shell, keyboard Retry, busy state, and recovered content
- focused test — 1 passed
- dashboard/settings controls — 17 passed

## Verification

- frontend lint and typecheck
- React Doctor changed-files — 100/100
- changed-file LSP diagnostics clean
- production build to isolated output
- strict OpenSpec validation with `@fission-ai/openspec@1.11.0` and `@fission-ai/openspec@1.8.0` (see OpenSpec)
- dual independent visual QA — PASS / APPROVED

## Browser QA

The real built dashboard passed at 375x844, 768x900, and 1280x900:

- terminal alert rendered with zero skeletons
- Retry reached through actual Tab navigation with a visible 3px focus ring
- Retry disabled with `aria-busy=true` and settled opacity `0.5`
- terminal error stayed visible during refetch
- exactly one overview retry request
- recovered account content replaced the error
- shell retained and no horizontal overflow

## Screenshots

Both frames are the built dashboard at 1280x900 (2x DPR) against deterministic harness fixtures; only `/api/dashboard/overview` is forced to HTTP 500 on initial load, every other endpoint returns fixture data.

**Before (`upstream/main`)** — the outage text sits above a page-wide loading skeleton with no alert semantic and no Retry:

<img width="1280" height="900" alt="Before: dashboard after an overview outage on main, showing the error above a page-wide loading skeleton with no Retry action" src="https://github.com/user-attachments/assets/096d3ebc-191f-4e55-9626-73b097aa8ee2" />

**After (this head)** — an announced error card with a keyboard-operable Retry replaces the skeleton, and the shell is retained:

<img width="1280" height="900" alt="After: dashboard after the same overview outage on the PR head, showing an announced error card with Retry and no loading skeleton" src="https://github.com/user-attachments/assets/5de88440-49d2-4d7e-9145-a41a53f14546" />

## Scope and independence

- based directly on `upstream/main`
- no dependency on another pull request
- no API, query-key, retry-policy, locale, dependency, backend, navigation, or global alert change
- no broad DESIGN.md or main-spec context expansion
- no matching issue or pull request found

No existing issue is claimed by this independently discovered defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Dashboard overview failures now display a clear error alert instead of leaving the loading skeleton indefinitely.
* Added an accessible **Retry** action that shows a busy state while refreshing.
* Successful retries restore dashboard content in place.
* Cached dashboard content remains visible when later refreshes fail.
* Retry state is cleared when switching dashboard timeframes.

## Tests
* Added integration coverage for dashboard overview failure, retry, recovery, timeframe changes, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->