### PR TITLE
fix(audit): restrict log access to admins

### DIFF
--- a/app/modules/audit/api.py
+++ b/app/modules/audit/api.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
 
-from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.auth.dependencies import require_dashboard_admin_access, set_dashboard_error_format
 from app.dependencies import AuditContext, get_audit_context
 from app.modules.audit.schemas import AuditLogResponse
 
 router = APIRouter(
     prefix="/api/audit-logs",
     tags=["dashboard"],
-    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+    dependencies=[Depends(require_dashboard_admin_access), Depends(set_dashboard_error_format)],
 )
 
 

--- a/openspec/changes/restrict-guest-audit-log-access/.openspec.yaml
+++ b/openspec/changes/restrict-guest-audit-log-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/restrict-guest-audit-log-access/context.md
+++ b/openspec/changes/restrict-guest-audit-log-access/context.md
@@ -1,0 +1,14 @@
+# Guest audit-log access context
+
+## Decision
+
+Apply the existing `require_dashboard_admin_access` dependency to the audit
+router. It rejects before audit context/service resolution and uses the stable
+`admin_access_required` envelope.
+
+## Constraints
+
+- Do not design a partially redacted guest schema; arbitrary `details` requires
+  an independently specified allowlist.
+- Preserve raw actor IP, details, and request ID for admins.
+- No persistence, retention, filtering, setting, or frontend change.

