### PR TITLE
fix(logging): redact secrets in asyncio loop exception-handler context and harden proxy username validation

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import sqlite3
 import sys
@@ -141,6 +142,10 @@ def _load_shutdown_drain_timeout_seconds() -> int:
 
 
 def _run_server(app: str, **kwargs: Any) -> None:
+    # Route warnings.warn() output (for example aiohttp ResourceWarning reprs
+    # that embed connection keys) through the redacting log handlers instead
+    # of raw stderr.
+    logging.captureWarnings(True)
     uvicorn = _load_uvicorn()
     drain_timeout_seconds = _load_shutdown_drain_timeout_seconds()
     config = uvicorn.Config(

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -29,7 +29,8 @@ from app.core.resilience.network_recovery import (
 )
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 
-_RESERVED = frozenset({"akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy"})
+_RESERVED = frozenset({"akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy", "proxy_headers"})
+_TLS_TARGET_SCHEMES = frozenset({"https", "wss"})
 _CODEX_SKIP_AUTO_IDENTITY_HEADERS = frozenset({aiohttp.hdrs.ACCEPT, aiohttp.hdrs.ACCEPT_ENCODING})
 
 
@@ -243,6 +244,7 @@ class CodexClient:
         aiohttp_kwargs = dict(kwargs)
         _normalize_aiohttp_request_kwargs(aiohttp_kwargs)
         endpoints = (route.endpoint, *route.fallbacks)
+        _reject_credentialed_plaintext_target(url, endpoints)
         allow_fallback = _is_idempotent_method(method)
         for index, endpoint in enumerate(endpoints):
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
@@ -283,7 +285,7 @@ class CodexClient:
                         response = await self._session.request(
                             method,
                             url,
-                            proxy=endpoint.proxy_url,
+                            **endpoint.aiohttp_proxy_kwargs(),
                             **aiohttp_kwargs,
                         )
                     except Exception as exc:
@@ -336,7 +338,8 @@ class CodexClient:
         if route is None:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
         _reject_reserved(kwargs)
-        result = self._session.ws_connect(url, proxy=route.proxy_url, **kwargs)
+        _reject_credentialed_plaintext_target(url, (route.endpoint,))
+        result = self._session.ws_connect(url, **route.endpoint.aiohttp_proxy_kwargs(), **kwargs)
         if asyncio.iscoroutine(result):
             return await result
         return result
@@ -354,6 +357,7 @@ class CodexClient:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
         _reject_reserved(kwargs)
         endpoints = (route.endpoint, *route.fallbacks)
+        _reject_credentialed_plaintext_target(url, endpoints)
         for index, endpoint in enumerate(endpoints):
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
             context: Any | None = None
@@ -386,7 +390,7 @@ class CodexClient:
                 else:
                     context = self._session.ws_connect(
                         url,
-                        proxy=endpoint.proxy_url,
+                        **endpoint.aiohttp_proxy_kwargs(),
                         **kwargs,
                     )
                     if asyncio.iscoroutine(context):
@@ -840,6 +844,23 @@ async def _read_response_body(response: Any) -> bytes | None:
 def _response_status(response: Any) -> int:
     value = getattr(response, "status", getattr(response, "status_code", 0))
     return int(value or 0)
+
+
+def _reject_credentialed_plaintext_target(url: str, endpoints: tuple[ResolvedProxyEndpoint, ...]) -> None:
+    # Proxy credentials ride in a Proxy-Authorization header (never URL
+    # userinfo, which aiohttp reprs into ConnectionKey/ClientHttpProxyError).
+    # aiohttp only forwards proxy_headers on the CONNECT tunnel, so a
+    # credentialed endpoint requires a TLS target. Checked once for the whole
+    # ordered pool, ahead of every transport branch and before any dispatch,
+    # so a credential-free fallback cannot quietly absorb a misconfigured
+    # primary. Raised as a connect-phase transport error so callers map it to
+    # the usual upstream-unavailable response instead of an unhandled failure.
+    if any(endpoint.username for endpoint in endpoints) and URL(url).scheme not in _TLS_TARGET_SCHEMES:
+        raise CodexTransportError(
+            "credentialed aiohttp proxy routes require an https/wss upstream target",
+            failure_phase="connect",
+            retryable_same_contract=False,
+        )
 
 
 def _reject_reserved(kwargs: Mapping[str, Any]) -> None:

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -1132,14 +1132,17 @@ async def _connect_upstream_websocket(
             ),
         ) from exc
     except InvalidProxy as exc:
-        message = (
-            "Invalid upstream websocket proxy configuration"
-            if policy.credential_safe_connect_errors
-            else (str(exc) or "Invalid upstream websocket proxy configuration")
-        )
+        # str(exc) embeds the full proxy URL including userinfo; the URL is
+        # operator configuration, never actionable for the API client. The
+        # websockets reason (``exc.msg``) never contains the URL.
+        logger.warning("%s rejected upstream websocket proxy configuration: %s", policy.operation, exc.msg)
         raise ProxyResponseError(
             502,
-            openai_error("upstream_unavailable", message, error_type="server_error"),
+            openai_error(
+                "upstream_unavailable",
+                "Invalid upstream websocket proxy configuration",
+                error_type="server_error",
+            ),
         ) from exc
     except InvalidHandshake as exc:
         message = (

--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -21,9 +21,60 @@ _SENSITIVE_LOG_VALUE_PATTERNS = (
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
     re.compile(r"(?i)(authorization\s*[=:]\s*)(?!\s*bearer\b)([^,&]+)"),
 )
+# RFC 7617 ``Basic <base64>`` token: a reversible encoding of ``user:password``
+# that aiohttp reprs verbatim (``ClientHttpProxyError.request_info.headers``
+# carries the CONNECT ``Proxy-Authorization`` header). Applied to every record
+# behind cheap substring scans for the canonical, lowercase and uppercase
+# scheme spellings (the auth-scheme is case-insensitive per RFC 7235); the
+# regex itself is case-insensitive once a precheck hits.
+_BASIC_TOKEN_PATTERN = re.compile(r"(?i)(basic\s+)[A-Za-z0-9+/=]+")
+_BASIC_TOKEN_PRECHECKS = ("Basic ", "basic ", "BASIC ")
+# Fail-closed rendering when a redaction pass itself raises: the record is
+# still emitted (timestamp/level/logger intact) but never with the original,
+# possibly credential-bearing text.
+_REDACTION_FAILED_PLACEHOLDER = "[REDACTED: log redaction failed]"
 _JSON_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
     r'(?i)("(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)"\s*:\s*")'
     r'(?:\\.|[^"\\])*(")'
+)
+# ``scheme://user:pass@`` userinfo, e.g. aiohttp ConnectionKey proxy URL reprs.
+# RFC 3986 userinfo never contains ``/``, ``?`` or ``#``, so a bare host
+# followed by a query/fragment holding an ``@`` is left alone. ``'`` is an
+# RFC 3986 sub-delim that yarl leaves unencoded in userinfo (``URL('http://u:p'w@h')``),
+# so it must stay matchable; ``"`` is not valid unencoded userinfo (yarl emits
+# ``%22``) and stays excluded so a compact JSON document holding a URL and an
+# e-mail address is not over-matched.
+_USERINFO_PATTERN = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)([^/?#\s@\"]+)@")
+# Python ``repr()`` of a secret-keyed mapping, ``{'password': 'x', 'token': 1}``:
+# the quote between key and colon defeats the ``key=value`` pattern above and
+# the JSON pattern below is double-quote only. Reached by ``%r``-logged
+# mappings and by the JSON formatter whenever a structured extra has to be
+# rendered as text (depth limit, exploding iteration, unserializable rebuild).
+# The key matches on suffix like ``_SENSITIVE_LOG_KEY_PATTERN``; the value is
+# a quoted string (quotes kept), bytes, a flat container, or a bare token up to
+# the next separator. Containers nested under a secret key are masked only to
+# their first level: a best-effort text backstop, not the structural pass.
+_PYTHON_REPR_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
+    r"(?i)('[^'\\]*(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)'\s*:\s*)"
+    r"(b?'(?:\\.|[^'\\])*'|b?\"(?:\\.|[^\"\\])*\"|\[[^\[\]]*\]|\([^()]*\)|\{[^{}]*\}|[^,}\]\)\s]+)"
+)
+# Structured (JSON extra) keys whose string values are secrets by name.
+_SENSITIVE_LOG_KEY_PATTERN = re.compile(r"(?i)(password|passwd|pwd|token|secret|api[_-]?key|authorization)$")
+# Case-folded substrings that must be present before the keyed/bearer/
+# authorization/JSON patterns above can match; keeps the per-record cost of
+# credential-free lines to a casefold plus substring scans.
+_SECRET_HINTS = (
+    "password",
+    "passwd",
+    "pwd",
+    "token",
+    "secret",
+    "api_key",
+    "api-key",
+    "apikey",
+    "bearer",
+    "basic",
+    "authorization",
 )
 _LOG_REDACTION = "[REDACTED]"
 
@@ -32,11 +83,54 @@ def _redact_log_value(value: str | None) -> str | None:
     collapsed = _collapse_log_value(value)
     if collapsed is None:
         return None
-    redacted = collapsed
-    redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, redacted)
+    return _redact_secret_patterns(_USERINFO_PATTERN.sub(_redact_userinfo, collapsed))
+
+
+def _redact_secret_patterns(text: str) -> str:
+    redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, text)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[0].sub(_redact_keyed_secret, redacted)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[1].sub(_redact_bearer_token, redacted)
-    return _SENSITIVE_LOG_VALUE_PATTERNS[2].sub(_redact_authorization_value, redacted)
+    redacted = _BASIC_TOKEN_PATTERN.sub(_redact_bearer_token, redacted)
+    redacted = _SENSITIVE_LOG_VALUE_PATTERNS[2].sub(_redact_authorization_value, redacted)
+    # Last, so ``'Proxy-Authorization': 'Basic [REDACTED]'`` keeps the scheme
+    # the token passes above already exposed.
+    return _PYTHON_REPR_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_python_repr_secret, redacted)
+
+
+def redact_rendered_log_text(text: str, *, keyed_secrets: bool = True) -> str:
+    """Mask URL userinfo, Basic tokens and, optionally, keyed secrets in a rendered log string.
+
+    Applied to every rendered record regardless of the originating logger
+    (asyncio, aiohttp, uvicorn, tracebacks). ``keyed_secrets=False`` limits the
+    pass to the substring-precheck patterns (URL userinfo and ``Basic <token>``
+    in its ``Basic``/``basic``/``BASIC`` spellings); formatters use it for INFO and lower records because the
+    keyed patterns cost tens of microseconds on long hot-path lines. Never
+    raises: if a pass fails the text is replaced with a fail-closed placeholder
+    so logging itself cannot break and the original text is never emitted.
+    """
+    try:
+        redacted = text
+        if "@" in text and "://" in text:
+            redacted = _USERINFO_PATTERN.sub(_redact_userinfo, redacted)
+        if any(precheck in text for precheck in _BASIC_TOKEN_PRECHECKS):
+            redacted = _BASIC_TOKEN_PATTERN.sub(_redact_bearer_token, redacted)
+        if not keyed_secrets:
+            return redacted
+        folded = text.casefold()
+        for hint in _SECRET_HINTS:
+            if hint in folded:
+                return _redact_secret_patterns(redacted)
+        return redacted
+    except Exception:
+        return _REDACTION_FAILED_PLACEHOLDER
+
+
+def _redact_record_text(record: logging.LogRecord, text: str) -> str:
+    return redact_rendered_log_text(text, keyed_secrets=record.levelno >= logging.WARNING)
+
+
+def _redact_userinfo(match: re.Match[str]) -> str:
+    return f"{match.group(1)}{_LOG_REDACTION}@"
 
 
 def _redact_keyed_secret(match: re.Match[str]) -> str:
@@ -45,6 +139,14 @@ def _redact_keyed_secret(match: re.Match[str]) -> str:
 
 def _redact_json_secret(match: re.Match[str]) -> str:
     return f"{match.group(1)}{_LOG_REDACTION}{match.group(2)}"
+
+
+def _redact_python_repr_secret(match: re.Match[str]) -> str:
+    value = match.group(2)
+    if _LOG_REDACTION in value:
+        return match.group(0)
+    quote = value[0] if value[0] in "'\"" else ""
+    return f"{match.group(1)}{quote}{_LOG_REDACTION}{quote}"
 
 
 def _redact_bearer_token(match: re.Match[str]) -> str:
@@ -59,12 +161,93 @@ def _utc_converter(seconds: float | None) -> time.struct_time:
     return time.gmtime(seconds)
 
 
