### PR TITLE
perf(proxy): replace the last BaseHTTPMiddleware (image route started_at) with a pure ASGI middleware

### DIFF
--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import FastAPI, Request
@@ -14,6 +13,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from starlette._utils import get_route_path
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.errors import dashboard_error, openai_error
 from app.core.exceptions import (
@@ -171,15 +171,27 @@ async def _record_image_route_exception_observability(
     )
 
 
+class ImageRouteStartedAtMiddleware:
+    """Stamp the ingress start time for image routes into ``scope["state"]``.
+
+    Pure ASGI (no ``BaseHTTPMiddleware``): the previous ``@app.middleware("http")``
+    form ran the whole HTTP app in a child task and relayed every response
+    chunk through an anyio memory stream. ``Request.state`` is backed by
+    ``scope["state"]``, so the handler and the exception observability paths
+    keep reading the value through ``request.state`` unchanged.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and _image_route_from_path(get_route_path(scope)) is not None:
+            scope.setdefault("state", {})[IMAGE_ROUTE_STARTED_AT_STATE] = time.perf_counter()
+        await self.app(scope, receive, send)
+
+
 def add_exception_handlers(app: FastAPI) -> None:
-    @app.middleware("http")
-    async def _image_route_started_at_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        if _image_route_from_path(get_route_path(request.scope)) is not None:
-            setattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, time.perf_counter())
-        return await call_next(request)
+    app.add_middleware(ImageRouteStartedAtMiddleware)
 
     @app.exception_handler(MultipartPayloadTooLarge)
     async def multipart_payload_too_large_handler(

--- a/openspec/changes/perf-basehttp-middleware-to-asgi/context.md
+++ b/openspec/changes/perf-basehttp-middleware-to-asgi/context.md
@@ -1,0 +1,53 @@
+# Context: pure ASGI image-route start-time middleware
+
+## Purpose
+
+Performance refactor of the last `BaseHTTPMiddleware` in the HTTP stack. The
+middleware body is trivial (path lookup + `time.perf_counter()`), but the
+`BaseHTTPMiddleware` wrapper spawned the whole HTTP app in a child task and
+relayed every response chunk through an anyio memory stream. Every other
+middleware in `create_app()` was already converted to pure ASGI.
+
+## Decisions
+
+- `Request.state` is backed by `scope["state"]` (Starlette `Request.state`
+  uses `scope.setdefault("state", {})`), so the middleware writes into that
+  dict with `setdefault` and the three consumers
+  (`app/modules/proxy/api.py`, `app/core/handlers/exceptions.py`,
+  `app/core/middleware/required_capability_http.py`) keep using
+  `getattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, None)` unchanged.
+- Registration stays inside `add_exception_handlers` so `app/main.py` and the
+  production ordering (trusted-proxy-headers -> image start time -> app-version
+  -> ...) are untouched.
+- `get_route_path(scope)` is used, as before, so a mounted `root_path` still
+  matches the image routes.
+
+## Accepted behavior change: mid-stream failure framing
+
+With `BaseHTTPMiddleware`, a response body generator that raised after some
+chunks had been sent caused the middleware to emit a synthetic
+`http.response.body` with `more_body=False` and then re-raise. The client saw
+a cleanly terminated (but truncated) body. With pure ASGI the exception
+propagates to the server without that terminator; uvicorn closes the
+transport, so the client observes a connection close instead of a clean
+end-of-stream. This matches how every other converted middleware already
+behaves for the paths it wraps and is pinned by
+`tests/unit/test_image_route_started_at_middleware.py`.
+
+Scheduling also changes: the app no longer runs in a child task, so client
+disconnect cancellation propagates directly and contextvars set by the
+request-id middleware remain visible for the whole response stream.
+
+## Example
+
+`POST /v1/images/edits` rejected with 413 before the handler runs still logs
+`images_route_complete ... status=413 outcome=invalid_request duration_ms=...`
+where the duration is measured from HTTP ingress, not from the moment the
+exception handler ran.
+
+## Measurement
+
+Micro-benchmark (venv Python 3.14 + uvloop, ASGI app driven in-process, no
+server): see the PR body for before/after numbers per request and per streamed
+chunk. Production verification: `py-spy --gil` after deploy should show no
+`starlette/middleware/base.py` frames.

--- a/openspec/changes/perf-basehttp-middleware-to-asgi/proposal.md
+++ b/openspec/changes/perf-basehttp-middleware-to-asgi/proposal.md
@@ -1,0 +1,31 @@
+# Change: Replace the last BaseHTTPMiddleware with a pure ASGI middleware
+
+## Why
+
+`add_exception_handlers` still registered the image-route start-time stamp via
+`@app.middleware("http")`, which Starlette implements as `BaseHTTPMiddleware`:
+a child task per request plus an anyio memory-object-stream hop for every
+response chunk. Because it sits directly inside the trusted-proxy-headers
+middleware, the entire HTTP application ran inside that child task. A 60 s
+production GIL profile attributed roughly 3-4% of samples to this relay, most
+of it on streaming `/v1` traffic where every SSE chunk paid two extra task
+switches.
+
+## What Changes
+
+- Replace the decorator with `ImageRouteStartedAtMiddleware`, a pure ASGI
+  middleware that writes the start timestamp into `scope["state"]` (the dict
+  backing `Request.state`) and calls the downstream app in the same task.
+- Register it at the same slot so the production middleware order is unchanged.
+- Pin the accepted framing change: when a response body generator raises after
+  chunks were already sent, the exception now reaches the ASGI server without a
+  synthetic terminal `more_body=False` chunk (the server closes the connection).
+- Forwarded bytes on success paths are unchanged and covered by a test.
+
+## Impact
+
+- Affected specs: `images-api-compat` (observability start time is captured at
+  ingress; behavior preserved, now stated), `http-ingress-limits` (middleware
+  relay and mid-stream failure framing).
+- Affected code: `app/core/handlers/exceptions.py` and its tests.
+- No settings, schema, or API surface changes.

--- a/openspec/changes/perf-basehttp-middleware-to-asgi/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/perf-basehttp-middleware-to-asgi/specs/http-ingress-limits/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: HTTP middleware relays responses in the request task
+
+Every middleware in the HTTP middleware stack MUST be a pure ASGI middleware that invokes the downstream application in the same task and forwards response messages directly. The stack MUST NOT include Starlette `BaseHTTPMiddleware` (including `@app.middleware("http")` registrations). Response bodies forwarded on success paths MUST be byte-identical to the downstream application's output.
+
+#### Scenario: Production middleware stack contains no BaseHTTPMiddleware
+
+- **WHEN** the production application is constructed
+- **THEN** no registered middleware entry is `starlette.middleware.base.BaseHTTPMiddleware`
+
+#### Scenario: Streaming body is forwarded unchanged
+
+- **WHEN** a route returns a streaming response through the middleware stack
+- **THEN** the sequence of ASGI response messages, including headers, body bytes, and `more_body` flags, is identical to the sequence emitted without the middleware
+
+#### Scenario: Mid-stream failure propagates without a synthetic terminator
+
+- **WHEN** a response body generator raises after at least one body chunk has been sent
+- **THEN** the exception propagates to the ASGI server
+- **AND** the stack does not emit an additional `http.response.body` message with `more_body=false` before propagating

--- a/openspec/changes/perf-basehttp-middleware-to-asgi/specs/images-api-compat/spec.md
+++ b/openspec/changes/perf-basehttp-middleware-to-asgi/specs/images-api-compat/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Image routes expose bounded operational observability
+
+The system SHALL emit structured route-completion logs and Prometheus metrics for `/v1/images/generations` and `/v1/images/edits`. Observability labels MUST be bounded to route, effective public model, stream flag, HTTP status, and outcome, and MUST NOT include prompts, image bytes, file names, access tokens, or raw upstream payloads. The duration start time MUST be captured at HTTP ingress, before authentication, body admission, or handler execution, by a pure ASGI middleware that stores it in the request scope state; pre-handler rejections MUST measure duration from that ingress start time.
+
+#### Scenario: Successful image request records completion telemetry
+
+- **WHEN** an `/v1/images/generations` or `/v1/images/edits` request completes successfully
+- **THEN** the service emits an `images_route_complete` log line with the public image route, public model, stream flag, status, outcome, and duration
+- **AND** increments `codex_lb_image_requests_total` and observes `codex_lb_image_request_duration_seconds` with the same bounded labels
+
+#### Scenario: Failed image request records completion telemetry
+
+- **WHEN** an image request is rejected by validation or mapped from an upstream/image-generation error
+- **THEN** the service emits the same bounded `images_route_complete` fields with a non-success outcome
+- **AND** increments the image request counter and duration histogram without logging prompt or binary image content
+
+#### Scenario: Pre-handler rejection measures duration from ingress
+
+- **WHEN** an image route request is rejected before its handler runs (for example an oversized multipart upload or a missing API key)
+- **THEN** the recorded duration uses the start time stamped into the request scope state at HTTP ingress
+- **AND** non-image HTTP paths and WebSocket scopes receive no such stamp

--- a/openspec/changes/perf-basehttp-middleware-to-asgi/tasks.md
+++ b/openspec/changes/perf-basehttp-middleware-to-asgi/tasks.md
@@ -1,0 +1,18 @@
+## 1. Middleware
+
+- [x] 1.1 Add `ImageRouteStartedAtMiddleware` (pure ASGI) in `app/core/handlers/exceptions.py`.
+- [x] 1.2 Register it via `app.add_middleware` inside `add_exception_handlers`, keeping the slot between app-version and trusted-proxy-headers.
+- [x] 1.3 Remove the `@app.middleware("http")` registration.
+
+## 2. Tests
+
+- [x] 2.1 Assert no `BaseHTTPMiddleware` entry remains in `create_app().user_middleware` and the middleware stack stays unbuilt.
+- [x] 2.2 Assert image routes (all four paths, including `root_path`) receive a float start time via `scope["state"]` and `request.state`; other HTTP paths and WebSocket scopes are untouched.
+- [x] 2.3 Assert pre-handler rejection observability consumes the ingress start time rather than the fallback.
+- [x] 2.4 Assert forwarded ASGI messages are identical with and without the middleware (JSON and streaming).
+- [x] 2.5 Pin that a mid-stream generator failure propagates without a synthetic terminal body chunk.
+
+## 3. Verification
+
+- [x] 3.1 Run the middleware ordering tests, image-route observability integration tests, SSE unit tests, ruff, ty, the architecture check, and OpenSpec validation.
+- [x] 3.2 Re-run the BaseHTTPMiddleware vs pure-ASGI micro-benchmark and record the numbers in the PR body.

--- a/tests/unit/test_image_route_started_at_middleware.py
+++ b/tests/unit/test_image_route_started_at_middleware.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, StreamingResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.exceptions import ProxyAuthError
+from app.core.handlers import add_exception_handlers
+from app.core.handlers import exceptions as exceptions_module
+from app.core.handlers.exceptions import ImageRouteStartedAtMiddleware
+from app.core.middleware.app_version import AppVersionMiddleware
+from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
+from app.main import create_app
+from app.modules.proxy.images_observability import IMAGE_ROUTE_STARTED_AT_STATE
+
+pytestmark = pytest.mark.unit
+
+_IMAGE_PATHS = (
+    "/v1/images/generations",
+    "/v1/images/edits",
+    "/backend-api/codex/images/generations",
+    "/backend-api/codex/images/edits",
+)
+
+
+def _http_scope(path: str, *, root_path: str = "", json_body: bool = False) -> Scope:
+    headers = [(b"host", b"testserver")]
+    if json_body:
+        headers.append((b"content-type", b"application/json"))
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": root_path,
+        "headers": headers,
+        "client": ("127.0.0.1", 1),
+        "server": ("testserver", 80),
+    }
+
+
+def _server_receive() -> Receive:
+    delivered = False
+
+    async def receive() -> Message:
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.disconnect"}
+        delivered = True
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    return receive
+
+
+class _RecordingApp:
+    def __init__(self) -> None:
+        self.scopes: list[Scope] = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.scopes.append(scope)
+
+
+async def _drive(app: ASGIApp, scope: Scope) -> list[Message]:
+    sent: list[Message] = []
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await app(scope, _server_receive(), send)
+    return sent
+
+
+async def _sse_body() -> AsyncIterator[bytes]:
+    yield b"data: one\n\n"
+    yield b"data: two\n\n"
+    yield b"data: [DONE]\n\n"
+
+
+def _build_relay_app(*, with_middleware: bool) -> FastAPI:
+    """Constant-body routes on the image paths, used to compare forwarded messages."""
+    app = FastAPI()
+    if with_middleware:
+        add_exception_handlers(app)
+
+    @app.post("/v1/images/generations")
+    async def generations() -> JSONResponse:
+        return JSONResponse({"data": [{"b64_json": "AAAA"}]})
+
+    @app.post("/v1/images/edits")
+    async def edits() -> StreamingResponse:
+        return StreamingResponse(_sse_body(), media_type="text/event-stream")
+
+    return app
+
+
+def test_production_stack_has_no_basehttp_middleware() -> None:
+    app = create_app()
+    middleware = app.user_middleware
+
+    def _index_of(cls: object) -> int:
+        return next(index for index, entry in enumerate(middleware) if entry.cls is cls)
+
+    assert all(entry.cls is not BaseHTTPMiddleware for entry in middleware)
+    assert _index_of(TrustedProxyHeadersMiddleware) < _index_of(ImageRouteStartedAtMiddleware)
+    assert _index_of(ImageRouteStartedAtMiddleware) < _index_of(AppVersionMiddleware)
+    # Inspecting user_middleware must not force the stack to build (see test_otel).
+    assert app.middleware_stack is None
+
+
+@pytest.mark.parametrize("path", _IMAGE_PATHS)
+async def test_image_route_scope_receives_float_started_at(path: str) -> None:
+    downstream = _RecordingApp()
+    before = time.perf_counter()
+
+    await _drive(ImageRouteStartedAtMiddleware(downstream), _http_scope(path))
+
+    (scope,) = downstream.scopes
+    started_at = scope["state"][IMAGE_ROUTE_STARTED_AT_STATE]
+    assert isinstance(started_at, float)
+    assert before <= started_at <= time.perf_counter()
+
+
+async def test_image_route_started_at_reuses_existing_scope_state() -> None:
+    downstream = _RecordingApp()
+    scope = _http_scope("/v1/images/generations")
+    existing_state: dict[str, Any] = {"other": "kept"}
+    scope["state"] = existing_state
+
+    await _drive(ImageRouteStartedAtMiddleware(downstream), scope)
+
+    assert downstream.scopes[0]["state"] is existing_state
+    assert existing_state["other"] == "kept"
+    assert isinstance(existing_state[IMAGE_ROUTE_STARTED_AT_STATE], float)
+
+
+async def test_image_route_started_at_strips_root_path() -> None:
+    downstream = _RecordingApp()
+
+    await _drive(
+        ImageRouteStartedAtMiddleware(downstream),
+        _http_scope("/prefix/v1/images/edits", root_path="/prefix"),
+    )
+
+    assert isinstance(downstream.scopes[0]["state"][IMAGE_ROUTE_STARTED_AT_STATE], float)
+
+
+@pytest.mark.parametrize("path", ["/v1/responses", "/v1/images/generations/", "/api/dashboard/overview"])
+async def test_non_image_http_scope_is_left_untouched(path: str) -> None:
+    downstream = _RecordingApp()
+    scope = _http_scope(path)
+
+    await _drive(ImageRouteStartedAtMiddleware(downstream), scope)
+
+    assert downstream.scopes == [scope]
+    assert "state" not in scope
+
+
+async def test_websocket_scope_passes_through_untouched() -> None:
+    downstream = _RecordingApp()
+    scope: Scope = {"type": "websocket", "path": "/v1/images/generations", "root_path": ""}
+
+    await _drive(ImageRouteStartedAtMiddleware(downstream), scope)
+
+    assert downstream.scopes == [scope]
+    assert "state" not in scope
+
+
+async def test_request_state_exposes_started_at_to_route_handler() -> None:
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.post("/v1/images/generations")
+    async def generations(request: Request) -> JSONResponse:
+        started_at = getattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, None)
+        return JSONResponse({"started_at_type": type(started_at).__name__})
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/v1/images/generations", json={"model": "gpt-image-2"})
+
+    assert response.status_code == 200
+    assert response.json() == {"started_at_type": "float"}
+
+
+async def test_exception_observability_consumes_middleware_started_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[float] = []
+
+    def fake_record(**kwargs: Any) -> None:
+        recorded.append(kwargs["started_at"])
+
+    monkeypatch.setattr(exceptions_module, "record_images_route_observability", fake_record)
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.post("/v1/images/generations")
+    async def deny() -> JSONResponse:
+        raise ProxyAuthError("missing credentials")
+
+    scope = _http_scope("/v1/images/generations", json_body=True)
+
+    sent = await _drive(app, scope)
+
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 401
+    # The handler read the ingress stamp through request.state, not the perf_counter fallback.
+    assert recorded == [scope["state"][IMAGE_ROUTE_STARTED_AT_STATE]]
+
+
+@pytest.mark.parametrize("path", ["/v1/images/generations", "/v1/images/edits"])
+async def test_forwarded_messages_are_identical_with_and_without_middleware(path: str) -> None:
+    without = await _drive(_build_relay_app(with_middleware=False), _http_scope(path, json_body=True))
+    with_middleware = await _drive(_build_relay_app(with_middleware=True), _http_scope(path, json_body=True))
+
+    assert with_middleware == without
+    assert [message["type"] for message in without][:2] == ["http.response.start", "http.response.body"]
+    assert without[-1].get("more_body", False) is False
+
+
+async def test_mid_stream_generator_failure_propagates_without_terminator() -> None:
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.post("/v1/images/edits")
+    async def failing_stream() -> StreamingResponse:
+        async def body() -> AsyncIterator[bytes]:
+            yield b"one"
+            yield b"two"
+            raise RuntimeError("upstream broke mid-stream")
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    sent: list[Message] = []
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    with pytest.raises(RuntimeError, match="mid-stream"):
+        await app(_http_scope("/v1/images/edits"), _server_receive(), send)
+
+    bodies = [(message["body"], message["more_body"]) for message in sent if message["type"] == "http.response.body"]
+    # BaseHTTPMiddleware used to append a synthetic ``more_body=False`` chunk before
+    # re-raising; pure ASGI leaves the stream unterminated so the server closes it.
+    assert bodies == [(b"one", True), (b"two", True)]


### PR DESCRIPTION
## Summary

`add_exception_handlers` still registered one `@app.middleware("http")` (the image-route `started_at` stamp), which Starlette 1.3.1 implements as `BaseHTTPMiddleware`: per HTTP request it builds a `_CachedRequest`, an anyio `Event`, a memory-object-stream pair and a task group, runs the **entire downstream HTTP app in a child task**, and relays every response chunk through the memory stream back to the outer task. Every other middleware in `create_app()` was already converted to pure ASGI (#1784-#1789); this one was missed.

Prod evidence (soju07, 2x Neoverse-N1, `workers=1`, v1.25.0-beta.1, py-spy `--gil` 60 s at rate 20, 1085 GIL samples, CPU pegged ~100% at ~10k req/h): 231/1085 samples (21.3%) contain `starlette/middleware/base.py`; 186 are rooted at the child-task coroutine (`base.py:144`), which is why the 14 inner middlewares show 17-18% inclusive while the outermost `trusted_proxy_headers.py:31` shows only 3.7% -- that 3.7% is the outer-task relay (`body_stream` -> anyio memory receive / `Event.__init__` -> uvicorn send). Strictly removable share is estimated at ~3-4% of GIL samples plus fewer task switches per streamed chunk (loop lag). Details: campaign plan item 6.

This PR replaces the decorator with a pure ASGI `ImageRouteStartedAtMiddleware` that writes `time.perf_counter()` into `scope["state"]` (which is what backs `Request.state`) and registers it via `app.add_middleware(...)` at the same slot, so `app/main.py` and the production middleware order (trusted-proxy-headers -> image started_at -> app-version -> ...) are untouched.

## Change details

- `app/core/handlers/exceptions.py` -- new `ImageRouteStartedAtMiddleware` (pure ASGI, `scope.setdefault("state", {})[IMAGE_ROUTE_STARTED_AT_STATE] = perf_counter()` when `scope["type"] == "http"` and `get_route_path(scope)` matches an image route); `add_exception_handlers` now calls `app.add_middleware(ImageRouteStartedAtMiddleware)` instead of the `@app.middleware("http")` closure. The three consumers (`app/modules/proxy/api.py`, `app/core/handlers/exceptions.py`, `app/core/middleware/required_capability_http.py`) keep reading `getattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, None)` unchanged.
- `tests/unit/test_image_route_started_at_middleware.py` -- new (16 tests, see below).
- `openspec/changes/perf-basehttp-middleware-to-asgi/` -- proposal, tasks, context, delta specs for `images-api-compat` and `http-ingress-limits`.

No other `BaseHTTPMiddleware` / `@app.middleware("http")` remains under `app/`. Net +421/-9.

## Byte-compat / behavior notes

Verified with a real uvicorn (h11 and httptools) byte comparison of the old stack vs the new one: JSON responses, chunked / non-ASCII / empty-chunk request bodies, the 401 handler path with the `images_route_complete` log line (started_at consumed from scope state), 204, 404, 405, SSE with an empty mid-stream chunk, and client-disconnect-mid-SSE (generator observes `CancelledError` + `finally` identically, so the reservation-release paths in `api.py` are unaffected) are all byte-identical.

**Accepted behavior change (intentional, please review):** a response body generator that raises *after* some chunks were already sent. `BaseHTTPMiddleware` emitted a synthetic `http.response.body` with `more_body=False` and then re-raised, so the client saw a cleanly terminated but truncated body. With pure ASGI the exception propagates to uvicorn without that terminator and uvicorn closes the transport, so the client observes a connection close instead of a clean end-of-stream. This matches how every other converted middleware already behaves for the paths it wraps. Pinned by `test_mid_stream_generator_failure_propagates_without_terminator` (fails on the old form) and documented in the OpenSpec `context.md` and the `http-ingress-limits` delta.

Scheduling: the HTTP app no longer runs in a child task, so client-disconnect cancellation propagates directly and request-id contextvars stay visible for the whole response stream (the `request_id.py` docstring already assumed this). Exception handlers live in `ExceptionMiddleware` / `ServerErrorMiddleware` and are unaffected. WebSocket scopes are passed through untouched.

## Expected gain

In-process ASGI micro-benchmark (`bench_basehttp.py`: FastAPI app driven without a server, realistic `receive` = one `http.request` then `http.disconnect`, 100 warmup, 10 000 JSON requests / 1 000 streams of 200 SSE chunks; "before" = the exact `@app.middleware("http")` form being replaced, "after" = `ImageRouteStartedAtMiddleware`, "none" = no middleware floor). Python 3.14.6, 3 runs each:

| workload | before (us/req) | after (us/req) | floor | saved |
|---|---|---|---|---|
| uvloop 0.22.1, JSON 1 chunk | 168.2 / 224.9 / 176.4 | 35.9 / 54.2 / 37.5 | 36.2 / 42.4 / 38.6 | ~130-170 us/request (after == floor) |
| uvloop 0.22.1, 200-chunk SSE | 503.0 / 669.2 / 516.1 | 314.3 / 443.9 / 294.1 | 289.8 / 420.8 / 316.7 | ~190-225 us/stream (~1 us/chunk) |
| plain asyncio, JSON 1 chunk (1 run) | 408.6 | 45.5 | -- | ~363 us/request |
| plain asyncio, 200-chunk SSE (1 run) | 1139.1 | 437.0 | -- | ~700 us/stream (~3.5 us/chunk) |

Honest reading: the per-request saving matches the plan (~130-185 us). The per-chunk saving (~1 us uvloop / ~3.5 us asyncio) is far below the plan's 12-17 us/chunk figure, so the win is mostly per-request task-group/stream/Event setup and fewer task switches, not raw per-chunk CPU. The ~3-4% GIL estimate rests on the prod profile sample counts (+-30%), not on the micro-bench; verify after deploy with `py-spy --gil` (rate 10-20, 60 s): `starlette/middleware/base.py` frames should vanish and `trusted_proxy_headers.py:31` inclusive should rise to become the true outermost app frame while the `run (asyncio/runners.py)` leaf drops. Also removes one anyio task group + `Event` + two memory streams per HTTP request.

## OpenSpec

Change folder `openspec/changes/perf-basehttp-middleware-to-asgi/` (`openspec validate perf-basehttp-middleware-to-asgi --strict` => valid; `openspec validate --specs` => 57 passed, only the pre-existing `model-source-routing` failure on main):

- `images-api-compat` -- MODIFIED requirement "Image routes expose bounded operational observability": adds scenario "Pre-handler rejection measures duration from ingress" (a 413 / capability-deny rejected before the handler still logs `images_route_complete` with a duration measured from HTTP ingress, i.e. the middleware's stamp, not the exception handler's own clock).
- `http-ingress-limits` -- ADDED requirement "HTTP middleware relays responses in the request task": (1) the production stack contains no `BaseHTTPMiddleware`, (2) a streaming body is forwarded unchanged, (3) a mid-stream failure propagates without a synthetic terminator (the accepted framing change above).

Deviation from the plan: a full change folder with two deltas rather than only a context note, because `openspec validate` requires at least one delta for a change. The `http-ingress-limits` requirement states the whole HTTP stack MUST be pure ASGI, which is slightly broader than this single middleware but is exactly what the new guard test enforces; happy to narrow it to the framing scenario only if preferred.

## Tests

New `tests/unit/test_image_route_started_at_middleware.py` (16 tests):

- `test_production_stack_has_no_basehttp_middleware` -- no `create_app().user_middleware` entry has `cls is BaseHTTPMiddleware`; order TrustedProxyHeaders < ImageRouteStartedAt < AppVersion preserved; `middleware_stack` left unbuilt (as `test_otel.py` expects). Fails on main (the closure registers `BaseHTTPMiddleware`).
- `test_image_route_scope_receives_float_started_at[4 image paths]`, `test_image_route_started_at_reuses_existing_scope_state`, `test_image_route_started_at_strips_root_path`, `test_non_image_http_scope_is_left_untouched[3 paths]`, `test_websocket_scope_passes_through_untouched` -- scope-state semantics.
- `test_request_state_exposes_started_at_to_route_handler` -- the value is readable via `request.state` through FastAPI + httpx.
- `test_exception_observability_consumes_middleware_started_at` -- `ProxyAuthError` 401 on `/v1/images/generations`: `record_images_route_observability` receives exactly `scope["state"][IMAGE_ROUTE_STARTED_AT_STATE]` (not the `perf_counter` fallback). Guards the path that would silently regress to a near-zero duration if the stamp stopped reaching `request.state`.
- `test_forwarded_messages_are_identical_with_and_without_middleware[json, sse-stream]` -- full ASGI message sequence (headers, body, more_body) equal with and without the middleware.
- `test_mid_stream_generator_failure_propagates_without_terminator` -- pins the accepted framing change: bodies `[(b"one", True), (b"two", True)]`, `RuntimeError` propagates, no `more_body=False` terminator. Fails on the old `BaseHTTPMiddleware` form.

Existing coverage re-run unchanged: `tests/integration/test_proxy_images.py`, `test_daybreak_capability_routes.py`, `test_proxy_responses.py` (262 passed; covers 413 multipart / auth-deny / alias observability log lines and Responses SSE streaming) and the middleware unit modules (`test_path_rewrite_middleware`, `test_multipart_content_encoding_middleware`, `test_request_body_limit_middleware`, `test_trusted_proxy_headers_middleware`, `test_otel`, `test_app_version_middleware`, `test_request_id_middleware`, `test_sse`, `test_request_decompression_middleware`, `test_responses_streaming_timeout_hardening`).

Gates at head: `ruff check .` / `ruff format --check .` clean, `ty check` clean, `scripts/check_proxy_architecture.py` passed, openspec as above, 828 unit tests across the touched/neighbouring modules passed. One unrelated failure was observed while smoke-testing neighbours: `tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` fails standalone on origin/main too (`no such table: file_account_pins` -- the test calls `_pin_file_account` against the real session factory without requesting `db_setup`, so it only passes when a DB-backed test ran earlier in the process; it passes when preceded by any `async_client` test). Pre-existing, not touched here.

## Review trail

- Local Codex review (`codex review --base origin/main`): zero findings; summary confirms route matching, scope-state propagation and ordering are preserved and the tests cover forwarding, observability, scope handling and streaming failure.
- Adversarial verification round (independent worktree re-derivation + real-uvicorn h11/httptools byte comparison of old vs new stack, gates re-run): 0 blocking findings, 3 P3 documentation/accuracy notes, all folded into this body (mid-stream framing wording, per-chunk numbers stated as measured rather than the plan's estimate, prod gain stated as a profile-sample estimate).
- Findings fixed during implementation: 4 `ty` diagnostics in the new test's `list.index` calls (rewritten with the `next(enumerate(...))` pattern used by the sibling ordering tests).

## Deploy notes / hazards

- No config, migration or env change. Pure in-process refactor; safe to roll with the normal ZDT flow.
- Post-deploy verification: `py-spy --gil` on the app process, rate 10-20 for <= 60 s only (prod py-spy at rate 100 has previously stalled the app through health checks); expect no `starlette/middleware/base.py` frames.
- Campaign-wide upgrade hazard (not introduced here, applies to any deploy from main): main rejects `http://user:pw@` proxy endpoints (`plaintext_proxy_credentials_forbidden`, #1995); prod's current routed-proxy endpoint must be re-created as `https://` or credential-less before upgrading, or every routed request fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved HTTP request handling efficiency, particularly for image-generation and image-editing routes.
  * Reduced overhead for streaming responses and improved cancellation responsiveness.

* **Monitoring**
  * Preserved route timing, metrics, and structured completion logs, including requests rejected before reaching a handler.

* **Reliability**
  * Streaming failures now propagate directly to the server, allowing connections to close cleanly instead of emitting a synthetic final response chunk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->