### PR TITLE
fix(request-logs): keep rolling windows current

### DIFF
--- a/app/modules/dashboard/timeframes.py
+++ b/app/modules/dashboard/timeframes.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Final, cast
 
 from app.core.utils.time import utcnow
 from app.modules.dashboard.builders import _OVERVIEW_TIMEFRAME_CONFIGS
 from app.modules.dashboard.schemas import DashboardOverviewTimeframeKey
 
 CONVERSATION_TIMEFRAME_KEYS: frozenset[str] = frozenset({"1d", "7d", "30d"})
+REQUEST_LOG_TIMEFRAME_KEYS: frozenset[str] = frozenset({"1h", "24h", "7d"})
+_REQUEST_LOG_TIMEFRAME_MINUTES: Final = {"1h": 60, "24h": 24 * 60, "7d": 7 * 24 * 60}
 
 
 def resolve_conversation_timeframe(key: str) -> tuple[int, datetime]:
@@ -13,3 +15,7 @@ def resolve_conversation_timeframe(key: str) -> tuple[int, datetime]:
     _key = cast(DashboardOverviewTimeframeKey, key)
     timeframe = _OVERVIEW_TIMEFRAME_CONFIGS[_key]
     return timeframe.window_minutes, utcnow() - timedelta(minutes=timeframe.window_minutes)
+
+
+def resolve_request_log_timeframe(key: str) -> datetime:
+    return utcnow() - timedelta(minutes=_REQUEST_LOG_TIMEFRAME_MINUTES[key])

--- a/app/modules/request_logs/api.py
+++ b/app/modules/request_logs/api.py
@@ -13,7 +13,10 @@ from app.core.auth.dependencies import (
 )
 from app.core.utils.time import to_utc_naive, utcnow
 from app.dependencies import RequestLogsContext, get_request_logs_context