--- a/openspec/changes/restrict-guest-audit-log-access/proposal.md
+++ b/openspec/changes/restrict-guest-audit-log-access/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Security-audit rows contain raw actor IPs, request IDs, and arbitrary identifying
+details. The route currently uses the general dashboard read gate, allowing a
+read-only guest to receive operator-sensitive records.
+
+## What Changes
+
+- Require an admin dashboard principal for `GET /api/audit-logs`.
+- Return existing HTTP 403 `admin_access_required` behavior for guests.
+- Preserve the raw audit response contract for authorized operators.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-auth`: classify security-audit records as admin-only sensitive data.
+
+## Impact
+
+Audit router authorization and focused API tests only. No persistence,
+filtering, schema, frontend, setting, or operator-detail change.

--- a/openspec/changes/restrict-guest-audit-log-access/specs/admin-auth/spec.md
+++ b/openspec/changes/restrict-guest-audit-log-access/specs/admin-auth/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Security audit reads require an admin principal
+
+The dashboard security-audit route MUST require an admin principal. A guest
+MUST receive HTTP 403 with `admin_access_required` and MUST NOT receive an audit
+row, actor IP, identifying detail, or request ID. An admin MUST retain the
+existing response contract including `actorIp`, `details`, and `requestId`.
+
+#### Scenario: Guest cannot read security-audit records
+
+- **GIVEN** an audit row contains identifying fields
+- **WHEN** a guest requests `GET /api/audit-logs`
+- **THEN** the response is HTTP 403 `admin_access_required`
+- **AND** no identifying audit value is returned
+
+#### Scenario: Admin retains security-audit detail
+
+- **WHEN** an admin requests the same row
+- **THEN** the request succeeds
+- **AND** actor IP, details, and request ID remain present

--- a/openspec/changes/restrict-guest-audit-log-access/tasks.md
+++ b/openspec/changes/restrict-guest-audit-log-access/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define admin-only audit reads and unchanged operator detail.
+- [x] 1.2 Add guest/admin route coverage.
+- [x] 1.3 Capture guest identity disclosure RED.
+
+## 2. Implementation
+
+- [x] 2.1 Replace the audit router session dependency with admin access.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/broader tests and quality gates.
+- [x] 3.2 Run live guest/admin HTTP QA.
+- [x] 3.3 Record cleanup and publication evidence.

--- a/tests/integration/test_audit_logs_api.py
+++ b/tests/integration/test_audit_logs_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+import app.core.auth.dependencies as auth_dependencies
+from app.core.auth.dashboard_access import guest_principal
+from app.db.models import AuditLog
+from app.db.session import SessionLocal
+
+pytestmark = pytest.mark.integration
+
+ACTION = "guest_identity_privacy_test"
+ACTOR_IP = "203.0.113.77"
+REQUEST_ID = "req-sensitive"
+DETAILS = '{"account_id":"acc-sensitive","key_id":"key-sensitive"}'
+
+
+async def _insert_sensitive_audit_log() -> None:
+    async with SessionLocal() as session:
+        session.add(
+            AuditLog(
+                action=ACTION,
+                actor_ip=ACTOR_IP,
+                details=DETAILS,
+                request_id=REQUEST_ID,
+                timestamp=datetime(2026, 8, 31, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_guest_security_audit_identity_is_denied(
+    app_instance: FastAPI,
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _insert_sensitive_audit_log()
+    original = auth_dependencies.validate_dashboard_session
+    app_instance.dependency_overrides[original] = guest_principal
+    monkeypatch.setattr(
+        auth_dependencies,
+        "validate_dashboard_session",
+        AsyncMock(return_value=guest_principal()),
+    )
+    try:
+        response = await async_client.get("/api/audit-logs", params={"action": ACTION})
+    finally:
+        app_instance.dependency_overrides.pop(original, None)
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "admin_access_required"
+    assert ACTOR_IP not in response.text
+    assert "acc-sensitive" not in response.text
+    assert "key-sensitive" not in response.text
+    assert REQUEST_ID not in response.text
+
+
+@pytest.mark.asyncio
+async def test_guest_security_audit_identity_preserves_operator_detail(
+    async_client: AsyncClient,
+) -> None:
+    await _insert_sensitive_audit_log()
+    response = await async_client.get("/api/audit-logs", params={"action": ACTION})
+
+    assert response.status_code == 200
+    entry = response.json()[0]
+    assert entry["actorIp"] == ACTOR_IP
+    assert entry["details"] == {
+        "account_id": "acc-sensitive",
+        "key_id": "key-sensitive",
+    }
+    assert entry["requestId"] == REQUEST_ID

--- a/tests/integration/test_audit_logs_api.py
+++ b/tests/integration/test_audit_logs_api.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 
 import app.core.auth.dependencies as auth_dependencies
-from app.core.auth.dashboard_access import guest_principal
+from app.core.auth.dashboard_access import DashboardAuthMode, admin_principal, guest_principal
 from app.db.models import AuditLog
 from app.db.session import SessionLocal
 
@@ -62,10 +62,20 @@ async def test_guest_security_audit_identity_is_denied(
 
 
 @pytest.mark.asyncio
-async def test_guest_security_audit_identity_preserves_operator_detail(
+async def test_admin_security_audit_identity_preserves_operator_detail(
     async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     await _insert_sensitive_audit_log()
+    monkeypatch.setattr(
+        auth_dependencies,
+        "validate_dashboard_session",
+        AsyncMock(
+            return_value=admin_principal(
+                auth_mode=DashboardAuthMode.STANDARD,
+            )
+        ),
+    )
     response = await async_client.get("/api/audit-logs", params={"action": ACTION})
 
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

- require an admin principal for dashboard security-audit reads
- reject guests before audit service/repository resolution with stable `admin_access_required`
- preserve raw actor IP/details/request ID for authorized operators

## OpenSpec

- `openspec/changes/restrict-guest-audit-log-access/`
- strict change and owning-spec validation pass

## Regression evidence

- RED: guest received HTTP 200 with raw audit identifiers; admin control passed
- GREEN: focused guest/admin cases — 2 passed
- dashboard auth/audit controls — 40 passed

## Verification

- Ruff, formatting, repository `ty check`, OpenSpec, and diff check
- Oracle RBAC/privacy review — PASS
- worktree LSP lacked third-party dependency resolution; direct type gate passed

## Live HTTP QA

Real isolated server and sessions:

- guest `GET /api/audit-logs` — HTTP 403 `admin_access_required`, no identifiers
- admin request — HTTP 200 with unchanged actor IP, details, and request ID

Server, cookies, SQLite/WAL/SHM, port, and environment were removed.

## Scope and independence

- based directly on current `upstream/main` `665e58e3`
- no dependency on another pull request
- no schema, persistence, filtering, retention, setting, or frontend change
- no issue or PR overlap found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Audit logs are now restricted to dashboard administrators.
  * Guests receive a 403 response and cannot access sensitive audit details.
  * Authorized administrators retain the existing audit log information.

* **Tests**
  * Added integration coverage confirming guest denial, administrator access, and protection of sensitive audit fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->