### PR TITLE
perf(dashboard): bound projection history to the EWMA tail plus a 3h floor and cheapen per-row hydration/signature

### DIFF
--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -48,16 +48,23 @@ from app.modules.usage.repository import NormalizedUsageWindow
 # fingerprint moves, so one busy account's 7-day window can hold tens of
 # thousands of rows while the consumers only read the recent tail. Rows
 # older than the equal-weight floor below feed only count-decaying EWMAs
-# (depletion rate, weekly-pace recent burn; alpha 0.4): a sample's weight
-# after ``n`` newer EWMA updates is ``0.6**n``, which is below double
-# precision (``0.6**64`` ~ 6e-15) past this many updates, so the tail
-# reproduces the full-window replay to within floating-point noise whenever
-# it spans at least this many distinct recorded seconds. The EWMA advances
-# once per distinct integer epoch second (``ewma_update`` skips a sample
-# whose ``naive_utc_to_epoch`` equals the previous one), so rows written
-# faster than one per second share an update: a tail packed into fewer
-# distinct seconds than the cap — a same-second write burst older than the
-# floor with no newer rows to decay it — may diverge from the full replay.
+# (depletion rate, weekly-pace recent burn; alpha 0.4). The first tail row
+# only seeds the EWMA, so a cap-row tail performs cap-1 updates and the
+# pre-tail state's residual on the replayed rate is at most
+# ``0.6**(cap-1)`` times the largest per-second sample slope: below
+# ~1.1e-12 %/s even at the theoretical 100 %/s step, and far below that at
+# real slopes, so the tail reproduces the full-window replay to
+# floating-point noise on the rate. Fields derived from the rate inherit
+# that residual scaled by their formulas (burn rate multiplies it by
+# seconds-until-reset over remaining percent), and the exhaustion ETA,
+# which is emitted only for a strictly positive rate, may be absent from
+# the tail replay when the full replay still carries a ghost rate below
+# the residual (an account flat at 100%). The EWMA advances once per
+# distinct integer epoch second (``ewma_update`` skips a sample whose
+# ``naive_utc_to_epoch`` equals the previous one), so rows written faster
+# than one per second share an update: a tail packed into fewer distinct
+# seconds than the cap — a same-second write burst older than the floor
+# with no newer rows to decay it — may diverge from the full replay.
 # Every equal-weight consumer is protected by the floor instead.
 _PROJECTION_EWMA_TAIL_ROWS = 64
 

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -49,10 +49,16 @@ from app.modules.usage.repository import NormalizedUsageWindow
 # thousands of rows while the consumers only read the recent tail. Rows
 # older than the equal-weight floor below feed only count-decaying EWMAs
 # (depletion rate, weekly-pace recent burn; alpha 0.4): a sample's weight
-# after ``n`` newer samples is ``0.6**n``, which is below double precision
-# (``0.6**64`` ~ 6e-15) past this many rows, so the tail reproduces the
-# full-window replay to within floating-point noise regardless of write
-# cadence. Every equal-weight consumer is protected by the floor instead.
+# after ``n`` newer EWMA updates is ``0.6**n``, which is below double
+# precision (``0.6**64`` ~ 6e-15) past this many updates, so the tail
+# reproduces the full-window replay to within floating-point noise whenever
+# it spans at least this many distinct recorded seconds. The EWMA advances
+# once per distinct integer epoch second (``ewma_update`` skips a sample
+# whose ``naive_utc_to_epoch`` equals the previous one), so rows written
+# faster than one per second share an update: a tail packed into fewer
+# distinct seconds than the cap — a same-second write burst older than the
+# floor with no newer rows to decay it — may diverge from the full replay.
+# Every equal-weight consumer is protected by the floor instead.
 _PROJECTION_EWMA_TAIL_ROWS = 64
 
 

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -26,7 +26,7 @@ from app.modules.dashboard.schemas import (
     WeeklyCreditApiKeyAttribution,
     WeeklyCreditPaceResponse,
 )