-from app.modules.dashboard.timeframes import resolve_conversation_timeframe
+from app.modules.dashboard.timeframes import (
+    resolve_conversation_timeframe,
+    resolve_request_log_timeframe,
+)
 from app.modules.request_logs.schemas import (
     ConversationDetailsResponse,
     ConversationsResponse,
@@ -54,6 +57,17 @@ def _parse_model_option(value: str) -> ServiceRequestLogModelOption | None:
     return ServiceRequestLogModelOption(model=model, reasoning_effort=effort or None)
 
 
+def _resolve_request_log_since(
+    timeframe: str | None,
+    since: datetime | None,
+) -> tuple[datetime | None, str | None]:
+    if timeframe is not None and since is not None:
+        raise HTTPException(status_code=422, detail="timeframe and since cannot be supplied together")
+    if timeframe is None:
+        return since, None
+    return resolve_request_log_timeframe(timeframe), timeframe
+
+
 @router.get("", response_model=RequestLogsResponse)
 async def list_request_logs(
     limit: int = Query(50, ge=1, le=1000),
@@ -66,6 +80,7 @@ async def list_request_logs(
     model: list[str] | None = Query(default=None),
     reasoning_effort: list[str] | None = Query(default=None, alias="reasoningEffort"),
     model_option: list[str] | None = Query(default=None, alias="modelOption"),
+    timeframe: str | None = Query(default=None, pattern="^(1h|24h|7d)$"),
     since: datetime | None = Query(default=None),
     until: datetime | None = Query(default=None),
     principal: DashboardPrincipal = Depends(validate_dashboard_session),
@@ -78,12 +93,13 @@ async def list_request_logs(
     if model_option:
         parsed = [_parse_model_option(value) for value in model_option]
         parsed_options = [value for value in parsed if value is not None] or None
+    effective_since, cache_timeframe = _resolve_request_log_since(timeframe, since)
     page = await context.service.list_recent(
         limit=limit,
         offset=offset,
         search=search,
         conversation_id=conversation_id,
-        since=since,
+        since=effective_since,
         until=until,
         account_ids=account_id,
         api_key_ids=api_key_id,
@@ -91,6 +107,8 @@ async def list_request_logs(
         models=model,
         reasoning_efforts=reasoning_effort,
         status=status,
+        cache_mode="timeframe" if cache_timeframe is not None else "since",
+        timeframe=cache_timeframe,
         include_sensitive_metadata=principal.role == DashboardRole.ADMIN,
     )
     return RequestLogsResponse(
@@ -109,6 +127,7 @@ async def list_request_log_filter_options(
     model: list[str] | None = Query(default=None),
     reasoning_effort: list[str] | None = Query(default=None, alias="reasoningEffort"),
     model_option: list[str] | None = Query(default=None, alias="modelOption"),
+    timeframe: str | None = Query(default=None, pattern="^(1h|24h|7d)$"),
     since: datetime | None = Query(default=None),
     until: datetime | None = Query(default=None),
     context: RequestLogsContext = Depends(get_request_logs_context),
@@ -118,8 +137,9 @@ async def list_request_log_filter_options(
     if model_option:
         parsed = [_parse_model_option(value) for value in model_option]
         parsed_options = [value for value in parsed if value is not None] or None
+    effective_since, _ = _resolve_request_log_since(timeframe, since)
     options = await context.service.list_filter_options(
-        since=since,
+        since=effective_since,
         until=until,
         account_ids=account_id,
         api_key_ids=api_key_id,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -1260,6 +1260,8 @@ class RequestLogsRepository:
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
         *,
+        cache_mode: str = "since",
+        timeframe: str | None = None,
         include_sensitive_metadata: bool = True,
     ) -> RequestLogsResult:
         since = _naive_utc(since) if since is not None else None
@@ -1316,9 +1318,10 @@ class RequestLogsRepository:
         ttl_seconds = _COUNT_CACHE_TTL_SECONDS
         if ttl_seconds <= 0:
             return RequestLogsResult(logs=logs, total=await self._count_recent(filters, demand_params))
+        window_identity = ("timeframe", timeframe) if cache_mode == "timeframe" else ("since", since)
         cache_key = (
             search,
-            since,
+            window_identity,
             until,
             conversation_id,
             tuple(account_ids or ()),

--- a/app/modules/request_logs/service.py
+++ b/app/modules/request_logs/service.py
@@ -99,6 +99,8 @@ class RequestLogsService:
         reasoning_efforts: list[str] | None = None,
         status: list[str] | None = None,
         *,
+        cache_mode: str = "since",
+        timeframe: str | None = None,
         include_sensitive_metadata: bool,
     ) -> RequestLogsPage:
         status_filter = _map_status_filter(status)
@@ -122,6 +124,8 @@ class RequestLogsService:
             include_error_other=status_filter.include_error_other,
             error_codes_in=status_filter.error_codes_in,
             error_codes_excluding=status_filter.error_codes_excluding,
+            cache_mode=cache_mode,
+            timeframe=timeframe,
             include_sensitive_metadata=include_sensitive_metadata,
         )
         logs = result.logs

--- a/frontend/src/__integration__/dashboard-flow.test.tsx
+++ b/frontend/src/__integration__/dashboard-flow.test.tsx
@@ -284,6 +284,74 @@ describe("dashboard flow integration", () => {
     expect(optionsCalls).toBe(optionsCallsBeforeRetry);
   });
 
+  it("keeps retained request-log rows through failed refresh and Retry recovery", async () => {
+    const user = userEvent.setup({ delay: null });
+    let requestLogsAvailable = true;
+    let recovered = false;
+    let requestLogCalls = 0;
+    const retainedLog = createRequestLogEntry({
+      requestId: "req_retained_refresh",
+      apiKeyName: "Retained API Key",
+    });
+    const recoveredLog = createRequestLogEntry({
+      requestId: "req_recovered_refresh",
+      apiKeyName: "Recovered API Key",
+    });
+
+    server.use(
+      http.get("/api/request-logs", () => {
+        requestLogCalls += 1;
+        if (!requestLogsAvailable) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: "forced_background_refresh_failure",
+                message: REQUEST_LOG_OUTAGE_MESSAGE,
+              },
+            },
+            { status: 503 },
+          );
+        }
+        return HttpResponse.json(
+          createRequestLogsResponse([recovered ? recoveredLog : retainedLog], 1, false),
+        );
+      }),
+    );
+
+    window.history.pushState({}, "", "/dashboard");
+    const { queryClient: testQueryClient } = renderWithProviders(<App />);
+
+    expect(await screen.findByText("Retained API Key")).toBeInTheDocument();
+    const section = screen.getByRole("heading", { name: "Request Logs" }).closest("section");
+    expect(section).not.toBeNull();
+    const requestLogs = within(section as HTMLElement);
+    expect(requestLogs.getByRole("table")).toBeVisible();
+
+    const callsBeforeRefresh = requestLogCalls;
+    requestLogsAvailable = false;
+    await act(async () => {
+      await testQueryClient.invalidateQueries({
+        queryKey: ["dashboard", "request-logs"],
+      });
+    });
+    await waitFor(() => expect(requestLogCalls).toBeGreaterThan(callsBeforeRefresh));
+    const alert = await requestLogs.findByRole("alert");
+
+    expect(alert).toHaveTextContent(REQUEST_LOG_OUTAGE_MESSAGE);
+    expect(requestLogs.getByRole("table")).toBeVisible();
+    expect(requestLogs.getByText("Retained API Key")).toBeVisible();
+
+    requestLogsAvailable = true;
+    recovered = true;
+    const retry = requestLogs.getByRole("button", { name: "Retry" });
+    retry.focus();
+    await user.keyboard("{Enter}");
+
+    expect(await requestLogs.findByText("Recovered API Key")).toBeVisible();
+    expect(requestLogs.queryByText("Retained API Key")).not.toBeInTheDocument();
+    expect(requestLogs.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("switches to conversations without reinterpreting request-log URL state", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(

--- a/frontend/src/features/dashboard/api.ts
+++ b/frontend/src/features/dashboard/api.ts
@@ -10,6 +10,7 @@ import {
   RequestLogsResponseSchema,
   type ConversationTimeframe,
   type OverviewTimeframe,
+  type RequestLogTimeframe,
 } from "@/features/dashboard/schemas";
 
 const DASHBOARD_PATH = "/api/dashboard";
@@ -24,12 +25,14 @@ export type RequestLogsListFilters = {
   apiKeyIds?: string[];
   statuses?: string[];
   modelOptions?: string[];
+  timeframe?: Exclude<RequestLogTimeframe, "all">;
   since?: string;
   until?: string;
   conversationId?: string;
 };
 
 export type RequestLogFacetFilters = {
+  timeframe?: Exclude<RequestLogTimeframe, "all">;
   since?: string;
   until?: string;
   accountIds?: string[];
@@ -80,6 +83,9 @@ export function getRequestLogs(params: RequestLogsListFilters = {}) {
   if (params.conversationId) {
     query.set("conversation_id", params.conversationId);
   }
+  if (params.timeframe) {
+    query.set("timeframe", params.timeframe);
+  }
   if (params.since) {
     query.set("since", params.since);
   }
@@ -92,6 +98,9 @@ export function getRequestLogs(params: RequestLogsListFilters = {}) {
 
 export function getRequestLogOptions(params: RequestLogFacetFilters = {}) {
   const query = new URLSearchParams();
+  if (params.timeframe) {
+    query.set("timeframe", params.timeframe);
+  }
   if (params.since) {
     query.set("since", params.since);
   }

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -502,81 +502,88 @@ export function DashboardPage() {
                 </>
               ) : null}
             </div>
-            {isAdmin && dashboardView === "conversations" ? <ConversationsView state={conversationsState} accounts={overview?.accounts ?? []} /> : logsQuery.isPending && !logPage ? (
-              <div className="rounded-xl border bg-card py-8">
-                <SpinnerBlock />
-              </div>
-            ) : logsQuery.error ? (
-              <div className="space-y-3 rounded-xl border bg-card p-4">
-                <div role="alert">
-                  <AlertMessage variant="error">{logsQuery.error.message}</AlertMessage>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    void logsQuery.refetch();
-                  }}
-                  disabled={logsQuery.isFetching}
-                >
-                  {t("common.actions.retry")}
-                </Button>
-              </div>
-            ) : logPage ? (
+            {isAdmin && dashboardView === "conversations" ? (
+              <ConversationsView state={conversationsState} accounts={overview?.accounts ?? []} />
+            ) : (
               <>
-            <RequestFilters
-              filters={filters}
-              accountOptions={accountOptions}
-              apiKeyOptions={apiKeyOptions}
-              modelOptions={modelOptions}
-              statusOptions={statusOptions}
-              onSearchChange={(search) => updateFilters({ search, offset: 0 })}
-              onTimeframeChange={(timeframe) => updateFilters({ timeframe, offset: 0 })}
-              onAccountChange={(accountIds) => updateFilters({ accountIds, offset: 0 })}
-              onApiKeyChange={(apiKeyIds) => updateFilters({ apiKeyIds, offset: 0 })}
-              onModelChange={(modelOptionsSelected) =>
-                updateFilters({ modelOptions: modelOptionsSelected, offset: 0 })
-              }
-              onStatusChange={(statuses) => updateFilters({ statuses, offset: 0 })}
-              onConversationDismiss={handleConversationDismiss}
-              onReset={() =>
-                updateFilters({
-                  search: "",
-                  timeframe: "all",
-                  accountIds: [],
-                  apiKeyIds: [],
-                  modelOptions: [],
-                  statuses: [],
-                  conversationId: null,
-                  offset: 0,
-                })
-              }
-            />
-            {conversationSummary ? (
-              <div className="rounded-xl border bg-card p-4">
-                <p className="text-sm text-muted-foreground">{conversationSummary}</p>
-              </div>
-            ) : null}
-            <div className="transition-opacity duration-200">
-              <RecentRequestsTable
-                requests={view.requestLogs}
-                accounts={overview?.accounts ?? []}
-                total={logPage?.total ?? 0}
-                visibleColumns={visibleColumns}
-                columnWidths={columnWidths}
-                onColumnWidthChange={setColumnWidth}
-                limit={filters.limit}
-                offset={filters.offset}
-                hasMore={logPage?.hasMore ?? false}
-                filtersApplied={emptyStateFiltersApplied}
-                onLimitChange={(limit) => updateFilters({ limit, offset: 0 })}
-                onOffsetChange={(offset) => updateFilters({ offset })}
-                onConversationClick={handleConversationClick}
-              />
-            </div>
+                {logsQuery.error ? (
+                  <div className="space-y-3 rounded-xl border bg-card p-4">
+                    <div role="alert">
+                      <AlertMessage variant="error">{logsQuery.error.message}</AlertMessage>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        void logsQuery.refetch();
+                      }}
+                      disabled={logsQuery.isFetching}
+                    >
+                      {t("common.actions.retry")}
+                    </Button>
+                  </div>
+                ) : null}
+                {logsQuery.isPending && !logPage ? (
+                  <div className="rounded-xl border bg-card py-8">
+                    <SpinnerBlock />
+                  </div>
+                ) : logPage ? (
+                  <>
+                    <RequestFilters
+                      filters={filters}
+                      accountOptions={accountOptions}
+                      apiKeyOptions={apiKeyOptions}
+                      modelOptions={modelOptions}
+                      statusOptions={statusOptions}
+                      onSearchChange={(search) => updateFilters({ search, offset: 0 })}
+                      onTimeframeChange={(timeframe) => updateFilters({ timeframe, offset: 0 })}
+                      onAccountChange={(accountIds) => updateFilters({ accountIds, offset: 0 })}
+                      onApiKeyChange={(apiKeyIds) => updateFilters({ apiKeyIds, offset: 0 })}
+                      onModelChange={(modelOptionsSelected) =>
+                        updateFilters({ modelOptions: modelOptionsSelected, offset: 0 })
+                      }
+                      onStatusChange={(statuses) => updateFilters({ statuses, offset: 0 })}
+                      onConversationDismiss={handleConversationDismiss}
+                      onReset={() =>
+                        updateFilters({
+                          search: "",
+                          timeframe: "all",
+                          accountIds: [],
+                          apiKeyIds: [],
+                          modelOptions: [],
+                          statuses: [],
+                          conversationId: null,
+                          offset: 0,
+                        })
+                      }
+                    />
+                    {conversationSummary ? (
+                      <div className="rounded-xl border bg-card p-4">
+                        <p className="text-sm text-muted-foreground">{conversationSummary}</p>
+                      </div>
+                    ) : null}
+                    <div className="transition-opacity duration-200">
+                      <RecentRequestsTable
+                        requests={view.requestLogs}
+                        accounts={overview?.accounts ?? []}
+                        total={logPage.total}
+                        visibleColumns={visibleColumns}
+                        columnWidths={columnWidths}
+                        onColumnWidthChange={setColumnWidth}
+                        limit={filters.limit}
+                        offset={filters.offset}
+                        hasMore={logPage.hasMore}
+                        filtersApplied={emptyStateFiltersApplied}
+                        onLimitChange={(limit) => updateFilters({ limit, offset: 0 })}
+                        onOffsetChange={(offset) => updateFilters({ offset })}
+                        onConversationClick={handleConversationClick}
+                      />
+                    </div>
+                  </>
+                ) : null}
               </>
-            ) : null}
+            )}
           </section>
         </>
       )}

--- a/frontend/src/features/dashboard/hooks/use-request-logs.test.ts
+++ b/frontend/src/features/dashboard/hooks/use-request-logs.test.ts
@@ -8,7 +8,7 @@ import {
   useNavigate,
   type NavigateFunction,
 } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { requestLogFiltersApplied, useRequestLogs } from "@/features/dashboard/hooks/use-request-logs";
 import { server } from "@/test/mocks/server";
@@ -66,6 +66,64 @@ function createWrapper(
 }
 
 describe("useRequestLogs", () => {
+  it("keeps symbolic timeframes stable across refetch despite browser clock skew", async () => {
+    const listCalls: URLSearchParams[] = [];
+    const optionCalls: URLSearchParams[] = [];
+    server.use(
+      http.get("/api/request-logs", ({ request }) => {
+        listCalls.push(new URL(request.url).searchParams);
+        return HttpResponse.json({ requests: [], total: 0, hasMore: false });
+      }),
+      http.get("/api/request-logs/options", ({ request }) => {
+        optionCalls.push(new URL(request.url).searchParams);
+        return HttpResponse.json({
+          accountIds: [],
+          apiKeys: [],
+          modelOptions: [],
+          statuses: [],
+        });
+      }),
+    );
+    const browserClock = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2036-08-31T12:00:00Z"));
+
+    try {
+      const queryClient = createTestQueryClient();
+      const wrapper = createWrapper(
+        queryClient,
+        "/dashboard?timeframe=24h&search=quota&accountId=acc_primary&apiKeyId=key_1&modelOption=gpt-5.1:::high&status=ok&limit=10&offset=20",
+      );
+      const { result } = renderHook(() => useRequestLogs(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.logsQuery.isSuccess).toBe(true);
+        expect(result.current.optionsQuery.isSuccess).toBe(true);
+      });
+      await act(async () => {
+        await Promise.all([
+          result.current.logsQuery.refetch(),
+          result.current.optionsQuery.refetch(),
+        ]);
+      });
+
+      expect(listCalls).toHaveLength(2);
+      expect(optionCalls).toHaveLength(2);
+      for (const params of [...listCalls, ...optionCalls]) {
+        expect(params.get("timeframe")).toBe("24h");
+        expect(params.has("since")).toBe(false);
+      }
+      for (const params of listCalls) {
+        expect(params.get("search")).toBe("quota");
+        expect(params.getAll("accountId")).toEqual(["acc_primary"]);
+        expect(params.getAll("apiKeyId")).toEqual(["key_1"]);
+        expect(params.getAll("modelOption")).toEqual(["gpt-5.1:::high"]);
+        expect(params.getAll("status")).toEqual(["ok"]);
+        expect(params.get("limit")).toBe("10");
+        expect(params.get("offset")).toBe("20");
+      }
+    } finally {
+      browserClock.mockRestore();
+    }
+  });
   it("maps URL params into filter state and query key", async () => {
     const queryClient = createTestQueryClient();
     const wrapper = createWrapper(
@@ -230,6 +288,7 @@ describe("useRequestLogs", () => {
       accountIds: string[];
       apiKeyIds: string[];
       modelOptions: string[];
+      timeframe: string | null;
       since: string | null;
     }> = [];
     server.use(
@@ -240,6 +299,7 @@ describe("useRequestLogs", () => {
           accountIds: url.searchParams.getAll("accountId"),
           apiKeyIds: url.searchParams.getAll("apiKeyId"),
           modelOptions: url.searchParams.getAll("modelOption"),
+          timeframe: url.searchParams.get("timeframe"),
           since: url.searchParams.get("since"),
         });
         return HttpResponse.json({
@@ -271,7 +331,8 @@ describe("useRequestLogs", () => {
     );
     expect(matchingCall).toBeDefined();
     expect(matchingCall?.statuses).toEqual([]);
-    expect(matchingCall?.since).toMatch(/T/);
+    expect(matchingCall?.timeframe).toBe("24h");
+    expect(matchingCall?.since).toBeNull();
   });
 
   it("removes stale status from request parameters immediately after unselect", async () => {

--- a/frontend/src/features/dashboard/hooks/use-request-logs.ts
+++ b/frontend/src/features/dashboard/hooks/use-request-logs.ts
@@ -104,19 +104,6 @@ function writeFilterState(state: FilterState, base?: URLSearchParams): URLSearch
   return params;
 }
 
-function timeframeToSinceIso(timeframe: FilterState["timeframe"]): string | undefined {
-  if (timeframe === "all") {
-    return undefined;
-  }
-  const now = Date.now();
-  const lookup: Record<Exclude<FilterState["timeframe"], "all">, number> = {
-    "1h": 60 * 60 * 1000,
-    "24h": 24 * 60 * 60 * 1000,
-    "7d": 7 * 24 * 60 * 60 * 1000,
-  };
-  return new Date(now - lookup[timeframe]).toISOString();
-}
-
 export type UseRequestLogsOptions = {
   enabled?: boolean;
 };
@@ -127,7 +114,7 @@ export function useRequestLogs(options: UseRequestLogsOptions = {}) {
 
   const filters = useMemo(() => parseFilterState(searchParams), [searchParams]);
   const filtersApplied = requestLogFiltersApplied(filters);
-  const since = useMemo(() => timeframeToSinceIso(filters.timeframe), [filters.timeframe]);
+  const timeframe = filters.timeframe === "all" ? undefined : filters.timeframe;
   const listFilters = useMemo<RequestLogsListFilters>(
     () => ({
       search: filters.search || undefined,
@@ -137,19 +124,19 @@ export function useRequestLogs(options: UseRequestLogsOptions = {}) {
       apiKeyIds: filters.apiKeyIds,
       statuses: filters.statuses,
       modelOptions: filters.modelOptions,
-      since,
+      timeframe,
       conversationId: filters.conversationId ?? undefined,
     }),
-    [filters, since],
+    [filters, timeframe],
   );
   const facetFilters = useMemo<RequestLogFacetFilters>(
     () => ({
-      since,
+      timeframe,
       accountIds: filters.accountIds,
       apiKeyIds: filters.apiKeyIds,
       modelOptions: filters.modelOptions,
     }),
-    [filters.accountIds, filters.apiKeyIds, filters.modelOptions, since],
+    [filters.accountIds, filters.apiKeyIds, filters.modelOptions, timeframe],
   );
 
   const {

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -277,9 +277,12 @@ export const RequestLogFilterOptionsSchema = z.object({
   statuses: z.array(z.string()),
 });
 
+const RequestLogTimeframeSchema = z.enum(["all", "1h", "24h", "7d"]);
+export type RequestLogTimeframe = z.infer<typeof RequestLogTimeframeSchema>;
+
 export const FilterStateSchema = z.object({
   search: z.string(),
-  timeframe: z.enum(["all", "1h", "24h", "7d"]),
+  timeframe: RequestLogTimeframeSchema,
   accountIds: z.array(z.string()),
   apiKeyIds: z.array(z.string()),
   modelOptions: z.array(z.string()),

--- a/openspec/changes/fix-request-log-timeframe-refresh/.openspec.yaml
+++ b/openspec/changes/fix-request-log-timeframe-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/fix-request-log-timeframe-refresh/context.md
+++ b/openspec/changes/fix-request-log-timeframe-refresh/context.md
@@ -1,0 +1,26 @@
+# Request-log timeframe and refresh context
+
+## Purpose
+
+Keep rolling Request Logs windows truthful during long sessions and retain
+useful rows during transient refresh failures.
+
+## Decision
+
+The frontend sends `timeframe=1h|24h|7d`; each backend request derives its
+lower bound from server UTC. `all` remains unbounded. Literal bounds remain
+compatible, but `timeframe` and `since` are mutually exclusive.
+
+Membership always uses the live lower bound. Only display total metadata keeps
+the 30-second cache, keyed by symbolic timeframe rather than derived timestamp.
+
+A listing error renders independently from content. If data exists, the same
+section-local alert/Retry appears above retained filters/table/pagination.
+
+## Constraints
+
+- Overview and request-log timeframes remain independent.
+- List and options remain separate requests.
+- Preserve all manual filters, literal bounds, response schemas, and retry
+  cadence.
+- No new component, token, setting, or dependency.

--- a/openspec/changes/fix-request-log-timeframe-refresh/proposal.md
+++ b/openspec/changes/fix-request-log-timeframe-refresh/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Request Logs `1h`, `24h`, and `7d` filters freeze one browser-derived `since`
+timestamp for the selected filter lifetime. Refetches stop moving the rolling
+window and inherit browser clock skew. Separately, a failed background listing
+refresh hides rows TanStack Query retained.
+
+## What Changes
+
+- Add server-authoritative symbolic timeframes to listing and options.
+- Keep literal `since`/`until`; reject ambiguous `timeframe + since`.
+- Give count metadata semantic timeframe cache identity.
+- Send symbolic timeframes from the dashboard.
+- Keep retained rows visible with an announced refresh error and Retry.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `query-caching`
+- `frontend-architecture`
+
+## Impact
+
+Request-log query parameters/cache identity, dashboard API/hook/rendering, and
+focused tests. No response schema, setting, migration, dependency, or new UI
+primitive.

--- a/openspec/changes/fix-request-log-timeframe-refresh/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-request-log-timeframe-refresh/specs/frontend-architecture/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Dashboard request-log filters use symbolic rolling timeframes
+
+For `1h`, `24h`, and `7d`, the dashboard MUST send symbolic `timeframe` to
+listing and options and MUST NOT send browser-generated `since`. Selecting
+`all` MUST omit both. Refetches MUST preserve all applicable manual filters.
+
+#### Scenario: Browser skew does not alter request-log filters
+
+- **WHEN** the dashboard fetches or refetches `timeframe=24h`
+- **THEN** both requests contain `timeframe=24h`
+- **AND** neither contains `since`
+
+### Requirement: Background request-log failure preserves retained rows
+
+When a page loaded successfully and a later refresh fails, Request Logs MUST
+keep the last successful filters, rows, total, and pagination visible. It MUST
+also announce the current failure with a section-local alert and expose Retry.
+Error-only rendering remains valid only before any page succeeds.
+
+#### Scenario: Failed refresh retains table
+
+- **GIVEN** a successful request-log page is visible
+- **WHEN** a later refresh reaches terminal failure
+- **THEN** the table and rows remain visible
+- **AND** the section exposes alert and Retry

--- a/openspec/changes/fix-request-log-timeframe-refresh/specs/query-caching/spec.md
+++ b/openspec/changes/fix-request-log-timeframe-refresh/specs/query-caching/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Request-log endpoints accept server-authoritative timeframes
+
+`GET /api/request-logs` and `/api/request-logs/options` MUST accept
+`timeframe=1h|24h|7d` and derive each effective lower bound from the server UTC
+clock. Symbolic requests MUST NOT require a browser timestamp. `timeframe` and
+`since` MUST NOT be supplied together. Existing standalone `since` and `until`
+MUST retain behavior; `until` MAY accompany a timeframe.
+
+#### Scenario: Symbolic timeframe advances on refresh
+
+- **WHEN** the server clock advances and a client refetches `timeframe=1h`
+- **THEN** listing and options derive a fresh lower bound
+- **AND** all other filters remain intact
+
+#### Scenario: Ambiguous lower bounds are rejected
+
+- **WHEN** a caller supplies both `timeframe` and `since`
+- **THEN** the endpoint returns HTTP 422
+
+### Requirement: Request-log total cache uses semantic window identity
+
+In symbolic mode, total-cache identity MUST use `("timeframe", timeframe)`.
+Legacy mode MUST use `("since", effective_since)`. Membership rows MUST always
+use the live derived timestamp.
+
+#### Scenario: Repeated timeframe requests reuse count metadata
+
+- **GIVEN** two requests use the same filters and timeframe within cache TTL
+- **WHEN** their derived timestamps differ
+- **THEN** the count query executes once
+- **AND** each membership query uses its live timestamp

--- a/openspec/changes/fix-request-log-timeframe-refresh/tasks.md
+++ b/openspec/changes/fix-request-log-timeframe-refresh/tasks.md
@@ -1,0 +1,20 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add server-clock API and ambiguity tests.
+- [x] 1.2 Add semantic count-cache identity coverage.
+- [x] 1.3 Add symbolic frontend query coverage.
+- [x] 1.4 Add retained-row refresh failure/recovery coverage.
+- [x] 1.5 Capture all intended RED failures.
+
+## 2. Implementation
+
+- [x] 2.1 Resolve request-log timeframes from server UTC.
+- [x] 2.2 Thread symbolic cache identity through service/repository.
+- [x] 2.3 Send symbolic timeframes from frontend API/hook.
+- [x] 2.4 Render refresh errors independently from retained rows.
+
+## 3. Verification
+
+- [x] 3.1 Run backend/frontend tests and quality gates.
+- [x] 3.2 Run real-browser timeframe/retained-row QA.
+- [x] 3.3 Record cleanup and publication evidence.

--- a/tests/integration/test_request_logs_filters.py
+++ b/tests/integration/test_request_logs_filters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from sqlalchemy import update
@@ -313,6 +313,77 @@ async def test_request_logs_filters_by_account_model_and_time(async_client, db_s
     assert len(payload) == 1
     assert payload[0]["model"] == "gpt-5.1"
     assert payload[0]["tokens"] == 4
+
+
+@pytest.mark.parametrize(
+    ("timeframe", "window"),
+    [
+        ("1h", timedelta(hours=1)),
+        ("24h", timedelta(hours=24)),
+        ("7d", timedelta(days=7)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_request_log_timeframe_uses_server_clock_for_rows_and_options(
+    async_client,
+    db_setup,
+    monkeypatch,
+    timeframe,
+    window,
+):
+    from app.modules.dashboard import timeframes as timeframes_module
+
+    fixed_now = datetime(2026, 8, 31, 12, 0, 0)
+    monkeypatch.setattr(timeframes_module, "utcnow", lambda: fixed_now)
+    async with SessionLocal() as session:
+        repo = RequestLogsRepository(session)
+        await repo.add_log(
+            account_id=None,
+            request_id=f"req_{timeframe}_inside",
+            model=f"model-{timeframe}-inside",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=10,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - window + timedelta(seconds=1),
+        )
+        await repo.add_log(
+            account_id=None,
+            request_id=f"req_{timeframe}_outside",
+            model=f"model-{timeframe}-outside",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=10,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - window - timedelta(seconds=1),
+        )
+
+    rows = await async_client.get("/api/request-logs", params={"timeframe": timeframe})
+    options = await async_client.get("/api/request-logs/options", params={"timeframe": timeframe})
+
+    assert rows.status_code == 200
+    assert [item["requestId"] for item in rows.json()["requests"]] == [f"req_{timeframe}_inside"]
+    assert options.status_code == 200
+    assert options.json()["modelOptions"] == [{"model": f"model-{timeframe}-inside", "reasoningEffort": None}]
+
+
+@pytest.mark.parametrize("path", ["/api/request-logs", "/api/request-logs/options"])
+@pytest.mark.asyncio
+async def test_request_log_timeframe_rejects_unknown_and_ambiguous_bounds(
+    async_client,
+    db_setup,
+    path,
+):
+    unknown = await async_client.get(path, params={"timeframe": "30d"})
+    ambiguous = await async_client.get(
+        path,
+        params={"timeframe": "1h", "since": "2026-08-31T00:00:00Z"},
+    )
+
+    assert unknown.status_code == 422
+    assert ambiguous.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_request_logs_list_count.py
+++ b/tests/integration/test_request_logs_list_count.py
@@ -286,3 +286,65 @@ async def test_list_recent_count_cache_key_includes_conversation_id(db_setup, mo
     logs_repository_module._clear_recent_count_cache()
     assert result_a.total == 2
     assert result_b.total == 1
+
+
+@pytest.mark.asyncio
+async def test_list_recent_count_cache_uses_symbolic_timeframe_identity(
+    db_setup,
+    monkeypatch,
+):
+    from app.modules.request_logs import repository as logs_repository_module
+
+    monkeypatch.setattr(logs_repository_module, "_COUNT_CACHE_TTL_SECONDS", 30.0)
+    logs_repository_module._clear_recent_count_cache()
+    statements: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        first_since = utcnow() - timedelta(hours=1)
+        async with SessionLocal() as session:
+            repo = RequestLogsRepository(session)
+            await repo.add_log(
+                account_id=None,
+                request_id="req_timeframe_cache",
+                model="gpt-5.1",
+                input_tokens=1,
+                output_tokens=1,
+                latency_ms=10,
+                status="success",
+                error_code=None,
+                requested_at=utcnow(),
+            )
+            statements.clear()
+            await repo.list_recent(
+                search="req_timeframe_cache",
+                since=first_since,
+                cache_mode="timeframe",
+                timeframe="1h",
+            )
+            await repo.list_recent(
+                search="req_timeframe_cache",
+                since=first_since + timedelta(minutes=1),
+                cache_mode="timeframe",
+                timeframe="1h",
+            )
+            await repo.list_recent(
+                search="req_timeframe_cache",
+                since=first_since,
+                cache_mode="timeframe",
+                timeframe="24h",
+            )
+            await repo.list_recent(
+                search="req_timeframe_cache",
+                since=first_since,
+                cache_mode="since",
+            )
+
+        count_queries = [statement for statement in statements if "count(request_logs.id)" in statement.lower()]
+        assert len(count_queries) == 3
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+        logs_repository_module._clear_recent_count_cache()


### PR DESCRIPTION
## Summary

- replace browser-derived frozen `since` values with server-authoritative `1h|24h|7d` request-log timeframes
- preserve literal bounds while rejecting ambiguous `timeframe + since`
- use semantic timeframe identity for cached totals while membership keeps a live server lower bound
- retain the last successful table and rows alongside an announced refresh error and local Retry

## OpenSpec

- `openspec/changes/fix-request-log-timeframe-refresh/`
- strict validation passes

## Regression evidence

- frontend RED: list/options sent browser `since`; retained rows disappeared after failed refresh
- backend RED: APIs ignored symbolic/ambiguous timeframes and repository rejected semantic cache arguments
- GREEN: targeted backend 6, backend domain 39, frontend hook/dashboard 24

## Verification

- backend Ruff, format, and direct `ty check`
- frontend lint, typecheck, React Doctor 100/100, and isolated production build
- changed-file LSP diagnostics clean
- strict OpenSpec validation and diff check
- Oracle pre-commit review — APPROVED
- dual visual QA — APPROVED / APPROVED

## Live API QA

- valid listing `timeframe=1h` — HTTP 200
- valid options `timeframe=24h` — HTTP 200
- unknown `timeframe=30d` — HTTP 422
- ambiguous `timeframe=1h&since=...` — HTTP 422

The isolated uvicorn process, SQLite database/WAL/SHM, port, and environment
were removed.

## Browser QA

Real built-dashboard Chromium QA at 375x844 and 1280x900 used a deliberately
skewed browser clock:

- every listing/options request contained `timeframe=24h` and no `since`
- failed background refresh retained filters, table, and `Retained API Key`
- section-local alert and keyboard Retry remained visible
- Retry recovered `Recovered API Key` and removed the alert
- no document overflow

Matched section-level and mobile horizontally-scrolled API-key captures were
reviewed and approved. Canonical screenshots will be attached before PR-ready.

## Scope and independence

- based directly on `upstream/main`
- no dependency on another pull request
- no overview-timeframe coupling, setting, migration, response schema, dependency, or new UI primitive
- no matching issue or competing PR found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 1-hour, 24-hour, and 7-day timeframe filters for request logs and filter options.
  * Timeframes now use the server clock for consistent results during refreshes.
  * Added validation for unsupported timeframes and conflicting date filters.

* **Bug Fixes**
  * Request-log rows and filters remain visible when refreshes fail.
  * Added section-specific error messaging and a Retry action for recovery.

* **Tests**
  * Added coverage for timeframe filtering, caching, clock changes, and refresh failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->