### PR TITLE
fix(usage): deactivate accounts only on explicit terminal signals, not bare 404/402

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -1351,10 +1351,9 @@ def _reset_at(reset_at: int | None, reset_after_seconds: int | None, now_epoch: 
     return now_epoch + max(0, int(reset_after_seconds))
 
 
-# The usage endpoint can return 403 for accounts that are still otherwise usable
-# for proxy traffic, so treat it as a refresh failure instead of a permanent
-# account-level deactivation signal.
-_DEACTIVATING_USAGE_STATUS_CODES = {402, 404}
+# Bare HTTP status codes from the usage endpoint are ambiguous and do not prove
+# that an account is permanently unavailable. Only explicit error content may
+# trigger an account-level status change.
 _DEACTIVATING_USAGE_MESSAGE_HINTS = (
     "your openai account has been deactivated",
     "account has been deactivated",
@@ -1362,8 +1361,6 @@ _DEACTIVATING_USAGE_MESSAGE_HINTS = (
 
 
 def _should_deactivate_for_usage_error(exc: UsageFetchError) -> bool:
-    if exc.status_code in _DEACTIVATING_USAGE_STATUS_CODES:
-        return True
     if exc.code in PERMANENT_FAILURE_CODES:
         return True
     lowered = exc.message.lower()

--- a/openspec/changes/usage-refresh-explicit-deactivation-only/.openspec.yaml
+++ b/openspec/changes/usage-refresh-explicit-deactivation-only/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/usage-refresh-explicit-deactivation-only/design.md
+++ b/openspec/changes/usage-refresh-explicit-deactivation-only/design.md
@@ -1,0 +1,44 @@
+## Context
+
+See [proposal.md](proposal.md) for the incident and motivation. Usage refresh currently classifies HTTP 402 and 404 as terminal before its ordinary non-deactivating error path. Both the initial fetch and the post-refresh retry call the same classifier, so the correction must live in that shared classifier.
+
+The usage client preserves an upstream envelope's nested `error.code` and `error.message`. Repository tests contain a concrete `account_deactivated` envelope with the message `Your OpenAI account has been deactivated.` and the balancer's existing permanent-failure registry defines the status mapping for credential/session and disabled-account codes. Searches of application code, tests, active specs, and published docs found no concrete usage-response envelope for account/subscription not-found, unpaid, or payment-required terminal states.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make persistent account-status changes depend only on explicit error content.
+- Preserve the existing permanent-code status mapping and explicit deactivation-message fallback.
+- Send ambiguous failures through the existing non-deactivating refresh-failure path on both fetch attempts.
+
+**Non-Goals:**
+
+- Automatically reactivate accounts already deactivated by prior failures.
+- Add fleet-wide outage correlation or new settings.
+- Change proxy request-path handling of upstream 404 responses.
+- Infer new terminal codes or messages without recorded upstream evidence.
+
+## Decisions
+
+### Remove HTTP status from the terminal classifier
+
+The shared usage-error classifier will inspect only recognized permanent-failure codes and existing explicit deactivation-message hints. The status-code allowlist will be removed. This automatically applies the same rule to the initial attempt and post-auth-refresh retry and reuses the existing non-deactivating path used by 403, including current logging/error accounting and retry eligibility.
+
+Alternative considered: retain 402 or 404 behind message/body checks tailored to account-not-found or payment-required responses. This was rejected because the repository has no concrete upstream envelope showing those conditions are account-specific and terminal.
+
+### Keep status mapping centralized
+
+Recognized codes continue through the balancer's existing permanent-failure registry and account-status mapper. Explicit deactivation-message hints continue to select `deactivated` when no recognized code exists. No second code registry or response-shape parser will be introduced in the updater.
+
+Alternative considered: duplicate specific terminal codes in the updater. This was rejected because it would create a second source of truth and could drift from proxy/auth failure handling.
+
+## Risks / Trade-offs
+
+- [A truly terminal upstream response exposes only a bare status] → The account remains eligible and refresh retries continue; this is intentionally safer than permanently removing healthy capacity on an ambiguous signal.
+- [Upstream introduces a new explicit terminal envelope] → Add support only after capturing concrete evidence and updating the policy and regression tests.
+- [Existing deactivated rows remain unavailable] → Operators must reactivate them through the existing endpoint; automatic repair is explicitly outside this change.
+
+## Migration Plan
+
+Deploy as a code-only policy correction with no data migration. Rollback restores the prior classifier but would reintroduce outage-driven fleet deactivation; already persisted statuses are unchanged in either direction.

--- a/openspec/changes/usage-refresh-explicit-deactivation-only/proposal.md
+++ b/openspec/changes/usage-refresh-explicit-deactivation-only/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+An upstream ChatGPT outage returned bare HTTP 404 responses from the usage endpoint, causing background refresh to deactivate every active account and preventing automatic recovery after the outage ended. Usage refresh must reserve persistent account removal for explicit, account-specific terminal signals rather than infer it from an ambiguous HTTP status.
+
+## What Changes
+
+- Require usage refresh to preserve account status for bare HTTP errors, including 402 and 404, while retaining normal refresh-failure logging, metrics, and retry behavior.
+- Continue mapping recognized permanent-failure codes through the existing permanent-failure account-status policy.
+- Continue deactivating accounts when the upstream error message explicitly says the account is deactivated.
+- Add regression coverage for ambiguous statuses and both explicit terminal-signal paths.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Restrict usage-refresh account deactivation and reauthentication transitions to explicit permanent-failure codes or explicit deactivation messages.
+
+## Impact
+
+The change affects the background usage updater and its unit tests. It changes no API, database schema, proxy request-path behavior, dashboard surface, settings, or automatic recovery policy for accounts that are already deactivated.

--- a/openspec/changes/usage-refresh-explicit-deactivation-only/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/usage-refresh-explicit-deactivation-only/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Usage refresh deactivates on clear deactivation signals
+
+The system MUST change an account to `deactivated` or `reauth_required` during
+usage refresh only when the upstream error contains an explicit,
+account-specific terminal signal. A recognized permanent-failure error code
+MUST be mapped through the existing permanent-failure account-status policy,
+and an error message that explicitly says the account is deactivated MUST mark
+the account `deactivated`. A bare HTTP status, including `402` or `404`, MUST
+NOT change account status or routing availability and MUST remain a refresh
+failure for existing logging, error accounting, and later refresh retries.
+
+#### Scenario: Bare usage 404 preserves account status
+
+- **GIVEN** an account eligible for background usage refresh
+- **WHEN** the usage endpoint returns HTTP `404` without an explicit permanent-failure code or deactivation message
+- **THEN** the account's current status is unchanged
+- **AND** the account is not marked routing-unavailable
+- **AND** the response is recorded as a refresh failure and a later refresh cycle may retry it
+
+#### Scenario: Bare usage 402 preserves account status
+
+- **GIVEN** an account eligible for background usage refresh
+- **WHEN** the usage endpoint returns HTTP `402` without an explicit permanent-failure code or deactivation message
+- **THEN** the account's current status is unchanged
+- **AND** the account is not marked routing-unavailable
+- **AND** the response is recorded as a refresh failure and a later refresh cycle may retry it
+
+#### Scenario: Usage 401 app session terminated requires re-authentication
+
+- **WHEN** usage refresh receives HTTP `401`
+- **AND** the upstream error code is `app_session_terminated`
+- **THEN** the account is marked `reauth_required`
+- **AND** later usage refresh cycles skip that account until re-authentication
+
+#### Scenario: Explicit usage deactivation message deactivates account
+
+- **WHEN** usage refresh receives an error whose message says `your OpenAI account has been deactivated`
+- **AND** the error has no recognized permanent-failure code
+- **THEN** the account is marked `deactivated`
+- **AND** the account is marked routing-unavailable

--- a/openspec/changes/usage-refresh-explicit-deactivation-only/tasks.md
+++ b/openspec/changes/usage-refresh-explicit-deactivation-only/tasks.md
@@ -1,0 +1,26 @@
+## 1. Policy and Implementation
+
+- [x] 1.1 Validate the OpenSpec change and confirm the delta replaces the full owning requirement.
+- [x] 1.2 Remove HTTP-status-only deactivation from the shared usage-error classifier while preserving permanent-code and explicit-message handling.
+- [x] 1.3 Audit all scoped usage-404 references and document whether any concrete account-not-found or payment-required terminal envelope exists.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Invert the existing bare 402 behavior test and add bare 404 coverage for unchanged status, no persistence update, no routing-unavailable mark, and retained refresh-failure logging.
+- [x] 2.2 Preserve regression coverage for permanent-failure status mapping and explicit deactivation-message handling.
+- [x] 2.3 Cover the post-auth-refresh retry path with an ambiguous HTTP error.
+
+## 3. Documentation
+
+- [x] 3.1 Review published usage-refresh documentation and update it only if it currently describes failure/deactivation semantics.
+
+## 4. Verification
+
+- [x] 4.1 Run the focused usage-updater tests and the full unit suite.
+- [x] 4.2 Run lint and type-check gates, restoring `uv.lock` if the type checker mutates it.
+- [x] 4.3 Run strict change validation and main-spec validation, then verify implementation coherence against the change.
+
+## 5. Delivery
+
+- [x] 5.1 Write `/tmp/usage404-report.md` with the capability choice, diff stat, reference audit, evidence conclusion, gate outputs, and explicit non-goals.
+- [x] 5.2 Commit the verified change on the feature branch with a Conventional Commit message.

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import Collection
 from contextlib import asynccontextmanager
@@ -12,6 +13,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.core.auth.refresh import RefreshError
+from app.core.balancer import account_status_for_permanent_failure
+from app.core.clients import usage as usage_client_module
 from app.core.crypto import TokenEncryptor
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 from app.core.usage import refresh_scheduler as refresh_scheduler_module
@@ -3186,34 +3189,64 @@ class StubAccountsRepository:
         return (email, chatgpt_account_id, workspace_id) in self.taken_workspace_slots
 
 
+@pytest.mark.parametrize(
+    ("status_code", "error_payload", "expected_message"),
+    [
+        (402, {"message": "Payment Required"}, "Payment Required"),
+        (404, {}, "Usage fetch failed (404)"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_usage_updater_deactivates_on_account_invalid_4xx(monkeypatch) -> None:
+async def test_usage_updater_keeps_account_active_on_bare_402_or_404(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    status_code: int,
+    error_payload: dict[str, Any],
+    expected_message: str,
+) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
-    from app.core.clients.usage import UsageFetchError
     from app.core.config.settings import get_settings
 
     get_settings.cache_clear()
 
-    async def stub_fetch_usage_402(**_: Any) -> UsagePayload:
-        raise UsageFetchError(402, "Payment Required")
+    fetch_calls = 0
 
-    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_402)
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return usage_client_module._usage_payload_or_raise(error_payload, status_code)
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+    routing_unavailable_calls: list[str] = []
+    monkeypatch.setattr(
+        usage_updater_module,
+        "mark_account_routing_unavailable",
+        routing_unavailable_calls.append,
+    )
 
     usage_repo = StubUsageRepository()
     accounts_repo = StubAccountsRepository()
     updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
 
-    acc = _make_account("acc_402", "workspace_402", email="payment@example.com")
+    acc = _make_account(
+        f"acc_{status_code}",
+        f"workspace_{status_code}",
+        email=f"status-{status_code}@example.com",
+    )
     accounts_repo.accounts_by_id[acc.id] = acc
 
-    await updater.refresh_accounts([acc], latest_usage={})
+    with caplog.at_level(logging.WARNING, logger="app.core.clients.usage"):
+        refresh_results = [
+            await updater.refresh_accounts([acc], latest_usage={}),
+            await updater.refresh_accounts([acc], latest_usage={}),
+        ]
 
-    assert len(accounts_repo.status_updates) == 1
-    update = accounts_repo.status_updates[0]
-    assert update["account_id"] == "acc_402"
-    assert update["status"] == AccountStatus.DEACTIVATED
-    assert "402" in update["deactivation_reason"]
-    assert "Payment Required" in update["deactivation_reason"]
+    assert refresh_results == [False, False]
+    assert fetch_calls == 2
+    assert acc.status == AccountStatus.ACTIVE
+    assert accounts_repo.status_updates == []
+    assert routing_unavailable_calls == []
+    assert expected_message in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3336,7 +3369,7 @@ async def test_usage_updater_marks_session_failures_as_reauth_required(
     assert len(accounts_repo.status_updates) == 1
     update = accounts_repo.status_updates[0]
     assert update["account_id"] == f"acc_401_{error_code}"
-    assert update["status"] == AccountStatus.REAUTH_REQUIRED
+    assert update["status"] == account_status_for_permanent_failure(error_code)
     assert "401" in update["deactivation_reason"]
     assert message_hint in update["deactivation_reason"]
     assert acc.status == AccountStatus.REAUTH_REQUIRED
@@ -3390,6 +3423,12 @@ async def test_usage_updater_deactivates_on_401_deactivated_message_without_code
         )
 
     monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_401_deactivated_message)
+    routing_unavailable_calls: list[str] = []
+    monkeypatch.setattr(
+        usage_updater_module,
+        "mark_account_routing_unavailable",
+        routing_unavailable_calls.append,
+    )
 
     usage_repo = StubUsageRepository()
     accounts_repo = StubAccountsRepository()
@@ -3402,6 +3441,56 @@ async def test_usage_updater_deactivates_on_401_deactivated_message_without_code
 
     assert len(accounts_repo.status_updates) == 1
     assert accounts_repo.status_updates[0]["status"] == AccountStatus.DEACTIVATED
+    assert routing_unavailable_calls == [acc.id]
+
+
+@pytest.mark.asyncio
+async def test_usage_updater_retry_keeps_account_active_on_bare_404(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        if fetch_calls == 1:
+            raise UsageFetchError(401, "Unauthorized")
+        return usage_client_module._usage_payload_or_raise({}, 404)
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+    routing_unavailable_calls: list[str] = []
+    monkeypatch.setattr(
+        usage_updater_module,
+        "mark_account_routing_unavailable",
+        routing_unavailable_calls.append,
+    )
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    assert updater._auth_manager is not None
+
+    acc = _make_account("acc_retry_404", "workspace_retry_404", email="retry-404@example.com")
+    accounts_repo.accounts_by_id[acc.id] = acc
+    ensure_fresh = AsyncMock(return_value=acc)
+    monkeypatch.setattr(updater._auth_manager, "ensure_fresh", ensure_fresh)
+
+    with caplog.at_level(logging.WARNING, logger="app.core.clients.usage"):
+        refreshed = await updater.refresh_accounts([acc], latest_usage={})
+
+    assert refreshed is False
+    assert fetch_calls == 2
+    ensure_fresh.assert_awaited_once_with(acc, force=True)
+    assert acc.status == AccountStatus.ACTIVE
+    assert accounts_repo.status_updates == []
+    assert routing_unavailable_calls == []
+    assert "Usage fetch failed (404)" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Background usage refresh (`app/modules/usage/updater.py`) treated a bare HTTP `402`/`404` from `/backend-api/wham/usage` as proof that the account no longer exists and moved it to `deactivated` (`_DEACTIVATING_USAGE_STATUS_CODES = {402, 404}`). A bare status code is not an account-specific signal, and during an upstream outage it is fleet-wide.

This PR removes the status-code branch. An account now changes status during usage refresh **only** on an explicit terminal signal:

- an error `code` in `PERMANENT_FAILURE_CODES` (mapped through `account_status_for_permanent_failure`, unchanged), or
- an error message that explicitly says the account is deactivated (`_DEACTIVATING_USAGE_MESSAGE_HINTS`, unchanged).

Everything else, including bare `402`/`404`, is now a plain refresh failure: logged, counted, status and routing availability untouched, retried on the next cycle (the same path `403` already took).

## Incident

2026-09-03 14:43–15:23 UTC: OpenAI returned HTTP 404 for every `chatgpt.com/backend-api/*` path for ~40 minutes (status.openai.com "Elevated errors across ChatGPT and Codex"). The 60s refresh loop deactivated all 17 active accounts within 3 minutes (`deactivation_reason = "Usage API error: HTTP 404 - Usage fetch failed (404)"`), the proxy entered `no_accounts` 503 degraded mode, and because `refresh_accounts()` skips `DEACTIVATED` accounts nothing recovered when upstream came back; every account had to be reactivated by hand. Two further accounts had been deactivated with the same reason on 09-01 and 09-02 and were healthy once reactivated.

## Changes

- `app/modules/usage/updater.py`: drop `_DEACTIVATING_USAGE_STATUS_CODES` and the status-only branch in `_should_deactivate_for_usage_error`. First-attempt and post-auth-refresh retry both go through the same classifier, so both reflect the new rule.
- `tests/unit/test_usage_updater.py`: invert the previous bare-402 ⇒ deactivated expectation and parameterize it with bare-404; assert status unchanged, no status write, no routing-unavailable mark, failure logged, later cycle retries; add a post-auth-refresh-retry 404 case; keep permanent-code mapping and explicit-message coverage.
- `openspec/changes/usage-refresh-explicit-deactivation-only/`: proposal, design, tasks, and a MODIFIED delta for `usage-refresh-policy` › "Usage refresh deactivates on clear deactivation signals" (whole requirement replaced; the existing `401 app_session_terminated` scenario is preserved; bare-404, bare-402, and explicit-message scenarios added).

No repo evidence exists for an upstream usage error envelope that explicitly means "account does not exist" or "payment required", so no new codes or message heuristics were introduced. `tests/fixtures/upstream_usage_with_additional.json` records a bare 404 while the account was otherwise fine, which supports treating 404 as ambiguous.

## Non-goals

- No auto-reactivation of accounts already deactivated by the old rule (operators use `POST /api/accounts/{id}/reactivate`).
- No fleet-wide outage detection or correlation heuristics.
- No change to how the proxy request path handles upstream 404 on `/v1/*`.

## Simplicity gates

No new `CODEX_LB_*` settings, no README/`.env.example`/dashboard changes. Behavior change is zero-config and narrows an existing rule.

## Verification

- `uv run pytest tests/unit/test_usage_updater.py -q` → 122 passed
- `uv run pytest tests/unit -q` → 7383 passed, 3 skipped
- `make lint` → passed; `uv run ty check` → passed (`uv.lock` unchanged)
- `openspec validate usage-refresh-explicit-deactivation-only --strict` → valid
- `openspec validate --specs` → 57 passed, 1 failed (`model-source-routing`, pre-existing on `origin/main` 575c20876, unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts are no longer deactivated solely because usage refresh returns HTTP 402 or 404 errors.
  * Ambiguous usage-refresh failures now preserve account status, routing availability, logging, and retry behavior.
  * Explicit permanent-failure codes and deactivation messages continue to trigger the appropriate account-status changes.
* **Tests**
  * Added coverage for ambiguous 402/404 responses and retry scenarios.
  * Preserved coverage for explicit reauthentication and deactivation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->