### PR TITLE
test(native-egress): synchronize websocket lifecycle events

### DIFF
--- a/crates/codex-lb-egress-worker/tests/websocket_protocol.rs
+++ b/crates/codex-lb-egress-worker/tests/websocket_protocol.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::net::TcpListener;
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::oneshot;
 use tokio_tungstenite::accept_async_with_config;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tungstenite::extensions::ExtensionsConfig;
@@ -62,6 +63,7 @@ async fn missing_pong_emits_liveness_timeout() {
         .await
         .expect("bind websocket server");
     let address = listener.local_addr().expect("server address");
+    let (release_server, wait_for_liveness_failure) = oneshot::channel();
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.expect("accept websocket client");
         let mut extensions = ExtensionsConfig::default();
@@ -73,7 +75,9 @@ async fn missing_pong_emits_liveness_timeout() {
             .expect("accept websocket handshake");
         // Do not poll the server stream: tungstenite therefore cannot observe
         // or automatically answer the helper's ping.
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        wait_for_liveness_failure
+            .await
+            .expect("liveness assertion must release websocket server");
     });
 
     let (mut helper, mut stdin, mut lines) = start_helper().await;
@@ -99,6 +103,9 @@ async fn missing_pong_emits_liveness_timeout() {
     assert_eq!(failure["failure_phase"], "liveness_timeout");
     assert_eq!(failure["retryable_same_contract"], false);
 
+    release_server
+        .send(())
+        .expect("release websocket server after liveness failure");
     drop(stdin);
     tokio::time::timeout(Duration::from_secs(2), helper.wait())
         .await
@@ -153,12 +160,6 @@ async fn explicit_cancel_aborts_websocket_and_emits_one_cancelled_event() {
     let cancelled = read_event(&mut lines, "cancel event timeout").await;
     assert_eq!(cancelled["type"], "cancelled");
     assert_eq!(cancelled["request_id"], "cancel-test");
-    assert!(
-        tokio::time::timeout(Duration::from_millis(100), lines.next_line())
-            .await
-            .is_err(),
-        "explicit cancellation must emit exactly one terminal event"
-    );
 
     server.await.expect("websocket server task");
     drop(stdin);
@@ -166,4 +167,16 @@ async fn explicit_cancel_aborts_websocket_and_emits_one_cancelled_event() {
         .await
         .expect("helper exit timeout")
         .expect("wait for helper");
+    let mut remaining_events = Vec::new();
+    while let Some(event) = lines
+        .next_line()
+        .await
+        .expect("drain native helper events after exit")
+    {
+        remaining_events.push(event);
+    }
+    assert!(
+        remaining_events.is_empty(),
+        "explicit cancellation must emit exactly one terminal event: {remaining_events:?}"
+    );
 }


### PR DESCRIPTION
## Summary

- keep the no-pong server alive until the helper's asserted liveness terminal
- replace the 100ms exactly-once window with helper-exit and stdout EOF
- remove wall-clock synchronization from the WebSocket lifecycle tests

## Regression evidence

- baseline tests passed but observed absence only inside fixed 250ms/100ms windows
- mutation emitted a second delayed `cancelled` terminal after 150ms
- hardened test failed for the intended duplicate event:

```text
explicit cancellation must emit exactly one terminal event
```

- production mutation was removed before final verification

## Verification

- focused WebSocket protocol tests: 2 passed
- single Tokio worker: 2 passed
- Rust workspace tests: pass
- `make rust-check`: pass through release build
- format, Clippy, and diff check: pass
- deep review and Oracle pre-commit review: APPROVED

## Manual QA

The actual helper process and local WebSocket server were exercised:

- no-pong socket remained owned until `liveness_timeout` was observed
- cancellation waited for server-observed closure
- helper stdin closed, process exited, and stdout drained to EOF
- no extra terminal event remained

## OpenSpec

Not applicable: this is deterministic test hardening with no production or
contract change.

## Scope and independence

- based directly on `upstream/main` `665e58e3`
- one changed Rust integration-test file
- no dependency on another pull request
- no production, dependency, lockfile, API, schema, migration, CI, or frontend change
- no open issue or active PR overlap found

No existing issue is claimed by this independently discovered test deficiency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved WebSocket protocol test reliability by waiting for liveness timeouts directly instead of using fixed delays.
  * Strengthened cancellation checks to verify that no unexpected events are emitted after process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->