### PR TITLE
perf(proxy-responses): parse each bridge SSE event once and relay unchanged upstream JSON text without re-dump

### DIFF
--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -120,12 +120,85 @@ def format_sse_event(payload: JsonPayload) -> str:
     return f"data: {data}\n\n"
 
 
+def _is_single_line_json_object_text(text: str) -> bool:
+    return text.startswith("{") and "\n" not in text and "\r" not in text
+
+
+def format_sse_event_from_text(payload: Mapping[str, JsonValue], text: str) -> str:
+    """Frame an already-serialized JSON object without re-dumping it.
+
+    ``text`` MUST be a JSON serialization of ``payload`` (the upstream frame the
+    payload was parsed from, or a compact re-dump of it). The result carries the
+    same ``event:`` line ``format_sse_event(payload)`` would emit, but its
+    ``data:`` line is ``text`` verbatim, so non-ASCII stays UTF-8 instead of
+    being ``\\uXXXX``-escaped and the JSON is never re-serialized. Anything
+    that would not produce a canonical single-line block (multi-line or
+    whitespace-prefixed text) falls back to ``format_sse_event``.
+    """
+    if not _is_single_line_json_object_text(text):
+        return format_sse_event(payload)
+    event_type = payload.get("type")
+    if isinstance(event_type, str) and event_type:
+        return f"event: {event_type}\ndata: {text}\n\n"
+    return f"data: {text}\n\n"
+
+
 def format_sse_data(payload: Mapping[str, JsonValue]) -> str:
     data = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
     return f"data: {data}\n\n"
 
 
+class ParsedSseBlock(str):
+    """An SSE event block that carries its already-parsed ``data:`` payload.
+
+    Behaves exactly like ``str`` (framing, encoding, comparison, ``startswith``);
+    ``payload`` is what ``parse_sse_data_json`` returns for the same text, so a
+    chain of stream stages parses each block once. The payload object is shared
+    by every stage that receives the block: consumers MUST treat it as read-only
+    and copy before mutating. Derived strings (``strip()``, concatenation) are
+    plain ``str`` and take the full parse path again.
+    """
+
+    # ``__slots__`` is not supported on ``str`` subclasses; the instance dict
+    # costs ~100-200 B per block, far less than a redundant JSON parse.
+    payload: dict[str, JsonValue] | None
+
+    def __new__(cls, block: str, payload: dict[str, JsonValue] | None) -> ParsedSseBlock:
+        instance = super().__new__(cls, block)
+        instance.payload = payload
+        return instance
+
+
+def sse_block_with_payload(event_block: str, payload: dict[str, JsonValue] | None) -> ParsedSseBlock:
+    """Attach ``payload`` (the result of ``parse_sse_data_json(event_block)``) to the block."""
+    if isinstance(event_block, ParsedSseBlock) and event_block.payload is payload:
+        return event_block
+    return ParsedSseBlock(event_block, payload)
+
+
+def parse_sse_data_json_text(text: str) -> dict[str, JsonValue] | None:
+    """Parse one ``data:`` value as a JSON object.
+
+    Equivalent to ``parse_sse_data_json(f"data: {text}\\n\\n")`` but skips SSE
+    line parsing when ``text`` is a single-line JSON object — the shape every
+    upstream websocket frame has. Other inputs (blank, ``[DONE]``, multi-line or
+    whitespace-prefixed text) take the exact SSE field path so the ``None`` and
+    line-joining semantics stay identical.
+    """
+    if _is_single_line_json_object_text(text):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        if is_json_dict(payload):
+            return payload
+        return None
+    return parse_sse_data_json(f"data: {text}\n\n")
+
+
 def parse_sse_data_json(event_block: str) -> dict[str, JsonValue] | None:
+    if isinstance(event_block, ParsedSseBlock):
+        return event_block.payload
     data = extract_sse_data(event_block)
     if data is None:
         return None

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -54,7 +54,7 @@ from app.core.openai.requests import (
 )
 from app.core.types import JsonObject, JsonValue
 from app.core.utils.request_id import ensure_request_id, ensure_request_scope_id
-from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.sse import format_sse_event, parse_sse_data_json, sse_block_with_payload
 from app.core.utils.time import utcnow
 from app.db.models import (
     HttpBridgeSessionState,
@@ -5219,7 +5219,9 @@ class _HTTPBridgeStreamingMixin:
                         request_state.error_http_status_override,
                         _openai_error_envelope_from_response_failed_payload(block_payload),
                     )
-                yield event_block
+                # Carry the parsed payload so the API-layer normalizers reuse
+                # it instead of parsing the same block again.
+                yield sse_block_with_payload(event_block, block_payload)
                 yielded_any = True
         finally:
             with anyio.CancelScope(shield=True):

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -2609,13 +2609,20 @@ class _HTTPBridgeUpstreamEventsMixin:
                     suppress_downstream_event = True
                 if payload is not None:
                     rewritten_payload = _rewrite_websocket_downstream_response_id(payload, matched_request_state)
-                    if rewritten_payload is not payload:
+                    # ``text`` is the serialization ``payload`` was parsed from (or the
+                    # tool-call rewrite's compact re-dump). Relaying it verbatim is
+                    # only valid while nothing above mutated ``payload`` in place:
+                    # ``mark_duplicate_tool_call_downstream_event`` trims partially
+                    # duplicated ``multi_tool_use.parallel`` arguments on
+                    # ``response.output_item.done`` items without returning a new
+                    # object, so those (rare, per-item) events are always
+                    # re-serialized. Every other pre-framing step is read-only.
+                    if rewritten_payload is not payload or event_type == "response.output_item.done":
                         payload = rewritten_payload
                         event_block = format_sse_event(payload)
                     else:
                         # Identity fast path: nothing changed, so frame the
-                        # upstream JSON text (or the tool-call rewrite's compact
-                        # re-dump) instead of serializing the dict again.
+                        # upstream JSON text instead of serializing the dict again.
                         event_block = format_sse_event_from_text(payload, text)
                 if _websocket_should_defer_reasoning_prelude(matched_request_state, event_type, payload):
                     matched_request_state.deferred_reasoning_downstream_texts.append(event_block)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -49,7 +49,7 @@ from app.core.types import JsonValue
 from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
-from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.sse import format_sse_event, format_sse_event_from_text, parse_sse_data_json_text
 from app.db.models import Account
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
@@ -2360,8 +2360,11 @@ class _HTTPBridgeUpstreamEventsMixin:
         session: "_HTTPBridgeSession",
         text: str,
     ) -> None:
+        # One JSON document per websocket text frame: parse it directly instead
+        # of framing it as SSE and running the line parser over it. The
+        # data-only block is what unmatched events relay.
         event_block = f"data: {text}\n\n"
-        payload = parse_sse_data_json(event_block)
+        payload = parse_sse_data_json_text(text)
         event_type = classify_event_type(payload)
         event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
         completed_delivery_scope = _HTTPBridgeCompletedDeliveryScope() if event_type == "response.completed" else None
@@ -2605,8 +2608,15 @@ class _HTTPBridgeUpstreamEventsMixin:
                     matched_request_state.suppress_next_created_downstream = False
                     suppress_downstream_event = True
                 if payload is not None:
