### PR TITLE
fix(api-keys): prevent caching returned secrets

### DIFF
--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -123,6 +123,7 @@ def _build_limit_inputs(payload: ApiKeyCreateRequest | ApiKeyUpdateRequest) -> l
 @router.post("/", response_model=ApiKeyCreateResponse)
 async def create_api_key(
     request: Request,
+    response: Response,
     payload: ApiKeyCreateRequest = Body(...),
     _write_access=Depends(require_dashboard_write_access),
     context: ApiKeysContext = Depends(get_api_keys_context),
@@ -160,6 +161,9 @@ async def create_api_key(
         actor_ip=request.client.host if request.client else None,
         details={"key_id": created.id},
     )
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
     return ApiKeyCreateResponse(
         **resp.model_dump(),
         key=created.key,
@@ -258,6 +262,7 @@ async def delete_api_key(
 @router.post("/{key_id}/regenerate", response_model=ApiKeyCreateResponse)
 async def regenerate_api_key(
     key_id: str,
+    response: Response,
     _write_access=Depends(require_dashboard_write_access),
     context: ApiKeysContext = Depends(get_api_keys_context),
 ) -> ApiKeyCreateResponse:
@@ -266,6 +271,9 @@ async def regenerate_api_key(
     except ApiKeyNotFoundError as exc:
         raise DashboardNotFoundError(str(exc)) from exc
     resp = _to_response(row)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
     return ApiKeyCreateResponse(
         **resp.model_dump(),
         key=row.key,

--- a/openspec/changes/fix-api-key-no-store/.openspec.yaml
+++ b/openspec/changes/fix-api-key-no-store/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/fix-api-key-no-store/context.md
+++ b/openspec/changes/fix-api-key-no-store/context.md
@@ -1,0 +1,19 @@
+# API-key secret response context
+
+## Decision
+
+Inject FastAPI `Response` into create/regenerate handlers and set the existing
+credential export policy only after successful service operations:
+
+- `Cache-Control: no-store, no-cache, must-revalidate, private`
+- `Pragma: no-cache`
+- `Expires: 0`
+
+Typed Pydantic responses remain unchanged. Error paths never receive secret
+headers or a plain key.
+
+## Constraints
+
+- Cover both collection URL forms and regeneration.
+- Do not apply to list/update/delete.
+- Preserve write authorization and secret-free application/audit logs.

--- a/openspec/changes/fix-api-key-no-store/proposal.md
+++ b/openspec/changes/fix-api-key-no-store/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+API-key creation and regeneration return a plain key available only once, but
+those responses do not instruct clients/intermediaries not to store it.
+
+## What Changes
+
+- Apply the existing credential-response cache policy to both create URLs.
+- Apply the same policy to regeneration.
+- Preserve payloads, authorization, errors, persistence, and secret-free logs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: one-time plain-key responses prevent storage.
+
+## Impact
+
+API-key route headers and focused integration tests only. No schema, database,
+setting, dependency, frontend, or generation change.

--- a/openspec/changes/fix-api-key-no-store/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-no-store/specs/api-keys/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: One-time API-key secret responses prevent storage
+
+Every successful response containing a full plain API key MUST include
+`Cache-Control: no-store, no-cache, must-revalidate, private`,
+`Pragma: no-cache`, and `Expires: 0`. This applies to both create URL forms and
+regeneration. The policy MUST NOT alter payload, generation, persistence,
+authorization, errors, or logging; plain keys MUST remain absent from logs.
+
+#### Scenario: Create through either collection URL
+
+- **WHEN** an authorized admin creates a key through either URL form
+- **THEN** all three directives are present
+- **AND** the existing one-time plain-key payload remains
+
+#### Scenario: Regenerate a key
+
+- **WHEN** an authorized admin regenerates a key
+- **THEN** all three directives are present
+- **AND** the existing regenerated-key payload remains
+
+#### Scenario: Unauthorized write stays rejected
+
+- **WHEN** a read-only principal attempts create or regenerate
+- **THEN** existing 403 behavior remains
+- **AND** no plain key or secret-response headers are returned

--- a/openspec/changes/fix-api-key-no-store/tasks.md
+++ b/openspec/changes/fix-api-key-no-store/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define success-only non-storage behavior and non-goals.
+- [x] 1.2 Add create/regenerate/auth/logging route coverage.
+- [x] 1.3 Capture missing-header RED.
+
+## 2. Implementation
+
+- [x] 2.1 Apply cache policy after successful create/regenerate operations.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/broader tests and quality gates.
+- [x] 3.2 Run real HTTP create/regenerate/auth QA.
+- [x] 3.3 Record cleanup and publication evidence.

--- a/tests/integration/test_api_key_secret_responses.py
+++ b/tests/integration/test_api_key_secret_responses.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Final
+
+import pytest
+from httpx import Response
+from sqlalchemy import select
+
+from app.core.audit.service import drain_audit_log_tasks
+from app.core.auth.dependencies import require_dashboard_write_access
+from app.core.exceptions import DashboardPermissionError
+from app.db.models import AuditLog
+from app.db.session import SessionLocal
+
+pytestmark = pytest.mark.integration
+
+_EXPECTED_HEADERS: Final = (
+    ("cache-control", "no-store, no-cache, must-revalidate, private"),
+    ("pragma", "no-cache"),
+    ("expires", "0"),
+)
+
+
+def _headers(response: Response) -> tuple[tuple[str, str | None], ...]:
+    return tuple((name, response.headers.get(name)) for name, _value in _EXPECTED_HEADERS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ("/api/api-keys", "/api/api-keys/"))
+async def test_api_key_secret_no_store_when_created(
+    async_client,
+    caplog: pytest.LogCaptureFixture,
+    path: str,
+) -> None:
+    with caplog.at_level(logging.DEBUG):
+        response = await async_client.post(path, json={"name": f"secret-{path.endswith('/')}"})
+        assert await drain_audit_log_tasks(timeout_seconds=1) is True
+
+    assert response.status_code == 200
+    assert _headers(response) == _EXPECTED_HEADERS
+    payload = response.json()
+    assert payload["key"].startswith("sk-clb-")
+    async with SessionLocal() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.action == "api_key_created"))
+        audit_log = result.scalar_one()
+    assert audit_log.details == json.dumps({"key_id": payload["id"]})
+    assert payload["key"] not in caplog.text
+    assert payload["key"] not in (audit_log.details or "")
+
+
+@pytest.mark.asyncio
+async def test_api_key_secret_no_store_when_regenerated(
+    async_client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    created = await async_client.post("/api/api-keys/", json={"name": "regenerated-secret"})
+    assert created.status_code == 200
+    assert await drain_audit_log_tasks(timeout_seconds=1) is True
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG):
+        regenerated = await async_client.post(f"/api/api-keys/{created.json()['id']}/regenerate")
+
+    assert regenerated.status_code == 200
+    assert _headers(regenerated) == _EXPECTED_HEADERS
+    assert regenerated.json()["key"] != created.json()["key"]
+    async with SessionLocal() as session:
+        audit_logs = (await session.execute(select(AuditLog))).scalars().all()
+    serialized = json.dumps([row.details for row in audit_logs])
+    assert regenerated.json()["key"] not in caplog.text
+    assert regenerated.json()["key"] not in serialized
+
+
+@pytest.mark.asyncio
+async def test_api_key_secret_no_store_preserves_write_authorization(
+    app_instance,
+    async_client,
+) -> None:
+    async def reject_write_access() -> None:
+        raise DashboardPermissionError(
+            "Read-only dashboard access cannot modify dashboard state",
+            code="read_only_access",
+        )
+
+    app_instance.dependency_overrides[require_dashboard_write_access] = reject_write_access
+    try:
+        denied = (
+            await async_client.post("/api/api-keys", json={"name": "blocked"}),
+            await async_client.post("/api/api-keys/", json={"name": "blocked-slash"}),
+            await async_client.post("/api/api-keys/missing/regenerate"),
+        )
+    finally:
+        app_instance.dependency_overrides.pop(require_dashboard_write_access, None)
+
+    assert [(response.status_code, response.json()["error"]["code"]) for response in denied] == [
+        (403, "read_only_access"),
+        (403, "read_only_access"),
+        (403, "read_only_access"),
+    ]
+    assert all(
+        _headers(response) == (("cache-control", None), ("pragma", None), ("expires", None)) for response in denied
+    )


### PR DESCRIPTION
## Summary

- apply the existing credential cache policy to both API-key creation URL forms
- apply the same policy to successful regeneration
- preserve payloads, authorization, errors, persistence, and secret-free logs

## OpenSpec

- `openspec/changes/fix-api-key-no-store/`
- strict validation passes

## Regression evidence

- RED: both create aliases and regeneration lacked all three directives; authorization control passed
- GREEN: focused 4 passed
- broader API-key/audit controls — 19 passed

## Verification

- Ruff, formatting, repository `ty check`, strict OpenSpec, and diff check
- Oracle security/privacy review — PASS
- worktree LSP lacked third-party dependency resolution; direct type gate passed

## Live HTTP QA

Real isolated uvicorn exercised:

- unslashed create — HTTP 200 with no-store/no-cache/private, pragma, expires
- slashed create — HTTP 200 with the same directives
- regeneration — HTTP 200, same ID/name, different plain key, same directives
- unauthenticated create — HTTP 401 without secret-response headers
- server logs contained no generated key

Server, cookie jar, SQLite/WAL/SHM, port, and environment were removed.

## Scope and independence

- based directly on current `upstream/main` `665e58e3`
- no dependency on another pull request
- no key generation, hashing, schema, database, setting, frontend, or list/update/delete change
- no issue or PR overlap found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key creation and regeneration responses now include no-cache headers to prevent temporary credentials from being stored.
  * Existing payloads, authorization behavior, and error responses remain unchanged.
  * API key secrets continue to be excluded from audit and debug logs.

* **Tests**
  * Added integration coverage for creation, regeneration, trailing-slash routes, caching headers, authorization failures, and secret-free logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->