-class UtcDefaultFormatter(DefaultFormatter):
+class _RedactingFormatterMixin(logging.Formatter):
+    """Redact the fully rendered record (message, exception text, stack info)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        rendered = _redact_record_text(record, super().format(record))
+        if rendered is _REDACTION_FAILED_PLACEHOLDER:
+            # Fail closed but keep a secret-free prefix (time, level, logger)
+            # so the line still says when and where it came from.
+            return f"{self.formatTime(record, self.datefmt)} {record.levelname} {record.name} {rendered}"
+        return rendered
+
+
+class UtcDefaultFormatter(_RedactingFormatterMixin, DefaultFormatter):
     converter: Callable[[float | None], time.struct_time] = staticmethod(_utc_converter)
 
 
-class UtcAccessFormatter(AccessFormatter):
+class UtcAccessFormatter(_RedactingFormatterMixin, AccessFormatter):
     converter: Callable[[float | None], time.struct_time] = staticmethod(_utc_converter)
+
+
+# Containers nested deeper than this are rendered as redacted text instead of
+# being rebuilt, so the key-aware pass can never recurse without bound.
+_MAX_JSON_LOG_DEPTH = 32
+# Placeholders for a container that refers back to an ancestor, mirroring the
+# ``{...}`` / ``[...]`` markers Python's own repr emits for recursive objects.
+_CYCLIC_JSON_LOG_PLACEHOLDERS: dict[type, str] = {dict: "{...}", list: "[...]", tuple: "(...)"}
+
+
+def _redact_json_log_value(
+    record: logging.LogRecord,
+    value: object,
+    *,
+    _ancestors: frozenset[int] = frozenset(),
+    _depth: int = 0,
+) -> object:
+    """Rebuild ``value`` with redaction applied to every reachable string (and secret-keyed field).
+
+    Cycles (a container that refers back to an ancestor) collapse to a repr
+    placeholder and nesting beyond ``_MAX_JSON_LOG_DEPTH`` is rendered as
+    redacted text, so redaction still applies wherever the structure is finite
+    and the rebuild itself cannot raise ``RecursionError``.
+    """
+    if isinstance(value, str):
+        return _redact_record_text(record, value)
+    if not isinstance(value, (dict, list, tuple)):
+        return value
+    if id(value) in _ancestors:
+        return next(marker for kind, marker in _CYCLIC_JSON_LOG_PLACEHOLDERS.items() if isinstance(value, kind))
+    if _depth >= _MAX_JSON_LOG_DEPTH:
+        return _redact_record_text(record, _safe_str(value))
+    ancestors = _ancestors | {id(value)}
+    depth = _depth + 1
+    if isinstance(value, dict):
+        return {
+            _redact_json_log_key(record, key): _redact_json_log_item(record, key, item, ancestors, depth)
+            for key, item in value.items()
+        }
+    return [_redact_json_log_value(record, item, _ancestors=ancestors, _depth=depth) for item in value]
+
+
+def _safe_str(value: object) -> str:
+    # ``str()`` of an extra can itself raise (exploding ``__repr__``, repr of a
+    # pathologically deep container); logging must still emit the record.
+    try:
+        return str(value)
+    except Exception:
+        return f"<unprintable {type(value).__name__}>"
+
+
+def _redact_json_log_key(record: logging.LogRecord, key: object) -> object:
+    # Keys are rendered too (``{"https://u:pw@proxy": "failed"}``).
+    return _redact_record_text(record, key) if isinstance(key, str) else key
+
+
+def _is_secret_json_log_key(record: logging.LogRecord, key: object) -> bool:
+    # Key-aware for WARNING+ like the keyed text patterns: ``{"password": x}``
+    # carries the secret in a value the value-only pass cannot recognise,
+    # whatever its type (string, list, number, bytes).
+    return record.levelno >= logging.WARNING and isinstance(key, str) and bool(_SENSITIVE_LOG_KEY_PATTERN.search(key))
+
+
+def _redact_json_log_item(
+    record: logging.LogRecord, key: object, value: object, ancestors: frozenset[int], depth: int
+) -> object:
+    if value is not None and _is_secret_json_log_key(record, key):
+        return _LOG_REDACTION
+    return _redact_json_log_value(record, value, _ancestors=ancestors, _depth=depth)
 
 
 class JsonFormatter(logging.Formatter):
@@ -72,11 +255,11 @@ class JsonFormatter(logging.Formatter):
         super().__init__()
 
     def format(self, record: logging.LogRecord) -> str:
-        log_entry = {
+        log_entry: dict[str, object] = {
             "timestamp": datetime.now(UTC).isoformat(),
             "level": record.levelname,
             "logger": record.name,
-            "message": record.getMessage(),
+            "message": _redact_record_text(record, record.getMessage()),
         }
 
         try:
@@ -117,15 +300,31 @@ class JsonFormatter(logging.Formatter):
         }
 
         for key, value in record.__dict__.items():
-            if key not in excluded_keys:
-                try:
-                    json.dumps(value)
-                    log_entry[key] = value
-                except (TypeError, ValueError):
-                    log_entry[key] = str(value)
+            if key in excluded_keys:
+                continue
+            safe_key = str(_redact_json_log_key(record, key))
+            if value is not None and _is_secret_json_log_key(record, key):
+                log_entry[safe_key] = _LOG_REDACTION
+                continue
+            # Rebuild containers key-aware first so a non-serializable leaf
+            # (bytes) cannot drag secret-keyed siblings into the str() fallback.
+            # Redaction never raises: if the rebuild fails anyway (a container
+            # whose iteration explodes), fall back to the legacy rendering of
+            # the original value rather than dropping the record.
+            try:
+                redacted = _redact_json_log_value(record, value)
+            except Exception:
+                redacted = value
+            try:
+                json.dumps(redacted)
+                log_entry[safe_key] = redacted
+            except Exception:
+                # TypeError/ValueError for unserializable leaves and cycles;
+                # anything else (RecursionError, exploding iteration) too.
+                log_entry[safe_key] = _redact_record_text(record, _safe_str(redacted))
 
         if record.exc_info:
-            log_entry["exception"] = self.formatException(record.exc_info)
+            log_entry["exception"] = _redact_record_text(record, self.formatException(record.exc_info))
 
         return json.dumps(log_entry, default=str)
 
@@ -138,7 +337,7 @@ class JsonAccessFormatter(logging.Formatter):
             "logger": record.name,
             "type": "access",
             "client": getattr(record, "client_addr", None),
-            "request": getattr(record, "request_line", None),
+            "request": cast(JsonValue, _redact_json_log_value(record, getattr(record, "request_line", None))),
             "status": getattr(record, "status_code", None),
         }
         return json.dumps(log_entry, default=str)

--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -408,6 +408,18 @@ class _RedactedRepr:
 # Context values the default handler renders as text rather than repr().
 _UNREDACTED_LOOP_CONTEXT_KEYS = frozenset({"message", "exception", "source_traceback", "handle_traceback"})
 _REDACTING_LOOP_HANDLER_MARKER = "_codex_lb_redacting_loop_handler"
+_LOOP_CONTEXT_REDACTION_FAILED = "[REDACTED: loop context redaction failed]"
+
+
+def _fail_closed_loop_context(context: dict[str, Any]) -> dict[str, Any]:
+    """Keep the textual entries and replace every object value with an opaque stand-in."""
+    try:
+        return {
+            key: value if key in _UNREDACTED_LOOP_CONTEXT_KEYS else _RedactedRepr(_LOOP_CONTEXT_REDACTION_FAILED)
+            for key, value in context.items()
+        }
+    except Exception:
+        return {"message": _LOOP_CONTEXT_REDACTION_FAILED}
 
 
 def install_redacting_loop_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
@@ -418,7 +430,10 @@ def install_redacting_loop_exception_handler(loop: asyncio.AbstractEventLoop) ->
     ``BasicAuth(... password='pw')``) into the ``asyncio`` logger before any
     formatter runs. Idempotent; delegates to the previously installed handler
     (or the default one) so formatting stays byte-identical for contexts that
-    contain no secrets, and falls back to the raw context on any failure.
+    contain no secrets. Fails closed: a value whose ``repr()`` raises is
+    replaced by an opaque stand-in, and any other failure delegates a context
+    whose object values are all stand-ins, so the report is still emitted but
+    no unredacted value ever reaches the delegate.
     """
     previous = loop.get_exception_handler()
     if previous is not None and getattr(previous, _REDACTING_LOOP_HANDLER_MARKER, False):
@@ -438,14 +453,16 @@ def install_redacting_loop_exception_handler(loop: asyncio.AbstractEventLoop) ->
                     continue
                 try:
                     rendered = repr(value)
-                except Exception:
+                except Exception as exc:
+                    # The default handler would call repr() again and lose the
+                    # whole report; an opaque stand-in keeps the message line.
+                    safe_context[key] = _RedactedRepr(f"<{type(value).__name__} repr failed: {type(exc).__name__}>")
                     continue
                 redacted = redact_rendered_log_text(rendered)
                 if redacted != rendered:
                     safe_context[key] = _RedactedRepr(redacted)
         except Exception:
-            _delegate(target_loop, context)
-            return
+            safe_context = _fail_closed_loop_context(context)
         _delegate(target_loop, safe_context)
 
     setattr(_handler, _REDACTING_LOOP_HANDLER_MARKER, True)

--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 import logging
@@ -7,7 +8,7 @@ import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from fastapi import Request
 from uvicorn.config import LOGGING_CONFIG
@@ -390,6 +391,65 @@ def build_log_config() -> LogConfig:
         "level": "INFO",
     }
     return cast(LogConfig, config)