-                    payload = _rewrite_websocket_downstream_response_id(payload, matched_request_state)
-                    event_block = format_sse_event(payload)
+                    rewritten_payload = _rewrite_websocket_downstream_response_id(payload, matched_request_state)
+                    if rewritten_payload is not payload:
+                        payload = rewritten_payload
+                        event_block = format_sse_event(payload)
+                    else:
+                        # Identity fast path: nothing changed, so frame the
+                        # upstream JSON text (or the tool-call rewrite's compact
+                        # re-dump) instead of serializing the dict again.
+                        event_block = format_sse_event_from_text(payload, text)
                 if _websocket_should_defer_reasoning_prelude(matched_request_state, event_type, payload):
                     matched_request_state.deferred_reasoning_downstream_texts.append(event_block)
                     matched_request_state.last_upstream_activity_at = now

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -9850,6 +9850,10 @@ def _looks_like_sse_data_block(event_block: str) -> bool:
 
 
 def _looks_like_sse_comment_block(event_block: str) -> bool:
+    if event_block.startswith(("event: ", "data: ")):
+        # Canonical event blocks open with a field line, which is neither
+        # blank nor a comment; skip the per-line scan on the hot path.
+        return False
     return bool(event_block.strip()) and all(
         not line.strip() or line.lstrip().startswith(":") for line in event_block.splitlines()
     )

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/context.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/context.md
@@ -1,0 +1,51 @@
+# Context
+
+## Where the cost was
+
+Production GIL profile (soju07, 2x Neoverse-N1, `workers=1`, 60 s, 1085 samples):
+
+- `_process_http_bridge_upstream_text -> parse_sse_data_json` 13 samples and the
+  unconditional `format_sse_event` at the matched-request site 11 samples (2.2%).
+- `parse_sse_data_json` under `_stream_http_bridge_session_events`,
+  `_normalize_reasoning_summary_stream`, and `_normalize_public_responses_stream`
+  another ~28 samples (2.6%): three full parses of a block whose payload was
+  already known.
+
+## Why the fast path is safe
+
+- Upstream websocket frames are one JSON document each. `parse_sse_data_json_text`
+  only takes the direct path when the text starts with `{` and contains no CR/LF,
+  which is exactly the case where the SSE field parser would have produced the
+  same string back; everything else (blank, `[DONE]`, pretty-printed, leading
+  whitespace) still goes through the field parser, so `None` semantics and the
+  multi-line join are unchanged. A Hypothesis test pins the equivalence.
+- `format_sse_event_from_text` requires that `text` is a serialization of
+  `payload`. At the call site this holds because the payload was parsed from that
+  text, or the tool-call rewrite replaced both together with a compact re-dump.
+  The `event:` line uses the same `isinstance(type, str) and type` rule as
+  `format_sse_event`, not `classify_event_type`, so typeless error frames remain
+  data-only exactly as before.
+- Bytes differ from the previous output only for non-ASCII frames (UTF-8 instead
+  of `\uXXXX`). Nothing hashes relayed event text; the durable fingerprint covers
+  request text only. `sse_event_type_from_block` and
+  `_has_canonical_event_framing` match on the `event:` line and accept raw UTF-8.
+
+## The carrier
+
+`ParsedSseBlock` is a plain `str` subclass with a `payload` attribute. It behaves
+like `str` for framing checks, `encode`, equality, and the ASGI body writer.
+Derived strings (`strip()`, concatenation) are plain `str`, so a stage that
+rewrites a block cannot accidentally forward a stale payload. Consumers must
+treat the payload as read-only; the API-layer normalizers already copy before
+mutating (`dict(payload)`), and
+`test_normalize_public_responses_stream_reuses_carried_payload_without_mutating_it`
+runs both normalizers over deep-frozen payloads to keep that true.
+
+## Measured (300-event stream, this venv, CPython 3.14)
+
+| path | before | after |
+|---|---|---|
+| reader parse + frame, ASCII | ~2.8-3.1 ms | ~1.1 ms |
+| reader parse + frame, Korean | ~3.3-3.5 ms | ~1.75 ms |
+| 3-stage consumer parse, ASCII | ~4.7-7.9 ms | ~2.2 ms |
+| 3-stage consumer parse, Korean | ~5.9-8.3 ms | ~2.1 ms |

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/proposal.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Every event an HTTP-bridge session receives from the upstream Responses websocket
+is one JSON document per text frame, yet the reader wraps it as `data: <text>\n\n`,
+runs the full SSE line parser over the synthesized block, and then — for every
+event routed to a pending request — re-serializes the parsed dict with
+`json.dumps(ensure_ascii=True)` even when nothing about the payload changed. The
+response-id rewrite helper already documents an identity fast path ("callers skip
+re-serialization when the original payload object comes back"), but the call site
+never honored it.
+
+Downstream, the same block is then parsed three more times by three generator
+stages that only share an `AsyncIterator[str]`: the bridge stream consumer, the
+reasoning-summary normalizer, and the public Responses normalizer.
+
+On the production profile (soju07, 60 s GIL sample, 1085 samples) the reader
+parse+re-dump and the triple downstream parse together account for roughly
+2.5-3.5% of GIL time. A 300-event micro-benchmark shows the reader path at
+~9-11 us/event and the consumer chain at ~15-27 us/event.
+
+## What Changes
+
+- The bridge reader parses each upstream frame directly as a JSON object when the
+  frame is a single-line object (the only shape upstream emits); every other
+  input keeps the exact SSE `data:` field semantics, so `None` results and
+  multi-line handling are unchanged.
+- When the downstream response-id rewrite returns the identical payload object,
+  the relayed block is framed from the upstream JSON text (or the tool-call
+  rewrite's compact re-dump) instead of being re-serialized. The `event:` line is
+  derived from the payload's string `type`, exactly as `format_sse_event` does;
+  typeless `{"error": ...}` frames stay data-only.
+- **Observable byte change**: relayed event `data:` lines are now the upstream
+  UTF-8 JSON text verbatim. For ASCII-only frames this is byte-identical to the
+  previous `json.dumps` output; for frames containing non-ASCII characters the
+  text is no longer `\uXXXX`-escaped. The JSON value is identical in every case
+  and every downstream consumer re-parses JSON. Rewritten payloads (response-id
+  alignment, tool-call dedupe, error masking) continue to be re-serialized.
+- The bridge stream consumer attaches the payload it already parsed to the block
+  it yields (`ParsedSseBlock`, a `str` subclass); `parse_sse_data_json` returns
+  that payload directly, so the two API-layer normalizers stop re-parsing
+  pass-through blocks. The shared payload is read-only by contract; all existing
+  consumers copy before mutating, and a test pins that with frozen payloads.
+
+## Impact
+
+- Affected specs: `responses-api-compat` (downstream SSE framing of relayed
+  bridge events).
+- Affected code: `app/core/utils/sse.py`,
+  `app/modules/proxy/_service/http_bridge/upstream_events.py`,
+  `app/modules/proxy/_service/http_bridge/streaming.py`,
+  `app/modules/proxy/api.py` (comment-block fast path only).
+- No new settings, no migration, no dashboard surface.
+- Durable bridge spools store the relayed block text, so transcripts written
+  after this change carry UTF-8 rather than escaped text for non-ASCII frames;
+  replay re-parses JSON and the request fingerprint covers request text only, so
+  no cross-version comparison is affected.

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/specs/responses-api-compat/spec.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/specs/responses-api-compat/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge relays unchanged upstream events as their upstream JSON text
+
+When an HTTP bridge session relays an upstream Responses event to a pending
+request's downstream SSE stream and the proxy did not change the event's JSON
+value (no downstream response-id alignment, tool-call rewrite, or error
+masking applied), the relayed `data:` line MAY be the upstream JSON text
+verbatim instead of a proxy re-serialization. The relayed block MUST use the
+canonical framing `event: <type>\ndata: <json>\n\n` when the payload carries a
+non-empty string `type`, and data-only framing `data: <json>\n\n` otherwise.
+Any SSE-compliant parser MUST obtain the identical JSON value from the relayed
+block that it would obtain from the proxy's re-serialized form. Events whose
+JSON value the proxy changed MUST continue to be re-serialized from the
+rewritten payload.
+
+#### Scenario: Unchanged event with non-ASCII text is relayed as upstream UTF-8
+
+- **GIVEN** an HTTP bridge request whose upstream response id already matches
+  its downstream response id
+- **WHEN** the upstream emits a single-line `response.output_text.delta` event
+  whose `delta` contains Korean text and U+2028
+- **THEN** the downstream block is `event: response.output_text.delta` followed
+  by a `data:` line containing the upstream JSON text unchanged
+- **AND** parsing the block yields the same JSON value as parsing the proxy's
+  re-serialized form of that event
+
+#### Scenario: Unchanged ASCII event is byte-identical to re-serialization
+
+- **WHEN** the upstream emits a compact, ASCII-only event that the proxy does not
+  rewrite
+- **THEN** the relayed block is byte-identical to the block the proxy would have
+  produced by re-serializing the parsed payload
+
+#### Scenario: Rewritten event is re-serialized
+
+- **GIVEN** an HTTP bridge request whose downstream response id differs from the
+  upstream response id
+- **WHEN** the upstream emits an event carrying the upstream response id
+- **THEN** the relayed block is re-serialized from the rewritten payload and
+  carries the downstream response id
+- **AND** the upstream JSON text does not appear in the relayed block
+
+#### Scenario: Typeless error frame stays data-only
+
+- **WHEN** an upstream frame is a JSON object without a string `type` field
+- **THEN** the relayed framing derived from that payload has no `event:` line

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/specs/responses-api-compat/spec.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/specs/responses-api-compat/spec.md
@@ -41,6 +41,17 @@ rewritten payload.
   carries the downstream response id
 - **AND** the upstream JSON text does not appear in the relayed block
 
+#### Scenario: In-place trimmed parallel tool uses are re-serialized
+
+- **GIVEN** an HTTP bridge request that already relayed a
+  `response.output_item.done` `multi_tool_use.parallel` call containing a
+  side-effect tool use
+- **WHEN** the upstream emits a second `response.output_item.done`
+  `multi_tool_use.parallel` call whose tool uses only partially repeat the first
+- **THEN** the relayed block is re-serialized from the trimmed payload and
+  carries only the non-duplicate tool uses
+- **AND** the untrimmed upstream JSON text does not appear in the relayed block
+
 #### Scenario: Typeless error frame stays data-only
 
 - **WHEN** an upstream frame is a JSON object without a string `type` field

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/tasks.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+## 1. Parse once at the bridge reader
+
+- [x] 1.1 Add `parse_sse_data_json_text` to `app/core/utils/sse.py`: direct
+      `json.loads` for single-line JSON-object text, exact `data:` field fallback
+      otherwise; property-test equivalence with `parse_sse_data_json(f"data: {text}\n\n")`
+- [x] 1.2 Use it in `_process_http_bridge_upstream_text` instead of framing and
+      re-parsing the upstream frame
+
+## 2. Relay unchanged events without re-serializing
+
+- [x] 2.1 Add `format_sse_event_from_text(payload, text)` producing the canonical
+      block from already-serialized text, with `format_sse_event` fallback for
+      non-canonical text
+- [x] 2.2 Honor the identity contract of `_rewrite_websocket_downstream_response_id`
+      in `_process_parsed_http_bridge_upstream_event`: re-serialize only when the
+      payload object changed
+
+## 3. Carry the parsed payload downstream
+
+- [x] 3.1 Add `ParsedSseBlock` (str subclass) and `sse_block_with_payload`;
+      `parse_sse_data_json` returns the carried payload
+- [x] 3.2 Yield carrier blocks from `_stream_http_bridge_session_events`
+- [x] 3.3 Fast-path canonical `event:`/`data:` blocks in `_looks_like_sse_comment_block`
+
+## 4. Verification
+
+- [x] 4.1 Reader parity tests: non-ASCII/U+2028 relay is JSON-equivalent to the
+      previous re-serialized block, ASCII relay is byte-identical, rewritten
+      response ids are re-serialized
+- [x] 4.2 Carrier survives both API-layer normalizers with byte-identical output and
+      a frozen shared payload (mutation-freedom contract)
+- [x] 4.3 Existing bridge streaming, transcript codec, and public contract tests pass

--- a/openspec/changes/relay-bridge-events-as-upstream-json-text/tasks.md
+++ b/openspec/changes/relay-bridge-events-as-upstream-json-text/tasks.md
@@ -16,6 +16,9 @@
 - [x] 2.2 Honor the identity contract of `_rewrite_websocket_downstream_response_id`
       in `_process_parsed_http_bridge_upstream_event`: re-serialize only when the
       payload object changed
+- [x] 2.3 Always re-serialize `response.output_item.done` events: the parallel
+      tool-use dedupe trims duplicated tool uses by mutating the payload in place,
+      so the upstream text can be stale for that event type
 
 ## 3. Carry the parsed payload downstream
 
@@ -31,4 +34,6 @@
       response ids are re-serialized
 - [x] 4.2 Carrier survives both API-layer normalizers with byte-identical output and
       a frozen shared payload (mutation-freedom contract)
+- [x] 4.4 Bridge-level regression: partially duplicated parallel tool uses reach the
+      client trimmed; the fast path only frames text that still serializes its payload
 - [x] 4.3 Existing bridge streaming, transcript codec, and public contract tests pass

--- a/tests/unit/test_http_bridge_cancel_drain.py
+++ b/tests/unit/test_http_bridge_cancel_drain.py
@@ -222,9 +222,9 @@ async def test_http_bridge_stream_waits_only_while_completed_delivery_is_active(
     queue_waiting = asyncio.Event()
     terminal_claimed = asyncio.Event()
     release_terminal = asyncio.Event()
-    parse_sse_data_json = Mock(wraps=http_bridge_upstream_events.parse_sse_data_json)
+    parse_sse_data_json_text = Mock(wraps=http_bridge_upstream_events.parse_sse_data_json_text)
     parse_sse_event_payload = Mock(wraps=http_bridge_upstream_events.parse_sse_event_payload)
-    monkeypatch.setattr(http_bridge_upstream_events, "parse_sse_data_json", parse_sse_data_json)
+    monkeypatch.setattr(http_bridge_upstream_events, "parse_sse_data_json_text", parse_sse_data_json_text)
     monkeypatch.setattr(http_bridge_upstream_events, "parse_sse_event_payload", parse_sse_event_payload)
 
     class ObservedQueue(asyncio.Queue[str | None]):
@@ -326,7 +326,7 @@ async def test_http_bridge_stream_waits_only_while_completed_delivery_is_active(
         finalize_request.assert_not_awaited()
     assert request_state.completed_delivery_scope is not None
     assert request_state.completed_delivery_scope.active is False
-    assert parse_sse_data_json.call_count == 1
+    assert parse_sse_data_json_text.call_count == 1
     assert parse_sse_event_payload.call_count == 1
     suppression_messages = [
         record.getMessage()

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -11,6 +11,7 @@ import pytest
 import app.modules.proxy.api as proxy_api_module
 from app.core.openai.models import CompactResponsePayload
 from app.core.types import JsonValue
+from app.core.utils.sse import ParsedSseBlock, format_sse_event, sse_block_with_payload
 
 pytestmark = pytest.mark.unit
 
@@ -2079,3 +2080,216 @@ async def test_normalize_public_stream_reframes_data_only_blocks_with_event_name
     reframed = [block for block in blocks if '"delta":"x"' in block]
     assert reframed
     assert reframed[0].startswith("event: response.output_text.delta\n")
+
+
+class _FrozenDict(dict[str, Any]):
+    """Test-only dict that fails loudly when a stream stage mutates a shared payload."""
+
+    def _frozen(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("shared SSE payload was mutated in place")
+
+    __setitem__ = __delitem__ = _frozen
+    clear = pop = popitem = setdefault = update = _frozen
+
+
+class _FrozenList(list[Any]):
+    def _frozen(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("shared SSE payload list was mutated in place")
+
+    __setitem__ = __delitem__ = __iadd__ = _frozen
+    append = extend = insert = pop = remove = clear = sort = reverse = _frozen
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _FrozenDict({key: _deep_freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return _FrozenList(_deep_freeze(item) for item in value)
+    return value
+
+
+_CARRIER_STREAM_PAYLOADS: list[dict[str, Any]] = [
+    {"type": "codex.rate_limits", "plan_type": "pro", "rate_limits": {"allowed": True}},
+    {"type": "response.created", "sequence_number": 0, "response": {"id": "resp_c", "status": "in_progress"}},
+    {
+        "type": "response.output_item.added",
+        "sequence_number": 1,
+        "output_index": 0,
+        "item": {"id": "rs_1", "type": "reasoning", "summary": []},
+    },
+    {
+        "type": "response.reasoning_summary_text.delta",
+        "sequence_number": 2,
+        "item_id": "rs_1",
+        "output_index": 0,
+        "summary_index": 0,
+        "delta": "\ud55c\uae00 thinking",
+    },
+    {
+        "type": "response.reasoning_summary_text.delta",
+        "sequence_number": 3,
+        "item_id": "rs_1",
+        "output_index": 0,
+        "summary_index": 0,
+        "delta": " more",
+    },
+    {
+        "type": "response.reasoning_summary_text.done",
+        "sequence_number": 4,
+        "item_id": "rs_1",
+        "output_index": 0,
+        "summary_index": 0,
+        "text": "\ud55c\uae00 thinking more",
+    },
+    {
+        "type": "response.output_item.done",
+        "sequence_number": 5,
+        "output_index": 0,
+        "item": {
+            "id": "rs_1",
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "\ud55c\uae00 thinking more"}],
+        },
+    },
+    {
+        "type": "response.output_item.added",
+        "sequence_number": 6,
+        "output_index": 1,
+        "item": {"id": "msg_1", "type": "message", "status": "in_progress", "role": "assistant", "content": []},
+    },
+    {
+        "type": "response.output_text.delta",
+        "sequence_number": 7,
+        "item_id": "msg_1",
+        "output_index": 1,
+        "content_index": 0,
+        "delta": "caf\u00e9 \u2028",
+    },
+    {
+        "type": "response.output_text.delta",
+        "sequence_number": 8,
+        "item_id": "msg_1",
+        "output_index": 1,
+        "content_index": 0,
+        "delta": " done",
+    },
+    {
+        "type": "response.output_item.done",
+        "sequence_number": 9,
+        "output_index": 1,
+        "item": {
+            "id": "msg_1",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "caf\u00e9 \u2028 done", "annotations": []}],
+        },
+    },
+    {
+        "type": "response.completed",
+        "sequence_number": 10,
+        "response": {
+            "id": "resp_c",
+            "status": "completed",
+            "output": [],
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        },
+    },
+]
+
+
+def _carrier_blocks(*, frozen: bool) -> list[str]:
+    blocks: list[str] = []
+    for payload in _CARRIER_STREAM_PAYLOADS:
+        text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        event_type = payload["type"]
+        block = f"event: {event_type}\ndata: {text}\n\n"
+        blocks.append(sse_block_with_payload(block, _deep_freeze(payload) if frozen else json.loads(text)))
+    return blocks
+
+
+async def _iter_prebuilt_blocks(blocks: list[str]) -> AsyncIterator[str]:
+    for block in blocks:
+        yield block
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enforce_openai_sdk_contract", [True, False])
+async def test_normalize_public_responses_stream_reuses_carried_payload_without_mutating_it(
+    enforce_openai_sdk_contract: bool,
+) -> None:
+    plain_blocks = [str(block) for block in _carrier_blocks(frozen=False)]
+    carrier_blocks = _carrier_blocks(frozen=True)
+
+    expected = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_prebuilt_blocks(plain_blocks),
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+        )
+    ]
+    actual = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_prebuilt_blocks(carrier_blocks),
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+        )
+    ]
+
+    # Same bytes whether or not the payload rode along with the block, and no
+    # stage mutated the shared (frozen) payload in place.
+    assert actual == expected
+    assert [type(block) is str for block in expected] == [True] * len(expected)
+    # Unchanged text deltas pass through as the very same carrier object.
+    delta_blocks = [block for block in carrier_blocks if block.startswith("event: response.output_text.delta\n")]
+    assert delta_blocks
+    for delta_block in delta_blocks:
+        assert any(block is delta_block for block in actual)
+    # Re-serialized blocks come back as plain ``str`` (full parse downstream).
+    reserialized = [block for block in actual if not isinstance(block, ParsedSseBlock)]
+    if enforce_openai_sdk_contract:
+        assert reserialized, "created/completed are re-framed on the public surface"
+        assert not any(block.startswith("event: codex.") for block in actual)
+    assert "\ud55c\uae00" in "".join(actual)
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_passes_carrier_through_and_reads_its_payload() -> None:
+    payload = {"type": "response.output_text.delta", "item_id": "msg_1", "delta": "plain"}
+    block = sse_block_with_payload(format_sse_event(payload), _deep_freeze(payload))
+    typeless_error = sse_block_with_payload(
+        'data: {"error":{"code":"server_error","message":"boom"}}\n\n',
+        _deep_freeze({"error": {"code": "server_error", "message": "boom"}}),
+    )
+
+    blocks = [
+        emitted
+        async for emitted in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(block, typeless_error))
+    ]
+
+    assert blocks[0] is block
+    assert blocks[1] is typeless_error
+
+
+def test_looks_like_sse_comment_block_fast_path_matches_scan() -> None:
+    blocks = [
+        ": keepalive\n\n",
+        ":\n: two\n\n",
+        "\n\n",
+        "",
+        "   ",
+        "data: [DONE]\n\n",
+        'data: {"type":"x"}\n\n',
+        'event: x\ndata: {"type":"x"}\n\n',
+        "event: x\r\ndata: {}\r\n\r\n",
+        "retry: 100\n\n",
+        ": comment\ndata: {}\n\n",
+    ]
+
+    def scan(event_block: str) -> bool:
+        return bool(event_block.strip()) and all(
+            not line.strip() or line.lstrip().startswith(":") for line in event_block.splitlines()
+        )
+
+    for event_block in blocks:
+        assert proxy_api_module._looks_like_sse_comment_block(event_block) is scan(event_block), repr(event_block)

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -44281,3 +44281,131 @@ async def test_process_http_bridge_upstream_text_reserializes_when_response_id_i
     assert cast(dict[str, Any], rewritten["response"])["id"] == "resp_client_visible"
     assert event_block == proxy_service.format_sse_event(rewritten)
     assert text not in event_block
