### PR TITLE
fix(accounts): keep ambiguous usage 404s retryable

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -1351,10 +1351,11 @@ def _reset_at(reset_at: int | None, reset_after_seconds: int | None, now_epoch: 
     return now_epoch + max(0, int(reset_after_seconds))
 
 
-# The usage endpoint can return 403 for accounts that are still otherwise usable
-# for proxy traffic, so treat it as a refresh failure instead of a permanent
-# account-level deactivation signal.
-_DEACTIVATING_USAGE_STATUS_CODES = {402, 404}
+# The usage endpoint can return 403 or 404 for accounts that are still otherwise
+# usable for proxy traffic, so treat those bare statuses as refresh failures
+# instead of permanent account-level deactivation signals. Explicit permanent
+# error codes and deactivation messages are still handled below.
+_DEACTIVATING_USAGE_STATUS_CODES = {402}
 _DEACTIVATING_USAGE_MESSAGE_HINTS = (
     "your openai account has been deactivated",
     "account has been deactivated",
@@ -1381,7 +1382,7 @@ async def _resolve_upstream_route_for_account(account: Account, *, operation: st
 
 
 def _mark_usage_refresh_auth_cooldown(account_id: str, status_code: int) -> None:
-    if status_code not in {401, 403}:
+    if status_code not in {401, 403, 404}:
         return
     cooldown_seconds = max(0.0, float(get_settings().usage_refresh_auth_failure_cooldown_seconds))
     if cooldown_seconds <= 0:

--- a/openspec/changes/keep-ambiguous-usage-404-retryable/context.md
+++ b/openspec/changes/keep-ambiguous-usage-404-retryable/context.md
@@ -1,0 +1,31 @@
+# Ambiguous usage 404 handling
+
+## Purpose
+
+Usage refresh should remove an account from service only when upstream sends
+account-level evidence that the account is permanently unavailable. A status
+code that can also describe the usage route itself is not enough evidence for
+a terminal account transition.
+
+## Decision
+
+A bare usage `404` follows the same temporary cooldown path as ambiguous usage
+authentication failures. The existing permanent-code and message classifiers
+still run first, so `account_deactivated`, `account_suspended`,
+`account_deleted`, or an explicit account-deactivation message remains a hard
+failure regardless of the HTTP status.
+
+This reuses the existing cooldown and setting rather than adding another
+operator control. The cooldown is process-local and deliberately temporary;
+after it expires, normal usage polling resumes and can observe quota reset or
+endpoint recovery.
+
+## Example
+
+An otherwise active account receives `HTTP 404` with no error code and the
+generic message `Usage fetch failed (404)`. codex-lb leaves the account active,
+waits for the configured usage-refresh failure cooldown, and tries the usage
+endpoint again. If a later response succeeds, normal snapshots and automatic
+quota recovery continue. If the response instead contains
+`code=account_deactivated`, codex-lb immediately transitions the account to
+`deactivated`.

--- a/openspec/changes/keep-ambiguous-usage-404-retryable/proposal.md
+++ b/openspec/changes/keep-ambiguous-usage-404-retryable/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+A bare `404` from the upstream usage endpoint is currently interpreted as
+proof that the account itself was permanently deactivated. That moves the
+account into the terminal `deactivated` state, removes it from routing, and
+stops later usage refreshes. If the `404` was endpoint-specific or transient,
+the account can no longer recover automatically after the endpoint or quota
+window recovers.
+
+The response status alone does not distinguish a missing usage route from a
+deleted account. Permanent upstream error codes and explicit deactivation
+messages already provide the stronger signal needed for a terminal transition.
+
+## What Changes
+
+- Treat a usage `404` without a known permanent code or explicit account
+  deactivation message as an ambiguous refresh failure.
+- Apply the existing usage-refresh cooldown to ambiguous `404` responses so
+  the scheduler does not hammer the upstream endpoint.
+- Preserve terminal handling for `402`, known permanent error codes, and
+  explicit account-deactivation messages, including when they arrive with a
+  `404` status.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: distinguish ambiguous usage-route `404` responses
+  from explicit permanent account failures.
+
+## Impact
+
+No new setting, dependency, schema change, API field, or dashboard change.
+Accounts remain eligible for routing after an ambiguous usage `404`, and the
+background scheduler retries them after the existing cooldown expires.

--- a/openspec/changes/keep-ambiguous-usage-404-retryable/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/keep-ambiguous-usage-404-retryable/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,56 @@
+# usage-refresh-policy Delta
+
+## MODIFIED Requirements
+
+### Requirement: Usage refresh cools down repeated auth-like failures
+
+Background usage refresh MUST apply a cooldown to accounts that fail usage
+refresh with ambiguous `401`, `403`, or `404` responses. Accounts in that
+cooldown window MUST be skipped until the cooldown expires or a later
+successful refresh clears it.
+
+#### Scenario: Zero-capacity monthly primary does not keep free accounts rate-limited
+
+- **GIVEN** a free-plan account whose persisted status is `rate_limited`
+- **AND** its latest primary usage row is a zero-capacity non-5h window (for
+  example a monthly upstream snapshot)
+- **AND** its normalized quota state reports available monthly quota
+- **WHEN** codex-lb derives account status for account summaries or proxy
+  runtime state
+- **THEN** the non-5h primary row is ignored for rate-limit recovery
+- **AND** the account is treated as `active`
+- **AND** downstream account views keep the monthly-only quota presentation
+
+#### Scenario: Ambiguous usage 404 enters cooldown without deactivation
+
+- **GIVEN** an active account
+- **WHEN** usage refresh receives HTTP `404`
+- **AND** the upstream response has no known permanent error code
+- **AND** the upstream message does not explicitly identify an account-level
+  deactivation
+- **THEN** the account remains active
+- **AND** subsequent refresh cycles skip the account until the cooldown expires
+- **AND** refresh resumes after the cooldown so later endpoint or quota recovery
+  can be observed
+
+### Requirement: Usage refresh deactivates on clear deactivation signals
+
+The system MUST deactivate accounts when usage refresh receives a permanent
+account deactivation signal. Credential or session invalidation codes MUST be
+marked `reauth_required` according to the existing permanent-failure mapping.
+A bare HTTP `404` without a known permanent error code or explicit account
+deactivation message MUST NOT be treated as a permanent account signal.
+
+#### Scenario: Usage 401 app session terminated requires re-authentication
+
+- **WHEN** usage refresh receives HTTP `401`
+- **AND** the upstream error code is `app_session_terminated`
+- **THEN** the account is marked `reauth_required`
+- **AND** later usage refresh cycles skip that account until re-authentication
+
+#### Scenario: Usage 404 with an explicit deactivation code deactivates the account
+
+- **WHEN** usage refresh receives HTTP `404`
+- **AND** the upstream error code is `account_deactivated`
+- **THEN** the account is marked `deactivated`
+- **AND** later usage refresh cycles skip that account

--- a/openspec/changes/keep-ambiguous-usage-404-retryable/tasks.md
+++ b/openspec/changes/keep-ambiguous-usage-404-retryable/tasks.md
@@ -1,0 +1,17 @@
+## 1. Usage refresh classification
+
+- [x] 1.1 Stop treating a bare usage HTTP `404` as a permanent account-level
+  deactivation signal.
+- [x] 1.2 Include ambiguous usage HTTP `404` failures in the existing refresh
+  cooldown.
+- [x] 1.3 Preserve deactivation for explicit permanent error codes and
+  deactivation messages carried by a `404` response.
+
+## 2. Verification
+
+- [x] 2.1 Add regression coverage proving a bare `404` leaves the account
+  active and suppresses repeated refresh attempts during the cooldown.
+- [x] 2.2 Add coverage proving an explicit `account_deactivated` code still
+  deactivates when returned with HTTP `404`.
+- [x] 2.3 Run targeted unit tests, Ruff, type checks, and strict validation for
+  the change and affected OpenSpec capability.

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -3342,22 +3342,23 @@ async def test_usage_updater_marks_session_failures_as_reauth_required(
     assert acc.status == AccountStatus.REAUTH_REQUIRED
 
 
+@pytest.mark.parametrize("status_code", [401, 404])
 @pytest.mark.asyncio
-async def test_usage_updater_deactivates_on_401_account_deactivated_code(monkeypatch) -> None:
+async def test_usage_updater_deactivates_on_account_deactivated_code(monkeypatch, status_code: int) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.clients.usage import UsageFetchError
     from app.core.config.settings import get_settings
 
     get_settings.cache_clear()
 
-    async def stub_fetch_usage_401_deactivated(**_: Any) -> UsagePayload:
+    async def stub_fetch_usage_deactivated(**_: Any) -> UsagePayload:
         raise UsageFetchError(
-            401,
+            status_code,
             "Your OpenAI account has been deactivated, please check your email for more information.",
             code="account_deactivated",
         )
 
-    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_401_deactivated)
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_deactivated)
 
     usage_repo = StubUsageRepository()
     accounts_repo = StubAccountsRepository()
@@ -3371,7 +3372,7 @@ async def test_usage_updater_deactivates_on_401_account_deactivated_code(monkeyp
     assert len(accounts_repo.status_updates) == 1
     update = accounts_repo.status_updates[0]
     assert update["status"] == AccountStatus.DEACTIVATED
-    assert "401" in update["deactivation_reason"]
+    assert str(status_code) in update["deactivation_reason"]
     assert "deactivated" in update["deactivation_reason"].lower()
 
 
@@ -3434,6 +3435,39 @@ async def test_usage_updater_cools_down_repeated_403_failures(monkeypatch) -> No
 
     assert fetch_calls == 1
     assert len(accounts_repo.status_updates) == 0
+
+
+@pytest.mark.asyncio
+async def test_usage_updater_cools_down_ambiguous_404_without_deactivation(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_AUTH_FAILURE_COOLDOWN_SECONDS", "300")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage_404(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        raise UsageFetchError(404, "Usage fetch failed (404)")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_404)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    acc = _make_account("acc_404_cooldown", "workspace_404_cooldown", email="missing@example.com")
+    accounts_repo.accounts_by_id[acc.id] = acc
+
+    await updater.refresh_accounts([acc], latest_usage={})
+    await updater.refresh_accounts([acc], latest_usage={})
+
+    assert fetch_calls == 1
+    assert len(accounts_repo.status_updates) == 0
+    assert acc.status == AccountStatus.ACTIVE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Keep an account active when the upstream usage endpoint returns an ambiguous
HTTP 404, allowing normal usage polling and quota recovery to resume after the
existing cooldown. Explicit permanent account codes and deactivation messages
still produce a terminal account state.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #2061

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/keep-ambiguous-usage-404-retryable/`

## Changes

- Remove bare HTTP 404 from status-only permanent usage failures.
- Put ambiguous usage 404 responses into the existing process-local refresh
  cooldown so the scheduler retries without hammering upstream.
- Preserve terminal handling for HTTP 402, known permanent error codes, and
  explicit account-deactivation messages.
- Add regression coverage for both ambiguous and explicit-permanent 404 paths.

## Simplicity

- [x] No new setting or required setup step.
- [x] No README, `.env.example`, dashboard navigation, dependency, or schema change.

## Test plan

```text
uv run pytest tests/unit/test_usage_updater.py -q
122 passed

make lint
proxy architecture checks passed
All checks passed
1003 files already formatted

uv run ty check
All checks passed

openspec validate keep-ambiguous-usage-404-retryable --type change --strict
Change 'keep-ambiguous-usage-404-retryable' is valid

openspec validate usage-refresh-policy --type spec --strict
Specification 'usage-refresh-policy' is valid
```

Repository-wide `openspec validate --specs` still reports the pre-existing
`model-source-routing` specification failure on current `main`; this PR does
not modify that capability.

## Screenshots / output

No dashboard rendering changes.

```text
HTTP 404, no permanent code/message -> account remains active; refresh cooldown applies
HTTP 404, code=account_deactivated -> account becomes deactivated
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue.
- [x] Added tests covering the change.
- [x] Ran the relevant local test, lint, type, and OpenSpec checks.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ambiguous usage-service `404` responses no longer permanently deactivate accounts.
  - These failures now enter a temporary cooldown, preventing repeated requests while allowing usage polling to resume later.
  - Explicit deactivation signals and permanent error codes continue to be handled as account deactivation.
  - Accounts remain eligible for routing when a `404` does not include a recognized permanent failure reason.

- **Documentation**
  - Added usage-refresh policy documentation covering temporary failures, cooldown behavior, recovery, and permanent deactivation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->