### PR TITLE
perf(proxy): share one process-wide SSLContext across per-call Codex sessions

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -457,9 +457,9 @@ class CodexClient:
 
 
 def create_codex_session(*, max_clients: int = 10) -> Any:
-    from app.core.clients.http import _build_ssl_context
+    from app.core.clients.http import _shared_ssl_context
 
-    connector = aiohttp.TCPConnector(limit=max_clients, ssl=_build_ssl_context())
+    connector = aiohttp.TCPConnector(limit=max_clients, ssl=_shared_ssl_context())
     return aiohttp.ClientSession(
         connector=connector,
         timeout=aiohttp.ClientTimeout(total=None),
@@ -534,7 +534,7 @@ async def _open_ws_via_socks_proxy(url: str, endpoint: ResolvedProxyEndpoint, **
 
 
 def _socks_proxy_connector(endpoint: ResolvedProxyEndpoint) -> ProxyConnector:
-    from app.core.clients.http import _build_ssl_context
+    from app.core.clients.http import _shared_ssl_context
 
     proxy_scheme = endpoint.proxy_url.split(":", 1)[0]
     return ProxyConnector(
@@ -544,7 +544,7 @@ def _socks_proxy_connector(endpoint: ResolvedProxyEndpoint) -> ProxyConnector:
         username=endpoint.username,
         password=endpoint.password,
         rdns=proxy_scheme == "socks5h",
-        ssl=_build_ssl_context(),
+        ssl=_shared_ssl_context(),
     )
 
 

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import os
 import socket
@@ -107,6 +108,25 @@ def _build_ssl_context() -> ssl.SSLContext:
     return context
 
 
+@functools.cache
+def _shared_ssl_context() -> ssl.SSLContext:
+    """Return the process-wide verification context shared by every outbound connector.
+
+    Building a context parses the system store plus the certifi bundle
+    (~7 ms CPU and ~700 KB per copy), and nothing mutates the context after
+    construction, so per-call sessions, SOCKS connectors, and the shared
+    client generations all reuse this one instance. ``_build_ssl_context`` is
+    looked up at call time so tests can still patch the constructor; the
+    cache is cleared by ``_reset_shared_ssl_context``.
+    """
+
+    return _build_ssl_context()
+
+
+def _reset_shared_ssl_context() -> None:
+    _shared_ssl_context.cache_clear()
+
+
 def _apply_tcp_keepalive(sock: socket.socket) -> None:
     """Enable OS keepalive probes on an upstream socket.
 
@@ -173,7 +193,7 @@ class HttpClientLease:
 
 async def _build_http_client() -> HttpClient:
     settings = get_settings()
-    ssl_context = _build_ssl_context()
+    ssl_context = _shared_ssl_context()
     proxy_env = (
         settings.upstream_websocket_proxy_env() if hasattr(settings, "upstream_websocket_proxy_env") else os.environ
     )
@@ -397,6 +417,7 @@ async def close_http_client() -> None:
         client = _http_client
         _http_client = None
         _last_generationless_network_rotation_at = None
+        _reset_shared_ssl_context()
         clients = (
             *((client,) if client is not None else ()),
             *_retired_http_clients,

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -19,7 +19,7 @@ from app.core.auth.dependencies import (
     set_dashboard_error_format,
     validate_dashboard_session,
 )
-from app.core.clients.http import _build_ssl_context
+from app.core.clients.http import _shared_ssl_context
 from app.core.config.settings import get_settings as get_app_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -567,7 +567,7 @@ async def _probe_upstream_proxy_endpoint(endpoint) -> int:
             username=endpoint.username,
             password=endpoint.password,
             rdns=endpoint.proxy_url.split(":", 1)[0] == "socks5h",
-            ssl=_build_ssl_context(),
+            ssl=_shared_ssl_context(),
         )
         async with aiohttp.ClientSession(
             connector=connector,

--- a/openspec/specs/outbound-http-clients/context.md
+++ b/openspec/specs/outbound-http-clients/context.md
@@ -1,0 +1,21 @@
+# Outbound HTTP Clients Context
+
+## Purpose and Scope
+
+This note records implementation decisions behind the outbound client layer that do not change the normative contracts in `spec.md`. It currently covers how the TLS verification context is shared across connectors.
+
+## Shared TLS verification context
+
+Every outbound aiohttp connector (the shared client generations built by `_build_http_client`, the per-call `create_codex_session()` sessions used by routed streams, bridge websockets, usage polls and token refreshes, the per-request SOCKS `_socks_proxy_connector`, and the dashboard proxy-endpoint probe) verifies upstream certificates with the same policy: `ssl.create_default_context()` plus the certifi bundle loaded on top.
+
+Before the `perf-shared-ssl-context` change each of those call sites built a fresh `ssl.SSLContext`. Building one parses the system trust store and the certifi PEM (~120 CAs): measured at ~7.5 ms CPU and ~650-740 KB RSS per copy on x86 with Python 3.14, roughly 2-3x that on the production Neoverse-N1 host. On a `workers=1` deployment with several upstream calls per second that cost showed up as ~1.75-2.5% of event-loop-thread wall time in the non-GIL py-spy profile (OpenSSL releases the GIL while parsing, so `--gil` profiles do not see it) and as ~120 MB of duplicated X509 stores across the ~170 live sessions found in a heap probe.
+
+`app/core/clients/http.py` now exposes `_shared_ssl_context()`, a `functools.cache`d accessor around the unchanged `_build_ssl_context()` constructor, and every connector listed above uses it. Rationale for treating this as a pure refactor rather than a spec delta:
+
+- No wire change. The context carries the same verification mode, hostname checking, protocol floor, and trust store as a per-call build (asserted by `test_shared_ssl_context_matches_a_fresh_build_verification_policy`); client-side contexts here do not enable TLS session resumption across connectors, so each connection still performs the same handshake it did before.
+- Nothing mutates the context after construction (`SSLContext` is treated as immutable-after-build throughout the codebase), which is the same sharing pattern aiohttp uses for its own module-level default contexts.
+- The shared client generations already reused one context per generation; the change only extends that reuse to the per-call sessions.
+
+The one operational consequence: updates to the certifi bundle or system CA store on disk are picked up only after a process restart. Per-call sessions previously re-read the bundle on every upstream call; the shared client had always behaved this way per generation, and there is no supported flow that swaps CA bundles under a running codex-lb, so no requirement changes. `close_http_client()` clears the cache during shutdown, and `_reset_shared_ssl_context()` exists for test isolation (tests that patch `_build_ssl_context` rely on the cache being empty when they start).
+
+Deferred on purpose: sharing one routed `TCPConnector`/`ClientSession` across per-call Codex clients (connection reuse through the proxy) is a separate change with connection-lifetime semantics of its own; on Docker deployments the native egress helper already pools routed connections.

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -9,8 +9,14 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 from python_socks import ProxyType
 
-import app.core.clients.codex as codex_module
-from app.core.clients.codex import CodexClient, CodexTransportError, require_route_or_direct_egress_opt_in
+from app.core.clients import codex as codex_module
+from app.core.clients.codex import (
+    CodexClient,
+    CodexTransportError,
+    create_codex_session,
+    require_route_or_direct_egress_opt_in,
+)
+from app.core.clients.http import _reset_shared_ssl_context, _shared_ssl_context
 from app.core.clients.native_egress import (
     NativeEgressRequest,
     NativeEgressTransportError,
@@ -933,3 +939,30 @@ async def test_socks_session_owned_response_releases_before_closing_session() ->
     await owned.release()
 
     assert order == ["release", "session_close"]
+
+
+@pytest.mark.asyncio
+async def test_create_codex_session_connectors_share_one_ssl_context() -> None:
+    _reset_shared_ssl_context()
+    first = create_codex_session()
+    second = create_codex_session()
+    try:
+        assert first.connector._ssl is second.connector._ssl
+        assert first.connector._ssl is _shared_ssl_context()
+    finally:
+        await first.close()
+        await second.close()
+        _reset_shared_ssl_context()
+
+
+@pytest.mark.asyncio
+async def test_socks_proxy_connector_reuses_shared_ssl_context() -> None:
+    _reset_shared_ssl_context()
+    endpoint = ResolvedProxyEndpoint("ep_1", "socks5h", "proxy.test", 1080)
+    connector = codex_module._socks_proxy_connector(endpoint)
+    try:
+        assert connector._ssl is _shared_ssl_context()
+        assert connector._rdns is True
+    finally:
+        await connector.close()
+        _reset_shared_ssl_context()

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +24,15 @@ def _settings() -> SimpleNamespace:
 async def _drain_close_tasks() -> None:
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_shared_ssl_context() -> Iterator[None]:
+    # The shared context is a process-wide cache; every test starts from an
+    # empty cache so ``_build_ssl_context`` patches take effect per test.
+    http_module._reset_shared_ssl_context()
+    yield
+    http_module._reset_shared_ssl_context()
 
 
 @pytest.mark.asyncio
@@ -336,6 +346,76 @@ def test_build_ssl_context_preserves_default_roots_and_adds_certifi_bundle() -> 
     create_default_context.assert_called_once_with()
     ssl_context.load_verify_locations.assert_called_once_with(cafile="/tmp/cacert.pem")
     assert context is ssl_context
+
+
+def test_build_ssl_context_is_not_cached() -> None:
+    first_context = MagicMock()
+    second_context = MagicMock()
+    with (
+        patch("app.core.clients.http.certifi.where", return_value="/tmp/cacert.pem"),
+        patch(
+            "app.core.clients.http.ssl.create_default_context",
+            side_effect=[first_context, second_context],
+        ) as create_default_context,
+    ):
+        assert http_module._build_ssl_context() is first_context
+        assert http_module._build_ssl_context() is second_context
+
+    assert create_default_context.call_count == 2
+
+
+def test_shared_ssl_context_builds_once_and_returns_the_same_instance() -> None:
+    ssl_context = MagicMock()
+    with patch("app.core.clients.http._build_ssl_context", return_value=ssl_context) as build:
+        first = http_module._shared_ssl_context()
+        second = http_module._shared_ssl_context()
+
+    assert first is ssl_context
+    assert first is second
+    build.assert_called_once_with()
+
+
+def test_reset_shared_ssl_context_forces_rebuild() -> None:
+    first_context = MagicMock()
+    second_context = MagicMock()
+    with patch(
+        "app.core.clients.http._build_ssl_context",
+        side_effect=[first_context, second_context],
+    ) as build:
+        assert http_module._shared_ssl_context() is first_context
+        http_module._reset_shared_ssl_context()
+        assert http_module._shared_ssl_context() is second_context
+        assert http_module._shared_ssl_context() is second_context
+
+    assert build.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_close_http_client_resets_shared_ssl_context() -> None:
+    first_context = MagicMock()
+    second_context = MagicMock()
+    with patch(
+        "app.core.clients.http._build_ssl_context",
+        side_effect=[first_context, second_context],
+    ):
+        assert http_module._shared_ssl_context() is first_context
+        await http_module.close_http_client()
+        assert http_module._shared_ssl_context() is second_context
+
+
+def test_shared_ssl_context_matches_a_fresh_build_verification_policy() -> None:
+    # Sharing must not change what the wire sees: same verification policy
+    # and the same trust store as a per-call build of the context.
+    shared = http_module._shared_ssl_context()
+    fresh = http_module._build_ssl_context()
+
+    assert shared is not fresh
+    assert shared.verify_mode == fresh.verify_mode
+    assert shared.check_hostname == fresh.check_hostname
+    assert shared.minimum_version == fresh.minimum_version
+    assert shared.options == fresh.options
+    assert shared.cert_store_stats() == fresh.cert_store_stats()
+    assert sorted(map(repr, shared.get_ca_certs())) == sorted(map(repr, fresh.get_ca_certs()))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_proxy_probe.py
+++ b/tests/unit/test_settings_proxy_probe.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.modules.settings.api as settings_api
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_socks_probe_uses_shared_ssl_context() -> None:
+    endpoint = SimpleNamespace(
+        scheme="socks5h",
+        host="proxy.test",
+        port=1080,
+        username=None,
+        password=None,
+        proxy_url="socks5h://proxy.test:1080",
+    )
+    shared_context = MagicMock()
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.get = AsyncMock(return_value=SimpleNamespace(status=204))
+
+    with (
+        patch("app.modules.settings.api._shared_ssl_context", return_value=shared_context) as shared_factory,
+        patch("app.modules.settings.api.ProxyConnector") as proxy_connector_cls,
+        patch("app.modules.settings.api.aiohttp.ClientSession", return_value=session),
+    ):
+        status = await settings_api._probe_upstream_proxy_endpoint(endpoint)
+
+    assert status == 204
+    shared_factory.assert_called_once_with()
+    assert proxy_connector_cls.call_args.kwargs["ssl"] is shared_context
+    assert proxy_connector_cls.call_args.kwargs["rdns"] is True


### PR DESCRIPTION
## Summary

Every per-call aiohttp session built for an upstream Codex call rebuilt an `ssl.SSLContext` from scratch: `ssl.create_default_context()` (system store parse) plus `load_verify_locations(cafile=certifi.where())`. On the routed path `codex_client` is never injected in `app/modules/proxy/**`, so every upstream turn, every http-bridge upstream websocket, every SOCKS connector, every usage/refresh/compact/control call, and every shared-client generation paid that cost on the event-loop thread.

Production evidence (soju07, 2x Neoverse-N1, workers=1, v1.25.0-beta.1, 2026-09-03 profile):

- Non-GIL py-spy profile (1201 non-idle samples): `_build_ssl_context` + `load_default_certs` + `create_codex_session` = 21 samples, ~1.75-2.5% of event-loop-thread wall time. These frames are absent from the `--gil` profile because OpenSSL releases the GIL while parsing, so they were invisible to the GIL-only view while still burning the single pegged core.
- Heap probe: 166 `ClientSession` / 172 `TCPConnector` / 167 `SSLProtocol`, each carrying its own ~720-736 KB X509 store, roughly 120 MB of duplicated trust stores in a 2 GB memcg that OOMed that morning.
- Cost split of the per-call build in `python:3.14-slim`: 14/21 samples parsing Debian's `/usr/lib/ssl/cert.pem` via `create_default_context()`, 7/21 the certifi load. Caching removes both.
- Independently reported in #2029 (macOS, SQLite): a sampled 74.8 s loop stall spent six consecutive 3 s samples inside `_ssl__SSLContext_set_default_verify_paths_impl -> X509_load_cert_crl_file`, and `set_default_verify_paths` was on the main thread in 15/127 samples over 10 idle minutes.

This PR makes the context a process-wide singleton. It is PR 4 of the 2026-09-03 CPU/memory campaign (Step A only; the shared routed connector, Step B, is intentionally deferred since native egress already pools per proxy URL on main).

Refs #2029 (resolves the `SSLContext` rebuild named there; the per-call `TCPConnector` and the wedged-teardown reclaim false positive it also describes are out of scope for this PR).

## Change details

- `app/core/clients/http.py`
  - New `_shared_ssl_context()` = `functools.cache` accessor around the unchanged `_build_ssl_context()` constructor. It resolves `_build_ssl_context` via module-global lookup at call time, so the existing `patch("app.core.clients.http._build_ssl_context")` tests keep taking effect.
  - New `_reset_shared_ssl_context()` (wraps `cache_clear`).
  - `_build_http_client` uses the shared context; `close_http_client()` clears the cache under `_http_client_lock` right after `_http_client = None`.
  - `_build_ssl_context` itself stays uncached.
- `app/core/clients/codex.py`: `create_codex_session` and `_socks_proxy_connector` use `_shared_ssl_context()` (import + one call each; hunks confined to those two functions).
- `app/modules/settings/api.py`: `_probe_upstream_proxy_endpoint` (dashboard SOCKS probe) uses `_shared_ssl_context()`.
- `openspec/specs/outbound-http-clients/context.md` (new): records the refactor exemption rationale and the single operational consequence (below).
- Tests: `tests/unit/test_http_client.py`, `tests/unit/test_codex_client.py`, new `tests/unit/test_settings_proxy_probe.py`.

Net +194 lines (202/-8), one concern.

## Byte-compat / behavior notes

- No wire change. The shared context has the same `verify_mode`, `check_hostname`, `minimum_version`, `options`, `cert_store_stats()` and `get_ca_certs()` set as a fresh per-call build; this is asserted by `test_shared_ssl_context_matches_a_fresh_build_verification_policy`. The adversarial pass additionally confirmed a SHA-256 over the sorted DER trust store is identical between `origin/main`'s `_build_ssl_context()` and this branch's `_shared_ssl_context()`, and that client-side contexts do not auto-resume TLS sessions (a local TLS server probe showed `session_reused=False` across 3 sequential connections on TLS 1.2 and 1.3 with one shared context).
- Nothing in `app/` mutates a context after construction (`load_verify_locations` appears only inside the constructor), so sharing is safe; aiohttp itself uses module-singleton contexts for its defaults.
- `functools.cache` does not cache exceptions, so a failing build still raises per call exactly as on main.
- **Accepted behavior change (operational only):** certifi / system CA bundle updates on disk are now picked up only after a process restart for per-call sessions as well. The shared client already behaved this way per generation, so this aligns the per-call paths with the existing model. Documented in `openspec/specs/outbound-http-clients/context.md`.
- `close_http_client()` is only called from `app/main.py` shutdown; clearing the cache there has no runtime effect and is harmless to live connectors, which keep their own reference.

## Expected gain

Dev-box microbench (CPython 3.14.6, aiohttp 3.14.3, x86, N=100 steady state after one warm-up), same script against `origin/main` and this branch:

| metric | before | after |
|---|---|---|
| `create_codex_session()` + close, per call | 7.773 ms | 0.055 ms (~140x) |
| `_socks_proxy_connector(socks5h)` per call | 6.838 ms | 0.006 ms |
| `ru_maxrss` delta, 100 simultaneously live sessions | 65.2 MB | 0.5 MB (~650 KB/session removed) |

Adversarial verifier reproduced independently: 5.23 ms -> 0.0003 ms per call; 100 live sessions add 0.3 MB with exactly one context object in the heap.

Production expectation (from the plan, not yet re-profiled on prod): ~1.75-2.5% of event-loop-thread wall time (21/1201 non-GIL samples; ~0% of GIL-held samples since OpenSSL releases the GIL), removal of a 10-30 ms synchronous loop stall per upstream call on the N1 host (a loop-lag contributor; the #2029 stall shape is exactly this stall under CPU contention), and ~120 MB less duplicated trust-store RSS at the observed ~170 live sessions.

## OpenSpec

Capability: `outbound-http-clients`. No change folder: this is a pure refactor with no wire or contract change (same verification mode, hostname check, protocol floor and CA set, proven by the parity test), which is the refactor exemption in CONTRIBUTING.md merge gate 4. The rationale and the one operational consequence (CA bundle refresh needs a restart for per-call sessions) are recorded in the new `openspec/specs/outbound-http-clients/context.md`. `openspec validate --specs`: 57 passed, 1 failed = the pre-existing `model-source-routing` failure on main; no new failures.

## Tests

New:

- `tests/unit/test_http_client.py`
  - `_isolate_shared_ssl_context` autouse fixture: clears the cache before/after every test so the existing `_build_ssl_context` patches at :74/:171/:224/:268 keep working.
  - `test_build_ssl_context_is_not_cached` (fails if someone caches the constructor itself).
  - `test_shared_ssl_context_builds_once_and_returns_the_same_instance` (fails on main: two distinct objects).
  - `test_reset_shared_ssl_context_forces_rebuild`.
  - `test_close_http_client_resets_shared_ssl_context`.
  - `test_shared_ssl_context_matches_a_fresh_build_verification_policy` (policy/trust-store parity vs a fresh `_build_ssl_context()`).
- `tests/unit/test_codex_client.py`
  - `test_create_codex_session_connectors_share_one_ssl_context`: two sessions' `connector._ssl` is the same object and is `_shared_ssl_context()` (fails if the `create_codex_session` call site is reverted).
  - `test_socks_proxy_connector_reuses_shared_ssl_context` (fails if the `_socks_proxy_connector` call site is reverted).
- `tests/unit/test_settings_proxy_probe.py` (new module): `test_socks_probe_uses_shared_ssl_context` asserts the `ProxyConnector` in `_probe_upstream_proxy_endpoint` receives the shared context (fails if that call site is reverted). No existing test exercised this function.

Verified by the adversarial pass: partial reverts of the `codex.py` and `settings/api.py` callers are caught by the new tests; a full revert fails at import. Known gap (P3, accepted): the `_build_http_client` call site is not pinned by a dedicated test.

Gates on the final head: touched modules `tests/unit/test_http_client.py tests/unit/test_codex_client.py tests/unit/test_settings_proxy_probe.py tests/unit/test_codex_upstream_paths.py tests/unit/test_proxy_websocket_client.py` -> 180 passed; unit smoke over every module importing `app.core.clients.http` / `codex` / `app.modules.settings.api` -> 320 passed; cross-module ordering run 1333 passed in both directions (no cache pollution); `ruff check .` and `ruff format --check .` clean; `ty check` clean; `scripts/check_proxy_architecture.py` passed. `tests/integration/test_native_routed_egress.py` skipped locally (needs `CODEX_LB_NATIVE_EGRESS_TEST_BINARY`), so the aiohttp-fallback path is covered here by unit tests only.

## Review trail

- Local `codex review --base origin/main` (round 1): zero findings; verdict that the change reuses the existing TLS verification policy across all targeted connectors with no regressions. Codex also ran the three touched test modules itself (70 passed).
- Independent verification (round 1): confirmed the diff is confined to the four planned call sites plus the accessor/reset pair and the cache clear under the lock; confirmed no post-build context mutation exists in `app/`. One optional P3 raised (widen the autouse reset fixture to a shared conftest) - not applied, since the two `codex.py` tests reset explicitly and no other module patches the constructor.
- Adversarial verification (round 1): approve. Reproduced trust-store SHA-256 parity, no-TLS-resumption probe, exception non-caching, forward/reverse module-order test runs, revert-detection of the new tests, perf and memory numbers, and disjointness from the sibling campaign worktrees (`fix-aiohttp-routed-stream-release` touches `codex.py` 3/122-186, `fix-credential-safe-proxy-logging` touches 31/259/312/362/817; this PR touches 430-440/507-521). One P3 raised (the `_build_http_client` call site is not pinned by a test) - accepted as documented above.
- Blocking findings: 0. P0-P2 fixed: 0 (none raised).

## Deploy notes / hazards

- No config, migration or env change. Rolling restart is enough; nothing to flip.
- CA bundle rotation: after upgrading the base image or certifi, restart the process to pick up the new trust store on per-call sessions (previously only the shared client needed this).
- Campaign-wide upgrade hazard, not specific to this PR but relevant to anyone deploying `main` to the current prod: since #1995 `main` rejects `http://user:pw@` proxy endpoints (`plaintext_proxy_credentials_forbidden`), so the current prod smartproxy pool fails closed on routed requests until the endpoint is re-created as `https://` or credential-less. Decide before deploying anything from this campaign.
- On `main` in Docker the native Rust egress helper serves the routed HTTP/WS hot paths and aiohttp is fallback-only; this PR still applies to the fallback, SOCKS, non-Docker, the WS path at `proxy.py:2826`, the dashboard proxy probe, and every eagerly built `CodexClient` session. Re-profile with `py-spy --gil` rate 10-20 for 60 s after deploy to measure the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved outbound connection efficiency by reusing a shared SSL verification context across HTTP, SOCKS, WebSocket, and proxy connections.
  * Reduced repeated SSL setup overhead during network operations.

* **Bug Fixes**
  * Ensured SSL settings are refreshed when the HTTP client shuts down and starts again.

* **Documentation**
  * Documented SSL context reuse, performance benefits, and certificate-update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->