+
+
+def _relay_parity_parallel_tool_call_done_text(call_id: str, patch_inputs: list[str]) -> str:
+    arguments = json.dumps(
+        {
+            "tool_uses": [
+                {"recipient_name": "functions.apply_patch", "parameters": {"input": patch_input}}
+                for patch_input in patch_inputs
+            ]
+        },
+        separators=(",", ":"),
+    )
+    return json.dumps(
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp_relay_parity",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": f"fc_{call_id}",
+                "call_id": call_id,
+                "name": "multi_tool_use.parallel",
+                "arguments": arguments,
+                "status": "completed",
+            },
+        },
+        separators=(",", ":"),
+    )
+
+
+def _relay_parity_parallel_patch_inputs(event_block: str) -> list[str]:
+    payload = proxy_service.parse_sse_data_json(event_block)
+    assert payload is not None
+    item = cast(dict[str, Any], payload["item"])
+    arguments = json.loads(cast(str, item["arguments"]))
+    return [tool_use["parameters"]["input"] for tool_use in arguments["tool_uses"]]
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_relays_trimmed_parallel_tool_uses_not_upstream_text() -> None:
+    # ``mark_duplicate_tool_call_downstream_event`` trims partially duplicated
+    # parallel tool uses by mutating the payload in place (no new object), so the
+    # identity fast path must not relay the untrimmed upstream text.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_relay_parity_request_state()
+    session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+
+    await service._process_http_bridge_upstream_text(
+        session, _relay_parity_parallel_tool_call_done_text("call_1", ["A", "B"])
+    )
+    second_text = _relay_parity_parallel_tool_call_done_text("call_2", ["A", "C"])
+    await service._process_http_bridge_upstream_text(session, second_text)
+
+    first_block = _relay_parity_downstream_block(request_state)
+    second_block = _relay_parity_downstream_block(request_state)
+    assert _relay_parity_parallel_patch_inputs(first_block) == ["A", "B"]
+    assert _relay_parity_parallel_patch_inputs(second_block) == ["C"]
+    assert second_text not in second_block
+    assert request_state.suppressed_duplicate_tool_call is False
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_fast_path_only_frames_text_that_serializes_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fast_path_event_types: list[str | None] = []
+    original_format_sse_event_from_text = http_bridge_upstream_events_module.format_sse_event_from_text
+
+    def _asserting_format_sse_event_from_text(payload: Mapping[str, Any], text: str) -> str:
+        # Precondition of the identity fast path: the relayed text must still be
+        # a serialization of the (possibly mutated) payload it was parsed from.
+        assert json.loads(text) == payload
+        fast_path_event_types.append(cast(str | None, payload.get("type")))
+        return original_format_sse_event_from_text(payload, text)
+
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "format_sse_event_from_text",
+        _asserting_format_sse_event_from_text,
+    )
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_relay_parity_request_state()
+    session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+    upstream_texts = [
+        json.dumps(
+            {"type": "response.created", "response": {"id": "resp_relay_parity", "status": "in_progress"}},
+            separators=(",", ":"),
+        ),
+        json.dumps(
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp_relay_parity",
+                "output_index": 0,
+                "item": {"type": "reasoning", "id": "rs_1", "summary": []},
+            },
+            separators=(",", ":"),
+        ),
+        json.dumps(
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs_1",
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "한글   café",
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        json.dumps(
+            {"type": "response.output_text.delta", "item_id": "msg_1", "output_index": 1, "delta": "hello"},
+            separators=(",", ":"),
+        ),
+        _relay_parity_parallel_tool_call_done_text("call_1", ["A", "B"]),
+        _relay_parity_parallel_tool_call_done_text("call_2", ["A", "C"]),
+    ]
+
+    for text in upstream_texts:
+        await service._process_http_bridge_upstream_text(session, text)
+
+    downstream_blocks = [_relay_parity_downstream_block(request_state) for _ in upstream_texts]
+    assert [
+        proxy_service.parse_sse_data_json(block) == json.loads(text)
+        for block, text in zip(downstream_blocks, upstream_texts, strict=True)
+    ] == [True, True, True, True, True, False]
+    assert _relay_parity_parallel_patch_inputs(downstream_blocks[-1]) == ["C"]
+    assert "response.output_text.delta" in fast_path_event_types
+    assert "response.reasoning_summary_text.delta" in fast_path_event_types
+    assert "response.output_item.done" not in fast_path_event_types

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -44190,3 +44190,94 @@ def test_suppression_message_names_the_timer_that_is_refusing_the_request() -> N
     assert "cooling down" not in half_open
     assert "480s" in half_open
     assert "42s" in cooldown