+
+
+class _RedactedRepr:
+    """Stand-in whose repr is the redacted rendering of the original object."""
+
+    __slots__ = ("_text",)
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def __repr__(self) -> str:
+        return self._text
+
+
+# Context values the default handler renders as text rather than repr().
+_UNREDACTED_LOOP_CONTEXT_KEYS = frozenset({"message", "exception", "source_traceback", "handle_traceback"})
+_REDACTING_LOOP_HANDLER_MARKER = "_codex_lb_redacting_loop_handler"
+
+
+def install_redacting_loop_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
+    """Redact credential-bearing object reprs before the loop's default handler logs them.
+
+    The default asyncio/uvloop handler renders every context value with
+    ``repr()`` (aiohttp ``Connection<ConnectionKey(... proxy=URL('http://u:pw@host'))>``,
+    ``BasicAuth(... password='pw')``) into the ``asyncio`` logger before any
+    formatter runs. Idempotent; delegates to the previously installed handler
+    (or the default one) so formatting stays byte-identical for contexts that
+    contain no secrets, and falls back to the raw context on any failure.
+    """
+    previous = loop.get_exception_handler()
+    if previous is not None and getattr(previous, _REDACTING_LOOP_HANDLER_MARKER, False):
+        return
+
+    def _delegate(target_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        if previous is None:
+            target_loop.default_exception_handler(context)
+        else:
+            previous(target_loop, context)
+
+    def _handler(target_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        try:
+            safe_context = dict(context)
+            for key, value in context.items():
+                if key in _UNREDACTED_LOOP_CONTEXT_KEYS:
+                    continue
+                try:
+                    rendered = repr(value)
+                except Exception:
+                    continue
+                redacted = redact_rendered_log_text(rendered)
+                if redacted != rendered:
+                    safe_context[key] = _RedactedRepr(redacted)
+        except Exception:
+            _delegate(target_loop, context)
+            return
+        _delegate(target_loop, safe_context)
+
+    setattr(_handler, _REDACTING_LOOP_HANDLER_MARKER, True)
+    loop.set_exception_handler(_handler)
 
 
 def log_error_response(

--- a/app/core/upstream_proxy/resolver.py
+++ b/app/core/upstream_proxy/resolver.py
@@ -141,6 +141,9 @@ def _resolve_endpoint(endpoint: ProxyEndpoint, *, encryptor: TokenEncryptor | No
         endpoint.username is not None or endpoint.password_encrypted is not None
     ):
         raise UpstreamProxyRouteError("plaintext_proxy_credentials_forbidden")
+    if endpoint.username is not None and ":" in endpoint.username:
+        # RFC 7617 Basic credentials cannot encode a colon in the user-id.
+        raise UpstreamProxyRouteError("invalid_proxy_username")
     password: str | None = None
     if endpoint.password_encrypted is not None:
         try:

--- a/app/core/upstream_proxy/types.py
+++ b/app/core/upstream_proxy/types.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote
+
+_PLAINTEXT_SCHEMES = frozenset({"http", "socks5", "socks5h"})
+
+
+def _encode_basic_proxy_auth(username: str, password: str) -> str:
+    # RFC 7617 Basic token encoded with latin1, byte-identical to the header
+    # value aiohttp derives from URL userinfo (``BasicAuth`` default encoding);
+    # the CONNECT request differs only in header order. Local so the declared
+    # ``aiohttp>=3.13`` floor holds (``aiohttp.encode_basic_auth`` is 3.14+).
+    if ":" in username:
+        raise ValueError("proxy usernames cannot contain ':'")
+    token = base64.b64encode(f"{username}:{password}".encode("latin1")).decode("ascii")
+    return f"Basic {token}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,17 +28,44 @@ class ResolvedProxyEndpoint:
     username: str | None = None
     password: str | None = None
 
+    def _reject_plaintext_credentials(self) -> None:
+        if self.scheme.lower() in _PLAINTEXT_SCHEMES and (self.username is not None or self.password is not None):
+            raise ValueError("credential-bearing plaintext proxy URLs are forbidden")
+
     @property
     def proxy_url(self) -> str:
-        if self.scheme.lower() in {"http", "socks5", "socks5h"} and (
-            self.username is not None or self.password is not None
-        ):
-            raise ValueError("credential-bearing plaintext proxy URLs are forbidden")
+        self._reject_plaintext_credentials()
         scheme = "socks5h" if self.scheme == "socks5" else self.scheme
         auth = ""
         if self.username:
             auth = f"{quote(self.username, safe='')}:{quote(self.password or '', safe='')}@"
         return f"{scheme}://{auth}{self.host}:{self.port}"
+
+    @property
+    def proxy_url_without_credentials(self) -> str:
+        scheme = "socks5h" if self.scheme == "socks5" else self.scheme
+        return f"{scheme}://{self.host}:{self.port}"
+
+    def aiohttp_proxy_kwargs(self) -> dict[str, Any]:
+        """Return ``proxy``/``proxy_headers`` kwargs for aiohttp request and ws_connect.
+
+        Credentials travel in a ``Proxy-Authorization`` header instead of URL
+        userinfo so aiohttp's ``ConnectionKey``/``Connection`` reprs and
+        ``ClientHttpProxyError.__str__`` never carry the password. ``latin1``
+        matches aiohttp's own userinfo encoding (``BasicAuth`` default), so the
+        CONNECT ``Proxy-Authorization`` value stays byte-identical (aiohttp
+        emits it right after ``Host`` instead of last, which no proxy
+        observes). aiohttp forwards ``proxy_headers``
+        only on the CONNECT tunnel request, i.e. for TLS (``https``/``wss``)
+        targets; callers must not use these kwargs for plaintext targets.
+        """
+        self._reject_plaintext_credentials()
+        kwargs: dict[str, Any] = {"proxy": self.proxy_url_without_credentials}
+        if self.username:
+            kwargs["proxy_headers"] = {
+                "Proxy-Authorization": _encode_basic_proxy_auth(self.username, self.password or ""),
+            }
+        return kwargs
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,7 @@ from app.core.resilience.bulkhead import BulkheadMiddleware, get_bulkhead
 from app.core.resilience.loop_lag_monitor import run_event_loop_lag_monitor
 from app.core.resilience.memory_monitor import configure as configure_memory_monitor
 from app.core.retention.scheduler import build_data_retention_scheduler
+from app.core.runtime_logging import install_redacting_loop_exception_handler
 from app.core.scheduling.leader_election import get_leader_election
 from app.core.shutdown import close_control_plane_task_admission
 from app.core.timeout_invariants import validate_runtime_timeout_invariants
@@ -447,6 +448,10 @@ async def lifespan(app: FastAPI):
     import app.core.startup as startup_module
 
     shutdown_state = import_module("app.core.shutdown")
+    # First app code on uvicorn's loop: mask credential-bearing object reprs
+    # (aiohttp ConnectionKey proxy URLs, BasicAuth) before the default handler
+    # renders them into the 'asyncio' logger.
+    install_redacting_loop_exception_handler(asyncio.get_running_loop())
     metrics_server = None
     metrics_server_task: asyncio.Task[None] | None = None
     ring_service = None

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -24,7 +24,7 @@ from app.core.config.settings import get_settings as get_app_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardBadRequestError, DashboardSettingsConflictError
-from app.core.upstream_proxy import resolve_proxy_endpoint
+from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_proxy_endpoint
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.db.models import Account, AccountProxyBinding, AccountStatus, ProxyEndpoint, ProxyPool, ProxyPoolMember
 from app.dependencies import SettingsContext, get_proxy_service_for_app, get_settings_context
@@ -276,6 +276,9 @@ async def create_upstream_proxy_endpoint(
             "Plaintext proxies cannot carry credentials",
             code="plaintext_proxy_credentials_forbidden",
         )
+    if payload.username is not None and ":" in payload.username:
+        # Mirrors the resolver: a Basic user-id cannot encode a colon.
+        raise DashboardBadRequestError('Proxy usernames cannot contain ":"', code="invalid_proxy_username")
     encryptor = TokenEncryptor()
     row = ProxyEndpoint(
         name=payload.name,
@@ -301,7 +304,11 @@ async def test_upstream_proxy_endpoint(
     row = await context.session.get(ProxyEndpoint, endpoint_id)
     if row is None:
         raise DashboardBadRequestError("Proxy endpoint not found", code="proxy_endpoint_not_found")
-    endpoint = resolve_proxy_endpoint(row, encryptor=TokenEncryptor())
+    try:
+        endpoint = resolve_proxy_endpoint(row, encryptor=TokenEncryptor())
+    except UpstreamProxyRouteError as exc:
+        # Persisted rows the resolver now rejects report the reason instead of 500.
+        return UpstreamProxyEndpointTestResponse(endpoint_id=row.id, ok=False, elapsed_ms=0, error=exc.reason)
     started = time.monotonic()
     try:
         status_code = await _probe_upstream_proxy_endpoint(endpoint)

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/proposal.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`credential-safe-proxy-logging` keeps proxy credentials out of aiohttp repr
+surfaces and redacts every rendered log record. Three defense-in-depth gaps
+remain around it: the asyncio/uvloop default loop exception handler renders
+context values with `repr()` (aiohttp `ConnectionKey` proxy URLs, `BasicAuth`,
+task exceptions) before any formatter runs, so a third-party or misconfigured
+handler would still see the secret; the dashboard accepts proxy usernames
+containing `:` that the resolver now rejects, turning the endpoint test route
+into an unhandled 500 for already persisted rows; and the direct websocket
+path forwards `websockets.InvalidProxy` text (the full proxy URL, userinfo
+included) to API clients under the Responses policy.
+
+## What Changes
+
+- The application installs a redacting asyncio loop exception handler once at
+  lifespan start. It copies the context, replaces every non-text value whose
+  `repr()` changes under redaction with a stand-in carrying the redacted repr,
+  and delegates to the previously installed (or default) handler, so
+  secret-free contexts render byte-identically. Idempotent; any failure falls
+  back to the raw context.
+- The dashboard rejects proxy usernames containing `:` at endpoint creation
+  with `invalid_proxy_username`, and the endpoint test route reports the
+  resolver reason as a failed probe instead of an unhandled error.
+- The direct websocket connector returns the fixed credential-safe message for
+  `InvalidProxy` under every policy (Responses included) and logs only the
+  URL-free websockets reason.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: application startup MUST install a redacting
+  asyncio loop exception handler whose secret-free output is byte-identical to
+  the default handler.
+- `upstream-proxy-routing`: the dashboard MUST reject colon usernames at
+  creation and the endpoint test route MUST report resolver rejections.
+- `realtime-api-compat`: the Responses websocket `InvalidProxy` message is now
+  the same fixed credential-safe message as the live sideband.
+
+## Impact
+
+- Depends on `credential-safe-proxy-logging` (`redact_rendered_log_text`, the
+  resolver `invalid_proxy_username` rule); stacked on that branch.
+- Code: `app/core/runtime_logging.py`, `app/main.py`,
+  `app/modules/settings/api.py`, `app/core/clients/proxy_websocket.py`.
+- Tests: `tests/unit/test_runtime_logging_loop_handler.py` (new),
+  `tests/integration/test_settings_api.py`,
+  `tests/unit/test_proxy_websocket_client.py`.
+- Runs only on loop exception-handler invocations and failing configuration
+  paths; no hot-path cost, no wire or payload change.
+- No settings, dependencies, schemas, routes, database, or frontend changes.

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/proposal.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/proposal.md
@@ -17,8 +17,10 @@ included) to API clients under the Responses policy.
   lifespan start. It copies the context, replaces every non-text value whose
   `repr()` changes under redaction with a stand-in carrying the redacted repr,
   and delegates to the previously installed (or default) handler, so
-  secret-free contexts render byte-identically. Idempotent; any failure falls
-  back to the raw context.
+  secret-free contexts render byte-identically. Idempotent and fail-closed: a
+  value whose `repr()` raises becomes an opaque stand-in, and any other failure
+  delegates a context whose object values are all stand-ins, so the report is
+  still emitted without rendering an unredacted value.
 - The dashboard rejects proxy usernames containing `:` at endpoint creation
   with `invalid_proxy_username`, and the endpoint test route reports the
   resolver reason as a failed probe instead of an unhandled error.

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
@@ -8,9 +8,12 @@ redacts the `repr()` of every context value the default handler would render
 `handle_traceback` entries) before delegating to the previously installed or
 default handler. Secret-free context output MUST be byte-identical to the
 default handler output, the exception object and its traceback MUST be passed
-through unchanged, installation MUST be idempotent, and any failure inside the
-redacting handler MUST fall back to delegating the original context so no
-diagnostic is lost.
+through unchanged, installation MUST be idempotent, and the handler MUST fail
+closed: a context value whose `repr()` raises MUST be replaced by an opaque
+stand-in, and any other failure inside the redacting handler MUST delegate a
+context that keeps the textual entries and replaces every other value with an
+opaque stand-in, so the report is still emitted and no unredacted value reaches
+the delegate.
 
 #### Scenario: Unclosed aiohttp connection repr is credential-free before logging
 
@@ -28,5 +31,9 @@ diagnostic is lost.
 
 - **WHEN** the context contains no secret pattern
 - **THEN** the emitted record message and exception info are byte-identical to the default handler output
-- **WHEN** a context value's `repr()` raises, or a handler was already installed
-- **THEN** the record is still emitted and the previously installed handler still receives the (redacted) context
+- **WHEN** a handler was already installed
+- **THEN** the previously installed handler still receives the (redacted) context
+- **WHEN** a context value's `repr()` raises
+- **THEN** the record is still emitted with its `message` line intact and that value rendered as an opaque stand-in naming the value type and the exception type
+- **WHEN** the redaction pass itself fails
+- **THEN** the record is still emitted with its `message`, exception and traceback entries intact and every other value rendered as an opaque redaction-failed stand-in

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Loop exception handler output redacts context value reprs
+
+Application startup MUST install an asyncio loop exception handler that
+redacts the `repr()` of every context value the default handler would render
+(all keys except the textual `message`, `exception`, `source_traceback` and
+`handle_traceback` entries) before delegating to the previously installed or
+default handler. Secret-free context output MUST be byte-identical to the
+default handler output, the exception object and its traceback MUST be passed
+through unchanged, installation MUST be idempotent, and any failure inside the
+redacting handler MUST fall back to delegating the original context so no
+diagnostic is lost.
+
+#### Scenario: Unclosed aiohttp connection repr is credential-free before logging
+
+- **GIVEN** an aiohttp connection is finalized without release and its connection key holds a credentialed proxy URL
+- **WHEN** the loop exception handler receives `Unclosed connection` with the connection object in its context
+- **THEN** the `asyncio` log record already contains `proxy=URL('scheme://[REDACTED]@host:port')`
+- **AND** the password appears nowhere in the record, independent of the formatter in use
+
+#### Scenario: Unretrieved task exception repr is redacted
+
+- **WHEN** a task whose exception text or repr carries URL userinfo or a `Basic <token>` header is garbage-collected unretrieved
+- **THEN** the `Task exception was never retrieved` record renders the task repr with `[REDACTED]` in place of the credential
+
+#### Scenario: Secret-free contexts and failures are transparent
+
+- **WHEN** the context contains no secret pattern
+- **THEN** the emitted record message and exception info are byte-identical to the default handler output
+- **WHEN** a context value's `repr()` raises, or a handler was already installed
+- **THEN** the record is still emitted and the previously installed handler still receives the (redacted) context

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/proxy-runtime-observability/spec.md
@@ -17,7 +17,7 @@ diagnostic is lost.
 - **GIVEN** an aiohttp connection is finalized without release and its connection key holds a credentialed proxy URL
 - **WHEN** the loop exception handler receives `Unclosed connection` with the connection object in its context
 - **THEN** the `asyncio` log record already contains `proxy=URL('scheme://[REDACTED]@host:port')`
-- **AND** the password appears nowhere in the record, independent of the formatter in use
+- **AND** the password appears nowhere in the record, independent of the formatter in use, including passwords carrying sub-delims such as `'` that yarl leaves unencoded
 
 #### Scenario: Unretrieved task exception repr is redacted
 

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/realtime-api-compat/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/realtime-api-compat/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Realtime forwarding preserves protocol context, privacy, and deterministic ownership
+
+The live connector MUST replace downstream proxy authorization, account identity, and client-supplied installation identity with the bound owner identity. It MUST preserve remaining ordered query pairs and supplied version-specific alpha value or absence, FedRAMP, residency, session/context, originator, and attestation headers; strip Responses-only beta values; synthesize neither `OpenAI-Beta` nor `Sec-WebSocket-Protocol`; and apply existing egress policy. It MUST pass the exact ordered downstream WebSocket subprotocol offers through the transport negotiation API, MUST accept downstream only with an upstream-selected value that the downstream offered, and MUST preserve no selection when upstream selects none. It MUST relay text and binary messages without interpretation, preserve only bounded valid close data, enforce the existing message-size boundary, and close/cancel/await each owned peer or task at most once. Both the initial upstream close and its post-cancel drain MUST be bounded; cancellation-resistant cleanup MUST NOT delay handler completion or stream-lease release, and any eventual late task result MUST be consumed without exposing its details.
+
+#### Scenario: protocol-faithful handshake
+
+- **WHEN** a live caller supplies supported query and context headers
+- **THEN** upstream receives those values in their required order with bound-owner credentials
+- **AND** it does not receive the downstream proxy bearer, client installation identity, duplicate call id, Responses beta, or synthesized subprotocol
+- **AND** any ordered subprotocol offers are negotiated upstream without a raw duplicated header
+- **AND** downstream receives only the upstream-selected offered value, or no value when upstream selects none
+
+#### Scenario: definitive denial and proxy errors remain isolated
+
+- **WHEN** routed upstream returns a definitive handshake status
+- **THEN** the proxy preserves the normalized status without route or credential details and does not replay the denial
+- **WHEN** the live connector raises `InvalidProxy`, `InvalidHandshake`, or `OSError`
+- **THEN** the sideband receives a fixed capability-specific, credential-safe message
+- **AND** the Responses WebSocket connector returns the same fixed credential-safe message for `InvalidProxy`, logging only the connector's URL-free reason, while its `InvalidHandshake` and `OSError` behavior remains unchanged
+
+#### Scenario: either peer disconnects or connection is cancelled
+
+- **WHEN** a peer closes, a paired relay finishes, or the handler/connection attempt is cancelled
+- **THEN** the opposite peer receives only a valid bounded close code/reason when available
+- **AND** paired work is cancelled and awaited
+- **AND** each peer, connector, and stream lease is released at most once
+- **AND** a close task that ignores cancellation is awaited only through a fixed post-cancel drain cap before lease release continues
+
+#### Scenario: diagnostics remain content-free
+
+- **GIVEN** payload tracing and Responses frame archiving are enabled
+- **WHEN** call creation carries SDP or the sideband carries realtime frames
+- **THEN** SDP and frame bodies are absent from traces and archives
+- **AND** sideband rows use `request_kind=realtime_live`, `transport=websocket`, and a redacted path
+- **AND** persisted private call-creation and sideband rows omit account identity, model content, upstream error text, failure metadata, live query text, and credentials

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/upstream-proxy-routing/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/specs/upstream-proxy-routing/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Dashboard rejects and reports proxy usernames the resolver cannot encode
+
+The dashboard MUST reject an upstream proxy endpoint whose username contains
+`:` at creation with a 400 error coded `invalid_proxy_username`, mirroring the
+resolver rule (RFC 7617 Basic credentials cannot encode a colon in the
+user-id). The endpoint test route MUST report a resolver rejection of an
+already persisted endpoint as a failed probe carrying the resolver reason
+rather than surfacing an unhandled error.
+
+#### Scenario: Colon username is rejected at creation
+
+- **WHEN** an operator creates an upstream proxy endpoint whose username contains `:`
+- **THEN** the request is rejected with a 400 error coded `invalid_proxy_username`
+
+#### Scenario: Endpoint test reports a persisted row the resolver rejects
+
+- **GIVEN** a persisted endpoint the resolver rejects (for example a username containing `:`)
+- **WHEN** the endpoint test route is invoked for it
+- **THEN** the response reports `ok: false` with the resolver reason as `error` and no status code
+- **AND** no probe is sent

--- a/openspec/changes/credential-safe-proxy-logging-loop-handler/tasks.md
+++ b/openspec/changes/credential-safe-proxy-logging-loop-handler/tasks.md
@@ -1,0 +1,26 @@
+## 1. Loop exception handler
+
+- [x] 1.1 Add idempotent `install_redacting_loop_exception_handler` that
+  redacts context reprs and delegates to the previous/default handler
+- [x] 1.2 Install once at lifespan start; test byte-identical output for
+  secret-free contexts, exploding reprs, chained handlers and unretrieved
+  task exceptions under asyncio and uvloop
+
+## 2. Dashboard colon-username hardening
+
+- [x] 2.1 Reject `:` in usernames at endpoint creation with
+  `invalid_proxy_username`
+- [x] 2.2 Report resolver rejections from the endpoint test route as a failed
+  probe instead of an unhandled 500
+
+## 3. Direct websocket InvalidProxy hardening
+
+- [x] 3.1 Use the fixed credential-safe message for `InvalidProxy` under
+  every policy; log only the URL-free reason
+- [x] 3.2 Update the Responses `InvalidProxy` test and the realtime spec
+
+## 4. Verification
+
+- [x] 4.1 Run focused unit and integration tests, ruff, ty, proxy
+  architecture check
+- [x] 4.2 Run strict scoped OpenSpec validation

--- a/openspec/changes/credential-safe-proxy-logging/proposal.md
+++ b/openspec/changes/credential-safe-proxy-logging/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+Production logs show `ERROR asyncio Unclosed connection` lines whose aiohttp
+`ConnectionKey` repr embeds the routed proxy URL with the plaintext proxy
+password. The Codex upstream client passes the credential-bearing proxy URL
+to aiohttp, which stores it verbatim in the connection pool key and renders it
+in `Connection.__repr__` and `ClientHttpProxyError.__str__`; the loop's default
+exception handler then logs that repr through the `asyncio` logger, and none
+of the application log formatters redact URL userinfo.
+
+## What Changes
+
+- Routed aiohttp requests and websocket connects carry proxy credentials in a
+  `Proxy-Authorization` header (latin1 Basic token, byte-identical to the one
+  aiohttp derives from URL userinfo) and a credential-free proxy URL, so
+  aiohttp repr surfaces never contain the password. Credentialed aiohttp routes
+  require a TLS (`https`/`wss`) upstream target because aiohttp forwards proxy
+  headers only on the CONNECT tunnel; plaintext targets fail closed for the
+  whole ordered pool before any dispatch and ahead of every transport branch
+  (native egress and SOCKS included), as a connect-phase transport error that
+  callers map to the usual upstream-unavailable response. The resolver rejects
+  usernames containing `:` (not encodable as Basic credentials). Native egress
+  and SOCKS transports keep their existing fields.
+- Every rendered log record (text and JSON formatters, any logger) masks
+  `scheme://user:pass@` userinfo and `Basic <token>` values in the
+  `Basic`/`basic`/`BASIC` spellings (the
+  reversible token aiohttp reprs from the CONNECT `Proxy-Authorization`
+  header); WARNING-and-higher records additionally get the existing
+  keyed/bearer/basic/authorization/JSON secret patterns and secret-keyed
+  structured extras (`password`, `*_token`, `api_key`, ...) of any value type,
+  and structured extra keys are redacted like values. Redaction never
+  raises, including for cyclic, pathologically deep, or unprintable structured
+  extras. `log_error_response` also masks URL userinfo. The server entrypoint
+  routes `warnings.warn` output through the same handlers.
+- Out of scope here, stacked as the follow-up change
+  `credential-safe-proxy-logging-loop-handler`: the redacting asyncio loop
+  exception handler (defense in depth for object reprs), the dashboard
+  colon-username hardening, and the Responses websocket `InvalidProxy`
+  message.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `upstream-proxy-routing`: aiohttp routed egress MUST carry proxy credentials
+  in `Proxy-Authorization`, never URL userinfo; credentialed aiohttp routes
+  MUST require a TLS target.
+- `proxy-runtime-observability`: rendered log records MUST redact URL
+  userinfo and keyed secrets regardless of the originating logger, and
+  redaction MUST never drop a record.
+
+## Impact
+
+- Code: `app/core/upstream_proxy/types.py`, `app/core/upstream_proxy/resolver.py`,
+  `app/core/clients/codex.py`, `app/core/runtime_logging.py`, `app/cli.py`.
+- Tests: `tests/unit/test_upstream_proxy_types.py` (new),
+  `tests/unit/test_codex_client.py`, `tests/unit/test_structured_logging.py`,
+  `tests/unit/test_upstream_proxy_resolver.py`, `tests/unit/test_cli.py`.
+- Wire compatibility: identical CONNECT `Proxy-Authorization` bytes, identical
+  per-proxy connection pooling (keyed through `proxy_headers_hash`), no
+  forwarded payload change. INFO-level log records cost ~1 us more to render.
+- No settings, dependencies, schemas, routes, database, or frontend changes.

--- a/openspec/changes/credential-safe-proxy-logging/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Rendered log records redact URL userinfo and keyed secrets
+
+Every log record rendered by the application's text, access, and JSON
+formatters MUST have URL userinfo, in both the `scheme://user:password@` and
+the username-only `scheme://user@` forms, replaced with
+`scheme://[REDACTED]@` and `Basic <token>` authorization tokens (in the
+`Basic`, `basic` and `BASIC` scheme spellings)
+(a reversible encoding of `user:password`, as carried in aiohttp proxy-error
+reprs) replaced with `Basic [REDACTED]`, regardless of the originating logger
+(application, `asyncio`, aiohttp, uvicorn) and including exception and stack
+text. Structured extra keys MUST be redacted like values. Records at WARNING
+level or higher MUST additionally have keyed secrets (`password=`, `token=`,
+`api_key=`, bearer, basic and authorization values in any letter case, JSON
+secret fields embedded in strings, and structured extra fields whose key names
+a secret, whatever the value type) redacted. Redaction MUST never raise and
+MUST fail closed: if a redaction pass fails, the affected text is replaced with
+a `[REDACTED: log redaction failed]` placeholder and the record is still
+emitted with its timestamp, level and logger; structured extras that are cyclic,
+pathologically deep, or unprintable MUST still be emitted with redaction
+applied to every finite, printable part. Application startup MUST route
+`warnings.warn` output through the same log handlers. Log records that contain
+no secret patterns MUST render byte-identically to the unredacted rendering.
+
+#### Scenario: Unclosed aiohttp connection repr is credential-free
+
+- **GIVEN** an aiohttp connection is finalized without release and its connection key holds a credentialed proxy URL
+- **WHEN** the loop exception handler logs `Unclosed connection` through the `asyncio` logger
+- **THEN** the rendered record contains `proxy=URL('scheme://[REDACTED]@host:port')`
+- **AND** the password appears in neither the text nor the JSON rendering
+
+#### Scenario: Userinfo containing unencoded sub-delims is redacted
+
+- **GIVEN** a proxy password containing an RFC 3986 sub-delim such as `'`, which yarl leaves unencoded in the URL userinfo, or a raw environment proxy string that is not percent-encoded at all
+- **WHEN** the URL is rendered in any log record at any level
+- **THEN** the record contains `scheme://[REDACTED]@host:port` and neither the raw nor the percent-encoded password
+
+#### Scenario: Username-only URL userinfo is redacted
+
+- **GIVEN** a URL whose userinfo carries only a username (a token used as the username, `scheme://user@host:port`) with no `:password` part
+- **WHEN** the URL is rendered in any log record at any level, text or JSON
+- **THEN** the record contains `scheme://[REDACTED]@host:port` and the username does not appear
+
+#### Scenario: Proxy error repr with a Basic token is masked
+
+- **GIVEN** an aiohttp proxy error whose tunnel request headers carry `Proxy-Authorization: Basic <token>`
+- **WHEN** the error is logged with `%r` at any level, or its repr is logged by the loop's exception handler for an unretrieved task
+- **THEN** the rendered record contains `'Proxy-Authorization': 'Basic [REDACTED]'`
+- **AND** neither the token nor the password appears in the text or JSON rendering
+
+#### Scenario: Secret-keyed structured extras are masked
+
+- **GIVEN** a WARNING or higher record carries an extra field such as `{"password": "..."}` or `{"access_token": "..."}`
+- **WHEN** the JSON formatter renders the record
+- **THEN** the field value is replaced with `[REDACTED]` whatever its type (string, list, number, bytes, mapping); a null value stays null
+- **AND** fields such as `attempt` or `tokens` keep their values
+- **AND** an extra key carrying URL userinfo is rendered as `scheme://[REDACTED]@host`
+
+#### Scenario: Secret-free records are unchanged
+
+- **WHEN** a record such as the one-time bootstrap token banner contains no URL userinfo or keyed secret pattern
+- **THEN** the rendered output is byte-identical to the unredacted rendering
+
+#### Scenario: Redaction failure never breaks logging and fails closed
+
+- **WHEN** a redaction pass raises while rendering a record
+- **THEN** the record is still emitted, in text and JSON, with its timestamp, level and logger
+- **AND** the affected text is rendered as `[REDACTED: log redaction failed]` rather than the original text
+
+#### Scenario: Cyclic or unprintable structured extras never drop the record
+
+- **GIVEN** a record carries an extra whose container refers back to itself, or whose `repr()` raises
+- **WHEN** the JSON formatter renders the record
+- **THEN** the record is emitted, the back-reference collapses to a `{...}` / `[...]` placeholder and the unprintable value to an `<unprintable ...>` marker
+- **AND** secret-keyed fields and URL userinfo in the finite part of the extra are still redacted
+
+#### Scenario: Secret-keyed mappings rendered as Python repr are masked
+
+- **GIVEN** a WARNING or higher record renders a mapping with `%r`, or the JSON formatter falls back to text for a structured extra (nesting beyond the depth limit, a container whose iteration raises, an unserializable rebuild)
+- **WHEN** the rendered text contains `'password': 'x'`, `'access_token': [...]` or `'api_key': 123`
+- **THEN** each secret-keyed value is replaced with `[REDACTED]` (quotes kept for quoted strings)
+- **AND** `'Proxy-Authorization': 'Basic <token>'` keeps rendering as `'Basic [REDACTED]'`

--- a/openspec/changes/credential-safe-proxy-logging/specs/upstream-proxy-routing/spec.md
+++ b/openspec/changes/credential-safe-proxy-logging/specs/upstream-proxy-routing/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Routed aiohttp egress carries proxy credentials outside the proxy URL
+
+When the Codex upstream client dispatches a routed HTTP request or WebSocket
+connect through aiohttp, it MUST pass a credential-free proxy URL
+(`scheme://host:port`) and MUST carry the endpoint username and password as a
+`Proxy-Authorization` Basic header whose bytes are identical to the header
+aiohttp derives from URL userinfo (latin1 encoding). The client MUST NOT place
+proxy credentials in the aiohttp proxy URL. Because aiohttp forwards proxy
+headers only on the CONNECT tunnel, a route whose ordered pool contains any
+credentialed endpoint MUST fail closed for a non-TLS (`http`/`ws`) upstream
+target before any connection is opened and ahead of every transport branch
+(aiohttp, native egress, SOCKS), surfacing as a credential-free connect-phase
+transport error, so a credential-free fallback endpoint cannot absorb the
+misconfigured primary. Route resolution MUST fail closed for a proxy username
+containing `:`. Native egress and SOCKS transports keep carrying credentials
+through their existing URL and field inputs.
+
+#### Scenario: Credentialed https endpoint uses Proxy-Authorization
+
+- **GIVEN** a resolved `https` proxy endpoint with a username and password
+- **WHEN** the Codex upstream client sends a routed request or opens a routed WebSocket through aiohttp
+- **THEN** the aiohttp `proxy` argument contains no userinfo
+- **AND** the CONNECT request carries a `Proxy-Authorization` header whose value is byte-identical to the userinfo-derived token
+- **AND** the aiohttp connection-key repr and the proxy-error message text contain neither the password nor its Basic token
+- **AND** the proxy-error repr, which carries the tunnel request headers, renders with `Basic [REDACTED]` through the log formatters (see `proxy-runtime-observability`)
+
+#### Scenario: Credentialed route to a plaintext target fails closed
+
+- **GIVEN** a resolved route whose primary proxy endpoint carries credentials and whose fallback does not
+- **WHEN** the Codex upstream client is asked to reach an `http` or `ws` upstream URL, for an idempotent or non-idempotent request or a WebSocket open, whether or not a native egress helper is available
+- **THEN** the client fails before dispatch with a credential-free connect-phase transport error
+- **AND** no endpoint in the pool, including the credential-free fallback, receives the request on any transport
+
+#### Scenario: Username with a colon is rejected at resolution
+
+- **WHEN** a proxy endpoint username contains `:`
+- **THEN** route resolution fails closed with reason `invalid_proxy_username`

--- a/openspec/changes/credential-safe-proxy-logging/tasks.md
+++ b/openspec/changes/credential-safe-proxy-logging/tasks.md
@@ -1,0 +1,29 @@
+## 1. Credentials out of aiohttp repr surfaces
+
+- [x] 1.1 Add `ResolvedProxyEndpoint.aiohttp_proxy_kwargs()` (credential-free
+  `proxy` + latin1 `Proxy-Authorization` header) and use it for routed aiohttp
+  requests and websocket connects; reserve `proxy_headers` from callers
+- [x] 1.2 Fail closed for credentialed routes to non-TLS targets (whole
+  pool, before dispatch, ahead of every transport, as a connect-phase
+  transport error) and for usernames containing `:` at the resolver
+- [x] 1.3 Pin byte-identical CONNECT header, credential-free `ConnectionKey`
+  repr and `ClientHttpProxyError` text with a fake CONNECT proxy
+
+## 2. Rendered log redaction backstop
+
+- [x] 2.1 Add never-throwing `redact_rendered_log_text` with URL userinfo and
+  Basic token patterns and cheap prechecks; fold both into `_redact_log_value`
+- [x] 2.2 Apply to text, access, and JSON formatters (message, exception,
+  extras incl. secret-keyed fields of any type and extra keys); route
+  `warnings.warn` through logging at server start
+- [x] 2.3 Regression tests: exact production line (text and JSON), `https`
+  variant, `BasicAuth` repr, exception traceback, never-throws, precheck
+  short-circuit, bootstrap token byte-identity, mid-line `Authorization:`,
+  cyclic/deep/unprintable extras (never-raise, incl. randomized nesting),
+  yarl-shaped userinfo with unencoded sub-delims (`'`), Python-repr
+  secret-keyed mappings (`%r` and the JSON formatter's text fallbacks)
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit tests, ruff, ty, proxy architecture check
+- [x] 3.2 Run strict scoped OpenSpec validation

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -11,7 +11,7 @@ from sqlalchemy import text
 import app.modules.settings.api as settings_api_module
 from app.core.auth import generate_unique_account_id
 from app.core.config.settings_cache import get_settings_cache
-from app.db.models import Account, AccountStatus, DashboardSettings
+from app.db.models import Account, AccountStatus, DashboardSettings, ProxyEndpoint
 from app.db.session import SessionLocal
 
 pytestmark = pytest.mark.integration
@@ -773,6 +773,43 @@ async def test_upstream_proxy_endpoint_create_rejects_plaintext_credentials(asyn
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "plaintext_proxy_credentials_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_upstream_proxy_endpoint_create_rejects_colon_in_username(async_client):
+    response = await async_client.post(
+        "/api/settings/upstream-proxy/endpoints",
+        json={
+            "name": "Colon proxy",
+            "scheme": "https",
+            "host": "proxy.internal",
+            "port": 8080,
+            "username": "user:name",
+            "password": "secret",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_proxy_username"
+
+
+@pytest.mark.asyncio
+async def test_upstream_proxy_endpoint_test_reports_unresolvable_persisted_row(async_client):
+    # A row persisted before the resolver rule existed must report the reason,
+    # not surface an unhandled 500 from the test route.
+    async with SessionLocal() as session:
+        row = ProxyEndpoint(name="Legacy", scheme="https", host="proxy.internal", port=8080, username="user:name")
+        session.add(row)
+        await session.commit()
+        endpoint_id = row.id
+
+    response = await async_client.post(f"/api/settings/upstream-proxy/endpoints/{endpoint_id}/test")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"] == "invalid_proxy_username"
+    assert payload["statusCode"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -227,6 +227,9 @@ def test_run_server_uses_graceful_server_and_shared_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
+    # Warnings (aiohttp ResourceWarning reprs) must flow through the redacting
+    # log handlers rather than raw stderr.
+    monkeypatch.setattr(logging, "captureWarnings", lambda capture: captured.__setitem__("capture_warnings", capture))
 
     class FakeConfig:
         def __init__(self, *args: object, **kwargs: object) -> None:
@@ -266,6 +269,7 @@ def test_run_server_uses_graceful_server_and_shared_timeout(
     assert captured["drain_timeout_seconds"] == 17
     assert captured["loaded"] is True
     assert captured["ran"] is True
+    assert captured["capture_warnings"] is True
 
 
 def test_load_http_protocol_class_falls_back_to_h11_without_httptools(

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -31,6 +32,21 @@ pytestmark = pytest.mark.unit
 
 def _route_basic_auth_url(user: str, value: str, authority: str) -> str:
     return runtime_basic_auth_url(user, value, authority).replace("http://", "https://", 1)
+
+
+# The Basic token aiohttp itself derives from ``https://u:p@`` userinfo (latin1).
+_ROUTE_PROXY_BASIC_TOKEN = "Basic " + base64.b64encode(b"u:p").decode("latin1")
+
+
+def _assert_credentialed_proxy_call(call: dict[str, Any]) -> None:
+    # Credentials ride in Proxy-Authorization, never in the pooled proxy URL.
+    assert call["proxy"] == "https://proxy.test:8080"
+    assert call["proxy_headers"] == {"Proxy-Authorization": _ROUTE_PROXY_BASIC_TOKEN}
+
+
+def _assert_credential_free_proxy_call(call: dict[str, Any], proxy_url: str) -> None:
+    assert call["proxy"] == proxy_url
+    assert "proxy_headers" not in call
 
 
 @dataclass
@@ -178,7 +194,7 @@ async def test_request_passes_resolver_proxy_and_builtin_fingerprint(route: Reso
 
     response = await client.request("POST", "https://upstream.test", route=route, json={"x": 1})
 
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
     assert session.calls[0]["json"] == {"x": 1}
     assert response.content == b'{"ok": true}'
 
@@ -244,7 +260,7 @@ async def test_routed_native_unavailable_falls_back_before_dispatch(route: Resol
 
     assert len(native.request_calls) == 1
     assert len(session.calls) == 1
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
 
 
 @pytest.mark.asyncio
@@ -324,7 +340,7 @@ async def test_streaming_request_can_opt_out_of_response_buffering(route: Resolv
         json={"x": 1},
     )
 
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
     assert "buffer_response" not in session.calls[0]
     assert isinstance(result.response, _Response)
 
@@ -344,11 +360,11 @@ async def test_request_converts_legacy_files_payload_to_form_data(route: Resolve
 
     assert "files" not in session.calls[0]
     assert isinstance(session.calls[0]["data"], aiohttp.FormData)
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("override", ["akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy"])
+@pytest.mark.parametrize("override", ["akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy", "proxy_headers"])
 async def test_runtime_route_and_fingerprint_overrides_are_rejected(
     route: ResolvedUpstreamRoute,
     override: str,
@@ -356,6 +372,63 @@ async def test_runtime_route_and_fingerprint_overrides_are_rejected(
     client = CodexClient(_Session())
     with pytest.raises(ValueError, match="controlled centrally"):
         await client.request("GET", "https://upstream.test", route=route, **{override: "bad"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["POST", "GET"])
+async def test_credentialed_route_requires_tls_target_for_request(route: ResolvedUpstreamRoute, method: str) -> None:
+    # aiohttp forwards proxy_headers only on the CONNECT tunnel, so a plaintext
+    # target would silently drop the proxy credentials; fail closed before any
+    # dispatch. The idempotent GET must not slip through the credential-free
+    # fallback endpoint either (the route fixture carries one). Surfaces as a
+    # connect-phase transport error so callers answer upstream-unavailable.
+    session = _Session()
+    client = CodexClient(session)
+
+    with pytest.raises(CodexTransportError, match="https/wss upstream target") as exc_info:
+        await client.request(method, "http://upstream.test", route=route, json={"x": 1})
+
+    assert session.calls == []
+    assert "proxy.test" not in str(exc_info.value)
+    assert exc_info.value.failure_phase == "connect"
+    assert exc_info.value.retryable_same_contract is False
+
+
+@pytest.mark.asyncio
+async def test_credentialed_route_requires_tls_target_for_ws_connect(route: ResolvedUpstreamRoute) -> None:
+    session = _Session()
+    client = CodexClient(session)
+
+    with pytest.raises(CodexTransportError, match="https/wss upstream target"):
+        await client.ws_connect("ws://upstream.test", route=route)
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_credentialed_route_requires_tls_target_for_ws_open_with_fallback(route: ResolvedUpstreamRoute) -> None:
+    session = _Session()
+    client = CodexClient(session)
+
+    with pytest.raises(CodexTransportError, match="https/wss upstream target"):
+        await client.open_ws_with_route_metadata("ws://upstream.test", route=route)
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_credential_free_route_allows_plaintext_target() -> None:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "https", "proxy.test", 8080),
+    )
+    session = _Session()
+    client = CodexClient(session)
+
+    await client.request("GET", "http://upstream.test", route=route)
+
+    _assert_credential_free_proxy_call(session.calls[0], "https://proxy.test:8080")
 
 
 @pytest.mark.asyncio
@@ -367,10 +440,8 @@ async def test_pre_response_failure_uses_same_pool_fallback(route: ResolvedUpstr
 
     assert result.fallback_used is True
     assert result.route.endpoint_id == "ep_2"
-    assert [call["proxy"] for call in session.calls] == [
-        _route_basic_auth_url("u", "p", "proxy.test:8080"),
-        "http://proxy-two.test:8081",
-    ]
+    _assert_credentialed_proxy_call(session.calls[0])
+    _assert_credential_free_proxy_call(session.calls[1], "http://proxy-two.test:8081")
 
 
 @pytest.mark.asyncio
@@ -383,7 +454,7 @@ async def test_non_idempotent_request_failure_does_not_fallback(route: ResolvedU
 
     assert "ep_1" in str(exc_info.value)
     assert len(session.calls) == 1
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
 
 
 def _proxy_connect_error() -> aiohttp.ClientProxyConnectionError:
@@ -420,10 +491,8 @@ async def test_non_idempotent_pre_dispatch_proxy_failure_uses_same_pool_fallback
 
     assert result.fallback_used is True
     assert result.route.endpoint_id == "ep_2"
-    assert [call["proxy"] for call in session.calls] == [
-        _route_basic_auth_url("u", "p", "proxy.test:8080"),
-        "http://proxy-two.test:8081",
-    ]
+    _assert_credentialed_proxy_call(session.calls[0])
+    _assert_credential_free_proxy_call(session.calls[1], "http://proxy-two.test:8081")
 
 
 @pytest.mark.asyncio
@@ -596,7 +665,7 @@ async def test_routed_native_websocket_unavailable_uses_python_connector(
     assert result.native is False
     assert len(native.websocket_calls) == 1
     assert len(session.calls) == 1
-    assert session.calls[0]["proxy"] == _route_basic_auth_url("u", "p", "proxy.test:8080")
+    _assert_credentialed_proxy_call(session.calls[0])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import errno
+import json
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -1935,8 +1936,13 @@ async def test_connect_responses_websocket_maps_generic_invalid_handshake(monkey
 
 
 @pytest.mark.asyncio
-async def test_connect_responses_websocket_maps_invalid_proxy(monkeypatch):
-    invalid_proxy = InvalidProxy("http://proxy.invalid", "unsupported proxy scheme")
+async def test_connect_responses_websocket_maps_invalid_proxy(monkeypatch, caplog):
+    # websockets' InvalidProxy str() embeds the full proxy URL (userinfo
+    # included); the Responses path must use the fixed message like live does.
+    invalid_proxy = InvalidProxy(
+        runtime_basic_auth_url("proxy-user", "proxy-secret", "proxy.invalid:1/path"),
+        "path is meaningless",
+    )
 
     async def fake_websocket_connect(url: str, **kwargs):
         del url, kwargs
@@ -1966,8 +1972,10 @@ async def test_connect_responses_websocket_maps_invalid_proxy(monkeypatch):
 
     assert exc_info.value.status_code == 502
     assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
-
-    assert _proxy_error_message(exc_info.value) == str(invalid_proxy)
+    assert _proxy_error_message(exc_info.value) == "Invalid upstream websocket proxy configuration"
+    assert "proxy-secret" not in json.dumps(exc_info.value.payload)
+    assert "proxy-secret" not in caplog.text
+    assert "path is meaningless" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runtime_logging_loop_handler.py
+++ b/tests/unit/test_runtime_logging_loop_handler.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Iterator
 import pytest
 import uvloop
 
+from app.core import runtime_logging
 from app.core.runtime_logging import install_redacting_loop_exception_handler
 from tests.unit._proxy_test_helpers import runtime_basic_auth_url
 
@@ -134,12 +135,35 @@ def test_handler_chains_previously_installed_handler(loop) -> None:
     assert f"[REDACTED]@{_PROXY_AUTHORITY}" in repr(context["client_connection"])
 
 
-def test_handler_survives_exploding_repr(loop, asyncio_log) -> None:
+def test_handler_replaces_exploding_repr_with_opaque_stand_in(loop, asyncio_log) -> None:
     install_redacting_loop_exception_handler(loop)
 
     loop.call_exception_handler({"message": "Unclosed connection", "client_connection": _ExplodingRepr()})
 
-    assert asyncio_log.records, "a log record must still be emitted"
+    (message,) = asyncio_log.messages
+    # The default handler never sees the raw object, so the message line
+    # survives instead of asyncio's generic "Unhandled error in exception handler".
+    assert message == "Unclosed connection\nclient_connection: <_ExplodingRepr repr failed: RuntimeError>"
+
+
+def test_handler_fails_closed_when_redaction_pass_raises(loop, asyncio_log, monkeypatch) -> None:
+    def _broken_redaction(text: str, **_kwargs: object) -> str:
+        raise ValueError("redaction broke")
+
+    monkeypatch.setattr(runtime_logging, "redact_rendered_log_text", _broken_redaction)
+    install_redacting_loop_exception_handler(loop)
+    exc = RuntimeError("boom")
+
+    loop.call_exception_handler(
+        {"message": "Unclosed connection", "exception": exc, "client_connection": _LeakyConnection()}
+    )
+
+    (record,) = asyncio_log.records
+    message = record.getMessage()
+    assert message.startswith("Unclosed connection\n")
+    assert "SECRETPW" not in message
+    assert "client_connection: [REDACTED: loop context redaction failed]" in message
+    assert record.exc_info is not None and record.exc_info[1] is exc
 
 
 @pytest.mark.parametrize("loop_factory", _LOOP_FACTORIES)

--- a/tests/unit/test_runtime_logging_loop_handler.py
+++ b/tests/unit/test_runtime_logging_loop_handler.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+from collections.abc import Callable, Iterator
+
+import pytest
+import uvloop
+
+from app.core.runtime_logging import install_redacting_loop_exception_handler
+from tests.unit._proxy_test_helpers import runtime_basic_auth_url
+
+pytestmark = pytest.mark.unit
+
+_LOOP_FACTORIES = [
+    pytest.param(asyncio.new_event_loop, id="asyncio"),
+    pytest.param(uvloop.new_event_loop, id="uvloop"),
+]
+_PROXY_AUTHORITY = "183.110.26.193:6014"
+
+
+class _LeakyConnection:
+    def __repr__(self) -> str:
+        proxy_url = runtime_basic_auth_url("smart-user", "SECRETPW", _PROXY_AUTHORITY)
+        return f"Connection<ConnectionKey(host='chatgpt.com', port=443, proxy=URL('{proxy_url}'), proxy_auth=None)>"
+
+
+class _ExplodingRepr:
+    def __repr__(self) -> str:
+        raise RuntimeError("repr failure")
+
+
+class _Recorder(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    @property
+    def messages(self) -> list[str]:
+        return [record.getMessage() for record in self.records]
+
+
+@pytest.fixture
+def asyncio_log() -> Iterator[_Recorder]:
+    logger = logging.getLogger("asyncio")
+    recorder = _Recorder()
+    logger.addHandler(recorder)
+    previous_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield recorder
+    finally:
+        logger.removeHandler(recorder)
+        logger.setLevel(previous_level)
+
+
+@pytest.fixture(params=_LOOP_FACTORIES)
+def loop(request: pytest.FixtureRequest) -> Iterator[asyncio.AbstractEventLoop]:
+    factory: Callable[[], asyncio.AbstractEventLoop] = request.param
+    loop = factory()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+def test_handler_redacts_credentialed_context_reprs(loop, asyncio_log) -> None:
+    install_redacting_loop_exception_handler(loop)
+
+    loop.call_exception_handler({"message": "Unclosed connection", "client_connection": _LeakyConnection()})
+
+    (message,) = asyncio_log.messages
+    assert message.startswith("Unclosed connection\nclient_connection: Connection<ConnectionKey(")
+    assert "SECRETPW" not in message
+    assert f"[REDACTED]@{_PROXY_AUTHORITY}" in message
+
+
+def test_handler_keeps_secret_free_context_byte_identical(loop, asyncio_log) -> None:
+    exc = RuntimeError("boom")
+    context = {"message": "Task exception was never retrieved", "exception": exc, "future": object()}
+
+    loop.default_exception_handler(dict(context))
+    install_redacting_loop_exception_handler(loop)
+    loop.call_exception_handler(context)
+
+    baseline, redacted = asyncio_log.records
+    assert redacted.getMessage() == baseline.getMessage()
+    assert redacted.exc_info == baseline.exc_info
+    assert redacted.exc_info is not None and redacted.exc_info[1] is exc
+
+
+def test_install_is_idempotent(loop) -> None:
+    install_redacting_loop_exception_handler(loop)
+    handler = loop.get_exception_handler()
+
+    install_redacting_loop_exception_handler(loop)
+
+    assert loop.get_exception_handler() is handler
+
+
+def test_handler_chains_previously_installed_handler(loop) -> None:
+    seen: list[dict[str, object]] = []
+    loop.set_exception_handler(lambda _loop, context: seen.append(dict(context)))
+    install_redacting_loop_exception_handler(loop)
+
+    loop.call_exception_handler({"message": "Unclosed connection", "client_connection": _LeakyConnection()})
+
+    (context,) = seen
+    assert context["message"] == "Unclosed connection"
+    assert "SECRETPW" not in repr(context["client_connection"])
+    assert f"[REDACTED]@{_PROXY_AUTHORITY}" in repr(context["client_connection"])
+
+
+def test_handler_survives_exploding_repr(loop, asyncio_log) -> None:
+    install_redacting_loop_exception_handler(loop)
+
+    loop.call_exception_handler({"message": "Unclosed connection", "client_connection": _ExplodingRepr()})
+
+    assert asyncio_log.records, "a log record must still be emitted"
+
+
+@pytest.mark.parametrize("loop_factory", _LOOP_FACTORIES)
+def test_unretrieved_task_exception_repr_is_redacted(loop_factory, asyncio_log) -> None:
+    async def _main() -> None:
+        install_redacting_loop_exception_handler(asyncio.get_running_loop())
+
+        async def _boom() -> None:
+            raise RuntimeError(runtime_basic_auth_url("u", "TASKPW", "h") + "/")
+
+        task = asyncio.get_running_loop().create_task(_boom())
+        await asyncio.sleep(0)
+        assert task.done()
+        del task
+        gc.collect()
+        await asyncio.sleep(0)
+
+    with asyncio.Runner(loop_factory=loop_factory) as runner:
+        runner.run(_main())
+
+    messages = [message for message in asyncio_log.messages if "Task exception was never retrieved" in message]
+    assert messages, asyncio_log.messages
+    assert all("TASKPW" not in message for message in messages)
+    assert any("http://[REDACTED]@h/" in message for message in messages)
+
+
+@pytest.mark.parametrize("loop_factory", _LOOP_FACTORIES)
+def test_unretrieved_task_client_http_proxy_error_repr_is_redacted(loop_factory, asyncio_log) -> None:
+    # Task repr embeds repr(exception); aiohttp's ClientHttpProxyError repr
+    # carries the CONNECT Proxy-Authorization header, a reversible Basic token.
+    import base64
+
+    import aiohttp
+    from aiohttp.client_reqrep import ClientRequest
+    from yarl import URL
+
+    from app.core.upstream_proxy import ResolvedProxyEndpoint
+
+    token = base64.b64encode(b"smart-user:SECRETPW").decode()
+
+    async def _main() -> None:
+        running = asyncio.get_running_loop()
+        install_redacting_loop_exception_handler(running)
+        endpoint = ResolvedProxyEndpoint("ep", "https", "proxy.test", 8080, "smart-user", "SECRETPW")
+        proxy_headers = endpoint.aiohttp_proxy_kwargs()["proxy_headers"]
+
+        async def _boom() -> None:
+            request = ClientRequest("CONNECT", URL("https://chatgpt.com/"), headers=proxy_headers, loop=running)
+            raise aiohttp.ClientHttpProxyError(request.request_info, (), status=502, message="nope")
+
+        task = running.create_task(_boom())
+        await asyncio.sleep(0)
+        assert task.done()
+        assert token in repr(task)
+        del task
+        gc.collect()
+        await asyncio.sleep(0)
+
+    with asyncio.Runner(loop_factory=loop_factory) as runner:
+        runner.run(_main())
+
+    messages = [message for message in asyncio_log.messages if "Task exception was never retrieved" in message]
+    assert messages, asyncio_log.messages
+    assert all(token not in message and "SECRETPW" not in message for message in messages)
+    assert any("'Proxy-Authorization': 'Basic [REDACTED]'" in message for message in messages)

--- a/tests/unit/test_runtime_logging_loop_handler.py
+++ b/tests/unit/test_runtime_logging_loop_handler.py
@@ -21,9 +21,17 @@ _PROXY_AUTHORITY = "183.110.26.193:6014"
 
 
 class _LeakyConnection:
+    password = "SECRETPW"
+
     def __repr__(self) -> str:
-        proxy_url = runtime_basic_auth_url("smart-user", "SECRETPW", _PROXY_AUTHORITY)
+        proxy_url = runtime_basic_auth_url("smart-user", self.password, _PROXY_AUTHORITY)
         return f"Connection<ConnectionKey(host='chatgpt.com', port=443, proxy=URL('{proxy_url}'), proxy_auth=None)>"
+
+
+class _ApostropheLeakyConnection(_LeakyConnection):
+    # yarl leaves the RFC 3986 sub-delim ' unencoded in userinfo, so this is
+    # the exact repr aiohttp produces for such a password.
+    password = "S'ECRETPW"
 
 
 class _ExplodingRepr:
@@ -77,6 +85,17 @@ def test_handler_redacts_credentialed_context_reprs(loop, asyncio_log) -> None:
     assert message.startswith("Unclosed connection\nclient_connection: Connection<ConnectionKey(")
     assert "SECRETPW" not in message
     assert f"[REDACTED]@{_PROXY_AUTHORITY}" in message
+
+
+def test_handler_redacts_apostrophe_password_in_context_repr(loop, asyncio_log) -> None:
+    install_redacting_loop_exception_handler(loop)
+
+    loop.call_exception_handler({"message": "Unclosed connection", "client_connection": _ApostropheLeakyConnection()})
+
+    (message,) = asyncio_log.messages
+    assert "S'ECRETPW" not in message
+    assert "ECRETPW" not in message
+    assert f"proxy=URL('http://[REDACTED]@{_PROXY_AUTHORITY}')" in message
 
 
 def test_handler_keeps_secret_free_context_byte_identical(loop, asyncio_log) -> None:

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+import io
 import json
 import logging
 
 import pytest
 
+import app.core.runtime_logging as runtime_logging
 from app.core.runtime_logging import (
+    JsonAccessFormatter,
     JsonFormatter,
+    UtcAccessFormatter,
     UtcDefaultFormatter,
     _error_log_field,
     _redact_log_value,
     build_log_config,
 )
+from tests.unit._proxy_test_helpers import runtime_basic_auth_url
 
 pytestmark = pytest.mark.unit
 
@@ -269,3 +274,663 @@ def test_build_log_config_exposes_app_loggers_via_root_handler(monkeypatch):
     assert root_logger.get("handlers") == ["default"]
     assert root_logger.get("level") == "INFO"
     get_settings.cache_clear()
+
+
+# --- rendered-record redaction backstop -------------------------------------
+
+
+_PROXY_AUTHORITY = "183.110.26.193:6014"
+
+
+def _connection_key_line(proxy_url: str) -> str:
+    # Exact shape uvloop's default exception handler logs for aiohttp
+    # Connection.__del__ (evidence: prod 'Unclosed connection' ERROR lines).
+    return (
+        "Unclosed connection\n"
+        "client_connection: Connection<ConnectionKey(host='chatgpt.com', port=443, is_ssl=True, ssl=True, "
+        f"proxy=URL('{proxy_url}'), proxy_auth=None, proxy_headers_hash=None, server_hostname=None)>"
+    )
+
+
+def _formatter_from_config(monkeypatch, log_format: str, name: str = "default") -> logging.Formatter:
+    import importlib
+    from typing import cast
+
+    from app.core.config.settings import get_settings
+
+    monkeypatch.setenv("CODEX_LB_LOG_FORMAT", log_format)
+    get_settings.cache_clear()
+    try:
+        spec = dict(cast(dict, cast(dict, build_log_config()["formatters"])[name]))
+    finally:
+        get_settings.cache_clear()
+    module_name, _, class_name = spec.pop("()").rpartition(".")
+    return getattr(importlib.import_module(module_name), class_name)(**spec)
+
+
+def _render(formatter: logging.Formatter, record: logging.LogRecord) -> str:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+    handler.handle(record)
+    return stream.getvalue()
+
+
+def _record(msg: str, *, level: int = logging.ERROR, name: str = "asyncio", exc_info=None) -> logging.LogRecord:
+    return logging.LogRecord(name, level, "connector.py", 1, msg, (), exc_info)
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_rendered_unclosed_connection_line_redacts_proxy_userinfo(monkeypatch, log_format, scheme):
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    proxy_url = runtime_basic_auth_url("smart-user", "SECRETPW", _PROXY_AUTHORITY).replace("http://", f"{scheme}://", 1)
+
+    output = _render(formatter, _record(_connection_key_line(proxy_url)))
+
+    assert "SECRETPW" not in output
+    assert f"[REDACTED]@{_PROXY_AUTHORITY}" in output
+    assert "Unclosed connection" in output
+    if log_format == "json":
+        assert json.loads(output)["message"] == _connection_key_line(f"{scheme}://[REDACTED]@{_PROXY_AUTHORITY}")
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+@pytest.mark.parametrize("password", ["sq'uote", 'dq"uote', "!$&()*+,;=", "at@sign", "sp ace"])
+def test_rendered_unclosed_connection_line_redacts_yarl_encoded_userinfo(monkeypatch, log_format, password):
+    # aiohttp reprs the proxy URL through yarl, which leaves RFC 3986 sub-delims
+    # (``'`` included) unencoded in userinfo and percent-encodes the rest.
+    from urllib.parse import quote
+
+    from yarl import URL
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    proxy_url = str(URL(f"https://smart-user:{quote(password, safe='')}@{_PROXY_AUTHORITY}"))
+
+    output = _render(formatter, _record(_connection_key_line(proxy_url), level=logging.INFO))
+
+    assert password not in output
+    assert quote(password, safe="") not in output
+    assert f"https://[REDACTED]@{_PROXY_AUTHORITY}" in output
+
+
+def test_redact_rendered_log_text_masks_raw_userinfo_with_apostrophe():
+    # Raw ``trust_env`` proxy strings are not percent-encoded at all.
+    line = "probe " + runtime_basic_auth_url("smart-user", "sq'uote", "h:1") + " failed"
+
+    assert runtime_logging.redact_rendered_log_text(line, keyed_secrets=False) == "probe http://[REDACTED]@h:1 failed"
+    assert _redact_log_value(line) == "probe http://[REDACTED]@h:1 failed"
+
+
+def test_redact_rendered_log_text_leaves_quoted_host_only_url_before_quoted_email_alone():
+    line = "proxy=URL('http://183.110.26.193:6014'), owner='ops@example.com'"
+
+    assert runtime_logging.redact_rendered_log_text(line) == line
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_rendered_basic_auth_repr_redacts_password(monkeypatch, log_format):
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    line = _connection_key_line(f"http://{_PROXY_AUTHORITY}").replace(
+        "proxy_auth=None",
+        "proxy_auth=BasicAuth(login='smart-user', password='SECRETPW', encoding='latin1')",
+    )
+
+    output = _render(formatter, _record(line))
+
+    assert "SECRETPW" not in output
+    assert "password=[REDACTED], encoding='latin1'" in output
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_rendered_exception_traceback_redacts_userinfo(monkeypatch, log_format):
+    import sys
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    password = "TRACEPW"  # kept off the raising line so the traceback source cannot echo it
+    try:
+        raise RuntimeError(runtime_basic_auth_url("u", password, "h") + "/")
+    except RuntimeError:
+        record = _record("request failed", name="app.core.clients.codex", exc_info=sys.exc_info())
+
+    output = _render(formatter, record)
+
+    assert "TRACEPW" not in output
+    assert "RuntimeError: http://[REDACTED]@h/" in output
+
+
+def test_redact_rendered_log_text_never_throws_and_fails_closed(monkeypatch, text_formatter, json_formatter):
+    class _Exploding:
+        def sub(self, *args, **kwargs):
+            raise RuntimeError("regex engine failure")
+
+    monkeypatch.setattr(runtime_logging, "_USERINFO_PATTERN", _Exploding())
+    line = _connection_key_line(runtime_basic_auth_url("u", "pw", _PROXY_AUTHORITY))
+    placeholder = runtime_logging._REDACTION_FAILED_PLACEHOLDER
+
+    assert runtime_logging.redact_rendered_log_text(line) == placeholder
+
+    text_output = _render(text_formatter, _record(line))
+    assert text_output.endswith(placeholder + "\n")
+    assert "pw" not in text_output
+    assert " ERROR asyncio " in text_output
+
+    json_output = json.loads(_render(json_formatter, _record(line)))
+    assert json_output["message"] == placeholder
+    assert json_output["level"] == "ERROR"
+    assert json_output["logger"] == "asyncio"
+    assert "pw" not in json.dumps(json_output)
+
+
+@pytest.mark.parametrize("level", [logging.INFO, logging.ERROR])
+def test_username_only_url_userinfo_is_redacted(text_formatter, json_formatter, level):
+    # Token-as-username URLs (``https://ghp_xxx@host``) carry the secret without a
+    # ``:password`` part; the userinfo pattern must not require the colon.
+    line = "proxy=URL('http://tok3n-as-user@proxy.test:8080') status=failed"
+    record = _record(line, level=level)
+
+    text_output = _render(text_formatter, record)
+    json_output = json.loads(_render(json_formatter, record))
+
+    assert "tok3n-as-user" not in text_output
+    assert "proxy=URL('http://[REDACTED]@proxy.test:8080') status=failed" in text_output
+    assert json_output["message"] == "proxy=URL('http://[REDACTED]@proxy.test:8080') status=failed"
+
+
+def test_credential_free_info_line_skips_regex_passes(monkeypatch, text_formatter):
+    calls: list[str] = []
+
+    class _Spy:
+        def sub(self, *args, **kwargs):
+            calls.append("userinfo")
+            raise AssertionError("precheck must short-circuit")
+
+    monkeypatch.setattr(runtime_logging, "_USERINFO_PATTERN", _Spy())
+    monkeypatch.setattr(runtime_logging, "_redact_secret_patterns", lambda text: calls.append("keyed") or text)
+    line = ("http_bridge_forward request_id=req_1 max_output_tokens=32768 route_mode=account_bound status=200 " * 6)[
+        :500
+    ]
+
+    output = _render(text_formatter, _record(line, level=logging.INFO, name="app.modules.proxy"))
+
+    assert line in output
+    assert calls == []
+
+
+def test_warning_records_apply_keyed_secret_patterns(text_formatter):
+    output = _render(text_formatter, _record("refresh failed password=SECRETPW code=401", level=logging.WARNING))
+
+    assert "SECRETPW" not in output
+    assert "password=[REDACTED] code=401" in output
+
+
+def test_warning_records_redact_python_repr_secret_keyed_mappings(text_formatter):
+    config = {
+        "password": "REPRPW",
+        "proxy_password": "it's",
+        "api_key": 123,
+        "secret": b"BYTESPW",
+        "access_token": ["LISTPW", "LISTPW2"],
+        "client_secret": None,
+        "attempt": 1,
+        "tokens": 7,
+    }
+
+    record = _record("config %r", level=logging.WARNING)
+    record.args = (config,)
+    output = _render(text_formatter, record)
+
+    for leaked in ("REPRPW", "it's", "BYTESPW", "LISTPW"):
+        assert leaked not in output
+    assert "'password': '[REDACTED]'" in output
+    assert "'proxy_password': \"[REDACTED]\"" in output
+    assert "'api_key': [REDACTED]" in output
+    assert "'secret': [REDACTED]" in output
+    assert "'access_token': [REDACTED]" in output
+    assert "'client_secret': [REDACTED]" in output
+    assert "'attempt': 1, 'tokens': 7" in output
+
+
+def test_info_records_keep_python_repr_secret_keyed_mappings(text_formatter):
+    # Keyed patterns are a WARNING+ policy; INFO renders the repr untouched.
+    record = _record("config %r", level=logging.INFO)
+    record.args = ({"password": "REPRPW"},)
+
+    output = _render(text_formatter, record)
+
+    assert "{'password': 'REPRPW'}" in output
+
+
+def test_authorization_midline_redaction_truncates_to_separator(text_formatter):
+    # Pins the existing pattern-2 behavior: the redaction consumes the rest of
+    # the line up to ',' or '&', so trailing fields on the same line are lost.
+    output = _render(text_formatter, _record("upstream rejected Authorization: Basic dXNlcjpwYXNz status=failed"))
+
+    assert "dXNlcjpwYXNz" not in output
+    assert output.endswith("upstream rejected Authorization: [REDACTED]\n")
+    assert "status=failed" not in output
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_bootstrap_token_output_is_byte_identical_through_redaction(monkeypatch, log_format):
+    from app.core.bootstrap import log_bootstrap_token
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("tests.bootstrap_token_redaction")
+    logger.propagate = False
+    logger.addHandler(handler := _Capture())
+    try:
+        log_bootstrap_token(logger, "bt_0123456789abcdefTOKENVALUE")
+    finally:
+        logger.removeHandler(handler)
+    (record,) = records
+
+    redacted_output = _render(formatter, record)
+    monkeypatch.setattr(runtime_logging, "redact_rendered_log_text", lambda text, **kwargs: text)
+    plain_output = _render(formatter, record)
+
+    assert "bt_0123456789abcdefTOKENVALUE" in redacted_output
+    if log_format == "json":
+        # JsonFormatter stamps datetime.now() per call; compare everything else.
+        redacted_entry, plain_entry = (json.loads(output) for output in (redacted_output, plain_output))
+        assert redacted_entry.pop("timestamp") and plain_entry.pop("timestamp")
+        assert redacted_entry == plain_entry
+    else:
+        assert redacted_output == plain_output
+
+
+def test_json_formatter_redacts_extras_and_nested_values(json_formatter):
+    record = _record("upstream failure", name="app.core.clients.codex")
+    record.proxy_url = runtime_basic_auth_url("u", "EXTRAPW", "proxy.test:1")
+    record.details = {"urls": [runtime_basic_auth_url("u", "NESTEDPW", "proxy.test:2")], "password": "PLAINPW"}
+
+    class _Unserializable:
+        def __repr__(self) -> str:
+            return "<Conn " + runtime_basic_auth_url("u", "REPRPW", "proxy.test:3") + ">"
+
+    record.connection = _Unserializable()
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["proxy_url"] == "http://[REDACTED]@proxy.test:1"
+    assert parsed["details"]["urls"] == ["http://[REDACTED]@proxy.test:2"]
+    assert parsed["details"]["password"] == "[REDACTED]"
+    assert parsed["connection"] == "<Conn http://[REDACTED]@proxy.test:3>"
+    for secret in ("EXTRAPW", "NESTEDPW", "REPRPW", "PLAINPW"):
+        assert secret not in json.dumps(parsed)
+
+
+@pytest.mark.parametrize("level", [logging.WARNING, logging.ERROR])
+def test_json_formatter_redacts_secret_keyed_extras_at_warning_and_above(json_formatter, level):
+    record = _record("proxy auth failed", level=level, name="app.core.clients.codex")
+    record.api_key = "TOPLEVELKEY"
+    record.details = {"access_token": "NESTEDTOKEN", "attempt": 2, "tokens": "not-a-secret"}
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["api_key"] == "[REDACTED]"
+    assert parsed["details"] == {"access_token": "[REDACTED]", "attempt": 2, "tokens": "not-a-secret"}
+
+
+def test_json_formatter_leaves_secret_keyed_extras_alone_below_warning(json_formatter):
+    # INFO extras keep the cheap value-only pass (same trade-off as text records).
+    record = _record("usage refreshed", level=logging.INFO, name="app.core.usage")
+    record.details = {"token_count": "12", "password": "info-level"}
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["details"] == {"token_count": "12", "password": "info-level"}
+
+
+def test_json_access_formatter_redacts_request_line():
+    record = _record("", level=logging.INFO, name="uvicorn.access")
+    record.client_addr = "10.0.0.5:1234"
+    record.request_line = "GET /probe?target=" + runtime_basic_auth_url("u", "ACCESSPW", "h") + " HTTP/1.1"
+    record.status_code = 200
+
+    parsed = json.loads(JsonAccessFormatter().format(record))
+
+    assert "ACCESSPW" not in parsed["request"]
+    assert parsed["request"] == "GET /probe?target=http://[REDACTED]@h HTTP/1.1"
+    assert parsed["client"] == "10.0.0.5:1234"
+
+
+def test_text_access_formatter_redacts_request_line():
+    formatter = UtcAccessFormatter(
+        fmt='%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+        use_colors=None,
+    )
+    record = _record('%s - "%s %s HTTP/%s" %d', level=logging.INFO, name="uvicorn.access")
+    record.args = ("10.0.0.5:1234", "GET", "/probe?target=" + runtime_basic_auth_url("u", "ACCESSPW", "h"), "1.1", 200)
+
+    output = formatter.format(record)
+
+    assert "ACCESSPW" not in output
+    assert "http://[REDACTED]@h" in output
+
+
+def test_redact_log_value_masks_url_userinfo():
+    value = "proxy " + runtime_basic_auth_url("user", "secret-pw", "proxy.test:8080") + "/path failed"
+
+    assert _redact_log_value(value) == "proxy http://[REDACTED]@proxy.test:8080/path failed"
+
+
+def test_redact_rendered_log_text_leaves_plain_email_addresses_alone():
+    line = "notify owner ops@example.com about https://status.example.com/incident"
+
+    assert runtime_logging.redact_rendered_log_text(line) == line
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "GET https://status.example?owner=ops@example.com done",
+        "see https://status.example#frag@x",
+        "https://host/path?owner=ops@example.com",
+    ],
+)
+def test_redact_rendered_log_text_leaves_host_only_urls_with_at_in_query_or_fragment_alone(line):
+    # RFC 3986 userinfo cannot contain ``?`` or ``#``; a bare host followed by
+    # a query/fragment holding an e-mail address is not a credential.
+    assert runtime_logging.redact_rendered_log_text(line) == line
+
+
+def test_redact_rendered_log_text_still_masks_userinfo_before_query():
+    line = "probe " + runtime_basic_auth_url("u", "QUERYPW", "h") + "?next=ops@example.com"
+
+    assert runtime_logging.redact_rendered_log_text(line) == "probe http://[REDACTED]@h?next=ops@example.com"
+
+
+def _client_http_proxy_error(password: str, loop=None):
+    # Exact aiohttp shape for a rejected CONNECT: the tunnel request's headers
+    # (our Proxy-Authorization) ride in request_info and are rendered by
+    # repr(exc); str(exc) and tracebacks stay credential-free.
+    import asyncio
+
+    import aiohttp
+    from aiohttp.client_reqrep import ClientRequest
+    from yarl import URL
+
+    from app.core.upstream_proxy import ResolvedProxyEndpoint
+
+    endpoint = ResolvedProxyEndpoint("ep", "https", "proxy.test", 8080, "smart-user", password)
+    proxy_headers = endpoint.aiohttp_proxy_kwargs()["proxy_headers"]
+    owned_loop = loop is None
+    loop = loop or asyncio.new_event_loop()
+    try:
+        request = ClientRequest("CONNECT", URL("https://chatgpt.com/"), headers=proxy_headers, loop=loop)
+    finally:
+        if owned_loop:
+            loop.close()
+    return aiohttp.ClientHttpProxyError(request.request_info, (), status=502, message="nope")
+
+
+def _basic_token(username: str, password: str) -> str:
+    import base64
+
+    return base64.b64encode(f"{username}:{password}".encode()).decode()
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+@pytest.mark.parametrize("level", [logging.INFO, logging.ERROR])
+def test_rendered_client_http_proxy_error_repr_redacts_basic_token(monkeypatch, log_format, level):
+    exc = _client_http_proxy_error("SECRETPW")
+    token = _basic_token("smart-user", "SECRETPW")
+    assert token in repr(exc)
+    assert token not in str(exc)
+    record = logging.LogRecord("aiohttp.client", level, "connector.py", 1, "proxy failure: %r", (exc,), None)
+
+    output = _render(_formatter_from_config(monkeypatch, log_format), record)
+
+    assert token not in output
+    assert "SECRETPW" not in output
+    assert "'Proxy-Authorization': 'Basic [REDACTED]'" in output
+    assert "real_url=URL('https://chatgpt.com/')" in output
+
+
+def test_redact_log_value_masks_basic_token_in_proxy_error_repr():
+    exc = _client_http_proxy_error("SECRETPW")
+
+    redacted = _redact_log_value(repr(exc))
+
+    assert redacted is not None
+    assert _basic_token("smart-user", "SECRETPW") not in redacted
+    assert "'Basic [REDACTED]'" in redacted
+
+
+@pytest.mark.parametrize("scheme", ["Basic", "basic", "BASIC"])
+def test_basic_token_redaction_without_keyed_secrets_covers_common_scheme_spellings(scheme):
+    token = _basic_token("user", "pass")
+    text = f"headers ('Proxy-Authorization': '{scheme} {token}')"
+
+    # INFO-level records (keyed_secrets=False) still mask the canonical,
+    # lowercase and uppercase scheme spellings via the substring prechecks.
+    assert runtime_logging.redact_rendered_log_text(text, keyed_secrets=False) == (
+        f"headers ('Proxy-Authorization': '{scheme} [REDACTED]')"
+    )
+    assert token not in runtime_logging.redact_rendered_log_text(text)
+
+
+def test_basic_token_redaction_without_keyed_secrets_skips_mixed_case_scheme():
+    token = _basic_token("user", "pass")
+    mixed = f"headers ('Proxy-Authorization': 'BaSiC {token}')"
+
+    # Deliberate hot-path trade-off: INFO-level records only pay for the three
+    # substring prechecks, so exotic mixed-case spellings are left to the
+    # WARNING-and-higher keyed pass (which runs the case-insensitive regex).
+    assert runtime_logging.redact_rendered_log_text(mixed, keyed_secrets=False) == mixed
+    assert runtime_logging.redact_rendered_log_text(mixed) == "headers ('Proxy-Authorization': 'BaSiC [REDACTED]')"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(["PW1", "PW2"], id="list"),
+        pytest.param(123456, id="int"),
+        pytest.param(b"PWBYTES", id="bytes"),
+        pytest.param({"nested": "PWNESTED"}, id="dict"),
+    ],
+)
+def test_json_formatter_redacts_non_string_values_under_secret_keys(json_formatter, value):
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.password = value
+    record.details = {"token": value, "attempt": 3}
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["password"] == "[REDACTED]"
+    assert parsed["details"] == {"token": "[REDACTED]", "attempt": 3}
+    assert "PW" not in json.dumps(parsed).replace("[REDACTED]", "")
+
+
+def test_json_formatter_keeps_null_under_secret_keys(json_formatter):
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.password = None
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["password"] is None
+
+
+def test_json_formatter_redacts_userinfo_in_extra_keys(json_formatter):
+    # Keys are rendered too; the cheap userinfo pass applies at every level.
+    record = _record("proxy failure", level=logging.INFO, name="app.core.clients.codex")
+    record.details = {runtime_basic_auth_url("u", "PWKEY", "proxy.test:1"): "failed"}
+    record.__dict__[runtime_basic_auth_url("u", "PWTOP", "proxy.test:2")] = "failed"
+
+    parsed = json.loads(json_formatter.format(record))
+
+    assert parsed["details"] == {"http://[REDACTED]@proxy.test:1": "failed"}
+    assert parsed["http://[REDACTED]@proxy.test:2"] == "failed"
+    assert "PWKEY" not in json.dumps(parsed)
+    assert "PWTOP" not in json.dumps(parsed)
+
+
+# --- never-raise: cyclic, deep and unprintable structured extras -------------
+
+
+class _ExplodingRepr:
+    def __repr__(self) -> str:
+        raise RuntimeError("repr failure")
+
+
+def test_json_formatter_emits_record_with_self_referential_dict_extra(json_formatter):
+    # Regression: the key-aware rebuild recursed on cycles and raised
+    # RecursionError ahead of the json.dumps guard, so the record was dropped.
+    details: dict[str, object] = {"password": "CYCLEPW", "proxy_url": runtime_basic_auth_url("u", "CYCLEURLPW", "h")}
+    details["self"] = details
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.details = details
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    parsed = json.loads(output)
+    assert parsed["message"] == "proxy auth failed"
+    assert parsed["details"] == {"password": "[REDACTED]", "proxy_url": "http://[REDACTED]@h", "self": "{...}"}
+    assert "CYCLEPW" not in output
+    assert "CYCLEURLPW" not in output
+
+
+def test_json_formatter_emits_record_with_list_cycle_extra(json_formatter):
+    urls: list[object] = [runtime_basic_auth_url("u", "LISTPW", "proxy.test:2")]
+    urls.append(urls)
+    record = _record("proxy failure", level=logging.INFO, name="app.core.clients.codex")
+    record.details = {"urls": urls, "attempt": 1}
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    parsed = json.loads(output)
+    assert parsed["details"] == {"urls": ["http://[REDACTED]@proxy.test:2", "[...]"], "attempt": 1}
+    assert "LISTPW" not in output
+
+
+def test_json_formatter_renders_over_deep_extras_as_redacted_text(json_formatter):
+    leaf: object = runtime_basic_auth_url("u", "DEEPPW", "h")
+    for _ in range(200):
+        leaf = [leaf]
+    record = _record("proxy failure", level=logging.INFO, name="app.core.clients.codex")
+    record.details = leaf
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    parsed = json.loads(output)
+    assert "DEEPPW" not in output
+    assert "http://[REDACTED]@h" in json.dumps(parsed["details"])
+
+
+def test_json_formatter_redacts_secret_keyed_leaf_below_depth_limit(json_formatter):
+    # Beyond ``_MAX_JSON_LOG_DEPTH`` the subtree is rendered as Python repr
+    # text; a secret-keyed mapping there must still be masked at WARNING+.
+    leaf: object = {"password": "DEEPKEYEDPW", "u": runtime_basic_auth_url("u", "DEEPURLPW", "h")}
+    for _ in range(runtime_logging._MAX_JSON_LOG_DEPTH + 8):
+        leaf = {"n": leaf}
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.details = leaf
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    assert json.loads(output)["message"] == "proxy auth failed"
+    assert "DEEPKEYEDPW" not in output
+    assert "DEEPURLPW" not in output
+    assert "'password': '[REDACTED]'" in output
+    assert "http://[REDACTED]@h" in output
+
+
+def test_json_formatter_emits_record_when_extra_repr_explodes(json_formatter):
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.details = {"password": "EXPLODEPW", "connection": _ExplodingRepr()}
+    record.connection = _ExplodingRepr()
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    parsed = json.loads(output)
+    assert parsed["message"] == "proxy auth failed"
+    assert parsed["details"] == "<unprintable dict>"
+    assert parsed["connection"] == "<unprintable _ExplodingRepr>"
+    assert "EXPLODEPW" not in output
+
+
+def test_json_formatter_emits_record_when_extra_iteration_explodes(json_formatter):
+    class _ExplodingItems(dict):
+        def items(self):
+            raise RuntimeError("iteration failure")
+
+    record = _record("proxy auth failed", level=logging.WARNING, name="app.core.clients.codex")
+    record.details = _ExplodingItems(attempt=1, password="ITEMSPW")
+
+    output = _render(json_formatter, record)
+
+    assert output, "the record must be emitted"
+    parsed = json.loads(output)
+    assert parsed["message"] == "proxy auth failed"
+    # dict.__repr__ bypasses the exploding items(); the text fallback masks the key.
+    assert "ITEMSPW" not in output
+    assert parsed["details"] == "{'attempt': 1, 'password': '[REDACTED]'}"
+
+
+def _fuzz_extra(rng, depth: int, containers: list[object]) -> object:
+    kind = rng.randrange(12)
+    if depth <= 0 or kind < 4:
+        return rng.choice(
+            [
+                "plain",
+                runtime_basic_auth_url("u", "FUZZPW", "h"),
+                b"FUZZBYTES",
+                42,
+                1.5,
+                None,
+                True,
+                _ExplodingRepr(),
+                "password=FUZZKEYED",
+            ]
+        )
+    if kind < 6 and containers:
+        return rng.choice(containers)  # back-reference: cycle or shared subtree
+    size = rng.randrange(4)
+    if kind < 8:
+        built: object = tuple(_fuzz_extra(rng, depth - 1, containers) for _ in range(size))
+    elif kind < 10:
+        items = [_fuzz_extra(rng, depth - 1, containers) for _ in range(size)]
+        built = items
+        containers.append(items)
+        if rng.random() < 0.3:
+            items.append(items)
+    else:
+        keys = ["password", "token", "attempt", "proxy_url", 7, runtime_basic_auth_url("u", "FUZZKEYPW", "h")]
+        mapping = {rng.choice(keys): _fuzz_extra(rng, depth - 1, containers) for _ in range(size)}
+        built = mapping
+        containers.append(mapping)
+        if rng.random() < 0.3:
+            mapping["self"] = mapping
+    return built
+
+
+@pytest.mark.parametrize("level", [logging.INFO, logging.ERROR])
+def test_json_formatter_never_raises_on_random_nested_extras(json_formatter, level):
+    import random
+
+    for seed in range(150):
+        rng = random.Random(seed)
+        record = _record("fuzz %s", level=level, name="app.core.clients.codex")
+        record.args = (seed,)
+        record.details = _fuzz_extra(rng, depth=5, containers=[])
+        record.leaf = _fuzz_extra(rng, depth=1, containers=[])
+
+        output = _render(json_formatter, record)
+
+        assert output, f"seed {seed}: the record must be emitted"
+        parsed = json.loads(output)
+        assert parsed["message"] == f"fuzz {seed}"
+        assert "details" in parsed and "leaf" in parsed

--- a/tests/unit/test_upstream_proxy_resolver.py
+++ b/tests/unit/test_upstream_proxy_resolver.py
@@ -146,6 +146,26 @@ def test_resolver_rejects_credentials_on_plaintext_proxy(scheme: str) -> None:
     assert exc_info.value.reason == "plaintext_proxy_credentials_forbidden"
 
 
+def test_resolver_rejects_colon_in_proxy_username() -> None:
+    # RFC 7617 Basic credentials cannot carry a colon in the user-id; aiohttp's
+    # encode_basic_auth raises, so fail closed at resolution instead.
+    encryptor = _encryptor()
+    endpoint = ProxyEndpoint(
+        id="colon",
+        name="colon",
+        scheme="https",
+        host="proxy.test",
+        port=8080,
+        username="user:name",
+        password_encrypted=encryptor.encrypt("secret"),
+    )
+
+    with pytest.raises(UpstreamProxyRouteError) as exc_info:
+        resolve_proxy_endpoint(endpoint, encryptor=encryptor)
+
+    assert exc_info.value.reason == "invalid_proxy_username"
+
+
 @pytest.mark.asyncio
 async def test_strict_default_pool_fails_closed_when_unconfigured(
     session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/test_upstream_proxy_types.py
+++ b/tests/unit/test_upstream_proxy_types.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from urllib.parse import quote
+
+import aiohttp
+import pytest
+from aiohttp.client_reqrep import ClientRequest
+from yarl import URL
+
+from app.core.upstream_proxy import ResolvedProxyEndpoint
+
+pytestmark = pytest.mark.unit
+
+# Synthetic fixture userinfo (not a credential). latin1 non-ASCII so the header
+# encoding is pinned against aiohttp's own userinfo path (BasicAuth.from_url
+# decodes userinfo as latin1; utf-8 differs).
+_FIXTURE_USER = "smart-user"
+_FIXTURE_PW = "p\u00e4ss-fixture-not-real"
+
+
+def _credentialed_endpoint(host: str = "proxy.test", port: int = 8080) -> ResolvedProxyEndpoint:
+    return ResolvedProxyEndpoint("ep_1", "https", host, port, _FIXTURE_USER, _FIXTURE_PW)
+
+
+def test_aiohttp_proxy_kwargs_without_credentials_only_sets_proxy() -> None:
+    endpoint = ResolvedProxyEndpoint("ep_1", "https", "proxy.test", 8080)
+
+    assert endpoint.aiohttp_proxy_kwargs() == {"proxy": "https://proxy.test:8080"}
+    assert endpoint.proxy_url_without_credentials == endpoint.proxy_url
+
+
+def test_aiohttp_proxy_kwargs_move_credentials_into_proxy_authorization() -> None:
+    kwargs = _credentialed_endpoint().aiohttp_proxy_kwargs()
+
+    assert kwargs["proxy"] == "https://proxy.test:8080"
+    assert "@" not in kwargs["proxy"]
+    header = kwargs["proxy_headers"]["Proxy-Authorization"]
+    # Byte-identical to the token aiohttp derives from ``https://u:p@`` userinfo
+    # (the ``BasicAuth.from_url`` path the ClientSession takes on every aiohttp
+    # release in the declared range; no 3.14-only helper involved).
+    assert header == "Basic " + base64.b64encode(f"{_FIXTURE_USER}:{_FIXTURE_PW}".encode("latin1")).decode("ascii")
+    aiohttp_userinfo_auth = aiohttp.BasicAuth.from_url(URL(f"https://{_FIXTURE_USER}:{_FIXTURE_PW}@proxy.test:8080"))
+    assert aiohttp_userinfo_auth is not None
+    assert header == aiohttp_userinfo_auth.encode()
+    assert header != "Basic " + base64.b64encode(f"{_FIXTURE_USER}:{_FIXTURE_PW}".encode("utf-8")).decode("ascii")
+
+
+@pytest.mark.parametrize("scheme", ["http", "socks5", "socks5h"])
+def test_aiohttp_proxy_kwargs_reject_plaintext_credentials(scheme: str) -> None:
+    endpoint = ResolvedProxyEndpoint("ep_1", scheme, "proxy.test", 8080, "u", "p")
+
+    with pytest.raises(ValueError, match="plaintext proxy URLs are forbidden"):
+        endpoint.aiohttp_proxy_kwargs()
+
+
+def test_aiohttp_proxy_kwargs_reject_colon_in_username() -> None:
+    endpoint = ResolvedProxyEndpoint("ep_1", "https", "proxy.test", 8080, "user:name", "p")
+
+    with pytest.raises(ValueError):
+        endpoint.aiohttp_proxy_kwargs()
+
+
+def test_socks_kwargs_keep_credential_free_socks5h_url() -> None:
+    endpoint = ResolvedProxyEndpoint("ep_1", "socks5", "proxy.test", 1080)
+
+    assert endpoint.aiohttp_proxy_kwargs() == {"proxy": "socks5h://proxy.test:1080"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("password", [_FIXTURE_PW, quote(_FIXTURE_PW, safe="")], ids=["raw", "quoted"])
+async def test_connection_key_repr_is_credential_free(password: str) -> None:
+    endpoint = ResolvedProxyEndpoint("ep_1", "https", "proxy.test", 8080, _FIXTURE_USER, password)
+    kwargs = endpoint.aiohttp_proxy_kwargs()
+    request = ClientRequest(
+        "GET",
+        URL("https://chatgpt.com/"),
+        loop=asyncio.get_running_loop(),
+        proxy=URL(kwargs["proxy"]),  # ClientSession performs this URL() wrap
+        proxy_headers=kwargs["proxy_headers"],
+    )
+
+    rendered = f"Connection<{request.connection_key!r}>"
+
+    assert password not in rendered
+    assert _FIXTURE_PW not in rendered
+    assert "proxy=URL('https://proxy.test:8080')" in rendered
+    assert "proxy_auth=None" in rendered
+    # Per-proxy pooling stays keyed through the header hash.
+    assert request.connection_key.proxy_headers_hash is not None
+
+
+class _FakeConnectProxy:
+    """Plaintext CONNECT proxy that records request heads and answers 502."""
+
+    def __init__(self) -> None:
+        self.heads: list[str] = []
+        self._server: asyncio.Server | None = None
+
+    async def __aenter__(self) -> "_FakeConnectProxy":
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        assert self._server is not None
+        self._server.close()
+        await self._server.wait_closed()
+
+    @property
+    def port(self) -> int:
+        assert self._server is not None
+        return self._server.sockets[0].getsockname()[1]
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        head = await reader.readuntil(b"\r\n\r\n")
+        self.heads.append(head.decode("latin1"))
+        writer.write(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        await writer.drain()
+        writer.close()
+
+
+def _proxy_authorization(head: str) -> str:
+    lines = [line for line in head.split("\r\n") if line.lower().startswith("proxy-authorization:")]
+    assert len(lines) == 1, head
+    return lines[0].split(":", 1)[1].strip()
+
+
+@pytest.mark.asyncio
+async def test_connect_header_is_byte_identical_and_proxy_error_is_credential_free() -> None:
+    async with _FakeConnectProxy() as proxy:
+        port = proxy.port
+        endpoint = _credentialed_endpoint("127.0.0.1", port)
+        kwargs = endpoint.aiohttp_proxy_kwargs()
+        # The fake proxy speaks plaintext; only the CONNECT bytes matter here.
+        kwargs["proxy"] = kwargs["proxy"].replace("https://", "http://", 1)
+        baseline_proxy = f"http://{quote(_FIXTURE_USER, safe='')}:{quote(_FIXTURE_PW, safe='')}@127.0.0.1:{port}"
+
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(aiohttp.ClientHttpProxyError):
+                await session.get("https://chatgpt.com/", proxy=baseline_proxy)
+            with pytest.raises(aiohttp.ClientHttpProxyError) as exc_info:
+                await session.get("https://chatgpt.com/", **kwargs)
+
+    assert len(proxy.heads) == 2
+    assert all(head.startswith("CONNECT chatgpt.com:443 HTTP/1.1\r\n") for head in proxy.heads)
+    baseline_header, header = (_proxy_authorization(head) for head in proxy.heads)
+    assert header == baseline_header == kwargs["proxy_headers"]["Proxy-Authorization"]
+
+    message = str(exc_info.value)
+    assert _FIXTURE_PW not in message
+    assert quote(_FIXTURE_PW, safe="") not in message
+    assert header.removeprefix("Basic ") not in message
+    assert f"http://127.0.0.1:{port}" in message


### PR DESCRIPTION
## Summary

**Was stacked on #2053 (merged to `main` as 9c188de2c); now rebased onto `main` and retargeted.** The diff is the loop-handler layer only (12 files, +514/-14).

#2053 keeps proxy credentials out of aiohttp repr surfaces and redacts every rendered log record. Three defense-in-depth gaps remain around it: the asyncio/uvloop default loop exception handler renders context values with `repr()` (aiohttp `ConnectionKey` proxy URLs, `BasicAuth`, task exceptions) before any formatter runs, so a third-party or misconfigured handler would still see the secret; the dashboard accepts proxy usernames containing `:` that the resolver now rejects, turning the endpoint test route into an unhandled 500 for already-persisted rows; and the direct websocket path forwards `websockets.InvalidProxy` text (the full proxy URL, userinfo included) to API clients under the Responses policy.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Refs #2028 (same redaction family); depends on #2053.

## Change details

- **Redacting loop exception handler** (`app/core/runtime_logging.py`, `app/main.py`): `install_redacting_loop_exception_handler(loop)` is installed once at the top of `lifespan`. It copies the context, `repr()`s every value except `message`/`exception`/`source_traceback`/`handle_traceback`, and only when `redact_rendered_log_text` changes that repr replaces the value with a `_RedactedRepr` stand-in carrying the redacted string, then delegates to the previously installed (or default) handler. Idempotent via a marker attribute; fail-closed: a value whose `__repr__` raises is replaced by an opaque stand-in (so the message line survives instead of asyncio's generic "Unhandled error in exception handler"), and any other failure delegates a context whose object values are all redaction-failed stand-ins, so the report is still emitted but no unredacted value ever reaches the delegate. Secret-free contexts render byte-identically under asyncio and uvloop.
- **Dashboard proxy username validation** (`app/modules/settings/api.py`): endpoint creation rejects usernames containing `:` with `invalid_proxy_username` (mirrors the resolver rule from #2053), and the endpoint test route reports a resolver rejection as `ok=false` with the reason instead of an unhandled 500.
- **Direct websocket `InvalidProxy`** (`app/core/clients/proxy_websocket.py`): the fixed message `Invalid upstream websocket proxy configuration` is returned under every policy (Responses included, previously `str(exc)` with the full proxy URL); only the URL-free websockets reason (`exc.msg`) is logged.

## Byte-compat / behavior notes

- The loop handler runs only on exception-handler invocations (the prod `Unclosed connection` rate is 44 to 1350/h), never on the request hot path. Default asyncio and uvloop output for 8 secret-free context shapes (exception, future/handle, source/handle traceback, empty) was verified byte-identical; a pre-existing handler is chained, not replaced.
- Loop-handler redaction covers object reprs only; the `exception` traceback text is still rendered by the default handler and relies on the formatter backstop from #2053 (the two layers are independent and both verified against the real aiohttp `Connection.__del__` path under uvloop).
- `InvalidProxy` is a fail-closed misconfiguration path (unsupported scheme, missing host, path/query in the proxy URL, username without password), so the message change only affects already-failing requests. Not the source of the observed prod leak (the prod-shaped URL parses fine in websockets 17), hence low-priority hardening.
- No wire, payload or pooling change.

## Expected effect

- Object-repr surfaces of the loop exception handler (`ConnectionKey.proxy` URL including yarl's unencoded `'` sub-delim, `BasicAuth(login=..., password=...)`, `Task ... exception=RuntimeError('...://u:pw@h')`) are masked before the log record exists, giving a second independent layer for the confirmed leak shape.
- Operators get a `400 invalid_proxy_username` at creation and a readable failed probe on the test route instead of a 500.
- Proxy credentials can never enter a client-visible 502 body or `request_logs` error text on the direct websocket path.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/credential-safe-proxy-logging-loop-handler/`
- `proxy-runtime-observability` (ADDED): application startup MUST install a redacting asyncio loop exception handler whose secret-free output is byte-identical to the default handler.
- `upstream-proxy-routing` (ADDED): the dashboard MUST reject colon usernames at creation and the endpoint test route MUST report resolver rejections.
- `realtime-api-compat` (MODIFIED): the Responses websocket `InvalidProxy` message is the same fixed credential-safe message as the live sideband (the spec previously said this path "remains unchanged").
- `openspec validate credential-safe-proxy-logging-loop-handler --strict` valid; `openspec validate --specs` 57 passed / 1 failed (pre-existing `model-source-routing` failure on `main`, unrelated).

## Tests

```
./.venv/bin/python -m pytest tests/unit/test_runtime_logging_loop_handler.py tests/unit/test_structured_logging.py \
  tests/unit/test_proxy_websocket_client.py tests/integration/test_settings_api.py \
  tests/unit/test_codex_client.py tests/unit/test_upstream_proxy_resolver.py -q
# 255 passed
ruff check . && ruff format --check . && ty check && python scripts/check_proxy_architecture.py   # all clean
```

- `tests/unit/test_runtime_logging_loop_handler.py` (new, parametrized asyncio + uvloop): `Unclosed connection` context with a userinfo-bearing `ConnectionKey`-like repr is masked and the `message` line is unchanged; apostrophe-in-password variant (the yarl shape `_USERINFO_PATTERN` on pre-fix `main` did not match); `Task exception was never retrieved` repr redacted; secret-free contexts byte-identical to the default handler; idempotent install; pre-existing handler chained; object whose `__repr__` raises renders as an opaque stand-in with the message line intact; a raising redaction pass yields a record with textual entries intact and every object value replaced by the redaction-failed stand-in.
- `tests/integration/test_settings_api.py`: `:` username -> `400 invalid_proxy_username`; test route on a persisted colon-username row -> `ok=false` with the resolver reason (was 500).
- `tests/unit/test_proxy_websocket_client.py`: Responses policy `InvalidProxy` returns the fixed message and no credential appears in payload or logs (parity with the existing live-sideband test).
- `lifespan` wiring is exercised by the existing lifespan-driven suites (`test_graceful_server`, `test_telemetry_consent`, `test_otel`), which pass unchanged.

## Review trail

- These three pieces were part of the original single branch and went through the same local `codex review` x3 and adversarial x3 rounds as #2053 (round-1 P2 "dashboard test route returns 500 for persisted colon usernames" is what added the `settings/api.py` change here; adversarial round 3 verified the handler byte-identical under asyncio and uvloop, idempotent, chained, and surviving an exploding repr). CodeRabbit (after retarget to `main`) flagged the raw-context fallback as fail-open; the handler now fails closed (opaque stand-ins) and the spec/proposal were updated to match. They were carved out in `a5f13322` to keep #2053 at one concern; the carve-out rebased cleanly onto the final core head and gained one regression test for the apostrophe userinfo shape.
- Known P3 from mutation testing: removing the `lifespan` install call is not caught by a dedicated unit test (the handler itself is fully covered); accepted as a wiring pin gap.

## Deploy notes

- Merge #2053 first; then retarget this PR to `main` (the diff collapses to the 12 files listed in the stat).
- No settings, schema, migration, route, dependency or frontend changes. Rolling restart only.
- Overriding the loop handler also fronts uvicorn's own error reporting; since it delegates to the default handler, formatting is preserved for secret-free contexts.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / parent PR above.
- [x] Added or updated tests covering the change.
- [x] Ran ruff check/format, ty, proxy architecture check, targeted pytest locally.
- [x] `openspec validate --specs` passes except the pre-existing `model-source-routing` failure on `main`.
- [x] Simplicity gates reviewed: no new setting, default or README section.
- [x] CHANGELOG is not edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Privacy**
  - Strengthened protection against proxy credentials appearing in logs, errors, connection details, and structured records.
  - WebSocket proxy errors now show a safe client-facing message without exposing sensitive connection details.

- **Proxy Handling**
  - Credentialed proxy requests use secure authorization headers and reject unsupported plaintext routes.
  - Proxy usernames containing colons are rejected with a clear validation error.
  - Proxy test failures are reported cleanly instead of returning server errors.

- **Reliability**
  - Warnings and asynchronous exception details are routed through credential-redacting logging safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
