### PR TITLE
perf(proxy-responses): stamp the account installation id once per request via identity memo and client_metadata splice

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -470,12 +470,68 @@ async def _settle_claimed_http_bridge_liveness_failure(
         )
 
 
+_CLIENT_METADATA_TAIL_KEY = ',"client_metadata":'
+
+
+def _dumps_compact(value: JsonValue) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def _splice_account_installation_id(text_data: str, codex_installation_id: str | None) -> str | None:
+    """Stamp ``client_metadata`` without decoding the rest of the frame.
+
+    Compact ``json.dumps`` (fixed separators, ``ensure_ascii``, insertion
+    order) is compositional: an object encodes as the concatenation of its
+    independently encoded members. For a frame produced by that encoder,
+    rewriting only the trailing top-level ``client_metadata`` value therefore
+    yields exactly the bytes a full decode/rewrite/encode would. This covers the
+    two dominant shapes -- ``client_metadata`` as the last key, or absent -- and
+    returns ``None`` for anything else so the caller falls back to the full
+    round trip.
+    """
+    if len(text_data) < 3 or text_data[0] != "{" or text_data[-1] != "}":
+        return None
+    index = text_data.rfind(_CLIENT_METADATA_TAIL_KEY)
+    if index < 0:
+        if '"client_metadata"' in text_data:
+            # Leading or nested key: not provably absent at the top level.
+            return None
+        inserted: dict[str, JsonValue] = {}
+        apply_codex_installation_metadata(inserted, codex_installation_id)
+        inserted_metadata = inserted.get("client_metadata")
+        if inserted_metadata is None:
+            return text_data
+        return f"{text_data[:-1]}{_CLIENT_METADATA_TAIL_KEY}{_dumps_compact(inserted_metadata)}}}"
+    encoded_metadata = text_data[index + len(_CLIENT_METADATA_TAIL_KEY) : -1]
+    if not encoded_metadata.startswith("{"):
+        return None
+    try:
+        raw_metadata = json.loads(encoded_metadata)
+    except json.JSONDecodeError:
+        # Nested match, or a value followed by further keys: not the trailing top-level key.
+        return None
+    if not isinstance(raw_metadata, dict):
+        return None
+    container: dict[str, JsonValue] = {"client_metadata": cast(dict[str, JsonValue], raw_metadata)}
+    apply_codex_installation_metadata(container, codex_installation_id)
+    metadata = container.get("client_metadata")
+    if metadata is None:
+        return f"{text_data[:index]}}}"
+    updated_metadata = _dumps_compact(metadata)
+    if updated_metadata == encoded_metadata:
+        return text_data
+    return f"{text_data[:index]}{_CLIENT_METADATA_TAIL_KEY}{updated_metadata}}}"
+
+
 def _text_with_account_installation_id(text_data: str, codex_installation_id: str | None) -> str:
+    spliced = _splice_account_installation_id(text_data, codex_installation_id)
+    if spliced is not None:
+        return spliced
     payload = json.loads(text_data)
     if not isinstance(payload, dict):
         return text_data
     apply_codex_installation_metadata(cast(dict[str, JsonValue], payload), codex_installation_id)
-    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    return _dumps_compact(payload)
 
 
 def _text_with_operation_id(text_data: str, operation_id: str | None) -> str:
@@ -805,18 +861,30 @@ class _HTTPBridgeRequestSubmitMixin:
         text_data: str,
     ) -> str:
         codex_installation_id = getattr(session.account, "codex_installation_id", None)
-        updated_text = _text_with_account_installation_id(text_data, codex_installation_id)
-        if request_state.fresh_upstream_request_text is not None:
-            updated_fresh_text = _text_with_account_installation_id(
-                request_state.fresh_upstream_request_text,
-                codex_installation_id,
-            )
+        # The memo holds the exact objects the previous call returned for this
+        # installation id; a text rewrite yields a new object and an account
+        # swap changes the id, so both miss and take the full stamp below.
+        memo_valid = request_state.installation_stamp_installation_id == codex_installation_id
+        if memo_valid and (
+            text_data is request_state.installation_stamp_text
+            or text_data is request_state.installation_stamp_fresh_text
+        ):
+            updated_text = text_data
+        else:
+            updated_text = _text_with_account_installation_id(text_data, codex_installation_id)
+        fresh_text = request_state.fresh_upstream_request_text
+        if fresh_text is not None and not (memo_valid and fresh_text is request_state.installation_stamp_fresh_text):
+            updated_fresh_text = _text_with_account_installation_id(fresh_text, codex_installation_id)
             _enforce_http_bridge_response_create_text_size(request_state, updated_fresh_text)
             request_state.fresh_upstream_request_text = updated_fresh_text
         if updated_text == text_data:
-            return text_data
-        request_state.request_text = updated_text
-        _enforce_response_create_size_limit(request_state)
+            updated_text = text_data
+        else:
+            request_state.request_text = updated_text
+            _enforce_response_create_size_limit(request_state)
+        request_state.installation_stamp_installation_id = codex_installation_id
+        request_state.installation_stamp_text = updated_text
+        request_state.installation_stamp_fresh_text = request_state.fresh_upstream_request_text
         return updated_text
 
     async def _inline_http_bridge_image_urls(

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1057,6 +1057,16 @@ class _WebSocketRequestState:
     # on, and dropping the anchor there would silently turn a continuation into
     # a context-free fresh turn.
     fresh_upstream_request_is_retry_safe: bool = False
+    # Memo for the account installation-id stamp applied to ``request_text`` /
+    # ``fresh_upstream_request_text`` on the HTTP bridge submit path. The stamp
+    # is re-applied at several submit and retry sites; these fields remember the
+    # exact ``str`` objects the last stamp returned for ``codex_installation_id``
+    # so an already-stamped object is recognised by identity instead of being
+    # decoded and re-encoded again. Every text rewrite yields a new ``str``
+    # object and an account swap changes the id, so both miss automatically.
+    installation_stamp_installation_id: str | None = None
+    installation_stamp_text: str | None = None
+    installation_stamp_fresh_text: str | None = None
     # Set only on the internally constructed one-shot request that replaces an
     # explicitly rejected stale anchor with a verified full-history payload.
     # It may bypass an older hard-key retry circuit without deleting that

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -286,6 +286,9 @@ from app.modules.proxy._service.http_bridge.helpers import (
 from app.modules.proxy._service.http_bridge.helpers import (
     _trim_http_bridge_previous_response_input_items as _trim_http_bridge_previous_response_input_items,
 )
+from app.modules.proxy._service.http_bridge.request_submit import (
+    _text_with_account_installation_id as _text_with_account_installation_id,
+)
 from app.modules.proxy._service.observability import (
     _hash_identifier as _hash_identifier,
 )
@@ -812,12 +815,8 @@ async def _wait_for_process_network_recovery(
 
 
 def _websocket_text_with_account_installation_id(text_data: str, account: Account) -> str:
-    payload = json.loads(text_data)
-    if not isinstance(payload, dict):
-        return text_data
     codex_installation_id = getattr(account, "codex_installation_id", None)
-    apply_codex_installation_metadata(cast(dict[str, JsonValue], payload), codex_installation_id)
-    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    return _text_with_account_installation_id(text_data, codex_installation_id)
 
 
 def _websocket_enforce_response_create_text_size(

--- a/openspec/changes/perf-bridge-installation-id-stamp/.openspec.yaml
+++ b/openspec/changes/perf-bridge-installation-id-stamp/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-09-03
+skip_specs: true

--- a/openspec/changes/perf-bridge-installation-id-stamp/context.md
+++ b/openspec/changes/perf-bridge-installation-id-stamp/context.md
@@ -1,0 +1,55 @@
+# Context: perf-bridge-installation-id-stamp
+
+## Purpose
+
+Pure performance refactor of the account installation-id stamp on the HTTP
+bridge and WebSocket relay paths. Output bytes are unchanged, so the governing
+requirements in `openspec/specs/upstream-proxy-routing/spec.md` ("Codex
+installation metadata must be account-owned") and
+`openspec/specs/responses-api-compat/spec.md` ("Selected Codex installation
+identity is internally consistent") need no delta.
+
+## Decisions
+
+- **Memo keyed on (installation id, `str` identity), not on content.** The
+  submit path re-stamps the same text at four method-body-level sites and the
+  retry paths re-stamp again. Every transformation that can change the frame
+  (`_text_without_operation_id`, `_text_with_previous_response_id`,
+  `_text_with_operation_id`, image inlining, slimming) returns a new `str`
+  object, and `replace_connection` changes the account and therefore the id, so
+  identity plus id is a sufficient and allocation-free cache key. The memo is
+  overwritten on every slow-path call with exactly the objects that call
+  returned, so a hit always means "the previous call under this id returned
+  this object".
+- **Splice instead of a recorded span.** The frame is our own compact
+  `json.dumps` output; compact encoding is compositional, so rewriting the
+  trailing `,"client_metadata":{...}}` segment (or appending one when the key
+  is absent) yields the same bytes as decode/rewrite/encode. Recording a span or
+  tail on the request state was rejected because fresh texts come from
+  discarded prepare states, and moving `client_metadata` to the last key was
+  rejected because it would change `durable_bridge_operation_fingerprint`
+  values persisted in `HttpBridgeOperationRecord.request_fingerprint`.
+- **Fallback stays the reference implementation.** Body-carried
+  `client_metadata` that precedes `type`, Responses-Lite frames where the
+  finalizer appends `reasoning` after `client_metadata`, nested keys, a leading
+  `client_metadata` key and non-object frames all take the original
+  decode/encode path.
+
+## Constraints and failure modes
+
+- The splice presumes a compact, canonical frame (no whitespace, insertion
+  order). All bridge and relay texts are produced in-process by that encoder;
+  for a non-canonical frame the splice still stamps correctly but would leave
+  the untouched prefix un-normalised where the old path would have re-encoded
+  it.
+- A hit skips the deterministic size re-check on an unchanged fresh text; the
+  check still runs once for every distinct stamped object.
+- Retry sites that pass a different session or text object miss and re-stamp.
+
+## Example
+
+A 216 KB Codex CLI frame with `client_metadata` as the last key: the four
+sequential stamps previously cost ~2.7 ms x 4 of decode/encode (x86); with this
+change the first stamp costs ~0.02 ms and the remaining three are identity
+checks. API-key/SDK traffic without `client_metadata` takes the insertion form
+(~0.16 ms, dominated by the substring scan and the single copy).

--- a/openspec/changes/perf-bridge-installation-id-stamp/proposal.md
+++ b/openspec/changes/perf-bridge-installation-id-stamp/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The HTTP bridge stamps the selected account's `x-codex-installation-id` into
+`client_metadata` at four sequential submit sites (pre-ledger, pre-admission,
+pre-send, final submit) plus the retry paths. Each stamp decodes and re-encodes
+the whole `response.create` frame (50-500 KB) even though calls two to four are
+idempotent no-ops and only a ~200-byte top-level object ever changes. On the
+single-core production deployment this helper is the largest app-attributed
+frame in the 60 s GIL profile (130/1085 samples, 12%), and the fresh
+(anchor-free) retry text doubles the cost when it is present.
+
+## What Changes
+
+- Memoize the stamp result on the request state by installation id and `str`
+  identity, so re-stamping an already-stamped text object is O(1). Every text
+  rewrite yields a new `str` object and an account swap changes the id, so both
+  miss and take the full path automatically. The pre-existing size check on the
+  fresh text runs once per stamped object instead of once per call.
+- Replace the first-pass full decode/encode with a byte-identical splice of the
+  trailing top-level `client_metadata` value (or an insertion when the key is
+  absent). Any other frame shape falls back to the existing decode/encode path.
+- The WebSocket relay reuses the same splice-first helper.
+- No spec delta: wire bytes, `request_text`, persisted operation fingerprints
+  and the account-owned installation-id contract are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- None. `upstream-proxy-routing` ("Codex installation metadata must be
+  account-owned") and `responses-api-compat` ("Selected Codex installation
+  identity is internally consistent") keep their requirements; this change only
+  makes the implementation cheaper while producing identical output.
+
+## Impact
+
+- Affected code: `app/modules/proxy/_service/http_bridge/request_submit.py`
+  (`_text_with_account_installation_id`,
+  `_http_bridge_text_with_account_installation_id`),
+  `app/modules/proxy/_service/support.py` (`_WebSocketRequestState` memo
+  fields), `app/modules/proxy/_service/websocket/mixin.py`
+  (`_websocket_text_with_account_installation_id`).
+- Tests: `tests/unit/test_proxy_http_bridge.py`, `tests/unit/test_proxy_utils.py`.
+- Expected production effect: helper share of GIL samples falls from ~12% to
+  under 2%; re-profile with `py-spy --gil` after deploy.

--- a/openspec/changes/perf-bridge-installation-id-stamp/tasks.md
+++ b/openspec/changes/perf-bridge-installation-id-stamp/tasks.md
@@ -1,0 +1,28 @@
+## 1. Memoize the bridge installation-id stamp
+
+- [x] 1.1 Add `installation_stamp_installation_id`, `installation_stamp_text`
+  and `installation_stamp_fresh_text` to `_WebSocketRequestState`.
+- [x] 1.2 In `_http_bridge_text_with_account_installation_id`, return the text
+  untouched when the installation id matches and the object is one the previous
+  call returned (main or fresh); skip the fresh re-stamp and size re-check on
+  the same condition; record the returned objects after the size checks pass.
+
+## 2. Splice the first stamp
+
+- [x] 2.1 Add `_splice_account_installation_id`: rewrite the trailing top-level
+  `client_metadata` value in place, insert it when the key is absent, and
+  return `None` for any other shape so the existing decode/encode path runs.
+- [x] 2.2 Route `_text_with_account_installation_id` and the WebSocket
+  `_websocket_text_with_account_installation_id` through the splice first.
+
+## 3. Verification
+
+- [x] 3.1 Unit tests: exactly one frame decode across four sequential stamps;
+  account swap, id change and text rewrite force a re-stamp; fresh-text memo
+  and size check; property test asserting splice == decode/encode output
+  byte-for-byte across client_metadata position, id value and value types.
+- [x] 3.2 Run `tests/unit/test_proxy_http_bridge.py`, `tests/unit/test_proxy_utils.py`,
+  ruff, ty, `scripts/check_proxy_architecture.py` and `openspec validate`.
+- [ ] 3.3 Post-deploy: `py-spy --gil` 60 s confirms the helper below 2% of GIL
+  samples and count "Waiting for account capacity before retrying HTTP bridge
+  submit" log lines per hour to confirm the resubmit-loop hypothesis.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -21,12 +21,18 @@ import aiohttp
 import anyio
 import pytest
 from fastapi import WebSocket
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
 from app.core.auth.refresh import RefreshError
-from app.core.clients.proxy import CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY, ProxyResponseError
+from app.core.clients.proxy import (
+    CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY,
+    ProxyResponseError,
+    apply_codex_installation_metadata,
+)
 from app.core.clients.proxy_websocket import (
     UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE,
     CodexUpstreamWebSocket,
@@ -69,6 +75,7 @@ from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_e
 from app.modules.proxy.http_bridge_event_batcher import TerminalOperationEventAppendResult
 from app.modules.proxy.http_bridge_forwarding import OwnerForwardRelayFailure
 from app.modules.proxy.load_balancer import CONTINUITY_OWNER_UNAVAILABLE, CatalogOmissionQuotaAdmission
+from tests.unit.hypothesis_strategies import json_values as hypothesis_json_values
 
 pytestmark = pytest.mark.unit
 
@@ -8110,6 +8117,254 @@ def test_submit_http_bridge_request_uses_bridge_installation_metadata_helper() -
 
     assert "_response_create_text_with_account_installation_id(" not in source
     assert source.count("_http_bridge_text_with_account_installation_id(") >= 3
+
+
+_real_json_loads = json.loads
+
+
+def _reference_text_with_account_installation_id(text_data: str, codex_installation_id: str | None) -> str:
+    """The pre-splice decode/rewrite/encode implementation, kept as the byte oracle."""
+    payload = _real_json_loads(text_data)
+    if not isinstance(payload, dict):
+        return text_data
+    apply_codex_installation_metadata(payload, codex_installation_id)
+    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _count_json_loads(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every ``json.loads`` input (frame, client_metadata segment, turn metadata)."""
+    decoded: list[str] = []
+    real_loads = json.loads
+
+    def counting_loads(text: str, *args: Any, **kwargs: Any) -> Any:
+        decoded.append(text)
+        return real_loads(text, *args, **kwargs)
+
+    monkeypatch.setattr(http_bridge_request_submit_module.json, "loads", counting_loads)
+    return decoded
+
+
+def _prepare_stamp_fixture(
+    service: proxy_service.ProxyService,
+) -> tuple[proxy_service._WebSocketRequestState, str]:
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "caf\u00e9 \u2014 large",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi " * 2000}]}],
+        }
+    )
+    return service._prepare_http_bridge_request(
+        payload,
+        {"x-codex-turn-metadata": '{"installation_id":"client-installation","turn_id":"payload-turn"}'},
+        api_key=None,
+        api_key_reservation=None,
+    )
+
+
+def test_http_bridge_installation_stamp_decodes_frame_once_across_sequential_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.account.codex_installation_id = "account-installation"
+    request_state, text_data = _prepare_stamp_fixture(service)
+    expected = _reference_text_with_account_installation_id(text_data, "account-installation")
+    decoded = _count_json_loads(monkeypatch)
+
+    first = service._http_bridge_text_with_account_installation_id(session, request_state, text_data)
+    decodes_after_first = len(decoded)
+    second = service._http_bridge_text_with_account_installation_id(session, request_state, first)
+    third = service._http_bridge_text_with_account_installation_id(session, request_state, second)
+    fourth = service._http_bridge_text_with_account_installation_id(session, request_state, third)
+
+    assert first == expected
+    assert second is first and third is first and fourth is first
+    assert request_state.request_text is first
+    # The splice decodes the client_metadata segment (and its turn metadata), never the frame.
+    assert [text for text in decoded if len(text) >= 1024] == []
+    assert decoded and all(text.startswith("{") for text in decoded)
+    assert len(decoded) == decodes_after_first
+    assert http_bridge_request_submit_module._text_without_account_installation_id(
+        first
+    ) == http_bridge_request_submit_module._text_without_account_installation_id(text_data)
+
+
+def test_http_bridge_installation_stamp_memo_misses_on_account_swap_and_text_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.account.codex_installation_id = "account-a"
+    request_state, text_data = _prepare_stamp_fixture(service)
+    decoded = _count_json_loads(monkeypatch)
+
+    stamped_a = service._http_bridge_text_with_account_installation_id(session, request_state, text_data)
+    decodes = len(decoded)
+    assert decodes > 0
+    assert service._http_bridge_text_with_account_installation_id(session, request_state, stamped_a) is stamped_a
+    assert len(decoded) == decodes
+
+    session.account.codex_installation_id = "account-b"
+    stamped_b = service._http_bridge_text_with_account_installation_id(session, request_state, stamped_a)
+    assert stamped_b is not stamped_a
+    assert stamped_b == _reference_text_with_account_installation_id(stamped_a, "account-b")
+    assert _real_json_loads(stamped_b)["client_metadata"]["x-codex-installation-id"] == "account-b"
+    assert len(decoded) > decodes
+    decodes = len(decoded)
+
+    cast(Any, session.account).codex_installation_id = None
+    unstamped = service._http_bridge_text_with_account_installation_id(session, request_state, stamped_b)
+    assert unstamped == _reference_text_with_account_installation_id(stamped_b, None)
+    assert "x-codex-installation-id" not in _real_json_loads(unstamped)["client_metadata"]
+    assert len(decoded) > decodes
+    decodes = len(decoded)
+
+    session.account.codex_installation_id = "account-b"
+    restamped = service._http_bridge_text_with_account_installation_id(session, request_state, unstamped)
+    assert restamped == stamped_b
+    assert len(decoded) > decodes
+
+    rewritten = http_bridge_request_submit_module._text_with_operation_id(restamped, "op_rewrite")
+    decoded.clear()
+    stamped_rewritten = service._http_bridge_text_with_account_installation_id(session, request_state, rewritten)
+    assert stamped_rewritten == _reference_text_with_account_installation_id(rewritten, "account-b")
+    decodes = len(decoded)
+    assert decodes > 0
+    assert service._http_bridge_text_with_account_installation_id(session, request_state, stamped_rewritten) is (
+        stamped_rewritten
+    )
+    assert len(decoded) == decodes
+    # No path above decoded the whole frame: every stamp went through the splice.
+    assert [text for text in decoded if len(text) >= 1024] == []
+
+
+def test_http_bridge_installation_stamp_memoizes_fresh_text_and_size_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.account.codex_installation_id = "account-installation"
+    request_state, text_data = _prepare_stamp_fixture(service)
+    fresh_text = json.dumps(
+        {"type": "response.create", "model": "gpt-5.4", "input": [], "client_metadata": {"k": "v"}},
+        separators=(",", ":"),
+    )
+    request_state.fresh_upstream_request_text = fresh_text
+    size_checks: list[str] = []
+    real_size_check = http_bridge_request_submit_module._enforce_http_bridge_response_create_text_size
+
+    def counting_size_check(state: proxy_service._WebSocketRequestState, checked: str) -> None:
+        size_checks.append(checked)
+        real_size_check(state, checked)
+
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_enforce_http_bridge_response_create_text_size",
+        counting_size_check,
+    )
+    decoded = _count_json_loads(monkeypatch)
+
+    stamped = service._http_bridge_text_with_account_installation_id(session, request_state, text_data)
+    stamped_fresh = request_state.fresh_upstream_request_text
+    assert stamped_fresh == _reference_text_with_account_installation_id(fresh_text, "account-installation")
+    assert size_checks == [stamped_fresh]
+    decodes = len(decoded)
+    assert decodes > 0
+
+    for _ in range(3):
+        assert service._http_bridge_text_with_account_installation_id(session, request_state, stamped) is stamped
+    assert request_state.fresh_upstream_request_text is stamped_fresh
+    assert size_checks == [stamped_fresh]
+    assert len(decoded) == decodes
+
+    # The pre-admission retry path submits the fresh text itself as the request text.
+    assert (
+        service._http_bridge_text_with_account_installation_id(session, request_state, stamped_fresh) is stamped_fresh
+    )
+    assert len(decoded) == decodes
+
+    # A new fresh object (equal bytes) is a different stamp target and is size-checked again.
+    request_state.fresh_upstream_request_text = "".join(stamped_fresh)
+    assert service._http_bridge_text_with_account_installation_id(session, request_state, stamped) is stamped
+    assert request_state.fresh_upstream_request_text is not None
+    assert size_checks == [stamped_fresh, request_state.fresh_upstream_request_text]
+    assert len(decoded) > decodes
+
+    # A size failure on the fresh text keeps the memo untouched so the next call re-checks.
+    oversized_fresh = json.dumps({"type": "response.create", "input": "x" * 64}, separators=(",", ":"))
+    request_state.fresh_upstream_request_text = oversized_fresh
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 65, raising=False)
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 64, raising=False)
+    with pytest.raises(proxy_service.ProxyResponseError):
+        service._http_bridge_text_with_account_installation_id(session, request_state, stamped)
+    assert request_state.installation_stamp_fresh_text is not oversized_fresh
+    with pytest.raises(proxy_service.ProxyResponseError):
+        service._http_bridge_text_with_account_installation_id(session, request_state, stamped)
+
+
+_STAMP_SPLICE_METADATA = st.dictionaries(
+    st.text(max_size=12).filter(lambda key: key.lower() not in {"client_metadata", "x-codex-installation-id"}),
+    hypothesis_json_values,
+    max_size=4,
+)
+_STAMP_SPLICE_TURN_METADATA = st.one_of(
+    st.none(),
+    st.just('{"installation_id":"client","turn_id":"t"}'),
+    st.just('{"turn_id":"t"}'),
+    st.just("not json"),
+    st.just("[1]"),
+)
+
+
+@given(
+    metadata=_STAMP_SPLICE_METADATA,
+    turn_metadata=_STAMP_SPLICE_TURN_METADATA,
+    include_client_installation_id=st.booleans(),
+    codex_installation_id=st.sampled_from(["account-installation", None, ""]),
+    position=st.sampled_from(["first", "middle", "last", "absent"]),
+    extra=hypothesis_json_values,
+)
+@settings(deadline=None, max_examples=300)
+def test_http_bridge_installation_stamp_splice_matches_reference_bytes(
+    metadata: dict[str, Any],
+    turn_metadata: str | None,
+    include_client_installation_id: bool,
+    codex_installation_id: str | None,
+    position: str,
+    extra: Any,
+) -> None:
+    client_metadata = dict(metadata)
+    if turn_metadata is not None:
+        client_metadata["x-codex-turn-metadata"] = turn_metadata
+    if include_client_installation_id:
+        client_metadata["x-codex-installation-id"] = "client-installation"
+    payload: dict[str, Any] = {}
+    if position == "first":
+        payload["client_metadata"] = client_metadata
+    payload.update({"model": "gpt-5.4", "input": [{"role": "user", "content": "caf\u00e9 \U0001f600"}], "extra": extra})
+    if position == "middle":
+        payload["client_metadata"] = client_metadata
+    payload.update({"reasoning": {"effort": "high"}, "store": False, "type": "response.create"})
+    if position == "last":
+        payload["client_metadata"] = client_metadata
+    text_data = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+    expected = _reference_text_with_account_installation_id(text_data, codex_installation_id)
+    stamped = http_bridge_request_submit_module._text_with_account_installation_id(text_data, codex_installation_id)
+    spliced = http_bridge_request_submit_module._splice_account_installation_id(text_data, codex_installation_id)
+
+    assert stamped == expected
+    assert http_bridge_request_submit_module._text_with_account_installation_id(stamped, codex_installation_id) == (
+        expected
+    )
+    if position in {"first", "middle"}:
+        assert spliced is None
+    elif text_data.count('"client_metadata"') == (1 if position == "last" else 0):
+        # Trailing or absent top-level key with no look-alike elsewhere: the splice must run.
+        assert spliced == expected
+        if spliced == text_data:
+            assert spliced is text_data
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5343,6 +5343,37 @@ def test_response_create_client_metadata_strips_installation_id_without_account_
     assert metadata is None
 
 
+def test_websocket_installation_metadata_stamping_matches_full_reencode() -> None:
+    account = cast(Any, SimpleNamespace(id="acc_ws_installation", codex_installation_id="account-installation"))
+    trailing = json.dumps(
+        {
+            "type": "response.create",
+            "input": [{"role": "user", "content": "caf\u00e9"}],
+            "client_metadata": {
+                "x-codex-installation-id": "client-installation",
+                "x-codex-turn-metadata": '{"installation_id":"client-installation","turn_id":"t"}',
+            },
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    leading = json.dumps(
+        {"client_metadata": {"k": "v"}, "type": "response.create", "input": "x"},
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    absent = '{"type":"response.create","input":"x"}'
+
+    for text in (trailing, leading, absent):
+        payload = json.loads(text)
+        proxy_module.apply_codex_installation_metadata(payload, "account-installation")
+        expected = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+        stamped = websocket_mixin._websocket_text_with_account_installation_id(text, account)
+        assert stamped == expected
+        assert json.loads(stamped)["client_metadata"]["x-codex-installation-id"] == "account-installation"
+        assert websocket_mixin._websocket_text_with_account_installation_id(stamped, account) == expected
+
+
 def test_websocket_installation_metadata_stamping_rechecks_response_create_size(monkeypatch):
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_ws_installation_size",


### PR DESCRIPTION
## Summary

The HTTP bridge stamps the selected account's `x-codex-installation-id` into the `response.create` frame's top-level `client_metadata` at four sequential, unconditional sites inside `_submit_http_bridge_request_with_handoff` (pre-ledger, pre-admission, pre-send, final submit) plus the retry paths. Each stamp did a full `json.loads` + `json.dumps` of the whole 50-500 KB frame, even though calls 2-4 are idempotent no-ops and only a ~200-byte top-level object can ever change. When `fresh_upstream_request_text` (anchor-free retry text) is set, every call also round-tripped that text and re-ran the utf-8 size check.

**Production evidence (soju07, 2x Neoverse-N1, workers=1, v1.25.0-beta.1, 2026-09-03 py-spy `--gil` 60 s / 1085 samples, CPU pegged ~100% at ~10k req/h):** this helper is the single largest app-attributed frame: 130/1085 inclusive samples = **12.0%** (`_http_bridge_text_with_account_installation_id` 9.7% incl / 5.2% self, leaf children `iterencode` 52 + `raw_decode` 13 samples). Per-site split 6/6/5/113 - the 4th stamp (final submit, after image inlining) dominates, plausibly re-run by the capacity-wait resubmit loop. stdlib `json` is 14.4% of all GIL leaf samples and this helper accounts for most of the `json.dumps` share.

This PR makes the stamp O(1) after the first application and makes the first application O(size of `client_metadata`) instead of O(size of frame), without touching the four call sites (the `>= 3 call sites` guard test stays valid) and with byte-identical output.

## Change details

- `app/modules/proxy/_service/support.py` - `_WebSocketRequestState` gains three memo slots: `installation_stamp_installation_id`, `installation_stamp_text`, `installation_stamp_fresh_text` (plain `str` references, no copies).
- `app/modules/proxy/_service/http_bridge/request_submit.py`
  - `_http_bridge_text_with_account_installation_id`: fast path when the installation id matches and `text_data is` the main or fresh object the previous call returned - returns `text_data` untouched and leaves `request_state.request_text` alone (same as today's `updated_text == text_data` branch). Slow path is unchanged (stamp, `request_text` update, fresh-text stamp + `_enforce_http_bridge_response_create_text_size`), and the memo is written only after both size checks pass, with the objects that call actually returned.
  - `_text_with_account_installation_id` / new `_splice_account_installation_id`: `rfind(',"client_metadata":')` on a frame ending in `}`; if the extracted tail decodes to a dict, apply the existing `apply_codex_installation_metadata` to that small dict and splice the compact re-encoding back (dropping the key when it empties). When `client_metadata` is absent (plain API-key/SDK traffic) use the insertion form. Any other shape (leading/middle `client_metadata`, nested key, non-dict value, Responses-Lite frame with `reasoning` appended after) falls back to the existing decode/encode path.
- `app/modules/proxy/_service/websocket/mixin.py` - `_websocket_text_with_account_installation_id` delegates to the same splice-first helper (import direction verified acyclic; the WS loop only stamps prepared compact frames).
- Tests: `tests/unit/test_proxy_http_bridge.py` (+4), `tests/unit/test_proxy_utils.py` (+1).
- OpenSpec: `openspec/changes/perf-bridge-installation-id-stamp/` (proposal, tasks, context, `.openspec.yaml`).

Diff: 514+/16- (498 net), one concern (perf of the installation-id stamp).

## Byte-compat / behavior notes

- **Wire bytes, `request_state.request_text`, and persisted `durable_bridge_operation_fingerprint` are unchanged.** Compact `json.dumps(ensure_ascii=True, separators=(",", ":"))` is compositional, so replacing only the `client_metadata` value segment yields the same bytes as re-dumping the mutated dict. `client_metadata` is deliberately NOT reordered to the last key (that would change persisted fingerprints across the deploy boundary). Verified against the old `loads/apply/dumps` oracle: 84 hand-built edge combinations + 9 degenerate frames, a 300-example hypothesis property test in-tree, and 40,000 random canonical frames + 33 adversarial shapes in adversarial verification - all byte-identical and idempotent, same exception types on degenerate input.
- The splice presumes the frame is our own compact canonical encoding (every in-tree producer is). For a hypothetical non-canonical frame (whitespace, raw non-ASCII, duplicate keys) the splice still stamps correctly but would not re-normalise the untouched prefix, and an invalid-JSON prefix would no longer raise `JSONDecodeError` at stamp time. No such producer exists today.
- **Accepted behavior delta:** the deterministic size check on an unchanged fresh text runs once per stamped object instead of at every call, and warn-threshold logs for an oversized frame are emitted once instead of 4x. Concrete trigger for the difference: a settings reload that lowers the size limit mid-request would only be enforced on the next new text object, not on the already-stamped one. The memo is populated only after the size check passes, so a failing check still raises on the next call.
- Memo correctness: every text rewrite (`_text_with_operation_id`, `_text_with_previous_response_id`, `_inline_http_bridge_image_urls`, slimming, `_text_without_operation_id`) returns a new `str`, and an account swap (`replace_connection`) changes the id, so both miss and take the full path. On every slow-path call the memo is fully overwritten with that call's returned objects, closing a stale-fresh-memo hole (fresh object stamped under account A, fresh cleared, swap to B, fresh restored).

## Expected gain

Plan estimate: ~9-11% of GIL samples in the profiled window (memo removes stamps 2-4 = 3/4 of the main-text cost; splice cuts the remaining first stamp ~10-30x). Steady-state floor from first principles ~3-4% of one core.

Micro-benchmark (x86 py3.14, 216-221 KB realistic Codex frame, n=300, 4 sequential stamps as in production, outputs asserted equal to the pre-PR helper):

| Shape | before | after |
|---|---|---|
| `client_metadata` last, no fresh text | 5.23 ms | 0.086 ms |
| `client_metadata` last, fresh text set | 7.74 ms | 1.10 ms (bench artifact: synthetic fresh text takes the fallback once) |
| `client_metadata` absent (API-key/SDK, insertion form), no fresh | 3.91 ms | 0.146 ms |
| `client_metadata` absent, fresh set | 9.02 ms | 0.276 ms |
| `client_metadata` middle (fallback shape), no fresh | 3.98 ms | 1.34 ms |
| `client_metadata` middle, fresh set | 8.77 ms | 2.56 ms |

Single first stamp: 2.7 ms -> 0.024 ms (cm last), 2.6 ms -> 0.16 ms (absent). Adversarial verification independently measured 5.78 ms -> 0.076 ms for 4 stamps on a 200 KB frame with fresh text, size checks 5 -> 2. N1 cores are ~2-3x slower, so production savings per request are proportionally larger.

## OpenSpec

Change folder `openspec/changes/perf-bridge-installation-id-stamp/` with `proposal.md`, `tasks.md`, `context.md` and `.openspec.yaml` carrying `skip_specs: true`. Rationale: this is a pure perf refactor with byte-identical output; the governing requirements - `upstream-proxy-routing` "Codex installation metadata must be account-owned" and `responses-api-compat` "Selected Codex installation identity is internally consistent" - are unchanged, so there is no delta to write. `openspec validate perf-bridge-installation-id-stamp --strict` is valid; `openspec validate --specs` is 57 passed / 1 failed with only the pre-existing `model-source-routing` failure on main. Note: this is the first spec-less change folder in the repo that relies on `skip_specs`; happy to convert to a no-op delta if maintainers prefer.

## Tests

New (all in `tests/unit`):

- `test_http_bridge_installation_stamp_decodes_frame_once_across_sequential_calls` - `json.loads` counter: the frame (>= 1 KiB) is never decoded across 4 sequential stamps, calls 2-4 return the identical object, `request_text` is the stamped object, fingerprint via `_text_without_account_installation_id` unchanged.
- `test_http_bridge_installation_stamp_memo_misses_on_account_swap_and_text_rewrite` - id A->B, B->None, None->B and a `_text_with_operation_id` rewrite each force a re-stamp equal to the decode/encode oracle; memo hits afterwards; no frame decode at any point.
- `test_http_bridge_installation_stamp_memoizes_fresh_text_and_size_check` - fresh text stamped + size-checked once, 3 further calls skip both, passing the fresh object as `text_data` (pre-admission retry pattern) hits, a new equal-bytes fresh object re-stamps and re-checks, a size failure leaves the memo untouched and re-raises on the next call.
- `test_http_bridge_installation_stamp_splice_matches_reference_bytes` - hypothesis, 300 examples: `client_metadata` first/middle/last/absent x id set/None/'' x turn-metadata variants x client-supplied installation id x random JSON values (non-ASCII, floats, nested); asserts splice == old loads/dumps byte-for-byte, idempotent re-application, fallback taken for first/middle, splice taken for trailing/absent, identity preserved when unchanged.
- `test_websocket_installation_metadata_stamping_matches_full_reencode` (`test_proxy_utils.py`) - WS helper equals full re-encode for trailing, leading and absent `client_metadata` shapes.

How they fail without the fix: with the three app files swapped back to `origin/main`, the four bridge tests fail (4 failed / 1 passed - the decode counter sees frame decodes, memo tests see re-stamps and repeated size checks); the WS test is an equivalence test and passes on both, as expected for a mirror.

Gates (worktree, `./.venv/bin/python`): `pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_websocket*.py` -> 2248 passed, 1 failed; the single failure `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` (sqlite `no such table: file_account_pins`) is pre-existing and reproduces identically on a pristine `origin/main` checkout in the same environment - CI is authoritative. `ruff check .` / `ruff format --check .` clean, `ty check` clean, `scripts/check_proxy_architecture.py` passed, CHANGELOG untouched.

## Review trail

- Local `codex review --base origin/main` (round 1): no actionable findings ("The splice preserves canonical serialized output, and the identity memo correctly invalidates when either the text object or installation ID changes"). 2 informational P3 notes (memo slot overwrite on a fresh-identity hit costs one cheap re-stamp; non-canonical prefixes not re-normalised, unreachable today). 0 blocking.
- Adversarial verification (round 1): approve. 40,000 random canonical frames + 33 adversarial hand shapes byte-identical to the origin/main oracle; differential simulation of the verbatim origin/main method vs the new one over 20,000 random op sequences (stamps, retry-with-fresh-as-text, rewrites, fresh set/None/restore, account swaps incl. None/'', external `request_text` reassignment) shows zero divergence in return value, `request_text`, fresh text, or exceptions with a fixed size limit. 3 P3 notes (the `skip_specs` precedent claim was corrected above; the settings-reload trigger for the size-check delta is recorded above). 0 P0-P2.
- Findings fixed during implementation: 1 `ty` diagnostic in a test (`cast(Any, ...)` for assigning `None` to `Account.codex_installation_id`).

## Deploy notes / hazards

- No config, migration, or env changes. Safe to roll in either direction; the stamped bytes are identical to those produced by the current release, so in-flight durable operation fingerprints stay stable across the deploy.
- Sibling PR `perf-request-shaping-dedupe` edits `_prepare_http_bridge_request` / `_prepare_response_bridge_request_state` in the same file; hunks are disjoint, but both add imports/tests to `tests/unit/test_proxy_http_bridge.py`, so a trivial import-block conflict is possible on rebase (this PR is ordered first in the campaign plan).
- Post-deploy verification (tasks.md 3.3): `py-spy --gil` rate 10-20 for 60 s, expecting the helper to fall from ~12% to < 2% of GIL samples and the `json.dumps` leaf share from ~10% to ~4-5%; count `Waiting for account capacity before retrying HTTP bridge submit` lines/h to confirm the resubmit-loop hypothesis behind the 4th-site skew.
- Campaign-wide upgrade hazard (unrelated to this PR but relevant to any deploy from main): main rejects `http://user:pw@` proxy endpoints since #1995 (`plaintext_proxy_credentials_forbidden`); production endpoints must be re-created as `https://` or credential-less before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved proxy request processing by reducing repeated installation-ID stamping work.
  * Optimized WebSocket and HTTP bridge handling while preserving existing request output and behavior.
  * Repeated submissions now avoid unnecessary processing when the request and installation ID are unchanged.

* **Reliability**
  * Added broader validation to ensure installation metadata remains correct across varied request formats and account changes.

* **Documentation**
  * Documented the performance improvements and confirmed that wire-format behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->