+
+
+def _make_relay_parity_request_state(
+    *,
+    response_id: str | None = "resp_relay_parity",
+    replay_downstream_response_id: str | None = None,
+) -> proxy_service._WebSocketRequestState:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-relay-parity",
+        response_id=response_id,
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    request_state.replay_downstream_response_id = replay_downstream_response_id
+    return request_state
+
+
+def _relay_parity_downstream_block(request_state: proxy_service._WebSocketRequestState) -> str:
+    assert request_state.event_queue is not None
+    event_block = request_state.event_queue.get_nowait()
+    assert isinstance(event_block, str)
+    return event_block
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_relays_unchanged_event_as_upstream_json_text() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_relay_parity_request_state()
+    session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+    payload = {
+        "type": "response.output_text.delta",
+        "item_id": "msg_1",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "\ud55c\uae00 \u2028 caf\u00e9",
+    }
+    text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    await service._process_http_bridge_upstream_text(session, text)
+
+    event_block = _relay_parity_downstream_block(request_state)
+    assert event_block == f"event: response.output_text.delta\ndata: {text}\n\n"
+    # JSON-equivalent to the re-serialized block the reader used to emit; only the
+    # escaping differs (upstream UTF-8 is kept, not ``\\uXXXX``-escaped).
+    legacy_block = proxy_service.format_sse_event(payload)
+    assert proxy_service.parse_sse_data_json(event_block) == proxy_service.parse_sse_data_json(legacy_block)
+    assert event_block != legacy_block
+    assert request_state.downstream_visible is True
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_ascii_relay_is_byte_identical_to_serialization() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_relay_parity_request_state()
+    session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+    payload = {"type": "response.output_text.delta", "item_id": "msg_1", "output_index": 0, "delta": "hello"}
+    text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+    await service._process_http_bridge_upstream_text(session, text)
+
+    assert _relay_parity_downstream_block(request_state) == proxy_service.format_sse_event(payload)
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_reserializes_when_response_id_is_rewritten() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_relay_parity_request_state(
+        response_id="resp_upstream",
+        replay_downstream_response_id="resp_client_visible",
+    )
+    session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+    payload = {
+        "type": "response.in_progress",
+        "response": {"id": "resp_upstream", "status": "in_progress", "metadata": {"note": "caf\u00e9"}},
+    }
+    text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    await service._process_http_bridge_upstream_text(session, text)
+
+    event_block = _relay_parity_downstream_block(request_state)
+    rewritten = proxy_service.parse_sse_data_json(event_block)
+    assert rewritten is not None
+    assert cast(dict[str, Any], rewritten["response"])["id"] == "resp_client_visible"
+    assert event_block == proxy_service.format_sse_event(rewritten)
+    assert text not in event_block

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -10,14 +10,19 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from app.core.openai.parsing import _LIFECYCLE_EVENT_TYPES, classify_event_type, parse_sse_event
+from app.core.types import JsonValue
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
+    ParsedSseBlock,
     extract_sse_data,
     format_sse_data,
     format_sse_event,
