### PR TITLE
perf(proxy-responses): compute to_payload once per bridge prepare and early-exit the 8 KiB usage estimate

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -54,7 +54,7 @@ from app.core.openai.requests import (
     ResponsesRequest,
 )
 from app.core.resilience.overload import is_local_overload_error_code
-from app.core.types import JsonValue
+from app.core.types import JsonObject, JsonValue
 from app.core.utils.request_id import (
     ensure_request_id,
     ensure_request_scope_id,
@@ -687,6 +687,9 @@ class _HTTPBridgeRequestSubmitMixin:
         enforce_openai_sdk_contract: bool = True,
         preserve_responses_lite_client_metadata: bool = False,
     ) -> tuple[_WebSocketRequestState, str]:
+        # One dump feeds client-metadata derivation, the frame and the usage
+        # budget; ``to_payload`` is deterministic so sharing it is exact.
+        base_payload = payload.to_payload()
         request_state, text_data = self._prepare_response_bridge_request_state(
             payload,
             api_key=api_key,
@@ -695,7 +698,7 @@ class _HTTPBridgeRequestSubmitMixin:
             attach_event_queue=True,
             transport=_REQUEST_TRANSPORT_HTTP,
             client_metadata=_response_create_client_metadata(
-                payload.to_payload(),
+                base_payload,
                 headers=headers,
                 preserve_existing_responses_lite=preserve_responses_lite_client_metadata,
             ),
@@ -703,6 +706,7 @@ class _HTTPBridgeRequestSubmitMixin:
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            upstream_payload_base=base_payload,
         )
         (
             request_state.useragent,
@@ -727,6 +731,7 @@ class _HTTPBridgeRequestSubmitMixin:
         request_id: str | None = None,
         request_log_id: str | None = None,
         enforce_openai_sdk_contract: bool = True,
+        upstream_payload_base: JsonObject | None = None,
     ) -> tuple[_WebSocketRequestState, str]:
         deduped_replayed_input_count: int | None = None
         deduped_replayed_input_fingerprint: str | None = None
@@ -741,12 +746,19 @@ class _HTTPBridgeRequestSubmitMixin:
                 deduped_replayed_input_count = len(replayed_input_items)
                 deduped_replayed_input_fingerprint = _fingerprint_input_items(replayed_input_items)
                 payload = payload.model_copy(update={"input": deduped_input_items})
+                # The caller's dump describes the un-deduped input; it must not
+                # become the forwarded frame or the budget base.
+                upstream_payload_base = None
         protected_agent_control_output_occurrences = (
             _historical_agent_control_output_occurrences(cast(list[JsonValue], payload.input))
             if isinstance(payload.input, list)
             else {}
         )
-        upstream_payload = dict(payload.to_payload())
+        if upstream_payload_base is None:
+            upstream_payload_base = payload.to_payload()
+        # Shallow copy: every mutation below rebinds top-level keys only, so
+        # ``upstream_payload_base`` stays the pristine dump for the budget.
+        upstream_payload = dict(upstream_payload_base)
         upstream_payload.pop("stream", None)
         upstream_payload.pop("background", None)
         if include_type_field:
@@ -792,7 +804,7 @@ class _HTTPBridgeRequestSubmitMixin:
             transport=transport,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             api_key=api_key,
