### PR TITLE
fix(proxy): release the aiohttp ClientResponse when a routed SSE stream stops before EOF

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import secrets
 from dataclasses import dataclass
@@ -120,19 +121,39 @@ class _PreparedNativeRequest:
     response_head_timeout_seconds: float | None
 
 
+async def release_codex_response(response: Any) -> None:
+    """Release an unbuffered upstream response once its consumer stops reading.
+
+    Streams routinely end before body EOF (terminal SSE event, idle timeout,
+    cancellation, downstream disconnect). Closing the owning session alone
+    leaves the aiohttp ``Connection`` acquired, so the cyclic GC later finalizes
+    it as ``Unclosed connection``. Duck-typed on purpose: aiohttp exposes
+    ``release()``, the native egress response exposes ``aclose()``, and buffered
+    or test responses expose neither.
+    """
+    for name in ("release", "close", "aclose"):
+        method = getattr(response, name, None)
+        if callable(method):
+            result = method()
+            if inspect.isawaitable(result):
+                await result
+            return
+
+
 class _SessionOwnedContent:
-    def __init__(self, content: Any, session: aiohttp.ClientSession) -> None:
-        self._content = content
+    def __init__(self, response: Any, session: aiohttp.ClientSession) -> None:
+        self._response = response
         self._session = session
 
     def iter_chunked(self, size: int) -> Any:
-        return self._iter_and_close(self._content.iter_chunked(size))
+        return self._iter_and_close(self._response.content.iter_chunked(size))
 
     async def _iter_and_close(self, iterator: Any) -> Any:
         try:
             async for chunk in iterator:
                 yield chunk
         finally:
+            await release_codex_response(self._response)
             await self._session.close()
 
 
@@ -143,7 +164,13 @@ class _SessionOwnedResponse:
         self.status = getattr(response, "status", getattr(response, "status_code", 0))
         self.status_code = getattr(response, "status_code", self.status)
         self.headers = getattr(response, "headers", {}) or {}
-        self.content = _SessionOwnedContent(response.content, session)
+        self.content = _SessionOwnedContent(response, session)
+
+    async def release(self) -> None:
+        try:
+            await release_codex_response(self._response)
+        finally:
+            await self._session.close()
 
     async def read(self) -> bytes:
         try:
@@ -156,7 +183,7 @@ class _SessionOwnedResponse:
                 return result.encode()
             return b""
         finally:
-            await self._session.close()
+            await self.release()
 
     async def text(self) -> str:
         return (await self.read()).decode("utf-8", errors="replace")

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import (
     Any,
     AsyncContextManager,
+    AsyncGenerator,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -44,6 +45,7 @@ from app.core.clients.codex import (
     CodexTransportError,
     codex_transport_error_message,
     create_codex_session,
+    release_codex_response,
     require_route_or_direct_egress_opt_in,
 )
 from app.core.clients.codex_version import get_codex_version_cache
@@ -560,6 +562,9 @@ class _CodexSSEResponse:
     async def text(self, *, encoding: str | None = None, errors: str = "strict") -> str:
         del encoding, errors
         return await _codex_response_text(self._response)
+
+    async def release(self) -> None:
+        await release_codex_response(self._response)
 
 
 class ProxyResponseError(Exception):
@@ -1425,7 +1430,7 @@ async def _iter_sse_events(
     resp: SSEResponse,
     idle_timeout_seconds: float,
     max_event_bytes: int,
-) -> AsyncIterator[str]:
+) -> AsyncGenerator[str, None]:
     async def _next_chunk() -> bytes:
         return await iterator.__anext__()
 
@@ -3569,26 +3574,33 @@ async def stream_responses(
     native_egress_client: NativeEgressClient | None = None,
 ) -> AsyncIterator[str]:
     effective_allow_direct_egress = allow_direct_egress or (route is None and session is not None)