+    format_sse_event_from_text,
     inject_sse_keepalives,
     parse_sse_data_json,
+    parse_sse_data_json_text,
+    sse_block_with_payload,
     sse_event_type_from_block,
 )
 from tests.unit.hypothesis_strategies import json_objects, json_values
@@ -263,3 +268,129 @@ def test_sse_event_type_from_block_rejects_non_lf_framing_and_multiline_data():
 def test_sse_event_type_from_block_rejects_non_object_data_payloads():
     assert sse_event_type_from_block("event: done\ndata: [DONE]\n\n") is None
     assert sse_event_type_from_block("event: ping\ndata: \n\n") is None
+
+
+_UNUSUAL_DATA_TEXTS = [
+    "",
+    "   ",
+    "[DONE]",
+    " [DONE] ",
+    "{not-json}",
+    "[1,2]",
+    "null",
+    '"string"',
+    '{"a":1}\n',
+    '{"a":1}\r\n',
+    ' {"a":1}',
+    '{"a":1} ',
+    '{\n  "type": "response.completed",\n  "response": {"id": "resp_1"}\n}',
+    '{"type":"response.output_text.delta","delta":"\u2028\u2029 \ud55c\uae00 \ud14d\uc2a4\ud2b8"}',
+    '{"error":{"code":"server_error","message":"boom"}}',
+]
+
+
+@pytest.mark.parametrize("text", _UNUSUAL_DATA_TEXTS)
+def test_parse_sse_data_json_text_matches_framed_parse(text: str) -> None:
+    assert parse_sse_data_json_text(text) == parse_sse_data_json(f"data: {text}\n\n")
+
+
+@given(payload=json_objects, ensure_ascii=st.booleans(), indent=st.sampled_from([None, 2]))
+@settings(max_examples=60, deadline=None)
+def test_parse_sse_data_json_text_matches_framed_parse_for_json_objects(payload, ensure_ascii, indent) -> None:
+    text = json.dumps(payload, ensure_ascii=ensure_ascii, indent=indent)
+    assert parse_sse_data_json_text(text) == parse_sse_data_json(f"data: {text}\n\n")
+
+
+def test_parse_sse_data_json_text_preserves_unicode_line_separators() -> None:
+    text = '{"type":"response.output_text.delta","delta":"a\u2028b\u2029c"}'
+    payload = parse_sse_data_json_text(text)
+    assert payload == {"type": "response.output_text.delta", "delta": "a\u2028b\u2029c"}
+
+
+def test_format_sse_event_from_text_frames_upstream_text_verbatim() -> None:
+    text = '{"type":"response.output_text.delta","item_id":"msg_1","delta":"\ud55c\uae00 \u2028 caf\u00e9"}'
+    payload = parse_sse_data_json_text(text)
+    assert payload is not None
+
+    block = format_sse_event_from_text(payload, text)
+
+    assert block == f"event: response.output_text.delta\ndata: {text}\n\n"
+    assert sse_event_type_from_block(block) == "response.output_text.delta"
+    assert parse_sse_data_json(block) == parse_sse_data_json(format_sse_event(payload))
+    # Upstream UTF-8 stays as-is instead of being re-escaped.
+    assert "\ud55c\uae00" in block
+    assert "\\u" not in block
+
+
+def test_format_sse_event_from_text_is_byte_identical_for_ascii_compact_text() -> None:
+    payload = {"type": "response.completed", "sequence_number": 7, "response": {"id": "resp_1", "output": []}}
+    text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    assert format_sse_event_from_text(payload, text) == format_sse_event(payload)
+
+
+def test_format_sse_event_from_text_keeps_typeless_error_frames_data_only() -> None:
+    text = '{"error":{"code":"server_error","message":"boom"}}'
+    payload = parse_sse_data_json_text(text)
+    assert payload is not None
+    assert classify_event_type(payload) == "error"
+
+    block = format_sse_event_from_text(payload, text)
+
+    assert block == f"data: {text}\n\n"
+    assert block == format_sse_event(payload)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{\n  "type": "response.completed",\n  "response": {"id": "resp_1"}\n}',
+        '{"type":"response.completed","response":{"id":"resp_1"}}\n',
+        ' {"type":"response.completed","response":{"id":"resp_1"}}',
+    ],
+)
+def test_format_sse_event_from_text_falls_back_to_serialization_for_non_canonical_text(text: str) -> None:
+    payload = json.loads(text)
+    assert format_sse_event_from_text(payload, text) == format_sse_event(payload)
+
+
+@given(payload=json_objects, ensure_ascii=st.booleans())
+@settings(max_examples=40, deadline=None)
+def test_format_sse_event_from_text_round_trips_arbitrary_json_objects(payload, ensure_ascii) -> None:
+    text = json.dumps(payload, ensure_ascii=ensure_ascii, separators=(",", ":"))
+    block = format_sse_event_from_text(payload, text)
+    assert parse_sse_data_json(block) == payload
+    assert sse_event_type_from_block(block) == sse_event_type_from_block(format_sse_event(payload))
+
+
+def test_parsed_sse_block_behaves_like_str_and_short_circuits_parse() -> None:
+    payload: dict[str, JsonValue] = {"type": "response.output_text.delta", "delta": "hi"}
+    plain = format_sse_event(payload)
+    block = sse_block_with_payload(plain, payload)
+
+    assert isinstance(block, ParsedSseBlock)
+    assert isinstance(block, str)
+    assert block == plain
+    assert block.startswith("event: response.output_text.delta\n")
+    assert block.encode("utf-8") == plain.encode("utf-8")
+    assert parse_sse_data_json(block) is payload
+    # Derived strings are plain ``str`` and take the full parse path.
+    assert type(block.strip()) is str
+    assert parse_sse_data_json(block.strip()) == payload
+    assert parse_sse_data_json(block + "") == payload
+    # Re-attaching the same payload is an identity operation.
+    assert sse_block_with_payload(block, payload) is block
+
+
+def test_parsed_sse_block_with_none_payload_matches_unparseable_parse() -> None:
+    for plain in (": keepalive\n\n", "data: [DONE]\n\n", "data: {not-json}\n\n"):
+        assert parse_sse_data_json(plain) is None
+        assert parse_sse_data_json(sse_block_with_payload(plain, None)) is None
+
+
+@given(payload=json_objects)
+@settings(max_examples=40, deadline=None)
+def test_sse_block_with_payload_agrees_with_full_parse(payload) -> None:
+    plain = format_sse_event(payload)
+    block = sse_block_with_payload(plain, parse_sse_data_json(plain))
+    assert parse_sse_data_json(block) == parse_sse_data_json(plain)
+    assert extract_sse_data(block) == extract_sse_data(plain)


