### PR TITLE
fix(config): reject invalid operator values

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -452,10 +452,10 @@ class Settings(BaseSettings):
     # --- Multi-replica & production settings ---
     # Prometheus metrics
     metrics_enabled: bool = False
-    metrics_port: int = 9090
+    metrics_port: int = Field(default=9090, ge=1, le=65535)
 
     # Logging
-    log_format: str = "text"  # "text" or "json"
+    log_format: Literal["text", "json"] = "text"
 
     # Leader election
     leader_election_enabled: bool = True

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -207,6 +207,10 @@
     "config": {
       "type": "object",
       "properties": {
+        "logFormat": {
+          "type": "string",
+          "enum": ["text", "json"]
+        },
         "shutdownDrainTimeoutSeconds": {
           "type": "integer",
           "minimum": 1,

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -238,7 +238,7 @@ the env-file locations have to be known before env files are read.
 
 | Environment variable | Type | Default |
 | --- | --- | --- |
-| `CODEX_LB_LOG_FORMAT` | `str` | `'text'` |
+| `CODEX_LB_LOG_FORMAT` | `'text' \| 'json'` | `'text'` |
 | `CODEX_LB_METRICS_ENABLED` | `bool` | `False` |
 | `CODEX_LB_METRICS_PORT` | `int` | `9090` |
 | `CODEX_LB_OTEL_ENABLED` | `bool` | `False` |

--- a/openspec/changes/reject-invalid-operator-config/.openspec.yaml
+++ b/openspec/changes/reject-invalid-operator-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/reject-invalid-operator-config/context.md
+++ b/openspec/changes/reject-invalid-operator-config/context.md
@@ -1,0 +1,14 @@
+# Operator config validation context
+
+## Decision
+
+Use Pydantic field constraints at the existing environment boundary and the
+matching Helm JSON schema. Metrics port zero remains invalid because the
+dedicated metrics endpoint is published as a stable service/scrape target.
+
+## Constraints
+
+- Preserve default metrics port 9090 and log format text.
+- Preserve valid boundaries and main/metrics collision validation.
+- Case-sensitive `text|json`; no alias or normalization.
+- No formatter, metrics task, or template refactor.

--- a/openspec/changes/reject-invalid-operator-config/proposal.md
+++ b/openspec/changes/reject-invalid-operator-config/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Settings accept impossible metrics ports and unknown log-format strings.
+Impossible ports can fail in a detached metrics task after startup continues;
+misspelled log formats silently select text. Helm constrains metrics ports but
+not `config.logFormat`.
+
+## What Changes
+
+- Accept metrics ports only in `1..65535`.
+- Accept log format only as `text` or `json`.
+- Add matching Helm log-format enum and retain metrics range.
+- Preserve defaults, valid boundaries, and collision validation.
+- Regenerate settings reference.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: fail-fast runtime and Helm validation.
+
+## Impact
+
+Existing settings declarations, Helm schema, generated reference, and focused
+tests. No new setting, dependency, migration, API, frontend, or startup path.

--- a/openspec/changes/reject-invalid-operator-config/specs/deployment-installation/spec.md
+++ b/openspec/changes/reject-invalid-operator-config/specs/deployment-installation/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Operator metrics and log configuration fails closed
+
+The application MUST accept `CODEX_LB_METRICS_PORT` only in inclusive
+`1..65535` and `CODEX_LB_LOG_FORMAT` only as `text` or `json`. Invalid values
+MUST produce field-specific validation errors before metrics startup or
+formatter selection. Existing main/metrics collision rejection MUST remain.
+
+Helm values schema MUST enforce the same metrics range and log-format set before
+rendering/install. Valid defaults/boundaries MUST remain unchanged.
+
+#### Scenario: Impossible metrics port is rejected
+
+- **WHEN** metrics port is zero, negative, or above 65535
+- **THEN** settings validation identifies `metrics_port`
+
+#### Scenario: Unknown log format is rejected
+
+- **WHEN** log format is not text or json
+- **THEN** settings validation identifies `log_format`
+
+#### Scenario: Helm rejects invalid operator values
+
+- **WHEN** Helm metrics/log values violate the same contract
+- **THEN** schema validation fails with the values path

--- a/openspec/changes/reject-invalid-operator-config/tasks.md
+++ b/openspec/changes/reject-invalid-operator-config/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define runtime/Helm fail-closed contract.
+- [x] 1.2 Add invalid/valid settings and Helm schema tests.
+- [x] 1.3 Capture accepted-invalid RED.
+
+## 2. Implementation
+
+- [x] 2.1 Constrain existing Pydantic fields and Helm schema.
+- [x] 2.2 Regenerate settings reference.
+
+## 3. Verification
+
+- [x] 3.1 Run focused/broader tests and quality gates.
+- [x] 3.2 Run real settings and Helm schema surfaces.
+- [x] 3.3 Record cleanup and publication evidence.

--- a/tests/unit/test_helm_shutdown_contract.py
+++ b/tests/unit/test_helm_shutdown_contract.py
@@ -69,3 +69,18 @@ def test_shutdown_values_are_typed_in_chart_schema() -> None:
         "minimum": 1,
         "maximum": 300,
     }
+
+
+def test_metrics_port_and_log_format_are_constrained_in_chart_schema() -> None:
+    schema = json.loads((_CHART_DIR / "values.schema.json").read_text())
+    properties = schema["properties"]
+
+    assert properties["metrics"]["properties"]["port"] == {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 65535,
+    }
+    assert properties["config"]["properties"].get("logFormat") == {
+        "type": "string",
+        "enum": ["text", "json"],
+    }

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -62,10 +62,18 @@ def test_settings_metrics_enabled_from_env(monkeypatch):
     assert settings.metrics_enabled is True
 
 
-def test_settings_metrics_port_from_env(monkeypatch):
-    monkeypatch.setenv("CODEX_LB_METRICS_PORT", "8080")
+@pytest.mark.parametrize("port", [1, 65535])
+def test_settings_metrics_port_from_env(monkeypatch, port: int):
+    monkeypatch.setenv("CODEX_LB_METRICS_PORT", str(port))
     settings = Settings()
-    assert settings.metrics_port == 8080
+    assert settings.metrics_port == port
+
+
+@pytest.mark.parametrize("port", [0, -1, 65536, 70000])
+def test_settings_rejects_out_of_range_metrics_port(monkeypatch, port: int):
+    monkeypatch.setenv("CODEX_LB_METRICS_PORT", str(port))
+    with pytest.raises(ValidationError, match="metrics_port"):
+        Settings()
 
 
 def test_settings_rejects_metrics_port_2455(monkeypatch):
@@ -75,10 +83,17 @@ def test_settings_rejects_metrics_port_2455(monkeypatch):
     assert "metrics_port must not match the main application port (2455)" in str(exc_info.value)
 
 
-def test_settings_log_format_from_env(monkeypatch):
-    monkeypatch.setenv("CODEX_LB_LOG_FORMAT", "json")
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_settings_log_format_from_env(monkeypatch, log_format: str):
+    monkeypatch.setenv("CODEX_LB_LOG_FORMAT", log_format)
     settings = Settings()
-    assert settings.log_format == "json"
+    assert settings.log_format == log_format
+
+
+def test_settings_rejects_unknown_log_format(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_LOG_FORMAT", "jsoon")
+    with pytest.raises(ValidationError, match="log_format"):
+        Settings()
 
 
 def test_settings_conversation_archive_queue_max_bytes_from_env(monkeypatch):


### PR DESCRIPTION
## Summary

- reject metrics ports outside `1..65535` at the existing settings boundary
- reject log formats other than `text|json`
- align Helm schema and generated settings reference while preserving defaults and collision validation

## OpenSpec

- `openspec/changes/reject-invalid-operator-config/`
- strict validation passes

## Regression evidence

- RED: 6 failed / 5 passed — invalid ports/log format accepted and Helm enum absent
- GREEN: focused 11 passed
- broader settings/logging/CLI/reference/Helm controls — 192 passed

## Verification

- Ruff, formatting, repository `ty check`, JSON schema parse, strict OpenSpec, and diff check
- Oracle pre-commit review — APPROVED after evidence count correction
- worktree LSP lacked third-party dependency resolution; direct type gate passed

## Manual QA

Actual `Settings(_env_file=None)`:

- rejected metrics ports `-1`, `70000`
- rejected log format `jsoon`
- accepted ports `1`, `65535`
- accepted formats `text`, `json`

The shipped Helm schema has the same range and enum.

```text
PASS operator config boundaries
```

Helm CLI is unavailable locally; cloud Helm lint remains authoritative.

## Scope and independence

- based directly on current `upstream/main` `665e58e3`
- no dependency on another pull request
- no new setting, formatter, metrics task, template, dependency, migration, API, or frontend change
- invalid-configuration compatibility break only
- no issue, PR, or OpenSpec overlap found

No existing issue is claimed by this independently discovered defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure metrics ports are between 1 and 65,535.
  * Restricted log formats to `text` or `json`.
  * Added matching validation for Helm deployment settings.

* **Documentation**
  * Updated the settings reference to document supported log formats.

* **Bug Fixes**
  * Invalid operator configuration is now rejected before deployment or service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->