-    async with lease_http_session(session) as client_session:
-        async for event_block in _stream_responses_with_session(
-            payload=payload,
-            headers=headers,
-            access_token=access_token,
-            account_id=account_id,
-            base_url=base_url,
-            raise_for_status=raise_for_status,
-            session=client_session,
-            upstream_stream_transport_override=upstream_stream_transport_override,
-            route=route,
-            codex_client=codex_client,
-            route_trace=route_trace,
-            allow_direct_egress=effective_allow_direct_egress,
-            codex_installation_id=codex_installation_id,
-            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
-            codex_lb_account_id=codex_lb_account_id,
-            suppress_live_usage=suppress_live_usage,
-            native_egress_client=native_egress_client,
-        ):
+    # aclosing() at every hop lets a consumer's aclose() reach the upstream
+    # response teardown synchronously instead of via the asyncgen finalizer.
+    async with (
+        lease_http_session(session) as client_session,
+        contextlib.aclosing(
+            _stream_responses_with_session(
+                payload=payload,
+                headers=headers,
+                access_token=access_token,
+                account_id=account_id,
+                base_url=base_url,
+                raise_for_status=raise_for_status,
+                session=client_session,
+                upstream_stream_transport_override=upstream_stream_transport_override,
+                route=route,
+                codex_client=codex_client,
+                route_trace=route_trace,
+                allow_direct_egress=effective_allow_direct_egress,
+                codex_installation_id=codex_installation_id,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                codex_lb_account_id=codex_lb_account_id,
+                suppress_live_usage=suppress_live_usage,
+                native_egress_client=native_egress_client,
+            )
+        ) as upstream_events,
+    ):
+        async for event_block in upstream_events:
             if not suppress_live_usage and (codex_lb_account_id or account_id) and EVENT_MARKER in event_block:
                 publish_live_usage(
                     parse_rate_limit_event_text(event_block),
@@ -3616,7 +3628,7 @@ async def _stream_responses_with_session(
     codex_lb_account_id: str | None = None,
     suppress_live_usage: bool = False,
     native_egress_client: NativeEgressClient | None = None,
-) -> AsyncIterator[str]:
+) -> AsyncGenerator[str, None]:
     settings = get_settings()
     headers = apply_codex_installation_headers(
         headers,
@@ -3757,10 +3769,11 @@ async def _stream_responses_with_session(
     async def _stream_via_http(
         current_headers: Mapping[str, str],
         current_timeout: aiohttp.ClientTimeout,
-    ) -> AsyncIterator[str]:
+    ) -> AsyncGenerator[str, None]:
         try:
-            async for event_block in _stream_via_http_attempt(current_headers, current_timeout):
-                yield event_block
+            async with contextlib.aclosing(_stream_via_http_attempt(current_headers, current_timeout)) as attempt:
+                async for event_block in attempt:
+                    yield event_block
         except aiohttp.SocketTimeoutError as exc:
             # A socket read timeout means the connection was established and
             # then produced nothing. That is an idle stream, not a transport
@@ -3771,12 +3784,13 @@ async def _stream_responses_with_session(
     async def _stream_via_http_attempt(
         current_headers: Mapping[str, str],
         current_timeout: aiohttp.ClientTimeout,
-    ) -> AsyncIterator[str]:
+    ) -> AsyncGenerator[str, None]:
         nonlocal status_code, last_stream_activity_at, error_code, error_message, seen_terminal
 
         if route is not None:
             owns_codex_client = codex_client is None
             active_codex_client = codex_client or CodexClient(create_codex_session())
+            raw_resp: Any = None
             try:
                 request_kwargs: dict[str, Any] = {
                     "json": payload_dict,
@@ -3866,41 +3880,53 @@ async def _stream_responses_with_session(
                     yield event_block
                     return
 
-                async for event_block in _iter_sse_events(
-                    cast(SSEResponse, resp),
-                    effective_idle_timeout,
-                    settings.max_sse_event_bytes,
-                ):
-                    last_stream_activity_at = time.monotonic()
-                    event_block = _normalize_sse_event_block(event_block)
-                    event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
-                        event_block,
-                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                async with contextlib.aclosing(
+                    _iter_sse_events(
+                        cast(SSEResponse, resp),
+                        effective_idle_timeout,
+                        settings.max_sse_event_bytes,
                     )
-                    if isinstance(normalized_event_type, str) and (
-                        normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
-                        or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
-                    ):
-                        seen_terminal = True
-                    archive_text(
-                        direction="server_to_codex",
-                        kind="responses",
-                        transport="http",
-                        text=event_block,
-                        account_id=account_id,
-                        method="POST",
-                        url=url,
-                        status_code=status_code,
-                        headers=current_headers,
-                        extra={"event_format": "sse"},
-                    )
-                    yield event_block
-                    if seen_terminal:
-                        break
+                ) as routed_events:
+                    async for event_block in routed_events:
+                        last_stream_activity_at = time.monotonic()
+                        event_block = _normalize_sse_event_block(event_block)
+                        event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
+                            event_block,
+                            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                        )
+                        if isinstance(normalized_event_type, str) and (
+                            normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                            or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
+                        ):
+                            seen_terminal = True
+                        archive_text(
+                            direction="server_to_codex",
+                            kind="responses",
+                            transport="http",
+                            text=event_block,
+                            account_id=account_id,
+                            method="POST",
+                            url=url,
+                            status_code=status_code,
+                            headers=current_headers,
+                            extra={"event_format": "sse"},
+                        )
+                        yield event_block
+                        if seen_terminal:
+                            break
                 return
             finally:
-                if owns_codex_client:
-                    await active_codex_client.close()
+                # The stream normally stops before body EOF (terminal event,
+                # idle timeout, cancellation, downstream disconnect). Release the
+                # response before the session goes away so the connection is
+                # returned or closed now instead of being finalized by the GC
+                # as "Unclosed connection".
+                try:
+                    if raw_resp is not None:
+                        await release_codex_response(raw_resp)
+                finally:
+                    if owns_codex_client:
+                        await active_codex_client.close()
 
         @asynccontextmanager
         async def _direct_response_context() -> AsyncIterator[aiohttp.ClientResponse | NativeEgressResponse]:
@@ -4005,37 +4031,40 @@ async def _stream_responses_with_session(
                 yield event_block
                 return
 
-            async for event_block in _iter_sse_events(
-                resp,
-                effective_idle_timeout,
-                settings.max_sse_event_bytes,
-            ):
-                last_stream_activity_at = time.monotonic()
-                event_block = _normalize_sse_event_block(event_block)
-                event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
-                    event_block,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            async with contextlib.aclosing(
+                _iter_sse_events(
+                    resp,
+                    effective_idle_timeout,
+                    settings.max_sse_event_bytes,
                 )
-                if isinstance(normalized_event_type, str) and (
-                    normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
-                    or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
-                ):
-                    seen_terminal = True
-                archive_text(
-                    direction="server_to_codex",
-                    kind="responses",
-                    transport="http",
-                    text=event_block,
-                    account_id=account_id,
-                    method="POST",
-                    url=url,
-                    status_code=status_code,
-                    headers=current_headers,
-                    extra={"event_format": "sse"},
-                )
-                yield event_block
-                if seen_terminal:
-                    break
+            ) as direct_events:
+                async for event_block in direct_events:
+                    last_stream_activity_at = time.monotonic()
+                    event_block = _normalize_sse_event_block(event_block)
+                    event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
+                        event_block,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                    )
+                    if isinstance(normalized_event_type, str) and (
+                        normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                        or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
+                    ):
+                        seen_terminal = True
+                    archive_text(
+                        direction="server_to_codex",
+                        kind="responses",
+                        transport="http",
+                        text=event_block,
+                        account_id=account_id,
+                        method="POST",
+                        url=url,
+                        status_code=status_code,
+                        headers=current_headers,
+                        extra={"event_format": "sse"},
+                    )
+                    yield event_block
+                    if seen_terminal:
+                        break
 
     _maybe_log_upstream_request_start(
         kind="responses",
@@ -4061,7 +4090,7 @@ async def _stream_responses_with_session(
         *,
         rejection_status: int | None,
         rejection_message: str,
-    ) -> AsyncIterator[str]:
+    ) -> AsyncGenerator[str, None]:
         nonlocal transport, upstream_headers, method, remaining_request_timeout, timeout, started_at, payload_dict
         nonlocal payload_json
 
@@ -4126,8 +4155,9 @@ async def _stream_responses_with_session(
             url=url,
             headers=upstream_headers,
         )
-        async for event_block in _stream_via_http(upstream_headers, timeout):
-            yield event_block
+        async with contextlib.aclosing(_stream_via_http(upstream_headers, timeout)) as http_events:
+            async for event_block in http_events:
+                yield event_block
 
     try:
         if transport == "websocket":
@@ -4177,22 +4207,29 @@ async def _stream_responses_with_session(
                     )
                     return
 
-                async for event_block in _stream_via_http_after_websocket_rejection(
-                    rejection_status=exc.status,
-                    rejection_message=str(exc),
-                ):
-                    yield event_block
+                async with contextlib.aclosing(
+                    _stream_via_http_after_websocket_rejection(
+                        rejection_status=exc.status,
+                        rejection_message=str(exc),
+                    )
+                ) as fallback_events:
+                    async for event_block in fallback_events:
+                        yield event_block
             except CodexTransportError as exc:
                 if not _should_fallback_to_http_after_codex_transport_error(transport_mode, exc):
                     raise
-                async for event_block in _stream_via_http_after_websocket_rejection(
-                    rejection_status=exc.status_code,
-                    rejection_message=str(exc),
-                ):
-                    yield event_block
+                async with contextlib.aclosing(
+                    _stream_via_http_after_websocket_rejection(
+                        rejection_status=exc.status_code,
+                        rejection_message=str(exc),
+                    )
+                ) as fallback_events:
+                    async for event_block in fallback_events:
+                        yield event_block
         else:
-            async for event_block in _stream_via_http(upstream_headers, timeout):
-                yield event_block
+            async with contextlib.aclosing(_stream_via_http(upstream_headers, timeout)) as http_events:
+                async for event_block in http_events:
+                    yield event_block
     except ProxyResponseError as exc:
         status_code = exc.status_code
         raise

--- a/openspec/changes/release-routed-upstream-stream-responses/proposal.md
+++ b/openspec/changes/release-routed-upstream-stream-responses/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Routed upstream streams (dashboard proxy pools, SOCKS routes, the aiohttp fallback
+behind the native egress helper) request the response unbuffered and consume it
+through the SSE framer. The consumer almost always stops before body EOF: the
+terminal `response.completed` event arrives while upstream keeps the keep-alive
+tunnel open, the idle timeout fires, the request is cancelled, or the downstream
+client disconnects. The only teardown on that path was closing the per-stream
+`ClientSession`, which closes the socket but never releases the `ClientResponse`.
+aiohttp then finalizes the still-acquired `Connection` from the cyclic GC and logs
+`ERROR asyncio Unclosed connection` with the `ConnectionKey` repr, which carries the
+proxy URL including its password.
+
+Production (v1.25.0-beta.1, 2026-09-03) showed 44 to 1350 of these lines per hour
+scaling with traffic, and a heap probe with ~170 dead
+`ClientSession`/`TCPConnector`/`ClientResponse`/`SSLProtocol` graphs pinned until the
+next full collection. The direct (non-routed) path is immune because it uses
+`async with session.post(...)`, whose exit releases the response.
+
+## What Changes
+
+- The routed HTTP streaming path releases the raw upstream response before closing
+  the per-stream client, on every exit: terminal-event break, idle timeout,
+  cancellation, downstream `aclose()`, oversized event, and non-2xx error mapping.
+- Release is duck-typed over the three response shapes the routed path can receive:
+  aiohttp `release()`, native egress `aclose()`, and buffered or test responses that
+  expose neither (no-op).
+- SOCKS-routed responses (`_SessionOwnedResponse`) release the wrapped response before
+  closing their private session, so the same guarantee holds there.
+- The SSE consumer chain (`stream_responses` down to the transport attempt) closes
+  its nested async generators under `contextlib.aclosing`, so a consumer's `aclose()`
+  reaches the upstream teardown synchronously instead of via the asyncgen finalizer.
+- Forwarded bytes, error mapping, retry classification, and cancellation semantics
+  are unchanged; release runs strictly after the last yielded event block.
+
+## Impact
+
+- Affected specs: `outbound-http-clients`
+- Affected code: `app/core/clients/proxy.py`, `app/core/clients/codex.py`
+- Operator-visible: the `Unclosed connection` error lines for routed HTTP streams
+  disappear, and the per-stream aiohttp graph is freed by refcount at stream end
+  instead of by the cyclic GC.
+- No new settings, no migration, no dashboard surface.
+- On Docker installs of current `main` the native egress helper serves the routed hot
+  path and aiohttp is fallback-only; this change covers that fallback, non-Docker
+  installs, and SOCKS routes.

--- a/openspec/changes/release-routed-upstream-stream-responses/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/release-routed-upstream-stream-responses/specs/outbound-http-clients/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Routed streaming upstream responses are released when the consumer stops before EOF
+
+When an upstream streaming request is issued through a resolved upstream proxy route,
+the response body is consumed unbuffered and the consumer routinely stops before the
+body reaches EOF: on the terminal stream event, on the stream idle timeout, on
+cancellation, on downstream disconnect, and when the response is mapped to an error
+before the body is drained. On every such exit the proxy MUST release or close the
+upstream response object before it closes the per-stream client that owns the
+connection, so the connection is returned or closed synchronously and no connection
+object is left to be finalized by the garbage collector.
+
+The release MUST work for every response shape the routed path can receive: an
+aiohttp response (`release()`), a native egress response (`aclose()`), and a buffered
+or duck-typed response that exposes neither (no-op). Responses obtained through a
+SOCKS route MUST release the wrapped response before closing the private session that
+carried it.
+
+Release MUST run only after the last event block has been yielded to the consumer and
+MUST NOT change the forwarded bytes, the error mapping, the retry classification, or
+the cancellation semantics of the stream.
+
+#### Scenario: Terminal event arrives while upstream holds the connection open
+
+- **GIVEN** a routed HTTP stream whose upstream emits `response.completed` and then keeps the connection open
+- **WHEN** the proxy stops reading on the terminal event
+- **THEN** the upstream response is released before the per-stream client is closed
+- **AND** no `Unclosed connection` event is reported to the event loop exception handler after a full garbage collection
+- **AND** the forwarded event blocks are byte-identical to the upstream frames
+
+#### Scenario: Stream idle timeout
+
+- **GIVEN** a routed HTTP stream whose upstream goes silent after the first event
+- **WHEN** the stream idle timeout elapses
+- **THEN** the synthetic `stream_idle_timeout` failure event is yielded as before
+- **AND** the upstream response is released before the per-stream client is closed
+
+#### Scenario: Cancellation or downstream disconnect mid-stream
+
+- **GIVEN** a routed HTTP stream that is cancelled, or whose consumer calls `aclose()`, while a body read is pending
+- **WHEN** the stream generator unwinds
+- **THEN** the upstream response is released before the per-stream client is closed
+- **AND** the cancellation propagates to the caller unchanged
+
+#### Scenario: Error status mapped before the body is drained
+
+- **GIVEN** a routed HTTP stream whose upstream answers with a non-2xx status
+- **WHEN** the proxy raises the mapped `ProxyResponseError`
+- **THEN** the upstream response is released before the per-stream client is closed
+
+#### Scenario: Response without a release method
+
+- **GIVEN** a routed response object that exposes neither `release()`, `close()` nor `aclose()`
+- **WHEN** the stream ends
+- **THEN** teardown is a no-op for the response and the stream result is unchanged

--- a/openspec/changes/release-routed-upstream-stream-responses/tasks.md
+++ b/openspec/changes/release-routed-upstream-stream-responses/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## 1. Release the routed response
+
+- [x] 1.1 Add the duck-typed `release_codex_response` helper in
+      `app/core/clients/codex.py` (`release()` -> `close()` -> `aclose()`, awaited
+      only when the result is awaitable)
+- [x] 1.2 Release the raw response in the routed branch of `_stream_via_http_attempt`
+      before the owned `CodexClient` is closed, on every exit path
+- [x] 1.3 Forward `release()` from `_CodexSSEResponse` to the wrapped response
+- [x] 1.4 SOCKS: `_SessionOwnedResponse.release()` releases the wrapped response then
+      closes the private session; `_SessionOwnedContent` and `read()` reuse it
+
+## 2. Deterministic generator teardown
+
+- [x] 2.1 Consume `_iter_sse_events` under `contextlib.aclosing` on both HTTP
+      streaming sites
+- [x] 2.2 Propagate `aclosing` through `stream_responses` ->
+      `_stream_responses_with_session` -> `_stream_via_http` ->
+      `_stream_via_http_attempt` (and the websocket-rejection HTTP fallback) so a
+      consumer's `aclose()` reaches the release synchronously
+
+## 3. Verification
+
+- [x] 3.1 Unit: release ordering (release before client close) for terminal break,
+      downstream `aclose()`, cancellation, idle timeout, non-2xx error, an
+      aclose-only (native egress shaped) response, and a response without either
+- [x] 3.2 Unit: SOCKS session-owned response releases before closing its session
+- [x] 3.3 Integration: real aiohttp client against an aiohttp.web HTTP proxy that holds
+      the tunnel open; zero `Unclosed connection` loop exception-handler events after
+      `gc.collect()`, `response.closed`, `response.connection is None`, forwarded
+      bytes identical to the upstream frames; repeated for the idle-timeout exit
+- [x] 3.4 `pytest tests/unit/test_codex_upstream_paths.py tests/unit/test_codex_client.py
+      tests/unit/test_proxy_utils.py tests/integration/test_routed_stream_release.py`,
+      `ruff check`, `ruff format --check`, `ty check`,
+      `scripts/check_proxy_architecture.py`, `openspec validate --strict`

--- a/tests/integration/test_routed_stream_release.py
+++ b/tests/integration/test_routed_stream_release.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import socket
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import pytest
+from aiohttp import web
+
+import app.core.clients.codex as codex_module
+import app.core.clients.proxy as proxy_module
+from app.core.clients.proxy import stream_responses
+from app.core.openai.requests import ResponsesRequest
+from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+
+pytestmark = pytest.mark.integration
+
+_SSE_CREATED = (
+    b'data: {"type":"response.created","response":{"id":"resp_1","object":"response","status":"in_progress"}}\n\n'
+)
+_SSE_COMPLETED = (
+    b'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed"}}\n\n'
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _HoldingUpstream:
+    """aiohttp.web app standing in for an HTTP forward proxy that keeps the tunnel open after the SSE frames."""
+
+    def __init__(self, frames: bytes) -> None:
+        self.frames = frames
+        self.port = 0
+        self._runner: web.AppRunner | None = None
+
+    async def _handle(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+        await response.prepare(request)
+        await response.write(self.frames)
+        try:
+            await asyncio.sleep(3600)
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass
+        return response
+
+    async def start(self) -> None:
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self._runner = web.AppRunner(app, shutdown_timeout=0.1)
+        await self._runner.setup()
+        self.port = _free_port()
+        await web.TCPSite(self._runner, "127.0.0.1", self.port).start()
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+
+@pytest.fixture
+def aiohttp_routed_egress(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Force the aiohttp fallback transport and capture every raw upstream response it produces."""
+
+    monkeypatch.setattr(codex_module, "discover_native_egress_client", lambda: None)
+    captured: list[Any] = []
+
+    class _RecordingCodexClient(codex_module.CodexClient):
+        async def request_with_route_metadata(self, *args: Any, **kwargs: Any) -> codex_module.CodexRequestResult:
+            result = await super().request_with_route_metadata(*args, **kwargs)
+            captured.append(result.response)
+            return result
+
+    monkeypatch.setattr(proxy_module, "CodexClient", _RecordingCodexClient)
+    return captured
+
+
+@pytest.fixture
+async def unclosed_connection_events() -> AsyncIterator[list[dict[str, Any]]]:
+    loop = asyncio.get_running_loop()
+    previous = loop.get_exception_handler()
+    events: list[dict[str, Any]] = []
+    # Flush garbage from earlier tests so only this test's teardown is measured.
+    gc.collect()
+
+    def _record(active_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        if context.get("message") == "Unclosed connection":
+            events.append(context)
+            return
+        if previous is not None:
+            previous(active_loop, context)
+        else:
+            active_loop.default_exception_handler(context)
+
+    loop.set_exception_handler(_record)
+    try:
+        yield events
+    finally:
+        loop.set_exception_handler(previous)
+
+
+async def _collect_routed_stream(port: int) -> list[str]:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "127.0.0.1", port),
+    )
+    payload = ResponsesRequest(model="gpt-5.2", instructions="Reply.", input="hello", stream=True)
+    return [
+        event
+        async for event in stream_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            base_url="http://upstream.invalid/backend-api",
+            raise_for_status=True,
+            session=cast(Any, object()),
+            upstream_stream_transport_override="http",
+            route=route,
+            allow_direct_egress=False,
+        )
+    ]
+
+
+async def _assert_released(captured: list[Any], unclosed: list[dict[str, Any]]) -> None:
+    assert len(captured) == 1
+    response = captured[0]
+    assert response.closed is True
+    assert response.connection is None
+    gc.collect()
+    await asyncio.sleep(0)
+    gc.collect()
+    assert unclosed == []
+
+
+async def test_routed_stream_terminal_event_releases_aiohttp_connection(
+    aiohttp_routed_egress: list[Any],
+    unclosed_connection_events: list[dict[str, Any]],
+) -> None:
+    upstream = _HoldingUpstream(_SSE_CREATED + _SSE_COMPLETED)
+    await upstream.start()
+    try:
+        events = await _collect_routed_stream(upstream.port)
+    finally:
+        await upstream.stop()
+
+    # Forwarded bytes are the upstream frames verbatim; release runs after the last one.
+    assert "".join(events).encode() == _SSE_CREATED + _SSE_COMPLETED
+    await _assert_released(aiohttp_routed_egress, unclosed_connection_events)
+
+
+async def test_routed_stream_idle_timeout_releases_aiohttp_connection(
+    aiohttp_routed_egress: list[Any],
+    unclosed_connection_events: list[dict[str, Any]],
+) -> None:
+    upstream = _HoldingUpstream(_SSE_CREATED)
+    await upstream.start()
+    try:
+        with proxy_module.override_stream_timeouts(idle_timeout_seconds=0.05):
+            events = await _collect_routed_stream(upstream.port)
+    finally:
+        await upstream.stop()
+
+    assert events[0].encode() == _SSE_CREATED
+    assert len(events) == 2
+    assert '"stream_idle_timeout"' in events[1]
+    await _assert_released(aiohttp_routed_egress, unclosed_connection_events)

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -9,6 +9,7 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 from python_socks import ProxyType
 
+import app.core.clients.codex as codex_module
 from app.core.clients.codex import CodexClient, CodexTransportError, require_route_or_direct_egress_opt_in
 from app.core.clients.native_egress import (
     NativeEgressRequest,
@@ -898,3 +899,37 @@ async def test_socks_websocket_cancel_during_enter_closes_local_session(
     assert session.closed == 1
     assert session.context.exited is False
     assert session.context.owned is False
+
+
+async def test_socks_session_owned_response_releases_before_closing_session() -> None:
+    order: list[str] = []
+
+    async def _noop() -> None:
+        return None
+
+    class _Content:
+        async def iter_chunked(self, size: int):
+            del size
+            yield b"data: first\n\n"
+            yield b"data: second\n\n"
+
+    class _RawResponse:
+        status = 200
+        headers: dict[str, str] = {}
+        content = _Content()
+
+        def release(self) -> Any:
+            order.append("release")
+            return _noop()
+
+    class _Session:
+        async def close(self) -> None:
+            order.append("session_close")
+
+    owned = codex_module._SessionOwnedResponse(_RawResponse(), cast(Any, _Session()))
+
+    async for _ in owned.content.iter_chunked(1024):
+        break
+    await owned.release()
+
+    assert order == ["release", "session_close"]

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import errno
 import socket
 from typing import Any, cast
@@ -1370,3 +1371,222 @@ async def test_responses_websocket_post_connect_network_failures_preserve_safe_c
     assert "user:pass" not in message.error
     assert rotate.await_count == 2
     assert all(call.kwargs["transport"] == "websocket" for call in rotate.await_args_list)
+
+
+_SSE_CREATED_CHUNK = b'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n'
+_SSE_COMPLETED_CHUNK = b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n'
+
+
+async def _noop() -> None:
+    return None
+
+
+class _HoldingStreamContent:
+    """Yield the given chunks, then hold the body open like an upstream keep-alive tunnel."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.drained = asyncio.Event()
+
+    async def iter_chunked(self, size: int):
+        del size
+        for chunk in self._chunks:
+            yield chunk
+        self.drained.set()
+        await asyncio.Event().wait()
+
+
+class _ReleasableStreamResponse:
+    """aiohttp-shaped: ``release()`` is synchronous and returns a non-suspending awaitable."""
+
+    headers = {"content-type": "text/event-stream"}
+
+    def __init__(self, order: list[str], chunks: list[bytes], *, status_code: int = 200) -> None:
+        self._order = order
+        self.status_code = status_code
+        self.content = _HoldingStreamContent(chunks)
+
+    def release(self) -> Any:
+        self._order.append("release")
+        return _noop()
+
+
+class _AcloseOnlyStreamResponse:
+    """Native-egress-shaped: only ``aclose()`` is available."""
+
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+
+    def __init__(self, order: list[str], chunks: list[bytes]) -> None:
+        self._order = order
+        self.content = _HoldingStreamContent(chunks)
+
+    async def aclose(self) -> None:
+        self._order.append("aclose")
+
+
+class _ReleasableErrorResponse:
+    status_code = 429
+    headers = {"content-type": "application/json"}
+    content = b'{"error":{"code":"rate_limit_exceeded","message":"slow down"}}'
+
+    def __init__(self, order: list[str]) -> None:
+        self._order = order
+
+    def json(self) -> dict[str, Any]:
+        return {"error": {"code": "rate_limit_exceeded", "message": "slow down"}}
+
+    def release(self) -> Any:
+        self._order.append("release")
+        return _noop()
+
+
+class _OwnedCodexClient(_RouteMetadataCodexClient):
+    def __init__(self, response: object, order: list[str]) -> None:
+        super().__init__(response)
+        self._order = order
+
+    async def close(self) -> None:
+        self._order.append("close")
+
+
+def _install_owned_codex_client(monkeypatch: pytest.MonkeyPatch, client: _OwnedCodexClient) -> None:
+    # No codex_client is passed, so the routed branch builds and owns its own
+    # per-stream client exactly like production does.
+    monkeypatch.setattr(proxy_module, "create_codex_session", lambda: None)
+    monkeypatch.setattr(proxy_module, "CodexClient", lambda session: client)
+
+
+def _routed_stream(route: ResolvedUpstreamRoute, *, raise_for_status: bool = False):
+    payload = ResponsesRequest(model="gpt-5.2", instructions="Reply.", input="hello", stream=True)
+    return stream_responses(
+        payload,
+        {"user-agent": "codex"},
+        "access",
+        "chatgpt_account",
+        raise_for_status=raise_for_status,
+        session=cast(Any, object()),
+        upstream_stream_transport_override="http",
+        route=route,
+        allow_direct_egress=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_terminal_event_releases_response_before_client_close(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    response = _ReleasableStreamResponse(order, [_SSE_CREATED_CHUNK, _SSE_COMPLETED_CHUNK])
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(response, order))
+
+    events = [event async for event in _routed_stream(route)]
+
+    assert events == [_SSE_CREATED_CHUNK.decode(), _SSE_COMPLETED_CHUNK.decode()]
+    assert order == ["release", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_downstream_disconnect_releases_response(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    response = _ReleasableStreamResponse(order, [_SSE_CREATED_CHUNK])
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(response, order))
+
+    stream = _routed_stream(route)
+    first = await stream.__anext__()
+    await stream.aclose()
+
+    assert first == _SSE_CREATED_CHUNK.decode()
+    assert order == ["release", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_cancellation_releases_response(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    response = _ReleasableStreamResponse(order, [_SSE_CREATED_CHUNK])
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(response, order))
+
+    async def _consume() -> list[str]:
+        return [event async for event in _routed_stream(route)]
+
+    task = asyncio.create_task(_consume())
+    await response.content.drained.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert order == ["release", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_idle_timeout_releases_response(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    response = _ReleasableStreamResponse(order, [_SSE_CREATED_CHUNK])
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(response, order))
+
+    with proxy_module.override_stream_timeouts(idle_timeout_seconds=0.01):
+        events = [event async for event in _routed_stream(route)]
+
+    assert events[0] == _SSE_CREATED_CHUNK.decode()
+    assert len(events) == 2
+    assert '"stream_idle_timeout"' in events[1]
+    assert order == ["release", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_error_status_releases_response(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(_ReleasableErrorResponse(order), order))
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in _routed_stream(route, raise_for_status=True):
+            pass
+
+    assert exc_info.value.status_code == 429
+    assert order == ["release", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_closes_aclose_only_response(
+    route: ResolvedUpstreamRoute, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    response = _AcloseOnlyStreamResponse(order, [_SSE_CREATED_CHUNK, _SSE_COMPLETED_CHUNK])
+    _install_owned_codex_client(monkeypatch, _OwnedCodexClient(response, order))
+
+    events = [event async for event in _routed_stream(route)]
+
+    assert events == [_SSE_CREATED_CHUNK.decode(), _SSE_COMPLETED_CHUNK.decode()]
+    assert order == ["aclose", "close"]
+
+
+@pytest.mark.asyncio
+async def test_routed_stream_tolerates_response_without_release(route: ResolvedUpstreamRoute) -> None:
+    # Plain duck-typed responses (buffered bodies, test fakes) expose neither
+    # release() nor aclose(); teardown must stay a no-op for them.
+    client = _CodexClient(_StreamResponse())
+    payload = ResponsesRequest(model="gpt-5.2", instructions="Reply.", input="hello", stream=True)
+
+    events = [
+        event
+        async for event in stream_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            upstream_stream_transport_override="http",
+            route=route,
+            codex_client=cast(Any, client),
+        )
+    ]
+
+    assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']


### PR DESCRIPTION
## Summary

Routed HTTP streams (dashboard proxy pools, SOCKS routes, the aiohttp fallback behind the native egress helper) request the upstream response unbuffered (`buffer_response=False`) and almost always stop reading before body EOF: on the terminal `response.completed` event while upstream holds the keep-alive tunnel open, on idle timeout, on cancellation, or on downstream disconnect. The only teardown on that branch of `_stream_via_http_attempt` was `await active_codex_client.close()`, which closes the per-stream `ClientSession` socket but never releases the `ClientResponse`. `ClientResponse <-> StreamReader` form an inherent reference cycle (`payload.on_eof(self._response_eof)`), so the graph is only reclaimed by the cyclic GC, and `Connection.__del__` finds `_protocol` still set and logs `ERROR asyncio Unclosed connection` with the `ConnectionKey` repr (proxy URL including its password). The direct (non-routed) path is immune because it uses `async with session.post(...)`.

Production evidence (soju07, v1.25.0-beta.1, 2026-09-03, aiohttp 3.14.3 / py3.14): `Unclosed connection` at **44 to 1350 lines per hour** scaling with traffic (~10k req/h), and a heap probe with ~170 dead per-stream graphs pinned until the next full collection (`ClientSession=166, TCPConnector=172, Connection=224, ClientResponse=170, StreamReader=208, ResponseHandler=337, SSLProtocol=167` -- the 1:1:1 session:connector:response ratio is the signature of per-stream routed sessions).

This PR releases the raw upstream response on every exit of the routed streaming branch, strictly before the owned client is closed, and makes nested async-generator teardown deterministic.

## Change details

- `app/core/clients/codex.py`
  - new duck-typed `release_codex_response(response)`: resolves `release` -> `close` -> `aclose`, awaits the result only if awaitable. Covers aiohttp `ClientResponse.release()` (sync, returns a noop awaitable), `NativeEgressResponse.aclose()`, and buffered/test responses that expose neither (no-op).
  - `_SessionOwnedResponse.release()` (SOCKS routes) releases the wrapped response and then closes its private session; `_SessionOwnedContent._iter_and_close` releases before `session.close()`.
- `app/core/clients/proxy.py`
  - `_stream_via_http_attempt` routed branch: `raw_resp: Any = None` is declared before the existing `try`; the existing `finally` becomes `try: await release_codex_response(raw_resp) finally: await active_codex_client.close()`, so release runs before the session close on terminal break, `StreamIdleTimeoutError`, `StreamEventTooLargeError`, cancellation/`GeneratorExit`, and non-2xx error mapping, and close still runs if release raises.
  - `_CodexSSEResponse.release()` forwards to the wrapped response.
  - `_iter_sse_events` consumption and each hop of the HTTP stream generator chain (`stream_responses` -> `_stream_responses_with_session` -> `_stream_via_http` -> `_stream_via_http_attempt`, plus the websocket-rejection HTTP fallback) are consumed under `contextlib.aclosing(...)`. Most of the 243 changed lines in this file are reindentation of unchanged loop bodies.
- Tests: `tests/unit/test_codex_upstream_paths.py`, `tests/unit/test_codex_client.py`, new `tests/integration/test_routed_stream_release.py`.
- OpenSpec: `openspec/changes/release-routed-upstream-stream-responses/` (proposal, tasks, delta under `outbound-http-clients`).

## Byte-compat / behavior notes

- Forwarded bytes, error mapping, retry classification and cancellation semantics are unchanged: release runs after the last yielded event block. Verified on the repro harness (main vs this branch, same upstream frames, `transport=http`): forwarded payload sha256 identical (n=10 `fc82775b1482ea6c`, n=30 `29179db7b97adf74`, adversarial n=20 `47ac88115b647f99`). The integration test also asserts the forwarded bytes equal the upstream frames verbatim.
- Operator-visible change: the `Unclosed connection` error lines for routed HTTP streams disappear (this is why a change folder is filed rather than a refactor exemption).
- Accepted behavior changes (deliberate):
  - Nested `aclosing` makes a consumer's `aclose()` reach the upstream teardown synchronously instead of via the asyncgen finalizer task. Python's `async for` does not close nested async generators, so without this the routed `finally` only ran later from the finalizer. `lease_http_session` now exits after the generator closes.
  - For native-egress routed streams the helper's `aclose()` (cancel round-trip, bounded <= 2.0 s) is now on the routed stream's teardown path. This is parity with the direct path, which already does `async with native_response`.
  - SOCKS path: `_SessionOwnedContent` finalizer and `_SessionOwnedResponse.release()` may both call `release()`; idempotent on aiohttp.

## Expected gain

- CPU: ~0 (aiohttp is ~1% of GIL samples; only the log formatting / `call_exception_handler` dispatch of up to ~1350 events/h goes away).
- Memory / hygiene: the per-stream graph (`ClientResponse`, `Connection`, `StreamReader`, `ResponseHandler`, `SSLProtocol`, `ClientSession`, `TCPConnector`) is freed by refcount at stream end instead of at the next gen-2 pass.
- Measured on the repro harness (aiohttp.web HTTP proxy emitting `response.created` + `response.completed` then holding the tunnel open; real `stream_responses(route=http endpoint, allow_direct_egress=False)`; loop exception handler recorder; gc disabled during the run, then `gc.collect()` x2):
  - n=10: `Unclosed connection` 10/10 -> **0/10**
  - n=30: 30/30 -> **0/30**; alive before GC: `ClientSession=30 TCPConnector=30 Connection=30 ClientResponse=30 SSLContext=32` -> `0/0/0/0/2`; maxrss 125,624 KB -> 104,524 KB (~700 KB/stream no longer pinned until GC)
  - wall 2.42 s vs 2.64 s, cpu_user 1.81 s vs 1.99 s: startup-dominated noise, consistent with the ~0 CPU claim.
- On Docker installs of current `main` the native egress helper (#1995) serves the routed HTTP hot path and aiohttp is fallback-only, so most of the prod line volume will vanish from the upgrade itself; this fix covers the aiohttp fallback, non-Docker installs, and SOCKS routes. Measure the residual after deploy (see hazards).

## OpenSpec

Change folder `openspec/changes/release-routed-upstream-stream-responses/` -- ADDED requirement under `outbound-http-clients`: routed streaming upstream responses MUST be released/closed when the consumer stops before body EOF so no connection object is finalized by the GC. `openspec validate release-routed-upstream-stream-responses --strict` valid; `openspec validate --specs` 57 passed / 1 failed (only the pre-existing `model-source-routing` failure present on `main`).

## Tests

New (10):
- `tests/unit/test_codex_upstream_paths.py`
  - `test_routed_stream_terminal_event_releases_response_before_client_close`
  - `test_routed_stream_downstream_disconnect_releases_response`
  - `test_routed_stream_cancellation_releases_response`
  - `test_routed_stream_idle_timeout_releases_response`
  - `test_routed_stream_error_status_releases_response`
  - `test_routed_stream_closes_aclose_only_response` (NativeEgressResponse-shaped fake)
  - `test_routed_stream_tolerates_response_without_release` (no-op guard)
- `tests/unit/test_codex_client.py::test_socks_session_owned_response_releases_before_closing_session`
- `tests/integration/test_routed_stream_release.py` (aiohttp.web AppRunner acting as an HTTP proxy that emits the terminal event and holds the connection; asserts 0 `Unclosed connection` exception-handler events after two `gc.collect()` and byte-identical forwarded payload)
  - `test_routed_stream_terminal_event_releases_aiohttp_connection`
  - `test_routed_stream_idle_timeout_releases_aiohttp_connection`

How they fail without the fix: with `app/core/clients/{proxy,codex}.py` swapped to `origin/main`, 9/10 new tests fail (release never called / `Unclosed connection` recorded); only the intentional no-op tolerance guard passes.

Gates (all from the worktree venv): ruff check + format clean (repo-wide); `ty check` project-wide clean; `scripts/check_proxy_architecture.py` passed; targeted pytest `test_codex_upstream_paths + test_codex_client + test_routed_stream_release` 97 passed; broader streaming-path run (`test_proxy_utils`, `test_native_egress`, `test_http_client`, `test_proxy_http_bridge`, `test_http_bridge_forwarding`, `test_native_routed_egress`, `test_proxy_transient_retry`, `test_proxy_responses`, `test_proxy_websocket_responses`, `test_proxy_compact`, `test_limit_warmup`, `test_ttft_optimization`, `test_proxy_api_responses_contract`) 1438 passed, 1 skipped (native binary probe needs `CODEX_LB_NATIVE_EGRESS_TEST_BINARY`). Net +629 lines (601 app+tests), one concern.

## Review trail

- Local `codex review --base origin/main`: 0 findings ("routed response teardown and nested async-generator cleanup are implemented consistently across aiohttp, native egress, SOCKS, cancellation, timeout, and error paths"); codex additionally ran the targeted modules (148 passed) and a `-W error` asyncio-debug run of the SOCKS test.
- Independent reviewer round 1: approve; code-level trace of release ordering, helper resolution order vs aiohttp/native/fake shapes, SOCKS wrapper idempotency, and the aclosing chain; 1 P3 nit (unused `_CodexSSEResponse.release()` forwarding kept for the wrapper contract).
- Adversarial verification round 1: no P0-P2. End-to-end main-vs-branch harness n=20 real aiohttp streams: 20/20 -> 0/20 `Unclosed connection`, 0 pinned objects, identical payload sha. 8 divergence probes (multi-event chunk + aclose, consumer exception with raising close(), SOCKS wrapper, cancel while suspended at yield, 429 with `raise_for_status=False`, EOF-before-terminal, shared codex_client): yielded events/exceptions identical between trees; only differences are the added release/aclose calls. Mutation check: 9/10 new tests fail on `main` app code. 3 P3 notes recorded above under accepted behavior changes (native-egress cancel round-trip on teardown path; `_iter_and_close` finally not nested; service-layer consumer above `stream_responses` still relies on the asyncgen finalizer).

## Deploy notes / hazards

- **Upgrade hazard (unrelated to this PR, but affects the same routed path)**: `main` rejects `http://user:pw@` proxy endpoints (`plaintext_proxy_credentials_forbidden`, #1995). A pool configured with plaintext-credential http proxies fails closed on every routed request after upgrading to `main` until the endpoint is re-created as `https://` or credential-less. Decide before deploying anything from this campaign.
- On main-in-Docker the native egress helper serves the routed HTTP/WS hot path; this fix only affects the aiohttp fallback, SOCKS routes and non-Docker installs, so the prod `Unclosed connection` volume will mostly disappear from the upgrade alone. After deploy, `grep -c 'Unclosed connection'` per hour should reach 0; if a residual remains with the same `ConnectionKey` repr, the routed upstream WebSocket teardown (out of scope here) is the next suspect.
- The credential exposure in the log line itself (password in `ConnectionKey` repr) is addressed at the source in the sibling credential-safe-proxy-logging PR; this PR removes the line for routed HTTP streams but does not redact it elsewhere.
- No new settings, no migration, no dashboard surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of routed streaming connections when streams end early, time out, are cancelled, disconnected, or encounter errors.
  * Prevented unclosed connection warnings and reduced the risk of lingering network resources.
  * Preserved streamed content, error handling, retry behavior, and cancellation semantics.

* **Tests**
  * Added coverage for connection cleanup across HTTP, SOCKS, native transport, and fallback streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->