### PR DESCRIPTION
## Summary

Campaign PR 9/12 of the 2026-09-03 codex-lb CPU campaign (prod soju07, 2x Neoverse-N1, workers=1, CPU pegged ~100% at ~10k req/h; py-spy 60 s `--gil` profile, 1085 samples).

Every event an HTTP-bridge session receives from the upstream Responses websocket is one JSON document per text frame. Today the reader wraps it as `data: <text>\n\n`, runs the full SSE line parser over the synthesized block, and then re-serializes the parsed dict with `json.dumps(ensure_ascii=True)` for every event routed to a pending request, even though `_rewrite_websocket_downstream_response_id` documents an identity fast path ("callers skip re-serialization when the original payload object comes back") that the call site never honored. Downstream, the same block is fully parsed three more times by three generator stages (`_stream_http_bridge_session_events`, `_normalize_reasoning_summary_stream`, `_normalize_public_responses_stream`) that only share an `AsyncIterator[str]`.

Prod evidence: reader `parse_sse_data_json` 13 samples + `format_sse_event` at the relay call site 11 samples = 24/1085 (2.2% of GIL); consumer/api-chain `parse_sse_data_json` a further ~28/1085 (2.6%). Combined target ~2.5-3.5% of GIL samples.

This PR parses each bridge event once and relays unchanged events as the upstream JSON text.