-            request_usage_budget=estimate_api_key_request_usage(payload),
+            request_usage_budget=estimate_api_key_request_usage(payload, upstream_payload=upstream_payload_base),
             previous_response_id=payload.previous_response_id,
             session_id=_normalize_session_id(session_id),
             hard_continuity_anchor=(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -52,7 +52,7 @@ from app.core.metrics.prometheus import (
 from app.core.openai.requests import (
     ResponsesRequest,
 )
-from app.core.types import JsonValue
+from app.core.types import JsonObject, JsonValue
 from app.core.utils.request_id import ensure_request_id, ensure_request_scope_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.core.utils.time import utcnow
@@ -979,8 +979,11 @@ class _HTTPBridgeStreamingMixin:
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
         request_id = ensure_request_id()
         self._raise_for_unsupported_input_image_references(payload)
+        # This dump is shared with the bridge attempt below (``bridge_payload``);
+        # the size gate itself must stay here, ahead of the bridge/WS decision.
+        bridge_payload = payload.to_payload()
         payload_size_estimate_bytes = len(
-            json.dumps(payload.to_payload(), ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+            json.dumps(bridge_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
         )
         rewritten_file_account_id = await self._resolve_forwarded_file_account_for_responses(
             payload,
@@ -1090,6 +1093,7 @@ class _HTTPBridgeStreamingMixin:
                     capacity_startup_wait_event=capacity_startup_wait_event,
                     capacity_startup_ready_event=capacity_startup_ready_event,
                     deferred_account_backoff_tracker=deferred_account_backoff_tracker,
+                    bridge_payload=bridge_payload,
                 ):
                     bridge_yielded_any = True
                     yield line
@@ -1240,6 +1244,7 @@ class _HTTPBridgeStreamingMixin:
         capacity_startup_wait_event: asyncio.Event | None = None,
         capacity_startup_ready_event: asyncio.Event | None = None,
         deferred_account_backoff_tracker: _DeferredAccountBackoffTracker | None = None,
+        bridge_payload: JsonObject | None = None,
         _denied_anchor_request_id: str | None = None,
     ) -> AsyncIterator[str]:
         del suppress_text_done_events
@@ -1250,7 +1255,10 @@ class _HTTPBridgeStreamingMixin:
         runtime_config = _http_bridge_runtime_config(dashboard_settings, _service_get_settings())
         if deferred_account_backoff_tracker is None:
             deferred_account_backoff_tracker = _DeferredAccountBackoffTracker()
-        bridge_payload = payload.to_payload()
+        if bridge_payload is None:
+            # ``_stream_http_bridge_or_retry`` passes its size-gate dump of this
+            # same ``payload``; direct callers fall back to a fresh dump.
+            bridge_payload = payload.to_payload()
         bridge_client_metadata = _response_create_client_metadata(
             bridge_payload,
             headers=headers,

--- a/app/modules/proxy/api_key_usage.py
+++ b/app/modules/proxy/api_key_usage.py
@@ -13,6 +13,12 @@ from app.modules.api_keys.service import (
 
 ApiKeyUsageEstimableRequest: TypeAlias = ResponsesRequest | ResponsesCompactRequest
 
+# Same serialization parameters the budget historically used with ``json.dumps``.
+# ``sort_keys`` and ``default`` cannot change the serialized length, but they
+# are kept so the streamed byte count stays exactly what the one-shot dump
+# produced.
+_BUDGET_ENCODER = json.JSONEncoder(ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str)
+
 _OPAQUE_INPUT_ITEM_TYPES = frozenset({"input_file", "input_image"})
 _INPUT_BUDGET_EXCLUDED_FIELDS = frozenset(
     {
@@ -27,14 +33,24 @@ _INPUT_BUDGET_EXCLUDED_FIELDS = frozenset(
 )
 
 
-def estimate_api_key_request_usage(payload: ApiKeyUsageEstimableRequest) -> ApiKeyRequestUsageBudget:
+def estimate_api_key_request_usage(
+    payload: ApiKeyUsageEstimableRequest,
+    *,
+    upstream_payload: JsonObject | None = None,
+) -> ApiKeyRequestUsageBudget:
     """Return a bounded local usage budget for API-key reservation admission.
 
     ``None`` means the proxy cannot size that side of the request locally, so
     API-key enforcement should use its conservative default for that dimension.
+
+    ``upstream_payload`` lets callers that already hold ``payload.to_payload()``
+    share it instead of paying for another full dump. It must be the pristine
+    ``to_payload()`` result for ``payload`` (``to_payload`` is deterministic, so
+    the budget is identical either way).
     """
 
-    upstream_payload = payload.to_payload()
+    if upstream_payload is None:
+        upstream_payload = payload.to_payload()
     return ApiKeyRequestUsageBudget(
         input_tokens=_estimate_request_input_tokens(payload, upstream_payload),
         output_tokens=None,
@@ -48,10 +64,29 @@ def _estimate_request_input_tokens(payload: ApiKeyUsageEstimableRequest, upstrea
         return None
 
     data = _input_budget_payload(upstream_payload)
-    serialized = json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str)
-    if not serialized:
-        return 0
-    return min(len(serialized.encode("utf-8")), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
+    # The budget is ``min(serialized_utf8_length, CAP)``. A JSON string literal
+    # is never shorter than its Python length (escapes only add bytes), so a
+    # long ``instructions`` field alone already proves the cap is reached; this
+    # is the common Codex CLI shape and avoids serializing multi-hundred-KB
+    # payloads to learn an 8 KiB answer.
+    instructions = data.get("instructions")
+    if isinstance(instructions, str) and len(instructions) >= API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET:
+        return API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    # Otherwise stream the serialization and stop as soon as the cap is proven.
+    # Only the first ~CAP bytes are ever produced, so a lone surrogate deeper in
+    # the payload no longer raises ``UnicodeEncodeError`` here (the full dump
+    # used to fail for a surrogate anywhere in the payload).
+    serialized_bytes = 0
+    for chunk in _BUDGET_ENCODER.iterencode(data):
+        # A chunk's UTF-8 length is at least its character count, so a chunk
+        # that alone covers the remaining budget (one large string literal)
+        # proves the cap without encoding it.
+        if len(chunk) >= API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET - serialized_bytes:
+            return API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+        serialized_bytes += len(chunk.encode("utf-8"))
+        if serialized_bytes >= API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET:
+            return API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    return serialized_bytes
 
 
 def _input_budget_payload(payload: JsonObject) -> dict[str, JsonValue]:

--- a/openspec/specs/api-keys/context.md
+++ b/openspec/specs/api-keys/context.md
@@ -1,0 +1,39 @@
+# API Keys Context
+
+See `openspec/specs/api-keys/spec.md` for normative requirements.
+
+## Request-aware reservation estimate
+
+The admission budget for token and `cost_usd` limits (Requirement
+"Request-aware API-key usage reservations") sizes the input side from the
+forwarded request payload: `min(utf8_length(serialized_payload_minus_caps), 8192)`.
+Two implementation notes keep that value exact while avoiding redundant work on
+the hot path:
+
+- **Shared dump.** `ResponsesRequest.to_payload()` is deterministic, so the
+  HTTP bridge prepare path computes it once and threads the same dict through
+  client-metadata derivation, the forwarded `response.create` frame and
+  `estimate_api_key_request_usage(payload, upstream_payload=...)`. The budget,
+  frame bytes and input fingerprints are byte-identical to computing each stage
+  from its own dump. When the prepare path rewrites the request (replayed
+  side-effect tool-call dedupe under `previous_response_id`) the caller's dump
+  is discarded and recomputed from the rewritten request, so the forwarded
+  frame never carries un-deduped input. Callers that do not hold a dump keep
+  the default single-argument form.
+- **Early-exit serialization.** Because the estimate is capped at 8192 bytes,
+  the estimator returns the cap as soon as it is proven: an `instructions`
+  string of 8192+ characters alone suffices (a JSON string literal is never
+  shorter than its character count), otherwise the payload is streamed through
+  the same `sort_keys`/`ensure_ascii=False` encoder and stopped once 8192 bytes
+  have been produced. Sub-cap payloads still yield the exact serialized length.
+  The opaque-context checks (`previous_response_id`, `conversation`, file or
+  image references) run before either shortcut, so the conservative `None`
+  budget is unchanged.
+
+Edge: a lone surrogate (`"\ud800"`) anywhere in the payload used to raise
+`UnicodeEncodeError` (HTTP 500) from the full dump. It now raises only when it
+sits in a chunk that is actually UTF-8 encoded, i.e. within the first ~8 KiB of
+serialized output and not inside a string literal that the length shortcuts
+(`instructions` >= 8192 chars, or a single chunk that alone covers the
+remaining budget) prove the cap without encoding. Surrogates skipped that way
+yield the 8192 cap like any other large payload.

--- a/tests/unit/test_http_bridge_payload_dedupe.py
+++ b/tests/unit/test_http_bridge_payload_dedupe.py
@@ -1,0 +1,324 @@
+"""Byte-compat coverage for the single-dump bridge prepare path.
+
+``_prepare_http_bridge_request`` computes ``payload.to_payload()`` once and
+threads it through client-metadata derivation, the forwarded frame and the
+API-key usage budget. These tests pin that the shared dump yields exactly what
+the independent per-stage dumps produced.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+import app.modules.proxy._service.http_bridge.streaming as bridge_streaming_module
+from app.core.openai.requests import ResponsesRequest
+from app.core.types import JsonObject, JsonValue
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.response_create import _response_create_client_metadata
+
+_LITE_HEADERS = {"x-codex-turn-state": "turn-1", "user-agent": "codex_cli_rs/0.99.0"}
+
+
+def _service() -> Any:
+    return proxy_service.ProxyService(cast(Any, nullcontext()))
+
+
+def _replayed_side_effect_input() -> list[JsonValue]:
+    """Two replays of one ``write_stdin`` call: the dedupe branch removes the second call."""
+    arguments = json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000, "max_output_tokens": 22000})
+    return [
+        {"type": "function_call", "name": "write_stdin", "arguments": arguments, "call_id": "call_first"},
+        {"type": "function_call_output", "call_id": "call_first", "output": "Process running with session ID 75180"},
+        {"type": "reasoning", "summary": []},
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps(
+                {"session_id": 75180, "chars": "", "yield_time_ms": 30000, "max_output_tokens": 4000}
+            ),
+            "call_id": "call_replay",
+        },
+        {"type": "function_call_output", "call_id": "call_replay", "output": "Process exited with code 0"},
+    ]
+
+
+_CASES: dict[str, tuple[dict[str, JsonValue], dict[str, str], bool]] = {
+    # (request body, headers, preserve_responses_lite_client_metadata)
+    "plain-client-metadata": (
+        {
+            "model": "gpt-5.6",
+            "instructions": "be brief 한국어",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "héllo"}]}],
+            "client_metadata": {"x-codex-turn-metadata": '{"turn_id":"t1"}', "caller": "stable"},
+            "stream": True,
+            "reasoning": {"effort": "medium"},
+        },
+        _LITE_HEADERS,
+        False,
+    ),
+    "client-metadata-dropped": (
+        {
+            "model": "gpt-5.6",
+            "instructions": "",
+            "input": "plain string input",
+            "client_metadata": {"x-codex-installation-id": "client-installation"},
+            "stream": True,
+            "background": False,
+        },
+        {},
+        False,
+    ),
+    "sanitized-input": (
+        {
+            "model": "gpt-5.6",
+            "instructions": "x" * 9000,
+            "input": [
+                {"role": "developer", "content": "sys"},
+                {"type": "reasoning", "summary": [], "encrypted_content": "abc"},
+                {
+                    "type": "function_call",
+                    "name": "multi_agent_v1__tool_search",
+                    "arguments": "{}",
+                    "call_id": "call_ns",
+                },
+                {"type": "function_call_output", "call_id": "call_ns", "output": "ok"},
+                {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
+            ],
+            "temperature": 0.2,
+            "truncation": None,
+            "stream": True,
+        },
+        {"x-codex-session-id": "sid-1"},
+        False,
+    ),
+    "responses-lite": (
+        {
+            "model": "gpt-5.6",
+            "instructions": "lite",
+            "input": [
+                {"type": "additional_tools", "tools": [{"type": "function", "name": "shell"}]},
+                {"role": "user", "content": "go"},
+            ],
+            "client_metadata": {"x-codex-responses-lite-websocket": "true"},
+            "reasoning": {"effort": "high", "summary": "auto"},
+        },
+        _LITE_HEADERS,
+        True,
+    ),
+    "previous-response-dedupe": (
+        {
+            "model": "gpt-5.6",
+            "instructions": "continue",
+            "input": _replayed_side_effect_input(),
+            "previous_response_id": "resp_parent",
+            "client_metadata": {"caller": "stable"},
+        },
+        _LITE_HEADERS,
+        False,
+    ),
+}
+
+
+def _prepare_state(
+    service: Any,
+    payload: ResponsesRequest,
+    *,
+    headers: dict[str, str],
+    preserve_lite: bool,
+    upstream_payload_base: JsonObject | None,
+) -> tuple[Any, str]:
+    return service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport="http",
+        client_metadata=_response_create_client_metadata(
+            payload.to_payload(),
+            headers=headers,
+            preserve_existing_responses_lite=preserve_lite,
+        ),
+        headers=headers,
+        request_id="ws_fixed",
+        request_log_id="req_fixed",
+        upstream_payload_base=upstream_payload_base,
+    )
+
+
+def _comparable(request_state: Any) -> dict[str, object]:
+    return {
+        "request_text": request_state.request_text,
+        "input_full_fingerprint": request_state.input_full_fingerprint,
+        "input_item_count": request_state.input_item_count,
+        "request_usage_budget": request_state.request_usage_budget,
+        "service_tier": request_state.service_tier,
+        "previous_response_id": request_state.previous_response_id,
+        "proxy_injected_anchor_had_full_resend_payload": request_state.proxy_injected_anchor_had_full_resend_payload,
+    }
+
+
+@pytest.mark.parametrize("case", sorted(_CASES))
+def test_prepare_state_with_shared_dump_matches_independent_dumps(case: str) -> None:
+    body, headers, preserve_lite = _CASES[case]
+    service = _service()
+    payload = ResponsesRequest.model_validate(body)
+    base_payload = payload.to_payload()
+    pristine_base = json.dumps(base_payload, sort_keys=True)
+
+    fresh_state, fresh_text = _prepare_state(
+        service, payload, headers=headers, preserve_lite=preserve_lite, upstream_payload_base=None
+    )
+    shared_state, shared_text = _prepare_state(
+        service, payload, headers=headers, preserve_lite=preserve_lite, upstream_payload_base=base_payload
+    )
+
+    assert shared_text == fresh_text
+    assert _comparable(shared_state) == _comparable(fresh_state)
+    assert json.dumps(base_payload, sort_keys=True) == pristine_base, "the shared dump must stay pristine"
+
+
+def test_prepare_state_dedupe_branch_discards_caller_dump_and_forwards_deduped_input() -> None:
+    body, headers, preserve_lite = _CASES["previous-response-dedupe"]
+    service = _service()
+    payload = ResponsesRequest.model_validate(body)
+    base_payload = payload.to_payload()
+    assert sum(1 for item in cast(list[Any], base_payload["input"]) if item.get("type") == "function_call") == 2
+
+    request_state, text_data = _prepare_state(
+        service, payload, headers=headers, preserve_lite=preserve_lite, upstream_payload_base=base_payload
+    )
+
+    forwarded = json.loads(text_data)
+    forwarded_calls = [item for item in forwarded["input"] if item.get("type") == "function_call"]
+    assert [item["call_id"] for item in forwarded_calls] == ["call_first"], "un-deduped caller dump leaked"
+    assert forwarded["previous_response_id"] == "resp_parent"
+    assert request_state.input_item_count == len(_replayed_side_effect_input())
+    assert request_state.request_usage_budget.input_tokens is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_calls"),
+    [
+        pytest.param("plain-client-metadata", 1, id="common-path"),
+        pytest.param("client-metadata-dropped", 1, id="metadata-dropped"),
+        pytest.param("sanitized-input", 1, id="sanitized-input"),
+        pytest.param("responses-lite", 1, id="responses-lite"),
+        pytest.param("previous-response-dedupe", 2, id="dedupe-recomputes-once"),
+    ],
+)
+def test_prepare_http_bridge_request_dumps_payload_at_most_twice(
+    monkeypatch: pytest.MonkeyPatch, case: str, expected_calls: int
+) -> None:
+    body, headers, preserve_lite = _CASES[case]
+    service = _service()
+    payload = ResponsesRequest.model_validate(body)
+    original_to_payload = ResponsesRequest.to_payload
+    calls: list[int] = []
+
+    def counting_to_payload(self: ResponsesRequest) -> JsonObject:
+        calls.append(id(self))
+        return original_to_payload(self)
+
+    monkeypatch.setattr(ResponsesRequest, "to_payload", counting_to_payload)
+
+    request_state, text_data = service._prepare_http_bridge_request(
+        payload,
+        headers,
+        api_key=None,
+        api_key_reservation=None,
+        request_id="req_fixed",
+        preserve_responses_lite_client_metadata=preserve_lite,
+    )
+
+    assert len(calls) == expected_calls
+    assert request_state.request_text == text_data
+    assert json.loads(text_data)["type"] == "response.create"
+
+
+def test_prepare_http_bridge_request_matches_legacy_per_stage_dumps() -> None:
+    """End-to-end: the public prepare entry point emits the same frame the per-stage dumps did."""
+    for case, (body, headers, preserve_lite) in _CASES.items():
+        service = _service()
+        payload = ResponsesRequest.model_validate(body)
+
+        request_state, text_data = service._prepare_http_bridge_request(
+            payload,
+            headers,
+            api_key=None,
+            api_key_reservation=None,
+            request_id="req_fixed",
+            preserve_responses_lite_client_metadata=preserve_lite,
+        )
+        legacy_state, legacy_text = _prepare_state(
+            service, payload, headers=headers, preserve_lite=preserve_lite, upstream_payload_base=None
+        )
+
+        assert text_data == legacy_text, case
+        comparable = _comparable(request_state)
+        legacy = _comparable(legacy_state)
+        assert comparable == legacy, case
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_shares_size_gate_dump_with_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _service()
+    settings = SimpleNamespace(upstream_stream_transport="auto", max_sse_event_bytes=16 * 1024 * 1024)
+
+    class _SettingsCache:
+        async def get(self) -> object:
+            return SimpleNamespace(upstream_stream_transport="default")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        bridge_streaming_module,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    monkeypatch.setattr(bridge_streaming_module, "upstream_websocket_transport_recently_failed", lambda: False)
+
+    async def resolve_none(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(service, "_resolve_forwarded_file_account_for_responses", resolve_none)
+    captured: dict[str, Any] = {}
+
+    async def fake_stream_via_http_bridge(payload: ResponsesRequest, headers: Any, **kwargs: Any):
+        captured["payload"] = payload
+        captured["kwargs"] = kwargs
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+    payload = ResponsesRequest.model_validate(_CASES["plain-client-metadata"][0])
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload,
+            {},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: bridge\n\n"]
+    assert captured["payload"] is payload
+    assert captured["kwargs"]["bridge_payload"] == payload.to_payload()

--- a/tests/unit/test_proxy_api_key_usage.py
+++ b/tests/unit/test_proxy_api_key_usage.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.core.types import JsonObject, JsonValue
 from app.modules.api_keys.service import (
     API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
     API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS,
     API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET,
     ApiKeyRequestUsageBudget,
 )
+from app.modules.proxy import api_key_usage
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
+from tests.unit.hypothesis_strategies import json_arrays, json_objects
 
 
 @pytest.mark.parametrize(
@@ -159,3 +168,202 @@ def test_estimate_api_key_request_usage_allows_structured_content_type_values() 
     budget = estimate_api_key_request_usage(payload)
 
     assert budget.input_tokens is not None
+
+
+# --- Estimate byte-compat: shared dump + early-exit serialization -----------
+
+
+def _legacy_estimate_request_input_tokens(input_value: JsonValue, upstream_payload: JsonObject) -> int | None:
+    """Reference implementation: the pre-early-exit full sorted dump."""
+    if api_key_usage._has_opaque_upstream_context(upstream_payload):
+        return None
+    if api_key_usage._contains_opaque_input_reference(input_value):
+        return None
+    data = api_key_usage._input_budget_payload(upstream_payload)
+    serialized = json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str)
+    if not serialized:
+        return 0
+    return min(len(serialized.encode("utf-8")), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
+
+
+def _estimate_for(upstream_payload: JsonObject) -> int | None:
+    request = cast(Any, SimpleNamespace(input=upstream_payload.get("input")))
+    return api_key_usage._estimate_request_input_tokens(request, upstream_payload)
+
+
+def _payload_with_serialized_length(target_bytes: int, *, filler: str = "a") -> dict[str, JsonValue]:
+    """Build ``{"input": ..., "instructions": filler*k}`` whose sorted dump is exactly ``target_bytes``."""
+    overhead = len(json.dumps({"input": "", "instructions": ""}, ensure_ascii=False, separators=(",", ":")).encode())
+    filler_bytes = len(filler.encode("utf-8"))
+    filler_count, ascii_padding = divmod(target_bytes - overhead, filler_bytes)
+    payload: dict[str, JsonValue] = {"input": "x" * ascii_padding, "instructions": filler * filler_count}
+    assert len(json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()) == target_bytes
+    return payload
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param({"model": "gpt-5.5", "instructions": "be brief", "input": "héllo wörld"}, id="small-non-ascii"),
+        pytest.param(
+            {"model": "gpt-5.5", "instructions": "x" * 20_000, "input": [{"role": "user", "content": "hi"}]},
+            id="long-instructions",
+        ),
+        pytest.param(
+            {
+                "model": "gpt-5.5",
+                "instructions": "short",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "한글 " * 3000}]}],
+                "reasoning": {"effort": "high"},
+                "tools": [{"type": "function", "name": "shell", "parameters": {"type": "object"}}],
+            },
+            id="large-multibyte-input",
+        ),
+        pytest.param(
+            {"model": "gpt-5.5", "instructions": "next", "input": "x", "previous_response_id": "resp_1"}, id="opaque"
+        ),
+    ],
+)
+def test_estimate_api_key_request_usage_shared_dump_matches_default_path(body: dict[str, JsonValue]) -> None:
+    payload = ResponsesRequest.model_validate(body)
+    upstream_payload = payload.to_payload()
+    calls = {"count": 0}
+    original_to_payload = ResponsesRequest.to_payload
+
+    def counting_to_payload(self: ResponsesRequest) -> JsonObject:
+        calls["count"] += 1
+        return original_to_payload(self)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(ResponsesRequest, "to_payload", counting_to_payload)
+        default_budget = estimate_api_key_request_usage(payload)
+        shared_budget = estimate_api_key_request_usage(payload, upstream_payload=upstream_payload)
+
+    assert shared_budget == default_budget
+    assert shared_budget.input_tokens == _legacy_estimate_request_input_tokens(payload.input, upstream_payload)
+    assert calls["count"] == 1, "the shared-dump path must not re-dump the request"
+
+
+@given(
+    payload=json_objects,
+    instructions=st.one_of(st.none(), st.text(max_size=200), st.text(min_size=8192, max_size=8300)),
+    input_value=st.one_of(st.none(), st.text(max_size=120), json_arrays),
+)
+@settings(deadline=None, max_examples=600)
+def test_estimate_request_input_tokens_matches_full_sorted_dump(
+    payload: dict[str, JsonValue],
+    instructions: str | None,
+    input_value: JsonValue,
+) -> None:
+    upstream_payload = dict(payload)
+    if instructions is not None:
+        upstream_payload["instructions"] = instructions
+    if input_value is not None:
+        upstream_payload["input"] = input_value
+
+    assert _estimate_for(upstream_payload) == _legacy_estimate_request_input_tokens(
+        upstream_payload.get("input"), upstream_payload
+    )
+
+
+@pytest.mark.parametrize(
+    ("target_bytes", "filler"),
+    [
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET - 1, "a", id="8191-ascii"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET, "a", id="8192-ascii"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET + 1, "a", id="8193-ascii"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET - 2, "é", id="8190-two-byte"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET + 2, "é", id="8194-two-byte"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET - 3, "한", id="8189-three-byte"),
+        pytest.param(API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET + 3, "한", id="8195-three-byte"),
+    ],
+)
+def test_estimate_request_input_tokens_cap_boundaries(target_bytes: int, filler: str) -> None:
+    upstream_payload = _payload_with_serialized_length(target_bytes, filler=filler)
+
+    estimate = _estimate_for(upstream_payload)
+
+    assert estimate == min(target_bytes, API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
+    assert estimate == _legacy_estimate_request_input_tokens(upstream_payload["input"], upstream_payload)
+
+
+def test_estimate_request_input_tokens_instructions_shortcut_stays_behind_opaque_checks() -> None:
+    long_instructions = "i" * API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+
+    assert (
+        _estimate_for({"instructions": long_instructions, "input": "x"}) == API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    )
+    assert _estimate_for({"instructions": long_instructions, "input": "x", "conversation": "conv_1"}) is None
+    assert (
+        _estimate_for({"instructions": long_instructions, "input": [{"type": "input_image", "file_id": "file_1"}]})
+        is None
+    )
+    # One character short of the cap must fall through to real serialization.
+    assert _estimate_for({"instructions": long_instructions[:-1], "input": ""}) == min(
+        len(json.dumps({"input": "", "instructions": long_instructions[:-1]}, separators=(",", ":")).encode()),
+        API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET,
+    )
+
+
+def test_estimate_request_input_tokens_large_payload_returns_cap_without_full_serialization() -> None:
+    upstream_payload: dict[str, JsonValue] = {
+        "instructions": "short",
+        "input": [
+            {"type": "function_call_output", "call_id": f"call_{index}", "output": "o" * 500} for index in range(2_000)
+        ],
+    }
+    data = api_key_usage._input_budget_payload(upstream_payload)
+    total_chunks = sum(1 for _ in api_key_usage._BUDGET_ENCODER.iterencode(data))
+    consumed_chunks = 0
+    original_iterencode = api_key_usage._BUDGET_ENCODER.iterencode
+
+    def counting_iterencode(value: object, _one_shot: bool = False):  # noqa: FBT001, FBT002
+        nonlocal consumed_chunks
+        for chunk in original_iterencode(value, _one_shot):
+            consumed_chunks += 1
+            yield chunk
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(api_key_usage._BUDGET_ENCODER, "iterencode", counting_iterencode)
+        assert _estimate_for(upstream_payload) == API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+
+    # ~1 MB of output: the early exit stops within the first few items.
+    assert 0 < consumed_chunks < total_chunks // 50
+
+
+def test_estimate_request_input_tokens_single_huge_string_returns_cap_without_encoding_it() -> None:
+    huge = "0123456789" * 100_000  # a single 1 MB string literal is one encoder chunk
+    upstream_payload: dict[str, JsonValue] = {"instructions": "short", "input": huge}
+    encoded: list[int] = []
+    original_encode = str.encode
+
+    class _Spy(str):
+        __slots__ = ()
+
+        def encode(self, *args: Any, **kwargs: Any) -> bytes:
+            encoded.append(len(self))
+            return original_encode(self, *args, **kwargs)
+
+    original_iterencode = api_key_usage._BUDGET_ENCODER.iterencode
+
+    def spying_iterencode(value: object, _one_shot: bool = False):  # noqa: FBT001, FBT002
+        for chunk in original_iterencode(value, _one_shot):
+            yield _Spy(chunk)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(api_key_usage._BUDGET_ENCODER, "iterencode", spying_iterencode)
+        assert _estimate_for(upstream_payload) == API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+
+    assert all(size < API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET for size in encoded), encoded
+
+
+def test_estimate_request_input_tokens_lone_surrogate_beyond_cap_no_longer_raises() -> None:
+    """Documented edge: a lone surrogate past the first ~8 KiB used to 500 the request."""
+    upstream_payload: dict[str, JsonValue] = {
+        "instructions": "short",
+        "input": [{"role": "user", "content": "p" * 9_000}, {"role": "user", "content": "\ud800"}],
+    }
+    with pytest.raises(UnicodeEncodeError):
+        _legacy_estimate_request_input_tokens(upstream_payload["input"], upstream_payload)
+
+    assert _estimate_for(upstream_payload) == API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET


### PR DESCRIPTION
## Summary

Part of the 2026-09-03 CPU campaign (prod soju07, 2x Neoverse-N1, `workers=1`, CPU pegged ~100% at ~10k req/h; 60 s py-spy `--gil` profile, 1085 samples). Request shaping accounted for ~8% of GIL samples; within it `ResponsesRequest.to_payload()` was 3.8% inclusive (+1.9% pydantic `model_dump` leaf) and `_estimate_request_input_tokens` 1.6% (17/20 samples on the `json.dumps(sort_keys=True)` line).

Root cause: on one HTTP-bridge `/responses` request the same immutable request model was dumped 5-6 times (size gate, bridge client-metadata derivation, prepare client-metadata derivation, forwarded frame, API-key usage budget, plus the api.py reservation), and the usage budget then fully serialized a 100 KB-2 MB payload with `sort_keys` to compute a value that is capped at 8192 bytes. Every Codex CLI request exceeds that cap from `instructions` alone.

This PR threads one dump through the bridge prepare path and makes the estimate stop as soon as the cap is proven. Frame bytes, input fingerprints, item counts, service tier and reservation budgets are byte-identical.

## Change details

- `app/modules/proxy/_service/http_bridge/request_submit.py`
  - `_prepare_http_bridge_request` computes `payload.to_payload()` once, feeds it to `_response_create_client_metadata` and passes it as a new keyword-only `upstream_payload_base` into `_prepare_response_bridge_request_state`.
  - Inside `_prepare_response_bridge_request_state` the base is discarded and recomputed whenever the replayed side-effect tool-call dedupe branch rebinds `payload` via `model_copy(update={"input": ...})`, so the frame never carries un-deduped input. The frame is built from a shallow `dict(...)` copy (all later mutations rebind top-level keys), and the pristine dict is handed to the budget estimate.
- `app/modules/proxy/api_key_usage.py`
  - `estimate_api_key_request_usage(payload, *, upstream_payload=None)`: optional pre-computed dump; the default single-argument path used by api.py, retry and websocket callers is unchanged.
  - `_estimate_request_input_tokens`: opaque checks first (unchanged), then return the cap when `instructions` alone is >= 8192 chars, otherwise stream a module-level `JSONEncoder.iterencode` with the same `sort_keys`/`ensure_ascii=False`/`separators`/`default` parameters and return the cap once 8192 bytes are proven (including a length-exact pre-check so a single multi-hundred-KB string literal is not encoded just to be discarded). Sub-cap payloads still yield the exact serialized length.
- `app/modules/proxy/_service/http_bridge/streaming.py`
  - `_stream_http_bridge_or_retry` passes its existing size-gate dump down through `_stream_via_http_bridge` (`*args/**kwargs`) as `bridge_payload` so `_stream_via_http_bridge_impl` does not re-dump. The size gate itself stays where it is (it precedes the bridge/WS decision).
- `openspec/specs/api-keys/context.md` (new): documents the shared dump, the early-exit estimate and the lone-surrogate edge.
- Tests: `tests/unit/test_proxy_api_key_usage.py` (+12), `tests/unit/test_http_bridge_payload_dedupe.py` (new, 13).

## Byte-compat / behavior notes

- `to_payload()` is deterministic, so sharing its result is behaviour-preserving. Verified by cross-codebase comparison (origin/main vs this branch, same venv) over 16 fixtures: frame SHA, request_text SHA, input fingerprint, item count, budget, service_tier and default estimate identical — including string input, lite marker, aliases + `service_tier=flex`, exotic Unicode/control chars, explicit `tools: []`, 200 KB and 3 MB payloads, the replayed-tool-call dedupe branch, `previous_response_id`/`conversation`/`input_image` opaque budgets, compaction trigger and cap-adjacent sizes.
- Estimate equality: 100k random nested payloads with hostile strings (U+2028, NUL, U+10FFFF, NaN/inf, 10^20 ints, non-ASCII keys, 8100-8300-char instruction bands) plus a 600-example hypothesis property test in-tree: 0 divergences outside the one documented edge below.
- **Accepted behavior edge (documented in the context note):** a lone surrogate (`"\ud800"`) anywhere in the payload previously raised `UnicodeEncodeError` (HTTP 500) from the full dump. It now raises only when it sits in a chunk that is actually UTF-8 encoded (within the first ~8 KiB of serialized output and not inside a string literal that the length shortcuts prove the cap without encoding). Deeper/skipped surrogates yield the 8192 cap. The api-keys spec only says the input side MAY be sized from the payload; the old 500 was unspecified crash behaviour, not a requirement.
- The budget's `_contains_opaque_input_reference` scan is untouched (0 profile samples, out of plan scope) and is now the dominant remaining cost of the estimate (~0.47 ms per 240 KB).
- Sub-8 KiB payloads pay ~10 us more (pure-Python `iterencode` vs the C one-shot dump); bounded and negligible against the 1+ ms saved on large payloads.

## Expected gain

Plan estimate: ~4-4.5% of GIL samples (to_payload 5-6 -> 2-3 calls per request ~2.0-2.5%, estimate dumps ~1.5-1.8%).

Micro-benchmark (239,088-byte Codex-shaped `ResponsesRequest`: 20 KB non-ASCII instructions, ~330 input items incl. function_call/output, tools, reasoning, client_metadata; x86, this venv, min of repeats, +-20% noise):

| metric | before | after |
|---|---|---|
| `to_payload()` calls per `_prepare_http_bridge_request` | 3 | 1 (2 on the dedupe branch) |
| `to_payload()` calls per bridge request (size gate + bridge + prepare + frame + budget + api.py reservation) | 5-6 | 2-3 |
| `_prepare_http_bridge_request` | 6.34 ms | 3.51-3.64 ms (-43%) |
| estimate serialization part | 0.64 ms | ~0.02 ms (instructions shortcut) / ~0.10 ms (iterencode early exit) |
| `_estimate_request_input_tokens` total | 1.08 ms | 0.42-0.67 ms (remainder = untouched opaque scan) |
| `estimate_api_key_request_usage(payload)` default path (api.py) | 2.45 ms | 1.90-2.03 ms (still pays its own dump, as scoped) |
| small ~700 B payload estimate | 0.009 ms | 0.014-0.020 ms |

Independent reproduction by the adversarial verifier on the same host: prepare 6.15 -> 3.52 ms, estimate serialization 0.888 -> 0.443 ms.

## OpenSpec

Capabilities: `responses-api-compat`, `api-keys` (Requirement "Request-aware API-key usage reservations" stays satisfied: same `min(utf8_length, 8192)` value). Pure performance refactor with byte-identical frames/fingerprints/budgets, so no change folder (refactor exemption); the implementation notes and the surrogate edge are recorded in a new `openspec/specs/api-keys/context.md`. `openspec validate --specs`: 57 passed, 1 pre-existing failure (`model-source-routing`, present on main).

## Tests

`tests/unit/test_proxy_api_key_usage.py` (new cases):
- `test_estimate_api_key_request_usage_shared_dump_matches_default_path[4]` — `estimate(p) == estimate(p, upstream_payload=p.to_payload())`, legacy formula equality, `to_payload` spy == 1.
- `test_estimate_request_input_tokens_matches_full_sorted_dump` — hypothesis property (600 examples, random nested non-ASCII payloads, instructions in the 8192..8300 band) new == old full sorted dump.
- `test_estimate_request_input_tokens_cap_boundaries[8191/8192/8193 ASCII, 8190/8194 two-byte, 8189/8195 three-byte]`.
- `test_estimate_request_input_tokens_instructions_shortcut_stays_behind_opaque_checks`.
- `test_estimate_request_input_tokens_large_payload_returns_cap_without_full_serialization` (encoder chunk counter: <2% of chunks consumed).
- `test_estimate_request_input_tokens_single_huge_string_returns_cap_without_encoding_it`.
- `test_estimate_request_input_tokens_lone_surrogate_beyond_cap_no_longer_raises` (documents old `UnicodeEncodeError` vs new cap).

`tests/unit/test_http_bridge_payload_dedupe.py` (new file):
- `test_prepare_state_with_shared_dump_matches_independent_dumps[5]` — plain client_metadata, `client_metadata=None` drop, sanitized/namespaced input + long instructions, responses-lite additional_tools, `previous_response_id` + duplicated replayed side-effect calls: identical `text_data`, `input_full_fingerprint`, `input_item_count`, `request_usage_budget`, `service_tier`; base dict stays pristine.
- `test_prepare_state_dedupe_branch_discards_caller_dump_and_forwards_deduped_input`.
- `test_prepare_http_bridge_request_dumps_payload_at_most_twice[5]` — `to_payload` spy: 1 call common path, 2 on the dedupe branch.
- `test_prepare_http_bridge_request_matches_legacy_per_stage_dumps`.
- `test_stream_http_bridge_or_retry_shares_size_gate_dump_with_bridge` — `bridge_payload` kwarg == `payload.to_payload()`.

How they fail without the fix: with the three app files reverted to origin/main, 20/40 tests fail (all shared-dump kwarg, `to_payload`-count, early-exit chunk-count, single-huge-string and surrogate tests); the 9 equivalence tests pass on both by design (legacy formula inline as the oracle).

Gates run from the worktree (CPython 3.14 venv): `ruff check .` / `ruff format --check .` clean; `ty check` clean; `scripts/check_proxy_architecture.py` passed; `pytest` on `test_proxy_api_key_usage`, `test_http_bridge_payload_dedupe`, `test_proxy_utils`, `test_websocket_transport_fallback`, `test_http_bridge_forwarding`, `test_bridge_ring_lifecycle`, `test_http_bridge_safe_continuity` = 1422 passed; `test_proxy_http_bridge.py` = 953 passed / 1 deselected (`..._fails_closed_before_file_affinity_when_previous_response_owner_misses` fails identically on unmodified main when run in isolation — sqlite `file_account_pins` table, pre-existing and unrelated); `tests/integration/test_http_responses_bridge.py -k "prepare_http_bridge_request or client_metadata or dedupe or replayed or usage_budget or reservation"` = 5 passed; neighbour smoke `test_proxy_api_usage`, `test_proxy_api_responses_contract`, `test_api_keys_service`, `test_proxy_api_websocket_auth` = 189 passed. CHANGELOG untouched; net +626 lines.

## Review trail

- Local `codex review` (1 round): 1 finding — a [P1] process objection that the surrogate edge needs an openspec change folder. Verified reachable (stdlib `request.json()` ingress accepts lone surrogates), but the spec only says the estimate MAY be payload-derived and the old 500 was unspecified crash behaviour; downgraded to P3 and recorded in the context note instead. No code defects found; independent re-verification of the shallow-copy/pristine-base invariant, the dedupe recompute, the `bridge_payload` non-rebinding in streaming.py and the exactness of the `len(chunk) >= CAP - n` pre-check.
- Adversarial verification (1 round): 0 P0-P2. 16-fixture cross-codebase byte comparison, 100k-case estimate fuzz (0 divergences outside the documented surrogate class), test-discrimination check (20/40 fail on main), shared-dict mutation trace of every consumer, gates rerun, perf reproduced. 1 P3 (surrogate-edge note wording was looser than the actual rule) — fixed in the context note in this commit.

## Deploy notes / hazards

- No config, env or migration changes. Call signatures gained optional keyword-only parameters only; all other callers (api.py reservation, retry, websocket) keep the default path.
- Sibling campaign PR `perf-bridge-installation-id-stamp` touches different functions in `request_submit.py` (`_text_with_account_installation_id` / `_http_bridge_text_with_account_installation_id`); hunks are disjoint, the only plausible collision is the shared `from app.core.types import ...` import line — trivial rebase whichever lands second.
- Post-deploy verification: re-profile with `py-spy --gil` at rate 10-20 for <= 60 s (prod hazard: rate 100 previously stalled the app on the 2-core host and tripped health checks). Expect `to_payload` inclusive and the `_estimate_request_input_tokens` dumps line to roughly quarter.
- Campaign-wide upgrade hazard (not introduced here, listed for the operator): main rejects `http://user:pw@` proxy endpoints since #1995; prod's current proxy pool must be re-created as `https://` or credential-less before deploying anything from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved request processing efficiency by reusing serialized request data.
  * Reduced unnecessary serialization during HTTP bridge retries and request preparation.
  * Accelerated usage estimation by stopping once usage limits are reached.

* **Bug Fixes**
  * Corrected usage estimates and forwarded payloads when replayed tool-call inputs are deduplicated.
  * Improved handling of unusual Unicode content during usage estimation.

* **Documentation**
  * Added documentation describing API-key usage estimation and relevant edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->