### PR TITLE
fix(metrics): aggregate latency histogram buckets

### DIFF
--- a/deploy/helm/codex-lb/dashboards/codex-lb.json
+++ b/deploy/helm/codex-lb/dashboards/codex-lb.json
@@ -123,7 +123,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -132,7 +132,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -141,7 +141,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(codex_lb_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -303,7 +303,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(codex_lb_upstream_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(codex_lb_upstream_request_duration_seconds_bucket{namespace=\"$namespace\",job=~\"$job\"}[5m])))",
           "legendFormat": "p99",
           "refId": "A"
         }

--- a/deploy/helm/codex-lb/templates/prometheusrule.yaml
+++ b/deploy/helm/codex-lb/templates/prometheusrule.yaml
@@ -33,7 +33,9 @@ spec:
         - alert: CodexLBHighLatency
           expr: |
             histogram_quantile(0.99,
-              rate(codex_lb_request_duration_seconds_bucket[5m])
+              sum by (namespace, job, le) (
+                rate(codex_lb_request_duration_seconds_bucket[5m])
+              )
             ) > 10
           for: 5m
           labels:

--- a/openspec/changes/fix-latency-promql-aggregation/.openspec.yaml
+++ b/openspec/changes/fix-latency-promql-aggregation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/fix-latency-promql-aggregation/context.md
+++ b/openspec/changes/fix-latency-promql-aggregation/context.md
@@ -1,0 +1,22 @@
+# Aggregate latency PromQL context
+
+## Purpose
+
+Classic histogram quantiles require bucket aggregation while retaining `le`.
+
+## Decision
+
+Grafana already selects namespace/job, so matching five-minute rates are summed
+by `le` before quantile. The alert preserves namespace/job scope by summing by
+namespace, job, and `le`.
+
+## Constraints
+
+- Preserve windows, quantiles, thresholds, duration, and instrumentation.
+- Remove method/path/replica/scrape labels before quantile.
+- Cover all four dashboard expressions and the named alert.
+
+## Example
+
+Multiple request paths and replicas under one selected dashboard scope produce
+one p50, p95, and p99 instead of indistinguishable duplicate series.

--- a/openspec/changes/fix-latency-promql-aggregation/proposal.md
+++ b/openspec/changes/fix-latency-promql-aggregation/proposal.md
@@ -24,5 +24,7 @@ None.
 
 ## Impact
 
-Grafana JSON, PrometheusRule, artifact tests, and OpenSpec only. No metric,
-label, threshold, window, setting, dependency, or runtime code change.
+Grafana JSON, PrometheusRule, artifact tests, and OpenSpec only. No metric
+schema or instrumentation-label change; only query aggregation changes output
+series cardinality. Thresholds, windows, settings, dependencies, and runtime
+code remain unchanged.

--- a/openspec/changes/fix-latency-promql-aggregation/proposal.md
+++ b/openspec/changes/fix-latency-promql-aggregation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Bundled Grafana latency panels and the high-latency alert pass raw histogram
+bucket rates to `histogram_quantile`. Residual method, path, scrape, pod, and
+instance labels therefore produce multiple quantiles instead of the intended
+aggregate.
+
+## What Changes
+
+- Sum selected dashboard buckets by `le` before p50/p95/p99.
+- Sum alert buckets by namespace, job, and `le` before p99.
+- Cover every shipped latency quantile expression.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: aggregate bundled histogram quantiles at their
+  intended dashboard and alert scopes.
+
+## Impact
+
+Grafana JSON, PrometheusRule, artifact tests, and OpenSpec only. No metric,
+label, threshold, window, setting, dependency, or runtime code change.

--- a/openspec/changes/fix-latency-promql-aggregation/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/fix-latency-promql-aggregation/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Bundled Grafana latency quantiles aggregate selected buckets
+
+Every bundled Grafana request/upstream `histogram_quantile` MUST apply selected
+namespace/job filters and sum five-minute bucket rates by `le` before quantile.
+Residual method, path, instance, pod, replica, and scrape labels MUST NOT create
+additional quantile series.
+
+#### Scenario: Selected latency produces one series per quantile
+
+- **GIVEN** matching buckets span methods, paths, and scrape targets
+- **WHEN** bundled request p50/p95/p99 or upstream p99 evaluates
+- **THEN** matching rates are summed by `le` first
+- **AND** one selected-scope series remains per quantile
+
+### Requirement: High-latency alert aggregates by operational scope
+
+`CodexLBHighLatency` MUST calculate p99 from request buckets summed by
+namespace, job, and `le`. It MUST retain the ten-second threshold and
+five-minute duration.
+
+#### Scenario: Residual labels produce one alert value per scope
+
+- **GIVEN** one namespace/job has buckets across methods, paths, and replicas
+- **WHEN** the alert evaluates
+- **THEN** one aggregate p99 remains for that namespace/job

--- a/openspec/changes/fix-latency-promql-aggregation/tasks.md
+++ b/openspec/changes/fix-latency-promql-aggregation/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define dashboard and alert aggregation semantics.
+- [x] 1.2 Add complete artifact regressions.
+- [x] 1.3 Capture raw-rate RED.
+
+## 2. Monitoring artifacts
+
+- [x] 2.1 Aggregate dashboard buckets by `le`.
+- [x] 2.2 Aggregate alert buckets by namespace, job, and `le`.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/full artifact and quality gates.
+- [x] 3.2 Parse shipped latency query artifacts.
+- [x] 3.3 Record cleanup and publication evidence.

--- a/tests/unit/test_helm_monitoring_artifacts.py
+++ b/tests/unit/test_helm_monitoring_artifacts.py
@@ -78,3 +78,46 @@ def test_grafana_error_rate_aggregates_request_series_before_division() -> None:
         '(sum(rate(codex_lb_requests_total{namespace="$namespace",job=~"$job",status=~"5.."}[5m]))'
         ' or vector(0)) / sum(rate(codex_lb_requests_total{namespace="$namespace",job=~"$job"}[5m]))'
     )
+
+
+def test_grafana_latency_quantiles_aggregate_selected_bucket_series_by_le() -> None:
+    latency_queries = {
+        (dashboard_path.name, panel["title"], target["legendFormat"]): target["expr"]
+        for dashboard_path in (_CHART_DIR / "dashboards").glob("*.json")
+        for panel in json.loads(dashboard_path.read_text())["panels"]
+        for target in panel.get("targets", [])
+        if "histogram_quantile(" in target.get("expr", "")
+    }
+
+    assert latency_queries == {
+        ("codex-lb.json", "Request Duration (p50/p95/p99)", "p50"): (
+            "histogram_quantile(0.50, sum by (le) (rate("
+            'codex_lb_request_duration_seconds_bucket{namespace="$namespace",job=~"$job"}[5m])))'
+        ),
+        ("codex-lb.json", "Request Duration (p50/p95/p99)", "p95"): (
+            "histogram_quantile(0.95, sum by (le) (rate("
+            'codex_lb_request_duration_seconds_bucket{namespace="$namespace",job=~"$job"}[5m])))'
+        ),
+        ("codex-lb.json", "Request Duration (p50/p95/p99)", "p99"): (
+            "histogram_quantile(0.99, sum by (le) (rate("
+            'codex_lb_request_duration_seconds_bucket{namespace="$namespace",job=~"$job"}[5m])))'
+        ),
+        ("codex-lb.json", "Upstream Request Duration (p99)", "p99"): (
+            "histogram_quantile(0.99, sum by (le) (rate("
+            'codex_lb_upstream_request_duration_seconds_bucket{namespace="$namespace",job=~"$job"}[5m])))'
+        ),
+    }
+
+
+def test_high_latency_quantile_aggregates_bucket_series_by_scope_and_le() -> None:
+    prometheus_rule = (_CHART_DIR / "templates" / "prometheusrule.yaml").read_text()
+    match = re.search(
+        r"(?ms)^\s*- alert: CodexLBHighLatency\n\s+expr: \|\n(?P<expr>.*?)(?=^\s+for: 5m$)",
+        prometheus_rule,
+    )
+
+    assert match is not None
+    assert " ".join(match.group("expr").split()) == (
+        "histogram_quantile(0.99, sum by (namespace, job, le) ("
+        " rate(codex_lb_request_duration_seconds_bucket[5m]) ) ) > 10"
+    )


### PR DESCRIPTION
## Summary

- aggregate selected Grafana request/upstream histogram buckets by `le` before p50/p95/p99
- aggregate high-latency alert buckets by namespace, job, and `le`
- remove residual method/path/replica/scrape labels without changing thresholds or windows

## OpenSpec

- `openspec/changes/fix-latency-promql-aggregation/`
- strict validation passes

## Regression evidence

- RED: two artifact regressions found raw `rate(bucket[5m])` quantiles
- GREEN: focused 2 and complete artifact file 6 passed

## Verification

- Ruff, format, direct type check, JSON parsing, strict OpenSpec, and diff check
- actual shipped Grafana JSON and PrometheusRule parser
- Oracle pre-commit PromQL review — PASS

## Manual artifact QA

```text
PASS latency_queries=5 dashboard=4 alert=1 residual_method_path_scrape_labels=none
```

Helm is unavailable locally, so no local rendered-chart result is claimed.
Machine artifact tests/parsers pass and cloud Helm gates remain authoritative.

## Scope and independence

- based directly on current `upstream/main` `665e58e3`
- no dependency on another pull request
- no instrumentation, metric labels, thresholds, windows, settings, dependencies, or runtime code changes
- no issue or PR overlap found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved latency percentile calculations in Grafana dashboards by aggregating histogram data correctly.
  * Improved high-latency alert accuracy by consolidating histogram buckets across monitoring scopes.
  * Prevented duplicate or misleading percentile series caused by residual metric labels.

* **Tests**
  * Added regression coverage for dashboard latency quantiles and high-latency alert aggregation.

* **Documentation**
  * Added specifications and implementation notes describing the updated latency aggregation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->