## Change details

- `app/core/utils/sse.py`
  - `parse_sse_data_json_text(text)`: direct `json.loads` when `text` is a single-line JSON object (the only shape upstream emits); every other input (blank, `[DONE]`, multi-line, whitespace-prefixed) takes the exact `parse_sse_data_json(f"data: {text}\n\n")` path so `None` and line-joining semantics are unchanged.
  - `format_sse_event_from_text(payload, text)`: frames already-serialized text in the canonical `event: <type>\ndata: <json>\n\n` shape, deriving the `event:` line from the payload's non-empty string `type` exactly like `format_sse_event` (typeless `{"error": ...}` frames stay data-only); falls back to `format_sse_event` for non-canonical text.
  - `ParsedSseBlock(str)` + `sse_block_with_payload()`: a `str` subclass carrying the already-parsed payload; `parse_sse_data_json` returns `block.payload` for such blocks. The payload is read-only by contract (all existing consumers copy before mutating; pinned by tests with frozen payloads).
- `app/modules/proxy/_service/http_bridge/upstream_events.py`
  - `_process_http_bridge_upstream_text`: `parse_sse_data_json_text(text)` instead of framing + SSE line parse.
  - `_process_parsed_http_bridge_upstream_event`: honor the identity contract of `_rewrite_websocket_downstream_response_id`. When it returns the same object, relay `format_sse_event_from_text(payload, text)`; when it returns a rewritten payload, or the event is `response.output_item.done` (the only event type `mark_duplicate_tool_call_downstream_event` mutates in place when trimming partially duplicated `multi_tool_use.parallel` arguments), re-serialize with `format_sse_event` as before.
- `app/modules/proxy/_service/http_bridge/streaming.py`: yield `sse_block_with_payload(event_block, block_payload)` so the two API-layer normalizers reuse the payload already parsed at the consumer.
- `app/modules/proxy/api.py`: `_looks_like_sse_comment_block` short-circuits on blocks opening with `event: `/`data: ` (a block whose first line is a field line can never be all-comment/blank; provably equivalent).
- `tests/unit/test_http_bridge_cancel_drain.py`: one existing assertion adjusted to the carrier type.
- OpenSpec change folder `openspec/changes/relay-bridge-events-as-upstream-json-text/`.

App delta: +108/-9 lines across 4 files; the rest of the 864 net lines are tests (+570) and the OpenSpec change folder (+204). Single capability (`responses-api-compat` downstream SSE framing), so the CONTRIBUTING "~800 net lines AND multiple concerns" split rule does not apply; if a stricter read is preferred, `tests/unit/test_proxy_api_responses_contract.py` (+214) is the natural split.

## Byte-compat / behavior notes

- **Accepted, deliberate byte change**: for relayed bridge events the proxy did not rewrite, the downstream `data:` line is now the upstream UTF-8 JSON text verbatim instead of `json.dumps(payload, ensure_ascii=True, separators=(",", ":"))`. ASCII-only compact frames are byte-identical (upstream emits compact JSON). Frames containing non-ASCII (Korean deltas, U+2028) are no longer `\uXXXX`-escaped; the JSON value is identical in every case and every in-repo consumer re-parses JSON (verified: no `type(x) is str`, no hash over event text; durable fingerprint covers request text only; body writers use `isinstance(chunk, str)` and `.encode()`).
- Durable bridge spools store the relayed block text, so transcripts written after this change carry UTF-8 rather than escaped text for non-ASCII frames; replay re-parses JSON, no cross-version comparison.
- Rewritten events (downstream response-id alignment, tool-call dedupe including the in-place `multi_tool_use.parallel` trim on `response.output_item.done`, error masking) continue to be re-serialized from the rewritten payload.
- `parse_sse_data_json_text` is exactly equivalent to today's framed parse for single-line `{`-prefixed text (the SSE field parser strips exactly one space after `data:` and hands the same string to `json.loads`); everything else takes the literal old path. Fuzzed 25k inputs with 0 mismatches (round-2 adversarial verification).
- No settings, migration, or dashboard surface changes.

## Expected gain

- Plan estimate: ~2.5-3.5% of GIL samples (reader parse+re-dump ~1.2-1.5%, downstream triple parse ~1.3%).
- Microbench (`/tmp/sse-bench/bench_pr9.py`, 300-event realistic stream, this host, noisy +-15-30%):
  - reader (parse + frame): 10.3 -> 2.8 us/event ASCII, 11.3 -> 3.4 us/event Korean (implementer); adversarial re-run 2356 -> 752 us/stream ASCII (-68%), 2840 -> 827 Korean (-71%); round 2: 1717 -> 586 (-66%) / 1844 -> 655 (-64%).
  - 3-stage consumer chain: 15.8 -> 6.4 / 22.1 -> 7.0 us/event (implementer); with carriers the two API-layer stages drop to ~72-82 us/stream total (round 2), the single remaining parse living in `streaming.py`.