-from app.modules.dashboard.weekly_pace import DEMAND_WINDOW, build_weekly_credit_pace
+from app.modules.dashboard.weekly_pace import DEMAND_WINDOW, FLEET_BURN_WINDOW, build_weekly_credit_pace
 from app.modules.usage.builders import (
     align_bucket_window_start,
     build_activity_summaries,
@@ -44,19 +44,16 @@ from app.modules.usage.repository import NormalizedUsageWindow
 
 # Newest-first per-account row bound for the projections history fetch
 # (PostgreSQL; the SQLite snapshot cache keeps the shared floor). Live
-# snapshot ingestion appends usage rows per proxied request, so one busy
-# account's 7-day secondary window can hold tens of thousands of rows while
-# the consumers only read the recent tail. The cap alone covers the
-# tail-weighted consumers: the EWMA depletion/burn rates (alpha 0.4 — a
-# sample's contribution decays by 0.6^n within a few dozen newer samples)
-# are insensitive to samples this deep regardless of write cadence. The one
-# equal-weight consumer — the weekly-pace smoothing mean over the configured
-# window (<= 240 minutes) — is protected by ``uncapped_recent_floor``
-# instead, because ingestion writes on every fingerprint change and a burst
-# could out-write any fixed cap inside the smoothing window. 4320 rows cover
-# the 6-hour recent-burn window at the ingestor's 5-second per-account write
-# throttle floor; sparse accounts stay under the cap entirely.
-_PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP = 4320
+# snapshot ingestion appends a usage row whenever an account's usage
+# fingerprint moves, so one busy account's 7-day window can hold tens of
+# thousands of rows while the consumers only read the recent tail. Rows
+# older than the equal-weight floor below feed only count-decaying EWMAs
+# (depletion rate, weekly-pace recent burn; alpha 0.4): a sample's weight
+# after ``n`` newer samples is ``0.6**n``, which is below double precision
+# (``0.6**64`` ~ 6e-15) past this many rows, so the tail reproduces the
+# full-window replay to within floating-point noise regardless of write
+# cadence. Every equal-weight consumer is protected by the floor instead.
+_PROJECTION_EWMA_TAIL_ROWS = 64
 
 
 def _parse_weekly_pace_working_days(value: str) -> set[int]:
@@ -363,19 +360,22 @@ async def _load_projection_histories(
             if acct_since < sec_since:
                 sec_since = acct_since
 
-    # The weekly-pace smoothing mean weighs every sample in its window
-    # equally, so rows inside the configured smoothing window are exempt from
-    # the row cap (ingestion writes per fingerprint change; a burst could
-    # otherwise out-write the cap and silently shift the smoothed values).
-    smoothing_floor = now - timedelta(minutes=smoothing_window_minutes)
+    # The weekly-pace smoothing mean (configured window) and fleet burn
+    # (fixed 3h window) weigh every sample in their windows equally, so rows
+    # inside the wider of the two are exempt from the row cap (ingestion
+    # writes per fingerprint change; a burst could otherwise out-write the
+    # cap and silently shift those values). The floor applies to both
+    # fetches: weekly-only accounts sourced from the primary stream feed
+    # ``secondary_history`` too, so the primary fetch cannot go floorless.
+    uncapped_floor = now - max(timedelta(minutes=smoothing_window_minutes), FLEET_BURN_WINDOW)
     all_pri_rows = (
         await repo.bulk_usage_history_since(
             pri_fetch_ids,
             "primary",
             pri_since,
             cutoffs=pri_cutoffs,
-            per_account_row_cap=_PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP,
-            uncapped_recent_floor=smoothing_floor,
+            per_account_row_cap=_PROJECTION_EWMA_TAIL_ROWS,
+            uncapped_recent_floor=uncapped_floor,
         )
         if pri_fetch_ids
         else {}
@@ -386,8 +386,8 @@ async def _load_projection_histories(
             "secondary",
             sec_since,
             cutoffs=sec_cutoffs,
-            per_account_row_cap=_PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP,
-            uncapped_recent_floor=smoothing_floor,
+            per_account_row_cap=_PROJECTION_EWMA_TAIL_ROWS,
+            uncapped_recent_floor=uncapped_floor,
         )
         if sec_fetch_ids
         else {}

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from hashlib import blake2b
 from typing import TypeAlias
 
 from app.core.usage.depletion import (
@@ -26,7 +25,7 @@ class _HistorySignature:
     row_count: int
     first: _RowEdgeSignature
     latest: _RowEdgeSignature
-    content_digest: str | None
+    content_digest: int | None
 
 
 class _SignedHistory(list):
@@ -222,25 +221,11 @@ def attach_depletion_history_signature(history: Iterable) -> list:
 
 
 def filter_depletion_history_since(history: Iterable, cutoff: datetime) -> list:
-    """Filter rows by cutoff and attach the cache signature in the same pass."""
-    rows = []
-    digest = blake2b(digest_size=16)
-    for entry in history:
-        if entry.recorded_at < cutoff:
-            continue
-        rows.append(entry)
-        _update_history_digest(digest, entry)
+    """Filter rows by cutoff and attach the cache signature."""
+    rows = [entry for entry in history if entry.recorded_at >= cutoff]
     if not rows:
         return []
-    return _SignedHistory(
-        rows,
-        _HistorySignature(
-            row_count=len(rows),
-            first=_row_edge_signature(rows[0]),
-            latest=_row_edge_signature(rows[-1]),
-            content_digest=digest.hexdigest(),
-        ),
-    )
+    return _SignedHistory(rows, _history_signature_from_rows(rows))
 
 
 def _history_signature(history: list) -> _HistorySignature:
@@ -253,14 +238,17 @@ def _history_signature(history: list) -> _HistorySignature:
 def _history_signature_from_rows(history: list) -> _HistorySignature:
     if not history:
         raise ValueError("history must not be empty")
-    digest = blake2b(digest_size=16)
-    for entry in history:
-        _update_history_digest(digest, entry)
+    # One fixed-width hash over every row's value-bearing fields: cheap
+    # enough to run per dashboard poll on dense histories, and still
+    # detects in-place corrections that leave the edges and count intact.
+    # The signature cache is process-local, so a process-local ``hash`` is
+    # sufficient; only the int is retained, never the per-row tuples.
+    edges = tuple(map(_row_edge_signature, history))
     return _HistorySignature(
-        row_count=len(history),
-        first=_row_edge_signature(history[0]),
-        latest=_row_edge_signature(history[-1]),
-        content_digest=digest.hexdigest(),
+        row_count=len(edges),
+        first=edges[0],
+        latest=edges[-1],
+        content_digest=hash(edges),
     )
 
 
@@ -287,10 +275,3 @@ def _row_edge_signature(entry) -> _RowEdgeSignature:
         entry.reset_at,
         entry.window_minutes,
     )
-
-
-def _update_history_digest(digest, entry) -> None:
-    for value in _row_edge_signature(entry):
-        digest.update(repr(value).encode("utf-8"))
-        digest.update(b"\0")
-    digest.update(b"\1")

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1075,16 +1075,16 @@ class UsageRepository:
         )
         result = await self._session.execute(stmt)
         grouped: dict[str, list[UsageHistorySnapshot]] = {}
-        for row in result.all():
+        for id_, account_id, used_percent, recorded_at, reset_at, window_minutes in result.tuples():
             snapshot = UsageHistorySnapshot(
-                id=int(row.id),
-                account_id=row.account_id,
-                used_percent=float(row.used_percent),
-                recorded_at=row.recorded_at,
-                reset_at=float(row.reset_at) if row.reset_at is not None else None,
-                window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
+                id=int(id_),
+                account_id=account_id,
+                used_percent=float(used_percent),
+                recorded_at=recorded_at,
+                reset_at=float(reset_at) if reset_at is not None else None,
+                window_minutes=int(window_minutes) if window_minutes is not None else None,
             )
-            grouped.setdefault(snapshot.account_id, []).append(snapshot)
+            grouped.setdefault(account_id, []).append(snapshot)
         return grouped
 
     async def _bulk_history_since_capped_postgresql(
@@ -1170,16 +1170,19 @@ class UsageRepository:
         stmt = select(recent).select_from(account_cutoffs.join(recent, true()))
         result = await self._session.execute(stmt)
         grouped: dict[str, list[UsageHistorySnapshot]] = {}
-        for row in result.all():
+        # Positional unpacking: Row attribute lookups dominated the per-row
+        # cost of this loop on dense deployments (dashboard polls hydrate
+        # thousands of rows per call). Column order follows snapshot_columns.
+        for id_, account_id, used_percent, recorded_at, reset_at, window_minutes in result.tuples():
             snapshot = UsageHistorySnapshot(
-                id=int(row.id),
-                account_id=row.account_id,
-                used_percent=float(row.used_percent),
-                recorded_at=row.recorded_at,
-                reset_at=float(row.reset_at) if row.reset_at is not None else None,
-                window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
+                id=int(id_),
+                account_id=account_id,
+                used_percent=float(used_percent),
+                recorded_at=recorded_at,
+                reset_at=float(reset_at) if reset_at is not None else None,
+                window_minutes=int(window_minutes) if window_minutes is not None else None,
             )
-            grouped.setdefault(snapshot.account_id, []).append(snapshot)
+            grouped.setdefault(account_id, []).append(snapshot)
         for snapshots in grouped.values():
             snapshots.sort(key=lambda snapshot: (snapshot.recorded_at, snapshot.id))
         return grouped

--- a/openspec/changes/cap-projection-history-rows/proposal.md
+++ b/openspec/changes/cap-projection-history-rows/proposal.md
@@ -12,9 +12,9 @@ polled several times a minute while a tab is open, each row hydrated
 through SQLAlchemy `Row` attribute access and hashed field-by-field with
 `blake2b(repr(...))` for the depletion cache signature. That work is ~5% of
 the single worker core's GIL time and buys nothing the response can show:
-with alpha 0.4 a sample's EWMA weight after `n` newer samples is `0.6**n`,
-below double precision past a few dozen rows, and every equal-weight
-consumer is already protected by the uncapped floor.
+with alpha 0.4 a sample's EWMA weight after `n` newer EWMA updates is
+`0.6**n`, below double precision past a few dozen updates, and every
+equal-weight consumer is already protected by the uncapped floor.
 
 ## What Changes
 
@@ -22,7 +22,11 @@ consumer is already protected by the uncapped floor.
   time window at a write cadence: rows older than the uncapped floor feed
   only the count-decaying EWMA consumers (depletion rate, weekly-pace recent
   burn), whose replay over the tail equals the full replay to floating-point
-  noise regardless of write density.
+  noise whenever the tail spans at least 64 distinct recorded seconds. The
+  EWMA advances once per distinct integer epoch second, so a same-second
+  write burst older than the floor that is never followed by newer rows
+  may leave the tail short of that many updates; the bound is stated as a
+  distinct-second guarantee rather than a per-row one.
 - Widen the uncapped recent floor to the wider of the configured
   pace-smoothing window and the fixed 3-hour fleet-burn window, so every
   equal-weight consumer (smoothing mean, fleet burn sum/span, latest row)
@@ -54,8 +58,9 @@ consumer is already protected by the uncapped floor.
   account's rows older than the uncapped floor to a fixed EWMA tail, MUST
   exempt the wider of the pace-smoothing and fleet-burn windows from the
   cap on every projections fetch, MUST keep floor-covered consumers exact
-  and tail-weighted consumers equivalent within floating-point tolerance,
-  and the depletion cache MUST use a fixed-width content signature.
+  and tail-weighted consumers equivalent within floating-point tolerance
+  whenever the tail spans cap-many distinct recorded seconds, and the
+  depletion cache MUST use a fixed-width content signature.
 
 ## Impact
 

--- a/openspec/changes/cap-projection-history-rows/proposal.md
+++ b/openspec/changes/cap-projection-history-rows/proposal.md
@@ -1,37 +1,44 @@
 ## Why
 
-On the reference PostgreSQL deployment the dashboard projections bulk
-usage-history read returns ~307k rows per call (540 calls over 10 days,
-avg 2.54 s, max 56 s, `usage_history` at ~3M rows / 2.8 GB). Live snapshot
-ingestion appends usage rows per proxied request, so one busy account's
-7-day secondary window holds tens of thousands of rows — yet the projection
-consumers only read the recent tail: EWMA depletion/burn rates decay a
-sample's contribution by 0.6^n within a few dozen newer samples, the
-weekly-pace recent-burn window is 6 hours, and the pace smoothing mean is at
-most 240 minutes. Fetching every in-window row burns database reads, row
-transfer, and Python row-building for values no consumer can observe.
+Live snapshot ingestion appends a `usage_history` row whenever an
+account's usage fingerprint moves, so a busy account's 7-day window holds
+tens of thousands of rows while the dashboard projection consumers only
+read the recent tail. The first cut of this change bounded the PostgreSQL
+bulk read to the newest 4320 rows per account, sized to cover the 6-hour
+recent-burn EWMA window at a presumed 5-second write throttle. On the
+reference deployment that cap still binds on every account (all weekly-only,
+history sourced from the primary stream): ~82k rows per dashboard poll,
+polled several times a minute while a tab is open, each row hydrated
+through SQLAlchemy `Row` attribute access and hashed field-by-field with
+`blake2b(repr(...))` for the depletion cache signature. That work is ~5% of
+the single worker core's GIL time and buys nothing the response can show:
+with alpha 0.4 a sample's EWMA weight after `n` newer samples is `0.6**n`,
+below double precision past a few dozen rows, and every equal-weight
+consumer is already protected by the uncapped floor.
 
 ## What Changes
 
-- Bound the PostgreSQL projections bulk usage-history read to each
-  account's newest rows (newest-first per-account row cap) inside the
-  existing per-account cutoffs, via one lateral top-N probe per account
-  over the existing covering indexes (backward index-only scan that stops
-  at the cap or cutoff).
-- Exempt rows inside the configured pace-smoothing window from the cap
-  (uncapped recent floor supplied by the projections caller): ingestion
-  writes per proxied request whenever the usage fingerprint changes, so a
-  write burst could out-write any fixed cap inside the smoothing window,
-  and the smoothing mean weighs every in-window sample equally. The probe
-  splits into two disjoint branches over the same covering index — the
-  time-bounded floor branch returns in full, the cap bounds the older
-  remainder.
-- The dashboard projections caller supplies the cap, sized so the
-  tail-weighted consumers are unchanged (covers the 6-hour recent-burn
-  EWMA window at the ingestor's 5-second per-account write throttle
-  floor; EWMA contributions decay by 0.6^n well inside the cap).
-- SQLite keeps its shared-floor snapshot cache and ignores the cap, the
-  same way it ignores per-account cutoffs.
+- Size the per-account row cap to the EWMA tail (64 rows) instead of a
+  time window at a write cadence: rows older than the uncapped floor feed
+  only the count-decaying EWMA consumers (depletion rate, weekly-pace recent
+  burn), whose replay over the tail equals the full replay to floating-point
+  noise regardless of write density.
+- Widen the uncapped recent floor to the wider of the configured
+  pace-smoothing window and the fixed 3-hour fleet-burn window, so every
+  equal-weight consumer (smoothing mean, fleet burn sum/span, latest row)
+  keeps exact inputs. Both bulk fetches carry the floor: weekly-only
+  accounts sourced from the primary stream feed the weekly pace from the
+  primary fetch.
+- Hydrate PostgreSQL bulk-history rows by positional unpacking instead of
+  per-column `Row` attribute lookups (same snapshot values, same
+  oldest-first per-account ordering).
+- Replace the field-by-field `blake2b(repr(...))` depletion cache content
+  digest with a single fixed-width process-local hash over every row's
+  value-bearing fields. The signature stays bounded, still detects in-place
+  corrections that leave the endpoints and row count intact, and the cache
+  it guards is process memory only.
+- SQLite keeps its shared-floor snapshot cache and its own cache digest,
+  and ignores the cap and floor the same way it ignores per-account cutoffs.
 - No schema change: the existing covering indexes already serve the capped
   probes index-only.
 
@@ -43,16 +50,19 @@ transfer, and Python row-building for values no consumer can observe.
 
 ### Modified Capabilities
 
-- `query-caching`: the projections history bulk read MUST additionally
-  bound each account's slice to its newest in-cutoff rows on PostgreSQL,
-  MUST exempt rows inside the configured pace-smoothing window from the
-  cap, and under-cap accounts MUST return slices equal to the shared-floor
-  fetch after per-account trimming.
+- `query-caching`: the projections history bulk read MUST bound each
+  account's rows older than the uncapped floor to a fixed EWMA tail, MUST
+  exempt the wider of the pace-smoothing and fleet-burn windows from the
+  cap on every projections fetch, MUST keep floor-covered consumers exact
+  and tail-weighted consumers equivalent within floating-point tolerance,
+  and the depletion cache MUST use a fixed-width content signature.
 
 ## Impact
 
-`app/modules/usage/repository.py` (capped PostgreSQL fetch shape),
-`app/modules/dashboard/repository.py` / `app/modules/dashboard/service.py`
-(cap plumbed from the projections caller), repository/plan/unit regression
-coverage. No API, response-schema, setting, migration, or dashboard UI
-change.
+`app/modules/dashboard/service.py` (tail cap constant, floor derivation),
+`app/modules/usage/repository.py` (positional hydration in the bulk
+fetch loops), `app/modules/usage/depletion_service.py` (content signature),
+unit and PostgreSQL regression coverage. Dashboard values are unchanged
+(equal-weight consumers exact; EWMA-derived fields equal to within
+floating-point noise) — no API, response-schema, setting, migration, or
+dashboard UI change.

--- a/openspec/changes/cap-projection-history-rows/proposal.md
+++ b/openspec/changes/cap-projection-history-rows/proposal.md
@@ -21,8 +21,13 @@ equal-weight consumer is already protected by the uncapped floor.
 - Size the per-account row cap to the EWMA tail (64 rows) instead of a
   time window at a write cadence: rows older than the uncapped floor feed
   only the count-decaying EWMA consumers (depletion rate, weekly-pace recent
-  burn), whose replay over the tail equals the full replay to floating-point
-  noise whenever the tail spans at least 64 distinct recorded seconds. The
+  burn). The first tail row seeds the EWMA, so the 64-row tail performs 63
+  updates and the pre-tail residual on the rate is at most
+  `0.6**63 * <largest per-second slope>` (~1.1e-12 %/s at the theoretical
+  100 %/s step, far smaller at real slopes); derived fields inherit that
+  residual through their formulas, and the exhaustion ETA (emitted only for
+  a strictly positive rate) may be absent from the tail replay for an
+  account flat at 100% whose full replay still carries a ghost rate. The
   EWMA advances once per distinct integer epoch second, so a same-second
   write burst older than the floor that is never followed by newer rows
   may leave the tail short of that many updates; the bound is stated as a
@@ -58,8 +63,9 @@ equal-weight consumer is already protected by the uncapped floor.
   account's rows older than the uncapped floor to a fixed EWMA tail, MUST
   exempt the wider of the pace-smoothing and fleet-burn windows from the
   cap on every projections fetch, MUST keep floor-covered consumers exact
-  and tail-weighted consumers equivalent within floating-point tolerance
-  whenever the tail spans cap-many distinct recorded seconds, and the
+  and tail-weighted consumers' EWMA rate within the seed-row residual bound
+  whenever the tail spans cap-many distinct recorded seconds (derived
+  fields inherit it; a saturated account's exhaustion ETA MAY be absent), and the
   depletion cache MUST use a fixed-width content signature.
 
 ## Impact
@@ -69,5 +75,7 @@ equal-weight consumer is already protected by the uncapped floor.
 fetch loops), `app/modules/usage/depletion_service.py` (content signature),
 unit and PostgreSQL regression coverage. Dashboard values are unchanged
 (equal-weight consumers exact; EWMA-derived fields equal to within
-floating-point noise) — no API, response-schema, setting, migration, or
+floating-point noise, except that an account flat at 100% whose full replay
+carried only a ghost rate now reports no exhaustion ETA instead of an
+immediate one — fields the dashboard UI does not read) — no API, response-schema, setting, migration, or
 dashboard UI change.

--- a/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
+++ b/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
@@ -6,23 +6,33 @@
 The dashboard projections history fetch MUST NOT widen every account's
 lookback to the widest account window. On PostgreSQL the bulk usage-history
 read MUST bound rows per account by that account's own window cutoff, and
-MUST additionally bound each account's slice to a newest-first per-account
-row cap supplied by the projections caller. Because live snapshot ingestion
-writes a row per proxied request whenever the usage fingerprint changes, no
-fixed row cap alone can guarantee coverage of a fixed time window; the
-fetch MUST therefore exempt rows inside the configured pace-smoothing
-window (the projections caller supplies its start as an uncapped recent
-floor) so every row the equal-weight smoothing mean consumes is returned
-regardless of write density, while the cap MUST still bound the rows older
-than that floor. The cap MUST be sized to cover the remaining tail-weighted
-consumers' lookback (the recent-burn EWMA window) at the ingestor's minimum
-per-account write interval. Returned slices MUST keep the newest in-cutoff
-rows and MUST remain ordered oldest-first. For accounts whose in-cutoff
-rows do not exceed the cap, the returned histories MUST equal the previous
-shared-floor fetch after the existing per-account trimming; for accounts
-over the cap, the returned history MUST be exactly the union of every
-in-cutoff row at or after the uncapped recent floor and the newest cap-many
-in-cutoff rows older than the floor.
+MUST additionally bound each account's rows older than an uncapped recent
+floor to a newest-first per-account row cap supplied by the projections
+caller. Because live snapshot ingestion writes a row per proxied request
+whenever the usage fingerprint changes, no fixed row cap can guarantee
+coverage of a fixed time window; the fetch MUST therefore exempt rows at or
+after the uncapped recent floor from the cap so every row an equal-weight
+consumer reads is returned regardless of write density. The projections
+caller MUST derive the floor as the wider of the configured pace-smoothing
+window and the weekly-pace fleet-burn window, and MUST supply the cap and
+the floor on every projections bulk fetch, including the primary-window
+fetch (weekly-only accounts sourced from the primary stream feed the weekly
+pace from it). The cap MUST be sized to the tail-weighted consumers' EWMA
+decay rather than to a time window at an assumed write cadence: with the
+EWMA smoothing factor in use, a sample's weight after cap-many newer
+samples MUST be below double precision, so the tail replay reproduces the
+full replay within floating-point tolerance. Returned slices MUST keep the
+newest in-cutoff rows and MUST remain ordered oldest-first. For accounts
+whose in-cutoff rows do not exceed the cap, the returned histories MUST
+equal the shared-floor fetch after the existing per-account trimming; for
+accounts over the cap, the returned history MUST be exactly the union of
+every in-cutoff row at or after the uncapped recent floor and the newest
+cap-many in-cutoff rows older than the floor. Consumers that weigh every
+sample in a fixed time window equally MUST read only rows at or after the
+floor and MUST produce values identical to the uncapped fetch; consumers
+that replay a count-decaying EWMA MAY read the capped tail and MUST
+produce rate-bearing values equal to the uncapped fetch within
+floating-point tolerance (1e-12 relative or absolute).
 
 #### Scenario: One weekly account does not widen the fetch for short-window accounts
 - **GIVEN** one account with a 7-day window and several accounts with 5-hour windows
@@ -36,11 +46,24 @@ in-cutoff rows older than the floor.
 - **THEN** the account's slice MUST be exactly the in-cutoff rows at or after the uncapped recent floor plus the newest cap-many in-cutoff rows older than the floor, ordered oldest-first
 - **AND** accounts whose in-cutoff rows do not exceed the cap MUST return their full trimmed slice unchanged
 
-#### Scenario: A write burst inside the smoothing window is never truncated
-- **GIVEN** an account that wrote more usage-history rows inside the configured pace-smoothing window than the per-account row cap
+#### Scenario: Equal-weight consumers are exempt from the cap on every fetch
+- **GIVEN** the configured pace-smoothing window and the fixed weekly-pace fleet-burn window
+- **WHEN** the projections history fetch runs for the primary and the secondary window
+- **THEN** both bulk fetches MUST supply the per-account row cap
+- **AND** both MUST supply an uncapped recent floor equal to now minus the wider of the two windows
+- **AND** a weekly-only account whose history source is the primary stream MUST receive the same cap and floor on the primary fetch whether or not the caller requested primary-window depletion
+
+#### Scenario: A write burst inside an equal-weight window is never truncated
+- **GIVEN** an account that wrote more usage-history rows inside the smoothing or fleet-burn window than the per-account row cap
 - **WHEN** the projections history fetch runs on PostgreSQL
-- **THEN** every in-cutoff row at or after the smoothing-window start MUST be returned
-- **AND** the weekly-pace smoothed values MUST equal the values the uncapped fetch would produce
+- **THEN** every in-cutoff row at or after the floor MUST be returned
+- **AND** the weekly-pace smoothed values and fleet burn rate MUST equal the values the uncapped fetch would produce
+
+#### Scenario: EWMA consumers agree with the full replay over the tail
+- **GIVEN** an account with thousands of in-cutoff rows older than the floor
+- **WHEN** depletion or the weekly-pace recent burn rate is computed from the capped fetch and from the uncapped fetch
+- **THEN** the rate-bearing results MUST agree within 1e-12 (relative or absolute)
+- **AND** when a usage drop or window reset lands inside the returned tail the results MUST be identical
 
 #### Scenario: Capped probes stay index-only
 - **GIVEN** usage history rows for multiple accounts and a populated visibility map
@@ -49,6 +72,44 @@ in-cutoff rows older than the floor.
 
 #### Scenario: SQLite snapshot cache keeps the shared floor
 - **GIVEN** the SQLite backend serves the projections history fetch through its snapshot cache
-- **WHEN** per-account cutoffs and a per-account row cap are supplied
-- **THEN** the SQLite read MAY keep the shared floor and MAY ignore the row cap
+- **WHEN** per-account cutoffs, a per-account row cap, and an uncapped recent floor are supplied
+- **THEN** the SQLite read MAY keep the shared floor and MAY ignore the row cap and the floor
 - **AND** per-account trimming in the caller MUST still bound each account's slice
+
+### Requirement: Dashboard overview memoizes per-account depletion EWMA state
+
+`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice in the depletion cache check when its content is unchanged. The attached compact content signature MUST be fixed-width regardless of history length (row count, first and latest row edge tuples, and one fixed-width content hash over every row's value-bearing fields); it MAY be process-local because the cache it guards is process memory only, and the cache MUST NOT retain a per-row signature structure. SQLite bulk history cache hits MUST avoid rebuilding or materializing the full cached history window when compact digest metadata proves older rows are unchanged; they MUST append newly inserted rows by monotonic row ID and reuse the cached grouped history for older rows. Repository-owned mutations that reassign or delete usage-history rows MUST clear the SQLite bulk history cache.
+
+#### Scenario: Repeated polls with unchanged history reuse cached EWMA state
+- **GIVEN** the dashboard service has previously computed depletion for an account
+- **AND** a subsequent request supplies the same in-window history slice for that account with the same attached compact content signature
+- **WHEN** depletion is recomputed for the dashboard response
+- **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
+- **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
+- **AND** the cache hit check MUST compare fixed-width signature metadata and MUST NOT retain a per-row signature structure
+- **AND** the service MUST prune cached depletion state for account/window keys that are absent from the current dashboard history set
+
+#### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
+- **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)
+- **THEN** the service MUST rebuild the EWMA state from the new history slice
+- **AND** the recomputed rate MUST reflect the newly observed sample
+
+#### Scenario: Memoized EWMA state is invalidated when an older row ages out of the window
+- **WHEN** a later dashboard request supplies the same account's in-window history with the earliest row dropped (because it has aged past the window cutoff)
+- **THEN** the service MUST rebuild the EWMA state from the narrowed history slice
+- **AND** the cached state from the wider window MUST NOT influence the recomputed rate
+
+#### Scenario: Memoized EWMA state is invalidated when an existing usage row is corrected
+- **WHEN** a later dashboard request supplies the same account's in-window history with the same row count and endpoints but a corrected `used_percent`, `reset_at`, or `window_minutes` value on an existing row (including a value becoming or ceasing to be absent)
+- **THEN** the service MUST rebuild the EWMA state from the corrected history slice
+- **AND** the recomputed rate-bearing metrics MUST reflect the corrected row content
+
+#### Scenario: SQLite bulk history cache hit appends only new rows
+- **GIVEN** a SQLite bulk usage-history query has already cached rows for an account/window set
+- **WHEN** a later query uses a narrower `since` timestamp and the database only has new rows with IDs greater than the cached max ID
+- **THEN** the repository fetches the new rows and appends them to the cached grouped history
+- **AND** it does not materialize the older cached rows as snapshots when compact digest metadata proves they are unchanged
+
+#### Scenario: Usage-history ownership mutation clears SQLite bulk history cache
+- **WHEN** an account merge or delete operation updates or deletes `usage_history` rows
+- **THEN** the repository clears the SQLite bulk history cache before serving future cached dashboard history reads

--- a/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
+++ b/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
@@ -18,14 +18,17 @@ window and the weekly-pace fleet-burn window, and MUST supply the cap and
 the floor on every projections bulk fetch, including the primary-window
 fetch (weekly-only accounts sourced from the primary stream feed the weekly
 pace from it). The cap MUST be sized to the tail-weighted consumers' EWMA
-decay rather than to a time window at an assumed write cadence: with the
-EWMA smoothing factor in use, a sample's weight after cap-many newer EWMA
-updates MUST be below double precision. The EWMA advances once per distinct
-recorded second (its epoch resolution), so the tail replay reproduces the
-full replay within floating-point tolerance whenever the returned tail spans
-at least cap-many distinct recorded seconds; a tail packed into fewer
-distinct seconds (a same-second write burst older than the floor) MAY
-diverge from the full replay. Returned slices MUST keep the
+decay rather than to a time window at an assumed write cadence: the first
+tail row only seeds the EWMA, so a cap-row tail performs cap-minus-one
+updates, and with the EWMA smoothing factor in use the pre-tail state's
+residual on the replayed rate MUST be bounded by the retained weight after
+cap-minus-one updates times the largest per-second sample slope (below
+about 1e-12 percent per second at the theoretical 100-percent-per-second
+step). The EWMA advances once per distinct recorded second (its epoch
+resolution), so that bound holds whenever the returned tail spans at least
+cap-many distinct recorded seconds; a tail packed into fewer distinct
+seconds (a same-second write burst older than the floor) MAY diverge from
+the full replay. Returned slices MUST keep the
 newest in-cutoff rows and MUST remain ordered oldest-first. For accounts
 whose in-cutoff rows do not exceed the cap, the returned histories MUST
 equal the shared-floor fetch after the existing per-account trimming; for
@@ -34,10 +37,16 @@ every in-cutoff row at or after the uncapped recent floor and the newest
 cap-many in-cutoff rows older than the floor. Consumers that weigh every
 sample in a fixed time window equally MUST read only rows at or after the
 floor and MUST produce values identical to the uncapped fetch; consumers
-that replay a count-decaying EWMA MAY read the capped tail and MUST
-produce rate-bearing values equal to the uncapped fetch within
-floating-point tolerance (1e-12 relative or absolute) whenever the tail
-spans at least cap-many distinct recorded seconds.
+that replay a count-decaying EWMA MAY read the capped tail and, whenever
+the tail spans at least cap-many distinct recorded seconds, MUST produce an
+EWMA rate equal to the uncapped fetch within that residual bound (an
+absolute bound on the rate); fields derived from the rate (burn rate, risk,
+exhaustion ETA) MUST agree within that residual propagated through their
+formulas (the burn rate scales it by seconds-until-reset over remaining
+percent), and the exhaustion ETA fields, which are emitted only for a
+strictly positive rate, MAY be absent from the capped replay when the
+uncapped replay retains a positive ghost rate below the residual (an
+account flat at its limit).
 
 #### Scenario: One weekly account does not widen the fetch for short-window accounts
 - **GIVEN** one account with a 7-day window and several accounts with 5-hour windows
@@ -68,14 +77,27 @@ spans at least cap-many distinct recorded seconds.
 - **GIVEN** an account with thousands of in-cutoff rows older than the floor
 - **AND** the newest cap-many of those rows span at least cap-many distinct recorded seconds
 - **WHEN** depletion or the weekly-pace recent burn rate is computed from the capped fetch and from the uncapped fetch
-- **THEN** the rate-bearing results MUST agree within 1e-12 (relative or absolute)
+- **THEN** the EWMA rates MUST agree within the retained weight after cap-minus-one updates times the largest per-second sample slope in the history (an absolute bound on the rate)
+- **AND** burn rate, risk, and exhaustion ETA MUST agree within that residual propagated through their formulas
 - **AND** when a usage drop or window reset lands inside the returned tail the results MUST be identical
+
+#### Scenario: The seed row bounds the tail residual
+- **GIVEN** an account whose rows older than the floor are one step from zero to a high usage followed by cap-many flat rows one recorded second apart, so the uncapped replay retains a positive ghost rate while the capped tail decays to exactly zero
+- **WHEN** depletion is computed from the capped fetch and from the uncapped fetch
+- **THEN** the rates MAY differ, and the difference MUST NOT exceed the retained weight after cap-minus-one updates times the step's per-second slope
+- **AND** the burn rate MAY differ by that residual scaled by seconds-until-reset over remaining percent
+
+#### Scenario: A saturated account may lose its exhaustion ETA under the capped fetch
+- **GIVEN** an account that reached its limit and has held a flat usage for longer than the floor, so the uncapped replay still carries a positive ghost rate that has decayed below the residual while the capped tail replays only flat rows
+- **WHEN** depletion is computed from the capped fetch and from the uncapped fetch
+- **THEN** risk and burn rate MUST be identical
+- **AND** the capped replay MAY report no exhaustion ETA where the uncapped replay reports an immediate one, because the ETA is emitted only for a strictly positive rate
 
 #### Scenario: A same-second write burst older than the floor bounds the tail guarantee
 - **GIVEN** an account whose newest rows older than the floor were written several per recorded second, so the cap-many returned tail rows span fewer distinct recorded seconds than the cap
 - **WHEN** depletion is computed from the capped fetch and from the uncapped fetch
 - **THEN** the EWMA replays MAY diverge, because each recorded second contributes one EWMA update regardless of how many rows share it
-- **AND** a tail whose rows span cap-many distinct recorded seconds MUST agree within 1e-12 however many rows share each second
+- **AND** a tail whose rows span cap-many distinct recorded seconds MUST meet the residual bound however many rows share each second
 
 #### Scenario: Capped probes stay index-only
 - **GIVEN** usage history rows for multiple accounts and a populated visibility map

--- a/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
+++ b/openspec/changes/cap-projection-history-rows/specs/query-caching/spec.md
@@ -19,9 +19,13 @@ the floor on every projections bulk fetch, including the primary-window
 fetch (weekly-only accounts sourced from the primary stream feed the weekly
 pace from it). The cap MUST be sized to the tail-weighted consumers' EWMA
 decay rather than to a time window at an assumed write cadence: with the
-EWMA smoothing factor in use, a sample's weight after cap-many newer
-samples MUST be below double precision, so the tail replay reproduces the
-full replay within floating-point tolerance. Returned slices MUST keep the
+EWMA smoothing factor in use, a sample's weight after cap-many newer EWMA
+updates MUST be below double precision. The EWMA advances once per distinct
+recorded second (its epoch resolution), so the tail replay reproduces the
+full replay within floating-point tolerance whenever the returned tail spans
+at least cap-many distinct recorded seconds; a tail packed into fewer
+distinct seconds (a same-second write burst older than the floor) MAY
+diverge from the full replay. Returned slices MUST keep the
 newest in-cutoff rows and MUST remain ordered oldest-first. For accounts
 whose in-cutoff rows do not exceed the cap, the returned histories MUST
 equal the shared-floor fetch after the existing per-account trimming; for
@@ -32,7 +36,8 @@ sample in a fixed time window equally MUST read only rows at or after the
 floor and MUST produce values identical to the uncapped fetch; consumers
 that replay a count-decaying EWMA MAY read the capped tail and MUST
 produce rate-bearing values equal to the uncapped fetch within
-floating-point tolerance (1e-12 relative or absolute).
+floating-point tolerance (1e-12 relative or absolute) whenever the tail
+spans at least cap-many distinct recorded seconds.
 
 #### Scenario: One weekly account does not widen the fetch for short-window accounts
 - **GIVEN** one account with a 7-day window and several accounts with 5-hour windows
@@ -61,9 +66,16 @@ floating-point tolerance (1e-12 relative or absolute).
 
 #### Scenario: EWMA consumers agree with the full replay over the tail
 - **GIVEN** an account with thousands of in-cutoff rows older than the floor
+- **AND** the newest cap-many of those rows span at least cap-many distinct recorded seconds
 - **WHEN** depletion or the weekly-pace recent burn rate is computed from the capped fetch and from the uncapped fetch
 - **THEN** the rate-bearing results MUST agree within 1e-12 (relative or absolute)
 - **AND** when a usage drop or window reset lands inside the returned tail the results MUST be identical
+
+#### Scenario: A same-second write burst older than the floor bounds the tail guarantee
+- **GIVEN** an account whose newest rows older than the floor were written several per recorded second, so the cap-many returned tail rows span fewer distinct recorded seconds than the cap
+- **WHEN** depletion is computed from the capped fetch and from the uncapped fetch
+- **THEN** the EWMA replays MAY diverge, because each recorded second contributes one EWMA update regardless of how many rows share it
+- **AND** a tail whose rows span cap-many distinct recorded seconds MUST agree within 1e-12 however many rows share each second
 
 #### Scenario: Capped probes stay index-only
 - **GIVEN** usage history rows for multiple accounts and a populated visibility map

--- a/openspec/changes/cap-projection-history-rows/tasks.md
+++ b/openspec/changes/cap-projection-history-rows/tasks.md
@@ -6,9 +6,11 @@
 - [x] 1.2 Exempt an uncapped recent floor from the cap (disjoint floor +
       capped-tail branches in the lateral probe) so a per-request write burst
       can never truncate an equal-weight consumer window.
-- [x] 1.3 Size the cap to the EWMA tail (64 rows; `0.6**64` is below double
-      precision after 64 EWMA updates, one per distinct recorded second)
-      instead of a time window at an assumed write cadence, and
+- [x] 1.3 Size the cap to the EWMA tail (64 rows; the first row seeds the
+      EWMA so the tail performs 63 updates, one per distinct recorded
+      second, leaving a pre-tail residual of at most `0.6**63` times the
+      largest per-second slope, ~1e-12 %/s worst case) instead of a time
+      window at an assumed write cadence, and
       derive the floor as the wider of the configured pace-smoothing window
       and the 3-hour fleet-burn window on both projections fetches
       (weekly-only accounts sourced from the primary stream feed the weekly
@@ -39,6 +41,10 @@
       tail); a tail spanning 64 distinct recorded seconds matches within
       1e-12 however many rows share each second while a 64-row tail packed
       into fewer distinct seconds is the documented divergence boundary;
+      a zero-to-high step followed by 64 flat one-per-second rows pins the
+      seed-row residual (`0.6**63` times the step slope) and a saturated
+      account pins the ghost-rate exhaustion-ETA divergence (risk and burn
+      rate identical);
       weekly pace over a 7-day per-minute history equals the
       tail-bounded history within 1e-12; the content signature is stable
       for identical rows and changes for any corrected field including

--- a/openspec/changes/cap-projection-history-rows/tasks.md
+++ b/openspec/changes/cap-projection-history-rows/tasks.md
@@ -7,7 +7,8 @@
       capped-tail branches in the lateral probe) so a per-request write burst
       can never truncate an equal-weight consumer window.
 - [x] 1.3 Size the cap to the EWMA tail (64 rows; `0.6**64` is below double
-      precision) instead of a time window at an assumed write cadence, and
+      precision after 64 EWMA updates, one per distinct recorded second)
+      instead of a time window at an assumed write cadence, and
       derive the floor as the wider of the configured pace-smoothing window
       and the 3-hour fleet-burn window on both projections fetches
       (weekly-only accounts sourced from the primary stream feed the weekly
@@ -35,7 +36,10 @@
       primary-source account with and without `include_primary`.
 - [x] 2.4 Unit tests: depletion over a 5000-row history equals the 64-row
       tail replay within 1e-12 (exactly when a reset lands inside the
-      tail); weekly pace over a 7-day per-minute history equals the
+      tail); a tail spanning 64 distinct recorded seconds matches within
+      1e-12 however many rows share each second while a 64-row tail packed
+      into fewer distinct seconds is the documented divergence boundary;
+      weekly pace over a 7-day per-minute history equals the
       tail-bounded history within 1e-12; the content signature is stable
       for identical rows and changes for any corrected field including
       `None` variants.

--- a/openspec/changes/cap-projection-history-rows/tasks.md
+++ b/openspec/changes/cap-projection-history-rows/tasks.md
@@ -3,15 +3,23 @@
 - [x] 1.1 Add a newest-first per-account row cap to the PostgreSQL bulk
       usage-history read (lateral top-N probe per account, composed with the
       existing per-account cutoffs; oldest-first slices preserved).
-- [x] 1.2 Pass the cap from the dashboard projections history fetch, sized
-      so the tail-weighted EWMA consumers (depletion, weekly-pace burn) see
-      identical inputs.
-- [x] 1.3 Exempt the configured pace-smoothing window from the cap
-      (uncapped recent floor plumbed from the projections caller; disjoint
-      floor + capped-tail branches in the lateral probe) so a per-request
-      write burst can never truncate the equal-weight smoothing mean.
-- [x] 1.4 Keep the SQLite snapshot-cache path on the shared floor (cap
-      ignored, like cutoffs).
+- [x] 1.2 Exempt an uncapped recent floor from the cap (disjoint floor +
+      capped-tail branches in the lateral probe) so a per-request write burst
+      can never truncate an equal-weight consumer window.
+- [x] 1.3 Size the cap to the EWMA tail (64 rows; `0.6**64` is below double
+      precision) instead of a time window at an assumed write cadence, and
+      derive the floor as the wider of the configured pace-smoothing window
+      and the 3-hour fleet-burn window on both projections fetches
+      (weekly-only accounts sourced from the primary stream feed the weekly
+      pace from the primary fetch).
+- [x] 1.4 Hydrate PostgreSQL bulk-history rows positionally instead of via
+      per-column `Row` attribute access; keep the per-account sort and the
+      caller-side cutoff trimming.
+- [x] 1.5 Replace the field-by-field `blake2b(repr)` depletion cache content
+      digest with one fixed-width process-local hash over the row edge
+      tuples; keep the SQLite bulk-cache digest unchanged.
+- [x] 1.6 Keep the SQLite snapshot-cache path on the shared floor (cap and
+      floor ignored, like cutoffs).
 
 ## 2. Validation
 
@@ -20,8 +28,16 @@
       untouched, and never drop rows at or after the uncapped recent floor;
       SQLite ignores the cap.
 - [x] 2.2 PostgreSQL plan tests: the capped lateral probes (with and
-      without the floor branch) stay index-only on the covering indexes.
-- [x] 2.3 Unit test: the projections fetch supplies the cap and the
-      smoothing-window floor.
-- [x] 2.4 Run lint, type checks, sqlite + PostgreSQL test slices, and strict
+      without the floor branch) stay index-only on the covering indexes; the
+      covered read still matches the non-covered read.
+- [x] 2.3 Unit tests: both projections fetches supply the EWMA tail cap and
+      the `max(smoothing window, 3h)` floor, including a weekly-only
+      primary-source account with and without `include_primary`.
+- [x] 2.4 Unit tests: depletion over a 5000-row history equals the 64-row
+      tail replay within 1e-12 (exactly when a reset lands inside the
+      tail); weekly pace over a 7-day per-minute history equals the
+      tail-bounded history within 1e-12; the content signature is stable
+      for identical rows and changes for any corrected field including
+      `None` variants.
+- [x] 2.5 Run lint, type checks, sqlite + PostgreSQL test slices, and strict
       OpenSpec validation.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -1042,6 +1042,104 @@ async def test_dashboard_projections_weekly_only_depletion_uses_current_stream(a
     assert payload["depletionSecondary"]["risk"] == pytest.approx(0.37, abs=0.02)
 
 
+def _assert_json_close(actual: object, expected: object, path: str = "$") -> None:
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), path
+        assert actual.keys() == expected.keys(), path
+        for key in expected:
+            _assert_json_close(actual[key], expected[key], f"{path}.{key}")
+    elif isinstance(expected, list):
+        assert isinstance(actual, list) and len(actual) == len(expected), path
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _assert_json_close(left, right, f"{path}[{index}]")
+    elif isinstance(expected, float) and not isinstance(expected, bool):
+        assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12), path
+    else:
+        assert actual == expected, path
+
+
+@pytest.mark.asyncio
+async def test_dashboard_projections_ewma_tail_cap_matches_uncapped_history(async_client, db_setup, monkeypatch):
+    """The projections fetch caps rows older than the equal-weight floor to
+    the newest 64 per account. For a dense weekly-only account sourced from
+    the primary stream (the production shape) the response must be
+    equivalent to the uncapped fetch: exact for the floor-covered weekly
+    pace values, within floating-point noise for the EWMA-derived fields."""
+    from app.db.models import UsageHistory
+    from app.db.session import engine
+    from app.modules.dashboard import service as dashboard_service
+    from app.modules.dashboard.repository import DashboardRepository
+
+    now = utcnow().replace(microsecond=0)
+    # Freeze the service clock so both responses are computed for the same
+    # instant and only the fetched history can differ between them.
+    monkeypatch.setattr(dashboard_service, "utcnow", lambda: now)
+    fetched_row_counts: list[int] = []
+    real_bulk_fetch = DashboardRepository.bulk_usage_history_since
+
+    async def _recording_bulk_fetch(self, *args, **kwargs):
+        grouped = await real_bulk_fetch(self, *args, **kwargs)
+        fetched_row_counts.append(sum(len(rows) for rows in grouped.values()))
+        return grouped
+
+    monkeypatch.setattr(DashboardRepository, "bulk_usage_history_since", _recording_bulk_fetch)
+    reset_at = int(naive_utc_to_epoch(now + timedelta(days=2)))
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_dense_weekly", "dense@example.com", plan_type="pro"))
+        # One row every 10 minutes for 7 days on the primary stream carrying
+        # the weekly window: ~1000 rows, far more than the 64-row tail
+        # between the 7-day cutoff and the 3h floor.
+        rows = []
+        used = 3.0
+        for index in range(7 * 24 * 6, 0, -1):
+            used += 0.04 + 0.03 * ((index * 7919) % 11) / 11.0
+            rows.append(
+                UsageHistory(
+                    account_id="acc_dense_weekly",
+                    window="primary",
+                    window_minutes=10080,
+                    used_percent=round(used, 6),
+                    reset_at=reset_at,
+                    recorded_at=now - timedelta(minutes=10 * (index - 1) + 1),
+                )
+            )
+        session.add_all(rows)
+        await session.commit()
+
+    capped = await async_client.get("/api/dashboard/projections")
+    assert capped.status_code == 200
+    capped_payload = capped.json()
+    assert capped_payload["depletionSecondary"] is not None
+    assert capped_payload["weeklyCreditPace"] is not None
+    assert capped_payload["weeklyCreditPace"]["burnRateRecentCreditsPerHour"] > 0
+
+    # Same database, same instant: lift the cap so every in-cutoff row is
+    # hydrated, and compare against the capped response.
+    monkeypatch.setattr(dashboard_service, "_PROJECTION_EWMA_TAIL_ROWS", 10**6)
+    uncapped = await async_client.get("/api/dashboard/projections")
+    assert uncapped.status_code == 200
+    uncapped_payload = uncapped.json()
+
+    # One primary-window fetch per request (weekly-only primary-source
+    # account, no secondary rows). On PostgreSQL the capped fetch hydrates
+    # the 18 rows inside the 3h floor plus the 64-row tail; SQLite serves its
+    # shared-floor snapshot cache and ignores the cap.
+    assert len(fetched_row_counts) == 2
+    capped_rows, uncapped_rows = fetched_row_counts
+    assert uncapped_rows == 7 * 24 * 6
+    if str(engine.url).startswith("postgresql"):
+        assert capped_rows == 18 + 64
+    else:
+        assert capped_rows == uncapped_rows
+
+    _assert_json_close(
+        capped_payload["depletionSecondary"], uncapped_payload["depletionSecondary"], "$.depletionSecondary"
+    )
+    _assert_json_close(capped_payload["weeklyCreditPace"], uncapped_payload["weeklyCreditPace"], "$.weeklyCreditPace")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("timeframe", "expected_requests", "expected_bucket_count"),

--- a/tests/unit/test_dashboard_projection_history_cap.py
+++ b/tests/unit/test_dashboard_projection_history_cap.py
@@ -66,8 +66,9 @@ def _usage_entry(account_id: str, window: str, window_minutes: int, recorded_at:
 
 def test_projection_tail_cap_is_a_fixed_ewma_tail() -> None:
     # The cap is sized for the count-decaying EWMA consumers (alpha 0.4): a
-    # sample's weight after the cap-many newer samples is below double
-    # precision, so the tail replay equals the full replay to fp noise.
+    # sample's weight after cap-many newer EWMA updates (one per distinct
+    # recorded second) is below double precision, so a tail spanning that
+    # many distinct seconds replays to fp noise of the full replay.
     # Equal-weight consumers are covered by the floor, not the cap.
     assert _PROJECTION_EWMA_TAIL_ROWS == 64
     assert 0.6**_PROJECTION_EWMA_TAIL_ROWS < 1e-14

--- a/tests/unit/test_dashboard_projection_history_cap.py
+++ b/tests/unit/test_dashboard_projection_history_cap.py
@@ -65,13 +65,20 @@ def _usage_entry(account_id: str, window: str, window_minutes: int, recorded_at:
 
 
 def test_projection_tail_cap_is_a_fixed_ewma_tail() -> None:
-    # The cap is sized for the count-decaying EWMA consumers (alpha 0.4): a
-    # sample's weight after cap-many newer EWMA updates (one per distinct
-    # recorded second) is below double precision, so a tail spanning that
-    # many distinct seconds replays to fp noise of the full replay.
-    # Equal-weight consumers are covered by the floor, not the cap.
+    # The cap is sized for the count-decaying EWMA consumers (alpha 0.4). The
+    # first retained row only seeds the EWMA, so a cap-row tail spanning
+    # cap-many distinct recorded seconds performs cap-1 updates and the
+    # pre-tail state's weight on the replayed rate is ``0.6**(cap-1)``: below
+    # ~1.1e-12 %/s even at the theoretical 100 %/s per-second step, so the
+    # tail replays to fp noise of the full replay. Equal-weight consumers are
+    # covered by the floor, not the cap.
     assert _PROJECTION_EWMA_TAIL_ROWS == 64
-    assert 0.6**_PROJECTION_EWMA_TAIL_ROWS < 1e-14
+    residual_weight = 0.6 ** (_PROJECTION_EWMA_TAIL_ROWS - 1)
+    assert residual_weight < 1.1e-14
+    assert residual_weight * 100.0 < 1.1e-12
+    # Guard against loosening: the cap-1 bound is the tight one (0.6**cap is
+    # ~0.6x smaller and would not describe the seed-row arithmetic).
+    assert residual_weight > 0.6**_PROJECTION_EWMA_TAIL_ROWS
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_dashboard_projection_history_cap.py
+++ b/tests/unit/test_dashboard_projection_history_cap.py
@@ -1,8 +1,11 @@
-"""The projections history fetch must request the per-account row cap.
+"""The projections history fetch must request the EWMA-tail row cap and the
+equal-weight floor.
 
 The cap is what keeps the PostgreSQL bulk read bounded on deployments where
 live snapshot ingestion densifies ``usage_history``; losing the kwarg would
-silently regress the read back to full-window row counts.
+silently regress the read back to full-window row counts. The floor is what
+keeps the equal-weight consumers (weekly-pace smoothing mean, 3h fleet burn)
+exact regardless of write density.
 """
 
 from __future__ import annotations
@@ -15,9 +18,10 @@ import pytest
 from app.db.models import UsageHistory
 from app.modules.dashboard.repository import DashboardRepository
 from app.modules.dashboard.service import (
-    _PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP,
+    _PROJECTION_EWMA_TAIL_ROWS,
     _load_projection_histories,
 )
+from app.modules.dashboard.weekly_pace import FLEET_BURN_WINDOW
 
 pytestmark = pytest.mark.unit
 
@@ -60,8 +64,29 @@ def _usage_entry(account_id: str, window: str, window_minutes: int, recorded_at:
     )
 
 
+def test_projection_tail_cap_is_a_fixed_ewma_tail() -> None:
+    # The cap is sized for the count-decaying EWMA consumers (alpha 0.4): a
+    # sample's weight after the cap-many newer samples is below double
+    # precision, so the tail replay equals the full replay to fp noise.
+    # Equal-weight consumers are covered by the floor, not the cap.
+    assert _PROJECTION_EWMA_TAIL_ROWS == 64
+    assert 0.6**_PROJECTION_EWMA_TAIL_ROWS < 1e-14
+
+
 @pytest.mark.asyncio
-async def test_projection_history_fetch_passes_per_account_row_cap():
+@pytest.mark.parametrize(
+    ("smoothing_window_minutes", "expected_floor_minutes"),
+    [
+        # Smoothing window wider than the fleet-burn window: it sets the floor.
+        (240, 240),
+        # Default smoothing window (30 min): the 3h fleet-burn window wins.
+        (30, int(FLEET_BURN_WINDOW.total_seconds() // 60)),
+    ],
+)
+async def test_projection_history_fetch_passes_tail_cap_and_equal_weight_floor(
+    smoothing_window_minutes: int,
+    expected_floor_minutes: int,
+) -> None:
     now = datetime(2026, 8, 16, 12, 0, 0)
     repo = _RecordingRepo()
     primary_usage = {
@@ -76,16 +101,48 @@ async def test_projection_history_fetch_passes_per_account_row_cap():
         primary_usage,
         secondary_usage,
         now,
-        smoothing_window_minutes=240,
+        smoothing_window_minutes=smoothing_window_minutes,
     )
 
     assert len(repo.calls) == 2
     assert {call["window"] for call in repo.calls} == {"primary", "secondary"}
     for call in repo.calls:
-        assert call["per_account_row_cap"] == _PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP
+        assert call["per_account_row_cap"] == _PROJECTION_EWMA_TAIL_ROWS
         assert call["cutoffs"] is not None
-        # The weekly-pace smoothing mean weighs every in-window sample
-        # equally, so the fetch must exempt the configured smoothing window
-        # from the row cap; a write burst may otherwise out-write the cap and
-        # shift the smoothed schedule gap.
-        assert call["uncapped_recent_floor"] == now - timedelta(minutes=240)
+        # The weekly-pace smoothing mean and the 3h fleet burn weigh every
+        # in-window sample equally, so the fetch must exempt the wider of the
+        # two windows from the row cap on BOTH fetches; a write burst may
+        # otherwise out-write the cap and shift those values.
+        assert call["uncapped_recent_floor"] == now - timedelta(minutes=expected_floor_minutes)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_primary", [True, False])
+async def test_weekly_only_primary_source_account_keeps_floor_on_primary_fetch(include_primary: bool) -> None:
+    """Weekly-only accounts whose history source is the primary stream feed
+    ``secondary_history`` (weekly pace) from the PRIMARY bulk fetch, so that
+    fetch must carry the equal-weight floor too — it is not EWMA-only."""
+    now = datetime(2026, 8, 16, 12, 0, 0)
+    repo = _RecordingRepo()
+    # A weekly-only account: the primary stream carries the 7-day window and
+    # there is no secondary row at all.
+    primary_usage = {
+        "weekly": _usage_entry("weekly", "primary", 10080, now - timedelta(minutes=1)),
+    }
+    secondary_usage: dict[str, UsageHistory] = {}
+
+    await _load_projection_histories(
+        cast(DashboardRepository, repo),
+        primary_usage,
+        secondary_usage,
+        now,
+        smoothing_window_minutes=30,
+        include_primary=include_primary,
+    )
+
+    assert [call["window"] for call in repo.calls] == ["primary"]
+    (call,) = repo.calls
+    assert call["account_ids"] == ["weekly"]
+    assert call["cutoffs"] == {"weekly": now - timedelta(minutes=10080)}
+    assert call["per_account_row_cap"] == _PROJECTION_EWMA_TAIL_ROWS
+    assert call["uncapped_recent_floor"] == now - FLEET_BURN_WINDOW

--- a/tests/unit/test_dashboard_weekly_pace.py
+++ b/tests/unit/test_dashboard_weekly_pace.py
@@ -455,7 +455,8 @@ def test_weekly_pace_is_unchanged_by_ewma_tail_cap_under_fleet_burn_floor() -> N
     plus only the newest 64 older rows. The equal-weight consumers (fleet
     burn, smoothing mean, latest) read nothing older than the floor, so they
     are exact; the 6h recent-burn EWMA sees a 64-row tail instead of the full
-    3h..6h stretch and must agree to floating-point noise."""
+    3h..6h stretch and must agree to floating-point noise (the per-minute
+    cadence here gives the tail one EWMA update per row)."""
     from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
     from app.modules.dashboard.weekly_pace import FLEET_BURN_WINDOW
 

--- a/tests/unit/test_dashboard_weekly_pace.py
+++ b/tests/unit/test_dashboard_weekly_pace.py
@@ -432,3 +432,49 @@ async def test_weekly_pace_attribution_merges_rankings_and_dedupes_unnamed_key(d
     assert any(row.billable_tokens == 1_500 for row in rows)
     request_logs_table = cast(Table, RequestLog.__table__)
     assert "idx_logs_dash_usage_covering" in {index.name for index in request_logs_table.indexes}
+
+
+def _assert_close(actual: object, expected: object, path: str = "") -> None:
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), path
+        assert actual.keys() == expected.keys(), path
+        for key in expected:
+            _assert_close(actual[key], expected[key], f"{path}.{key}")
+    elif isinstance(expected, list):
+        assert isinstance(actual, list) and len(actual) == len(expected), path
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _assert_close(left, right, f"{path}[{index}]")
+    elif isinstance(expected, float) and not isinstance(expected, bool):
+        assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12), path
+    else:
+        assert actual == expected, path
+
+
+def test_weekly_pace_is_unchanged_by_ewma_tail_cap_under_fleet_burn_floor() -> None:
+    """The projections fetch returns every row inside the 3h fleet-burn floor
+    plus only the newest 64 older rows. The equal-weight consumers (fleet
+    burn, smoothing mean, latest) read nothing older than the floor, so they
+    are exact; the 6h recent-burn EWMA sees a 64-row tail instead of the full
+    3h..6h stretch and must agree to floating-point noise."""
+    from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
+    from app.modules.dashboard.weekly_pace import FLEET_BURN_WINDOW
+
+    account_id = "acc-dense"
+    # One row per minute for 7 days (denser than the cap inside 3h..6h).
+    rows: list[UsageHistory] = []
+    used = 2.0
+    for index in range(7 * 24 * 60, 0, -1):
+        used += 0.0045 + 0.002 * ((index * 7919) % 11) / 11.0
+        rows.append(_row(account_id, round(used, 6), NOW - timedelta(minutes=index)))
+    floor = NOW - FLEET_BURN_WINDOW
+    older = [row for row in rows if row.recorded_at < floor]
+    tail_bounded = older[-_PROJECTION_EWMA_TAIL_ROWS:] + [row for row in rows if row.recorded_at >= floor]
+    assert len(tail_bounded) < len(rows)
+
+    summaries = [_summary(account_id, used_percent=round(used, 6), reset_in_hours=30.0)]
+    full_pace = _build(summaries, {account_id: rows})
+    tail_pace = _build(summaries, {account_id: tail_bounded})
+
+    assert full_pace.burn_rate_recent_credits_per_hour is not None
+    assert full_pace.burn_rate_recent_credits_per_hour > 0
+    _assert_close(tail_pace.model_dump(), full_pace.model_dump())

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -352,8 +352,8 @@ def test_signature_cache_stores_compact_digest_not_per_row_tuple() -> None:
     assert result is not None
     signature = depletion_service._history_signatures[("acc1", "codex_other", "primary")]
     assert signature.row_count == 100
-    assert isinstance(signature.content_digest, str)
-    assert len(signature.content_digest) == 32
+    # A single fixed-width hash, not a per-row structure.
+    assert isinstance(signature.content_digest, int)
 
 
 def test_prune_depletion_cache_drops_absent_account_window_entries() -> None:
@@ -589,3 +589,94 @@ def test_post_reset_window_returns_none() -> None:
     now = BASE_TIME + timedelta(minutes=10)
     result = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
     assert result is None
+
+
+def _dense_history(
+    row_count: int,
+    *,
+    reset_at: int,
+    start: datetime,
+    reset_drop_at: int | None = None,
+) -> list[_FakeEntry]:
+    """Monotonic 1-minute cadence with a non-uniform slope; optionally one
+    usage drop (window reset) ``reset_drop_at`` rows before the end."""
+    rows: list[_FakeEntry] = []
+    used = 5.0
+    for index in range(row_count):
+        used += 0.012 + 0.006 * ((index * 7919) % 13) / 13.0
+        if reset_drop_at is not None and index == row_count - reset_drop_at:
+            used = 1.0
+        rows.append(_entry(round(used, 6), start + timedelta(minutes=index), reset_at=reset_at, window_minutes=10080))
+    return rows
+
+
+@pytest.mark.parametrize("reset_drop_at", [None, 20])
+def test_depletion_over_ewma_tail_matches_full_history_replay(reset_drop_at: int | None) -> None:
+    """The dashboard fetch caps rows older than the equal-weight floor to the
+    newest 64: with alpha 0.4 a sample's weight after 64 newer samples is
+    0.6**64 ~ 6e-15, so the tail replay must reproduce the full replay to
+    floating-point noise. A usage drop (window reset) inside the tail
+    discards all earlier state, so those cases must match exactly."""
+    from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
+
+    start = BASE_TIME - timedelta(minutes=5000)
+    now = BASE_TIME + timedelta(seconds=30)
+    reset_epoch = int((BASE_TIME + timedelta(days=2)).timestamp())
+    full = _dense_history(5000, reset_at=reset_epoch, start=start, reset_drop_at=reset_drop_at)
+    tail = full[-_PROJECTION_EWMA_TAIL_ROWS:]
+
+    reset_ewma_state()
+    full_result = compute_depletion_for_account("acc1", "standard", "secondary", _signed(full), now=now)
+    reset_ewma_state()
+    tail_result = compute_depletion_for_account("acc1", "standard", "secondary", _signed(tail), now=now)
+
+    assert full_result is not None
+    assert tail_result is not None
+    assert tail_result.risk_level == full_result.risk_level
+    assert tail_result.safe_usage_percent == full_result.safe_usage_percent
+    if reset_drop_at is not None:
+        # The reset inside the tail makes both replays start from the same row.
+        assert tail_result.rate_per_second == full_result.rate_per_second
+        assert tail_result.burn_rate == full_result.burn_rate
+        assert tail_result.risk == full_result.risk
+        assert tail_result.seconds_until_exhaustion == full_result.seconds_until_exhaustion
+        return
+    assert tail_result.rate_per_second == pytest.approx(full_result.rate_per_second, abs=1e-12, rel=1e-12)
+    assert tail_result.burn_rate == pytest.approx(full_result.burn_rate, abs=1e-12, rel=1e-12)
+    assert tail_result.risk == pytest.approx(full_result.risk, abs=1e-12, rel=1e-12)
+    assert full_result.seconds_until_exhaustion is not None
+    assert tail_result.seconds_until_exhaustion == pytest.approx(full_result.seconds_until_exhaustion, rel=1e-12)
+
+
+def test_history_signature_content_hash_tracks_row_content() -> None:
+    """The compact signature must be stable for identical content and change
+    for any value-bearing field, including ``None`` variants (id/reset_at)."""
+    from app.modules.usage.depletion_service import _history_signature_from_rows
+
+    reset_epoch = int((BASE_TIME + timedelta(minutes=30)).timestamp())
+    rows = [
+        _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
+    ]
+    baseline = _history_signature_from_rows(rows)
+    assert _history_signature_from_rows(list(rows)) == baseline
+    assert isinstance(baseline.content_digest, int)
+
+    middle = rows[1]
+    variants = [
+        [rows[0], _entry(25.0, middle.recorded_at, reset_at=reset_epoch, window_minutes=60), rows[2]],
+        [rows[0], _entry(20.0, middle.recorded_at, reset_at=None, window_minutes=60), rows[2]],
+        [rows[0], _entry(20.0, middle.recorded_at, reset_at=reset_epoch, window_minutes=None), rows[2]],
+        [
+            rows[0],
+            _entry(20.0, middle.recorded_at + timedelta(seconds=1), reset_at=reset_epoch, window_minutes=60),
+            rows[2],
+        ],
+    ]
+    for variant in variants:
+        changed = _history_signature_from_rows(variant)
+        assert changed.row_count == baseline.row_count
+        assert changed.first == baseline.first
+        assert changed.latest == baseline.latest
+        assert changed.content_digest != baseline.content_digest

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -613,9 +613,11 @@ def _dense_history(
 @pytest.mark.parametrize("reset_drop_at", [None, 20])
 def test_depletion_over_ewma_tail_matches_full_history_replay(reset_drop_at: int | None) -> None:
     """The dashboard fetch caps rows older than the equal-weight floor to the
-    newest 64: with alpha 0.4 a sample's weight after 64 newer EWMA updates
-    is 0.6**64 ~ 6e-15, so at this per-minute cadence (one update per row)
-    the tail replay must reproduce the full replay to floating-point noise.
+    newest 64: the first tail row seeds the EWMA and the other 63 update it,
+    so with alpha 0.4 the pre-tail residual on the rate is at most 0.6**63
+    times the largest per-second slope (~1e-14 %/s at this history's slopes),
+    and at this per-minute cadence (one update per row) the tail replay must
+    reproduce the full replay to floating-point noise.
     A usage drop (window reset) inside the tail discards all earlier state,
     so those cases must match exactly."""
     from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
@@ -708,6 +710,110 @@ def test_depletion_ewma_tail_guarantee_counts_distinct_recorded_seconds(rows_per
         return
     assert full_result.rate_per_second is not None and by_rows.rate_per_second is not None
     assert abs(by_rows.rate_per_second - full_result.rate_per_second) > 1e-12 * abs(full_result.rate_per_second)
+
+
+def test_depletion_ewma_tail_residual_is_bounded_by_seed_row_arithmetic() -> None:
+    """The first tail row only seeds the EWMA, so a 64-row tail performs 63
+    updates and the pre-tail residual on the rate is bounded by ``0.6**63``
+    times the largest per-second sample slope — not ``0.6**64``. Pin the
+    boundary with the worst-case history: one 0 -> 99 step in a single
+    recorded second, then 64 flat rows one second apart older than the floor.
+    The full replay keeps a ghost rate of ``99 * 0.6**63`` (~1.05e-12 %/s,
+    above a flat 1e-12 bound) while the tail decays to exactly 0.0; burn rate
+    inherits the residual scaled by seconds-until-reset over remaining
+    percent. If ``ewma_update`` ever blends the first sample instead of
+    seeding, this assertion of divergence fails on purpose so the spec's
+    stated bound gets revisited."""
+    from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
+
+    cap = _PROJECTION_EWMA_TAIL_ROWS
+    burst_end = BASE_TIME - timedelta(hours=3)
+    now = BASE_TIME
+    reset_epoch = int((BASE_TIME + timedelta(days=2)).timestamp())
+    step_slope = 99.0  # percent per second: the only positive sample slope in the history
+    full = [_entry(0.0, burst_end - timedelta(seconds=cap), reset_at=reset_epoch, window_minutes=10080)]
+    full += [
+        _entry(99.0, burst_end - timedelta(seconds=cap - 1 - index), reset_at=reset_epoch, window_minutes=10080)
+        for index in range(cap)
+    ]
+
+    def _depletion(history: list[_FakeEntry]) -> DepletionMetrics | None:
+        reset_ewma_state()
+        return compute_depletion_for_account("acc1", "standard", "secondary", _signed(history), now=now)
+
+    full_result = _depletion(full)
+    tail_result = _depletion(full[-cap:])
+    assert full_result is not None and tail_result is not None
+    assert full_result.rate_per_second is not None and tail_result.rate_per_second is not None
+
+    residual_bound = 0.6 ** (cap - 1) * step_slope
+    rate_diff = abs(full_result.rate_per_second - tail_result.rate_per_second)
+    assert tail_result.rate_per_second == 0.0
+    assert rate_diff > 1e-12, "seed-row residual must exceed a flat 1e-12 bound for this history"
+    assert rate_diff <= residual_bound
+    assert rate_diff > 0.6**cap * step_slope, "the residual is governed by cap-1 updates, not cap"
+
+    seconds_until_reset = reset_epoch - int(now.replace(tzinfo=timezone.utc).timestamp())
+    remaining_percent = 100.0 - 99.0
+    burn_diff = abs(full_result.burn_rate - tail_result.burn_rate)
+    assert tail_result.burn_rate == 0.0
+    assert burn_diff <= residual_bound * seconds_until_reset / remaining_percent
+    assert abs(full_result.risk - tail_result.risk) <= residual_bound * seconds_until_reset / 100.0
+    assert tail_result.risk_level == full_result.risk_level
+    # A ghost rate this small never projects exhaustion inside the window either.
+    assert full_result.seconds_until_exhaustion is None
+    assert tail_result.seconds_until_exhaustion is None
+
+
+def test_depletion_saturated_account_tail_replay_reports_no_exhaustion_eta() -> None:
+    """An account flat at 100% for longer than the floor: the full replay
+    keeps a positive ghost rate (``0.6 * r`` never reaches 0.0 — it is sticky
+    at the smallest denormal), so ``remaining / rate`` yields an immediate
+    exhaustion ETA (0.0 s, now), while the 64-row tail sees only flat rows,
+    replays a rate of exactly 0.0, and reports no ETA. Risk and burn rate
+    are identical (1.0 and 0.0) either way. Pins the documented divergence
+    so the spec's MAY stays honest."""
+    from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
+
+    cap = _PROJECTION_EWMA_TAIL_ROWS
+    reset_epoch = int((BASE_TIME + timedelta(days=2)).timestamp())
+    start = BASE_TIME - timedelta(hours=60)
+    rows: list[_FakeEntry] = []
+    used = 0.0
+    index = 0
+    while used < 100.0:
+        rows.append(_entry(used, start + timedelta(minutes=index), reset_at=reset_epoch, window_minutes=10080))
+        used += 0.5
+        index += 1
+    for _ in range(48 * 60):  # 48h saturated at the 60s poller cadence
+        rows.append(_entry(100.0, start + timedelta(minutes=index), reset_at=reset_epoch, window_minutes=10080))
+        index += 1
+    now = rows[-1].recorded_at + timedelta(seconds=30)
+    floor = now - timedelta(hours=3)
+
+    def _fetch(history: list[_FakeEntry], row_cap: int, uncapped_floor: datetime) -> list[_FakeEntry]:
+        older = [row for row in history if row.recorded_at < uncapped_floor]
+        recent = [row for row in history if row.recorded_at >= uncapped_floor]
+        return older[-row_cap:] + recent
+
+    def _depletion(history: list[_FakeEntry]) -> DepletionMetrics | None:
+        reset_ewma_state()
+        return compute_depletion_for_account("acc1", "standard", "secondary", _signed(history), now=now)
+
+    full_result = _depletion(rows)
+    tail_result = _depletion(_fetch(rows, cap, floor))
+    assert full_result is not None and tail_result is not None
+    assert full_result.rate_per_second is not None and full_result.rate_per_second > 0.0
+    assert full_result.rate_per_second <= 0.6 ** (cap - 1) * 0.5 / 60.0
+    assert tail_result.rate_per_second == 0.0
+
+    assert tail_result.risk == full_result.risk == 1.0
+    assert tail_result.burn_rate == full_result.burn_rate == 0.0
+    assert tail_result.risk_level == full_result.risk_level
+    assert full_result.seconds_until_exhaustion == 0.0
+    assert full_result.projected_exhaustion_at == now
+    assert tail_result.seconds_until_exhaustion is None
+    assert tail_result.projected_exhaustion_at is None
 
 
 def test_history_signature_content_hash_tracks_row_content() -> None:

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -613,10 +613,11 @@ def _dense_history(
 @pytest.mark.parametrize("reset_drop_at", [None, 20])
 def test_depletion_over_ewma_tail_matches_full_history_replay(reset_drop_at: int | None) -> None:
     """The dashboard fetch caps rows older than the equal-weight floor to the
-    newest 64: with alpha 0.4 a sample's weight after 64 newer samples is
-    0.6**64 ~ 6e-15, so the tail replay must reproduce the full replay to
-    floating-point noise. A usage drop (window reset) inside the tail
-    discards all earlier state, so those cases must match exactly."""
+    newest 64: with alpha 0.4 a sample's weight after 64 newer EWMA updates
+    is 0.6**64 ~ 6e-15, so at this per-minute cadence (one update per row)
+    the tail replay must reproduce the full replay to floating-point noise.
+    A usage drop (window reset) inside the tail discards all earlier state,
+    so those cases must match exactly."""
     from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
 
     start = BASE_TIME - timedelta(minutes=5000)
@@ -646,6 +647,67 @@ def test_depletion_over_ewma_tail_matches_full_history_replay(reset_drop_at: int
     assert tail_result.risk == pytest.approx(full_result.risk, abs=1e-12, rel=1e-12)
     assert full_result.seconds_until_exhaustion is not None
     assert tail_result.seconds_until_exhaustion == pytest.approx(full_result.seconds_until_exhaustion, rel=1e-12)
+
+
+def _burst_history(rows_per_second: int, *, seconds: int, reset_at: int, end: datetime) -> list[_FakeEntry]:
+    """48h of sparse rows followed by ``seconds`` recorded seconds each
+    holding ``rows_per_second`` fingerprint-changing rows, ending at ``end``."""
+    burst_start = end - timedelta(seconds=seconds)
+    rows: list[_FakeEntry] = []
+    used = 1.0
+    for index in range(288):
+        used += 0.01
+        recorded_at = burst_start - timedelta(minutes=10 * (288 - index))
+        rows.append(_entry(round(used, 6), recorded_at, reset_at=reset_at, window_minutes=10080))
+    for second in range(seconds):
+        for slot in range(rows_per_second):
+            used += 0.01 + 0.003 * ((second * 31 + slot * 7) % 5)
+            recorded_at = burst_start + timedelta(seconds=second, microseconds=(slot * 1_000_000) // rows_per_second)
+            rows.append(_entry(round(used, 6), recorded_at, reset_at=reset_at, window_minutes=10080))
+    return rows
+
+
+@pytest.mark.parametrize("rows_per_second", [1, 3, 8])
+def test_depletion_ewma_tail_guarantee_counts_distinct_recorded_seconds(rows_per_second: int) -> None:
+    """``ewma_update`` advances once per distinct integer epoch second
+    (``naive_utc_to_epoch`` truncates and ``dt == 0`` keeps the state), so
+    the tail cap's ``0.6**64`` argument counts distinct recorded seconds, not
+    rows. A tail spanning 64 distinct seconds must match the full replay
+    within 1e-12 however many rows share each second. A 64-row tail packed
+    into fewer distinct seconds is the documented boundary of the guarantee:
+    it diverges, which is why the spec states the bound per distinct second.
+    The burst is followed by 3h of idleness so nothing newer decays it — the
+    shape the projections fetch hands the depletion EWMA."""
+    from app.modules.dashboard.service import _PROJECTION_EWMA_TAIL_ROWS
+
+    cap = _PROJECTION_EWMA_TAIL_ROWS
+    burst_end = BASE_TIME - timedelta(hours=3)
+    now = BASE_TIME
+    reset_epoch = int((BASE_TIME + timedelta(days=2)).timestamp())
+    full = _burst_history(rows_per_second, seconds=cap, reset_at=reset_epoch, end=burst_end)
+
+    def _depletion(history: list[_FakeEntry]) -> DepletionMetrics | None:
+        reset_ewma_state()
+        return compute_depletion_for_account("acc1", "standard", "secondary", _signed(history), now=now)
+
+    full_result = _depletion(full)
+    assert full_result is not None
+
+    # cap-many distinct seconds, regardless of rows per second: equivalent.
+    by_seconds = _depletion(full[-(cap * rows_per_second) :])
+    assert by_seconds is not None
+    assert by_seconds.rate_per_second == pytest.approx(full_result.rate_per_second, abs=1e-12, rel=1e-12)
+    assert by_seconds.burn_rate == pytest.approx(full_result.burn_rate, abs=1e-12, rel=1e-12)
+    assert by_seconds.risk == pytest.approx(full_result.risk, abs=1e-12, rel=1e-12)
+
+    # cap-many rows: only equivalent when that is also cap-many distinct seconds.
+    by_rows = _depletion(full[-cap:])
+    assert by_rows is not None
+    if rows_per_second == 1:
+        assert by_rows.rate_per_second == pytest.approx(full_result.rate_per_second, abs=1e-12, rel=1e-12)
+        return
+    assert full_result.rate_per_second is not None and by_rows.rate_per_second is not None
+    assert abs(by_rows.rate_per_second - full_result.rate_per_second) > 1e-12 * abs(full_result.rate_per_second)
 
 
 def test_history_signature_content_hash_tracks_row_content() -> None:


### PR DESCRIPTION
## Summary

While a dashboard tab is open, `/api/dashboard/projections` and `/overview` each run the PostgreSQL bulk usage-history fetch with the `#1779` cap of **4320 rows/account/window**. On the reference deployment (soju07, 2x Neoverse-N1, `workers=1`, 19 accounts — all weekly-only with history sourced from the primary stream) that cap binds on every account: **~82k rows per poll, ~3 polls/min**, every row hydrated through six SQLAlchemy `Row` attribute lookups and then hashed field-by-field with `blake2b(repr(...))` for the depletion cache signature. In the 2026-09-03 60 s py-spy GIL profile (1085 samples) that was **6.5% of GIL time inclusive** (`bulk_history_since` hydration loop 5.3%, `_update_history_digest` 0.7%) and **14% of the non-GIL loop profile** — for rows the response cannot show: the only consumers of rows older than the uncapped floor are count-decaying EWMAs (alpha 0.4), whose weight after `n` newer updates is `0.6**n`, below double precision after a few dozen updates.

This PR sizes the cap to what the consumers read:

- `per_account_row_cap = 64` (`_PROJECTION_EWMA_TAIL_ROWS`) on **both** bulk fetches, instead of a 6h-at-5s-cadence time window (the 5 s coalescing premise was false: live ingest writes on every fingerprint change).
- `uncapped_recent_floor = now - max(smoothing_window_minutes, FLEET_BURN_WINDOW=3h)` on both fetches, so every equal-weight consumer (weekly-pace smoothing mean, 3h fleet-burn sum/span, `latest`) keeps exact inputs. The primary fetch keeps the floor because weekly-only primary-source accounts feed the weekly pace from it.
- Positional row unpacking in the two PG hydration loops (keyword construction kept after unpacking; casts kept; per-account sort kept; no outer `ORDER BY`, so the index-only plan assertions are untouched).
- Depletion cache content signature: `hash()` over the tuple of row edge tuples (`content_digest: int | None`) instead of five `blake2b(repr(...))` updates per row. Still detects in-place corrections that leave endpoints and count intact; the cache is process-local memory only. The SQLite bulk snapshot cache keeps its own sha256 digest (untouched).

## Change details

- `app/modules/dashboard/service.py` — `_PROJECTION_HISTORY_PER_ACCOUNT_ROW_CAP` (4320) -> `_PROJECTION_EWMA_TAIL_ROWS` (64); floor derived from `max(smoothing, FLEET_BURN_WINDOW)`; comment block stating the EWMA tail guarantee (per distinct recorded second, seed-row residual bound).
- `app/modules/usage/repository.py` — positional unpacking in `_bulk_history_since_capped_postgresql` and the uncapped bulk loop (column order matches `snapshot_columns`).
- `app/modules/usage/depletion_service.py` — `_history_signature_from_rows` / `filter_depletion_history_since` compute a single `hash()` content signature; `_update_history_digest` and blake2b removed.
- `openspec/changes/cap-projection-history-rows/{proposal,tasks}.md`, `specs/query-caching/spec.md` — pending change rewritten (see OpenSpec below).
- Tests: `tests/unit/test_depletion_service.py`, `tests/unit/test_dashboard_projection_history_cap.py`, `tests/unit/test_dashboard_weekly_pace.py`, `tests/integration/test_dashboard_overview.py`.

10 files, +763/-160 (net +603). No schema change, no setting, no API/response-schema change, no frontend change — dashboard values are unchanged, so no screenshots.

## Byte-compat / behavior notes

- **Equal-weight consumers are exact**: weekly pace (smoothing mean, fleet burn, latest) reads only rows inside the floor, which both fetches return uncapped. Verified end-to-end (adversarial round 3): 41,555-row PG seed across 9 constructed accounts, frozen clock, `/projections` + `/overview` JSON with `origin/main` `app` vs this branch — identical to 1e-12 on every field except the two documented cases below.
- **EWMA-derived fields (depletion rate, burn rate, risk, recent burn) agree within the seed-row residual**: the first tail row seeds the EWMA, so a 64-row tail performs 63 updates and the pre-tail residual on the rate is at most `0.6**63 x <largest per-second slope>` (~1.1e-12 %/s at the theoretical 100 %/s step; ~1e-14 or below at realistic slopes; invisible at 6 significant digits). The guarantee is per **distinct integer recorded second** (`ewma_update` skips `dt == 0`), so a >64-row same-second burst older than the floor with no newer rows may leave the tail short — the spec states this as a MAY-diverge boundary. Prod's 60 s poller writes a row per refresh (`add_account_snapshot` unconditional), which keeps prod out of that boundary.
- **Accepted behavior change (disclosed in the spec delta and proposal Impact)**: an account flat at exactly 100% for longer than the floor previously carried a denormal "ghost" rate (`0.6 * 5e-324 == 5e-324`) through the full replay and therefore reported `secondsUntilExhaustion = 0.0` / `projectedExhaustionAt = now`. The tail replay yields rate exactly `0.0` and reports `null`/`null`. `riskLevel`, `risk`, and `burnRate` are identical. The dashboard UI does not read these two fields (only the zod schema references them). A prod before/after JSON diff will show this for any saturated account — expected, not a regression.
- `content_digest` type changes `str` -> `int | None`; process-local, nothing persisted, no compatibility plan needed. `hash()` is not collision-resistant (~1e-19/compare for 64-bit; codex round 3 P3) — no app code path corrects `usage_history` rows in place, and any staleness self-heals on the next appended row.

## Expected gain

Measured on the 19-account PG bench replicating prod's weekly-only primary-source shape:

- rows/call **82,650 -> 4,636 (17.8x)**; adversarial e2e seed: 43,965 -> 3,251 (13.5x); dense 7d account: 1008 -> 82 rows.
- hydration **4.477 -> 1.633 us/row** (positional unpack); signature **2.213 -> 0.205 us/row** (blake2b -> hash, ~10x).
- Projected: removes ~5 of the 6.5% GIL samples attributed to `get_projections` while a tab is open (plus most of the 14% non-GIL fetch time and proportionally fewer PG index-only page reads on the shared 2-core host); 0 when no dashboard is open. Prod re-profile (`py-spy --gil`, rate 10-20, 60 s) still pending post-deploy.

## OpenSpec

Capability `query-caching`. The pending change folder `openspec/changes/cap-projection-history-rows` (which mandated the 6h-at-5s sizing) is rewritten in place: MODIFIED requirements "Projection history reads are bounded per account" (cap sized to the EWMA tail, floor = max(smoothing, fleet-burn), seed-row residual bound, distinct-second guarantee, saturated-account ETA MAY be absent) and the compact content signature requirement (fixed-width, bounded, still content-sensitive). New scenarios: "EWMA consumers agree with the full replay over the tail", "The seed row bounds the tail residual", "A saturated account may lose its exhaustion ETA under the capped fetch", plus the same-second-burst boundary scenario. `openspec validate cap-projection-history-rows --strict` valid; `openspec validate --specs` 57 passed / 1 failed (pre-existing `model-source-routing` only).

## Tests

New / changed (all fail on `origin/main`: `ImportError` on `_PROJECTION_EWMA_TAIL_ROWS`, `content_digest` str-vs-int assertion, e2e `assert 1008 == (18 + 64)` row-count probe):

- `tests/unit/test_dashboard_projection_history_cap.py::test_projection_tail_cap_is_a_fixed_ewma_tail`, `::test_projection_history_fetch_passes_tail_cap_and_equal_weight_floor`, `::test_weekly_only_primary_source_account_keeps_floor_on_primary_fetch[True/False]` — both fetches carry cap 64 + `max(smoothing, 180 min)` floor, including the weekly-only primary-source fixture.
- `tests/unit/test_depletion_service.py::test_depletion_over_ewma_tail_matches_full_history_replay[reset/no-reset]` — 5000-row synthetic history vs tail-64 within 1e-12 incl. reset in tail; `::test_depletion_ewma_tail_guarantee_counts_distinct_recorded_seconds` — pins the same-second boundary; `::test_depletion_ewma_tail_residual_is_bounded_by_seed_row_arithmetic` — 0 -> 99 step then 64 flat rows: asserts `|full - tail| <= 0.6**63 * 99` and `> 0.6**64 * 99` (a flat 1e-12 claim is provably wrong for this history), burn/risk propagate the residual, `risk_level` equal; `::test_depletion_saturated_account_tail_replay_reports_no_exhaustion_eta` — pins the ghost-rate ETA `0.0/now -> None/None` change; `::test_history_signature_content_hash_tracks_row_content` — hash signature tracks in-place corrections (existing correction-invalidation tests unchanged and passing).
- `tests/unit/test_dashboard_weekly_pace.py::test_weekly_pace_is_unchanged_by_ewma_tail_cap_under_fleet_burn_floor` — weekly pace identical under the 3h floor.
- `tests/integration/test_dashboard_overview.py::test_dashboard_projections_ewma_tail_cap_matches_uncapped_history` — PG e2e: dense 7d account returns 18 + 64 rows; projections equal the uncapped read.
- PG-backed suites (`tests/integration/test_usage_repository.py` index-only plan tests incl. `test_bulk_history_since_covered_read_matches_non_covered_read_postgresql`, `test_dashboard_overview.py`) re-run on a throwaway postgres:16 in every review round (latest: 62 passed).

Gates at `ec22461d5`: `ruff check .` / `ruff format --check .` clean (1003 files); `ty check` clean; `scripts/check_proxy_architecture.py` passed; pytest on touched modules + dashboard/usage unit smoke: **339 passed, 11 skipped (PG-only)**.

## Review trail

Three rounds of local `codex review` + independent adversarial verification (each round re-ran gates, PG suites on a throwaway container, and revert-checks of the new tests against `origin/main`):

- Round 1 — codex 1 finding (P2) + adversarial 1 (P2), both the same defect: the tail guarantee was stated per row but `ewma_update` advances per distinct integer second, so same-second bursts before the floor can diverge. Fixed (8eb80b60f): comment/spec/proposal reworded to a distinct-second guarantee, boundary scenario + regression test added.
- Round 2 — codex 1 finding (P2): the first tail row only seeds the EWMA (63 updates, not 64) and the flat 1e-12 MUST also covered `burn_rate`, which is unbounded relative when the true rate is 0. Adversarial 1 (P3): denormal ghost rate flips exhaustion ETA `0.0/now -> null` for saturated accounts. Both fixed (ec22461d5): spec states the `0.6**(cap-1) x slope` residual bound scoped to the EWMA rate with derived fields propagating it, saturated-ETA MAY clause, two regression tests; cap deliberately kept at 64 (bumping to 65 does not rescue a flat bound and would churn the `== 64` / `18 + 64` assertions for no closed hole).
- Round 3 — codex 1 finding, downgraded to P3 (`hash()` collision on in-place correction; no such code path, self-heals); adversarial 3 P3 notes, 0 blocking, approve: (a) the residual constant is exceedable by 1/0.6 in a pathological same-second pre-tail corner (already inside the MAY boundary), (b) pre-existing set-order tie-break in `compute_aggregate_depletion` will confound a prod before/after JSON diff unless `PYTHONHASHSEED` is pinned or the comparison is per-account, (c) proposal Impact wording omits the packed-second case. 300-trial randomized full-vs-capped hunt over the real `compute_depletion_for_account` (drops, `reset_at` changes, `None` fields, sub-second bursts): no `risk_level` flips, no ETA value drift, no burn-rate drift beyond fp noise.

Totals: 3 codex findings (2 fixed, 1 P3 accepted), 5 adversarial findings (2 fixed, 3 P3 notes accepted/disclosed above), 0 rejected.

## Deploy notes / hazards

- No migration, no setting, no env override; the 64-row cap and 3h floor are constants. Rollback is a plain image rollback.
- Prod verification plan: `py-spy --gil` at rate 10-20 for 60 s (never rate 100 on the N1 host) before/after with a dashboard tab open — expect `bulk_history_since` samples to fall from ~5% to <1%; compare `/api/dashboard/projections` JSON per account (pin `PYTHONHASHSEED` or diff per account to avoid the pre-existing aggregate tie-break noise). Expect `secondsUntilExhaustion`/`projectedExhaustionAt` to flip `0.0/now -> null` for any account sitting at exactly 100%.
- Campaign-wide upgrade hazard (unrelated to this PR's hunks, relevant to deploying anything from main): main rejects `http://user:pw@` proxy endpoints since #1995 (`plaintext_proxy_credentials_forbidden`); prod's current proxy pool must be re-created as `https://` or credential-less before upgrading or every routed request fails closed.
- No hunk overlap with the sibling campaign PRs (keepalive, aiohttp release, credential logging, SSL context, bridge stamp, middleware, request shaping, SSE relay, relay loop, account clone, pydantic passthrough).

Refs #1779 (the cap this PR re-sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced dashboard projection-history reads for faster calculations.
  - Improved efficiency when processing depletion history.

- **Reliability**
  - Preserved dashboard depletion and weekly pace results while using a bounded history tail.
  - Continued to protect recent activity needed for weekly pace and fleet-burn calculations.
  - Added safeguards for burst histories, usage changes, and saturated accounts.
  - Expanded validation to confirm results remain consistent with full-history calculations within expected floating-point tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->