- The `response.output_item.done` gate adds one string comparison per matched event and one `json.dumps` per output item (not per delta), so the delta-path gains are unchanged.
- Production confirmation: py-spy `--gil` (rate 10-20, 60 s) after deploy; expect `format_sse_event` under `upstream_events` and `_extract_sse_data_lines` under `_process_http_bridge_upstream_text` to vanish and `parse_sse_data_json` under `api.py` to drop ~2/3.

## OpenSpec

Change folder `openspec/changes/relay-bridge-events-as-upstream-json-text` (proposal, context, tasks, delta for `responses-api-compat`). Added requirement "HTTP bridge relays unchanged upstream events as their upstream JSON text" with scenarios: unchanged non-ASCII event relayed as upstream UTF-8; unchanged ASCII event byte-identical to re-serialization; rewritten (response-id) event re-serialized; in-place trimmed parallel tool uses re-serialized; typeless error frame stays data-only. `openspec validate relay-bridge-events-as-upstream-json-text` -> valid; `openspec validate --specs` -> 57 passed, 1 failed (pre-existing `model-source-routing` on main, untouched here).

## Tests

`tests/unit/test_sse.py`
- `test_parse_sse_data_json_text_matches_framed_parse`, `..._for_json_objects` (Hypothesis-style object round trip), `..._preserves_unicode_line_separators` -- fail on main (helper missing).
- `test_format_sse_event_from_text_frames_upstream_text_verbatim`, `..._is_byte_identical_for_ascii_compact_text`, `..._keeps_typeless_error_frames_data_only`, `..._falls_back_to_serialization_for_non_canonical_text`, `..._round_trips_arbitrary_json_objects`.
- `test_parsed_sse_block_behaves_like_str_and_short_circuits_parse`, `test_parsed_sse_block_with_none_payload_matches_unparseable_parse`, `test_sse_block_with_payload_agrees_with_full_parse`.

`tests/unit/test_proxy_http_bridge.py`
- `test_process_http_bridge_upstream_text_relays_unchanged_event_as_upstream_json_text` -- fails on main (Korean/U+2028 delta arrives `\uXXXX`-escaped).
- `test_process_http_bridge_upstream_text_ascii_relay_is_byte_identical_to_serialization`.
- `test_process_http_bridge_upstream_text_reserializes_when_response_id_is_rewritten`.
- `test_process_http_bridge_upstream_text_relays_trimmed_parallel_tool_uses_not_upstream_text` -- P1 regression from review round 1: two `response.output_item.done` `multi_tool_use.parallel` events with overlapping `functions.apply_patch` uses `[A,B]` then `[A,C]`; asserts the second downstream block carries only `['C']` and the untrimmed upstream text is absent. Fails on the unfixed fast path with `['A','C'] == ['C']`.
- `test_process_http_bridge_upstream_text_fast_path_only_frames_text_that_serializes_payload` -- pins the invariant `json.loads(text) == payload` on every fast-path call over a 6-event mix; asserts deltas take the fast path and `output_item.done` never does. Fails on the unfixed fast path.

`tests/unit/test_proxy_api_responses_contract.py`
- `test_normalize_public_responses_stream_reuses_carried_payload_without_mutating_it`, `test_normalize_reasoning_summary_stream_passes_carrier_through_and_reads_its_payload` (frozen payload; would fail if any stage mutated the shared dict), `test_looks_like_sse_comment_block_fast_path_matches_scan`.

Gates run at HEAD (`fc835cfcc`, rebased on `575c20876`): `ruff check .` and `ruff format --check .` clean; `ty check` clean; `scripts/check_proxy_architecture.py` passed; targeted units (`test_sse`, `test_proxy_http_bridge`, `test_proxy_api_responses_contract`, `test_http_bridge_cancel_drain`, `test_http_bridge_eventless_semantics`, `test_proxy_tool_call_dedupe`, `test_proxy_utils`, `test_durable_bridge_transcript_codec`, `test_proxy_websocket_model_source_guard`) 2417 passed; `tests/integration/test_http_responses_bridge.py` 154 passed.

## Review trail

- Round 1: local `codex review --base origin/main` -> no actionable findings (its own probes only showed JSON-equivalent byte differences for non-canonical upstream escapes, which the spec delta permits). Independent adversarial verification confirmed byte-compat (294-block ASCII stream byte-identical to main; Korean stream differs only in escaping) and the perf gain, but found a **P1**: `mark_duplicate_tool_call_downstream_event` mutates `payload["item"]["arguments"]` in place and returns `False`, so the identity fast path relayed the untrimmed upstream text for a partially duplicated `multi_tool_use.parallel` item (main: `['C']`, PR: `['A','C']`). Fixed in `fc835cfcc` by gating the fast path off `response.output_item.done` (the only event type the trimmer can mutate; `tool_call_dedupe.py` returns before touching anything for every other type) plus the two regression tests above. 2 blocking findings raised (P1 + the invariant pin), both fixed.
- Round 2: local codex review -> no findings ("Rewritten and in-place-mutated events are correctly re-serialized, with focused regression coverage"); codex also ran a custom pytest plugin asserting `json.loads(text) == payload` on every fast-path call across `test_proxy_http_bridge.py` (held). Adversarial verification fuzzed 25,038 inputs through main's framed parse vs `parse_sse_data_json_text` (0 mismatches), 50,014 cases through the `_looks_like_sse_comment_block` fast path vs the scan (0 mismatches), audited every in-place mutation site on the carrier path, and confirmed the two regression tests fail on HEAD~1 exactly as claimed. 0 blocking findings.
- Remaining P3 informational notes (pre-existing, outside this diff): (a) the WebSocket relay (`websocket/mixin.py` ~5443-5449) has the same stale-text hazard on the partially trimmed `multi_tool_use.parallel` item since it re-dumps only when the response-id rewrite returns a new object -- follow-up should mirror the `output_item.done` re-dump rule; (b) `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` in `test_proxy_http_bridge.py` is order-dependent (sqlite `no such table: file_account_pins` when that module runs first in a fresh process); passes in the full suite and on main identically; separate test-hygiene PR.

## Deploy notes / hazards

- No config, env, or migration changes; safe to roll with the regular ZDT deploy.
- Clients and durable spools see UTF-8 (not `\uXXXX`) in relayed non-ASCII `data:` lines after upgrade; JSON-equivalent. Anything outside this repo that diffed raw SSE bytes across versions would notice; nothing in-repo does.
- Campaign ordering: lands before `perf-bridge-relay-loop-churn` (same file, disjoint functions).
- Campaign-wide upgrade hazard (not specific to this PR): main since #1995 rejects `http://user:pw@` proxy endpoints (`plaintext_proxy_credentials_forbidden`); prod's routed proxy endpoint must be re-created as https:// or credential-less before deploying anything from main.
- Post-deploy verification: py-spy `--gil` at rate 10-20 for <= 60 s (never rate 100 on the N1 host), compare against the 2026-09-03 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved HTTP bridge event streaming by reducing redundant JSON parsing and serialization.
  * Unchanged upstream events can now be relayed with their original JSON text, preserving UTF-8 formatting.

* **Compatibility**
  * Events requiring response-ID updates, tool-use trimming, or error masking continue to be correctly rewritten.
  * Existing SSE framing behavior remains supported, including data-only error events.

* **Tests**
  * Added coverage for event relay parity, Unicode handling, payload reuse, and SSE parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->