### PR TITLE
fix(proxy): retire cooldown-suppressed HTTP bridge sessions unless another turn owns them

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1372,6 +1372,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "hongzexin",
+      "name": "Jason HONG",
+      "avatar_url": "https://avatars.githubusercontent.com/u/136784169?v=4",
+      "profile": "https://github.com/hongzexin",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/aaravrav"><img src="https://avatars.githubusercontent.com/u/37036762?v=4?s=100" width="100px;" alt="Aarav"/><br /><sub><b>Aarav</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=aaravrav" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Evan-Haug"><img src="https://avatars.githubusercontent.com/u/90289817?v=4?s=100" width="100px;" alt="Evan Haug"/><br /><sub><b>Evan Haug</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=Evan-Haug" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=Evan-Haug" title="Tests">⚠️</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/hongzexin"><img src="https://avatars.githubusercontent.com/u/136784169?v=4?s=100" width="100px;" alt="Jason HONG"/><br /><sub><b>Jason HONG</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=hongzexin" title="Code">💻</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol
 from app.core.clients.proxy import ProxyResponseError
 from app.core.openai.requests import ResponsesRequest
 from app.db.models import Account
-from app.modules.proxy._service.support import _HTTPBridgeSession, _HTTPBridgeSessionKey
+from app.modules.proxy._service.support import _HTTPBridgeSession, _HTTPBridgeSessionKey, _WebSocketRequestState
 from app.modules.proxy.durable_bridge_repository import DurableBridgeAliasRegistrationReceipt
 from app.modules.proxy.load_balancer import AccountSelection
 
@@ -70,6 +70,18 @@ class _HTTPBridgeServiceProtocol(Protocol):
         exc: BaseException,
     ) -> bool: ...
     async def _retire_http_bridge_after_drain_if_ready(self, session: _HTTPBridgeSession) -> bool: ...
+    async def _release_http_bridge_admission_preregistration(
+        self,
+        session: _HTTPBridgeSession,
+        *,
+        request_state: _WebSocketRequestState,
+    ) -> bool: ...
+    async def _retire_idle_http_bridge_session_on_cooldown_suppression(
+        self,
+        session: _HTTPBridgeSession,
+        *,
+        owned_unanchored_handoff: bool,
+    ) -> bool: ...
     async def _refresh_durable_http_bridge_session(self, session: _HTTPBridgeSession) -> None: ...
     def _http_bridge_pending_count_nowait(self, session: _HTTPBridgeSession, *, context: str) -> int | None: ...
     def _detach_http_bridge_session_locked(

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -649,6 +649,33 @@ def _request_kind_from_headers(headers: Mapping[str, str] | None) -> str:
     return "normal"
 
 
+def _http_bridge_session_unowned_locked(
+    session: "_HTTPBridgeSession",
+    *,
+    ignore_unanchored_reservation: bool = False,
+) -> bool:
+    """Whether no turn owns ``session`` right now; call under ``pending_lock``.
+
+    A registered admission waiter owns a turn that has not yet been counted
+    into the queue (it may be suspended on the pre-lock fair-share resolve,
+    issue #1971, or anywhere between the retry-circuit gate and dispatch);
+    retiring under it would fail an admitted turn with upstream_unavailable.
+    A deferred retirement re-runs on the turn's own drain triggers once it
+    proceeds; if the waiter instead fails admission, its cleanup releases the
+    registration and the submit finalizer retires the flagged session.
+    """
+    has_visible_pending = any(
+        _http_bridge_request_counts_against_queue(request_state) for request_state in session.pending_requests
+    )
+    return (
+        not has_visible_pending
+        and session.queued_request_count == 0
+        and session.admission_waiter_count == 0
+        and (ignore_unanchored_reservation or session.unanchored_reservation_id is None)
+        and not session.upstream_close_attempted
+    )
+
+
 class _HTTPBridgeRequestSubmitMixin:
     @staticmethod
     def _http_bridge_clean_close_retry_max_count() -> int:
@@ -988,6 +1015,12 @@ class _HTTPBridgeRequestSubmitMixin:
                 session,
                 request_scope_id=request_scope_id,
             )
+            # Like the half-open lease below, the admission registration the
+            # submit took at entry is handed back here when no dispatch took
+            # it over.
+            released_admission_waiter = await self._release_http_bridge_admission_preregistration(
+                session, request_state=request_state
+            )
             if request_state.claimed_half_open_until > 0.0 and request_state.response_create_attempt_count == 0:
                 # This admission claimed the half-open probe but the request
                 # never ATTEMPTED the upstream send — a poisoned-anchor
@@ -1012,11 +1045,13 @@ class _HTTPBridgeRequestSubmitMixin:
                 request_state.claimed_half_open_until = 0.0
             # Inner pre-submit cleanup may clear the reservation before control
             # returns here, so ownership must be captured before awaiting it.
-            # Only that request can make detached-session retirement newly
-            # ready; an ordinary send/reader failure already owns terminal
-            # settlement, and closing again would run that funnel twice.
+            # Only that request, or one whose pre-dispatch exit just released
+            # the admission registration a retirement was deferring on, can
+            # make detached-session retirement newly ready; an ordinary
+            # send/reader failure already owns terminal settlement, and
+            # closing again would run that funnel twice.
             if (
-                owned_unanchored_handoff
+                (owned_unanchored_handoff or released_admission_waiter)
                 and session.upstream_control.retire_after_drain
                 and not session.upstream_close_attempted
             ):
@@ -1078,6 +1113,15 @@ class _HTTPBridgeRequestSubmitMixin:
         owned_unanchored_handoff: bool,
         recovery_turn_state: str | None = None,
     ) -> None:
+        # Own admission from submit entry, not from the dispatch registration:
+        # a concurrent cooldown-suppressed sibling retires a session no turn
+        # owns, and between the retry-circuit gate and that registration this
+        # turn would otherwise be invisible to it (issue #1943 follow-up).
+        # The dispatch registration takes this over; the interruption cleanup
+        # and the submit finalizer release it on every earlier exit.
+        async with session.pending_lock:
+            session.admission_waiter_count += 1
+        request_state.admission_waiter_preregistered = True
         recovery_attempt_consumed = False
         allow_operation_fenced_continuity_replay = False
         if _http_bridge_operation_fence_for_hard_continuity_enabled(request_state):
@@ -1123,13 +1167,19 @@ class _HTTPBridgeRequestSubmitMixin:
             block_seconds, block_reason = await self._http_bridge_precreated_retry_block(session)
             retry_after_seconds = max(1, math.ceil(block_seconds))
             # The session may have been created before this late admission
-            # check.  Do not leave an unsubmitted socket reusable during the
-            # cooldown: mark it for retirement before surfacing the 503 and
-            # let the normal bounded drain path handle registry detach,
-            # aliases, leases, and close ownership.
-            session.upstream_control.reconnect_requested = True
-            session.upstream_control.retire_after_drain = True
-            await self._retire_http_bridge_after_drain_if_ready(session)
+            # check (issue #1943).  Do not leave an unsubmitted socket
+            # reusable during the cooldown: hand back this request's own
+            # admission registration, then retire the session when no other
+            # turn owns it, letting the bounded drain path handle registry
+            # detach, aliases, leases, and close ownership.  An admitted
+            # sibling (the half-open probe this cooldown permits) is a live
+            # owner even before its dispatch registration; flagging the
+            # session under it would fail that one allowed submission.
+            await self._release_http_bridge_admission_preregistration(session, request_state=request_state)
+            await self._retire_idle_http_bridge_session_on_cooldown_suppression(
+                session,
+                owned_unanchored_handoff=owned_unanchored_handoff,
+            )
             _log_http_bridge_event(
                 "submit_retry_circuit_suppressed",
                 session.key,
@@ -1704,6 +1754,7 @@ class _HTTPBridgeRequestSubmitMixin:
             )
         if session.upstream_control.retire_after_drain and not owned_unanchored_handoff:
             await _cleanup_unsubmitted_recovery_claim()
+            await self._release_http_bridge_admission_preregistration(session, request_state=request_state)
             if not session.upstream_close_attempted:
                 await self._retire_http_bridge_after_drain_if_ready(session)
             raise ProxyResponseError(
@@ -1795,7 +1846,12 @@ class _HTTPBridgeRequestSubmitMixin:
             # unwinding concurrently cannot see an apparently idle session
             # and release the lease the reacquire installs.
             async with session.pending_lock:
-                session.admission_waiter_count += 1
+                if request_state.admission_waiter_preregistered:
+                    # The submit entry already counted this turn; take that
+                    # registration over instead of counting it twice.
+                    request_state.admission_waiter_preregistered = False
+                else:
+                    session.admission_waiter_count += 1
                 admission_waiter_registered = True
                 # Snapshot under the same lock: with the waiter registered, a
                 # held lease cannot be idle-released, so a session that does
@@ -2700,8 +2756,9 @@ class _HTTPBridgeRequestSubmitMixin:
                 session.pending_requests.remove(request_state)
             if counted_in_queue:
                 session.queued_request_count = max(0, session.queued_request_count - 1)
-            if admission_waiter_registered:
+            if admission_waiter_registered or request_state.admission_waiter_preregistered:
                 session.admission_waiter_count = max(0, session.admission_waiter_count - 1)
+                request_state.admission_waiter_preregistered = False
             retire_closed_session = session.closed and session.admission_waiter_count == 0
         if (
             request_state.recovery_attempt_fingerprint is not None
@@ -3241,28 +3298,45 @@ class _HTTPBridgeRequestSubmitMixin:
                 ),
             )
 
+    async def _release_http_bridge_admission_preregistration(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        request_state: _WebSocketRequestState,
+    ) -> bool:
+        """Hand back a submit-entry admission registration the dispatch never took over.
+
+        Mirrors the interruption cleanup's waiter release for a turn that
+        never reached dispatch: the last waiter to leave a session that was
+        closed under it retires the session when nothing else owns it (a
+        fence-closed session with pending work and a live reader is settled
+        by that reader, not here), and a session left with no in-flight work
+        gives up an idle lease.
+        """
+        if not request_state.admission_waiter_preregistered:
+            return False
+        async with session.pending_lock:
+            session.admission_waiter_count = max(0, session.admission_waiter_count - 1)
+            request_state.admission_waiter_preregistered = False
+            retire_closed_session = session.closed and _http_bridge_session_unowned_locked(session)
+        if retire_closed_session:
+            await self._retire_stale_pending_http_bridge_session(
+                session,
+                detail="last_admission_waiter_cancelled",
+                response_events_seen=max(
+                    request_state.response_event_count,
+                    int(request_state.response_id is not None or request_state.latency_response_created_ms is not None),
+                ),
+                allow_liveness_revive=False,
+            )
+        await self._maybe_release_idle_http_bridge_session_lease(session)
+        return True
+
     async def _retire_http_bridge_after_drain_if_ready(self: Any, session: "_HTTPBridgeSession") -> bool:
         if not (session.upstream_control.reconnect_requested and session.upstream_control.retire_after_drain):
             return False
         async with session.pending_lock:
-            has_visible_pending = any(
-                _http_bridge_request_counts_against_queue(request_state) for request_state in session.pending_requests
-            )
-            should_reconnect = (
-                not has_visible_pending
-                and session.queued_request_count == 0
-                # A registered admission waiter owns a turn that has not yet
-                # been counted into the queue (it may be suspended on the
-                # pre-lock fair-share resolve, issue #1971); retiring under it
-                # would fail an admitted turn with upstream_unavailable. A
-                # deferred retirement re-runs on the turn's own drain
-                # triggers once it proceeds; if the waiter instead fails
-                # admission, its cleanup releases the idle lease and the
-                # flagged session falls back to idle-TTL close.
-                and session.admission_waiter_count == 0
-                and session.unanchored_reservation_id is None
-                and not session.upstream_close_attempted
-            )
+            should_reconnect = _http_bridge_session_unowned_locked(session)
             if should_reconnect:
                 session.pending_requests.clear()
                 session.upstream_close_attempted = True
@@ -3270,6 +3344,40 @@ class _HTTPBridgeRequestSubmitMixin:
             return False
 
         await self._close_http_bridge_session_bounded(session, reason="retire_after_drain")
+        return True
+
+    async def _retire_idle_http_bridge_session_on_cooldown_suppression(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        owned_unanchored_handoff: bool,
+    ) -> bool:
+        """Retire a cooldown-suppressed session unless another turn owns it.
+
+        The bridge opens or selects the session before the hard-key retry
+        circuit decides admission, so a suppressed request can leave a socket
+        that never carried ``response.create`` in the reuse pool, where the
+        next half-open probe picks it up (issue #1943). Flagging the session
+        for retirement and running the bounded drain path closes that socket
+        — but only when no other turn owns the session. A pending or queued
+        turn, a registered admission waiter (the admitted probe between its
+        gate and dispatch), or a foreign unanchored handoff is a live owner
+        whose own lifecycle governs retirement; flagging the session under it
+        would trip the pre-dispatch retiring fence for the one submission the
+        cooldown permits. The caller's own unanchored handoff does not count:
+        its submit finalizer releases it and retires the flagged session.
+        """
+        async with session.pending_lock:
+            idle = _http_bridge_session_unowned_locked(
+                session,
+                ignore_unanchored_reservation=owned_unanchored_handoff,
+            )
+            if idle:
+                session.upstream_control.reconnect_requested = True
+                session.upstream_control.retire_after_drain = True
+        if not idle:
+            return False
+        await self._retire_http_bridge_after_drain_if_ready(session)
         return True
 
     async def _http_bridge_claim_miss_shows_remote_probe(

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1122,6 +1122,14 @@ class _HTTPBridgeRequestSubmitMixin:
         if not retry_allowed:
             block_seconds, block_reason = await self._http_bridge_precreated_retry_block(session)
             retry_after_seconds = max(1, math.ceil(block_seconds))
+            # The session may have been created before this late admission
+            # check.  Do not leave an unsubmitted socket reusable during the
+            # cooldown: mark it for retirement before surfacing the 503 and
+            # let the normal bounded drain path handle registry detach,
+            # aliases, leases, and close ownership.
+            session.upstream_control.reconnect_requested = True
+            session.upstream_control.retire_after_drain = True
+            await self._retire_http_bridge_after_drain_if_ready(session)
             _log_http_bridge_event(
                 "submit_retry_circuit_suppressed",
                 session.key,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -4431,14 +4431,16 @@ class _HTTPBridgeStreamingMixin:
                 request_state.request_id,
                 retry_cooldown_seconds,
             )
-            # Session creation precedes this startup admission check.  Mark
-            # the opened bridge as retiring before returning the terminal
-            # cooldown result so no later request can reuse its socket.  The
-            # bounded helper closes immediately when idle and otherwise waits
-            # for existing owners to drain.
-            session.upstream_control.reconnect_requested = True
-            session.upstream_control.retire_after_drain = True
-            await self._retire_http_bridge_after_drain_if_ready(session)
+            # Session creation precedes this startup admission check (issue
+            # #1943).  Retire the opened bridge before returning the terminal
+            # cooldown result so no later request reuses its socket — unless
+            # another turn (an admitted probe, pending work, a handoff owner)
+            # owns it, in which case that owner's lifecycle governs it.  A
+            # continuity-bound request never holds the unanchored handoff.
+            await self._retire_idle_http_bridge_session_on_cooldown_suppression(
+                session,
+                owned_unanchored_handoff=False,
+            )
             # This path returns before the request is submitted, so the normal
             # detach/finally cleanup cannot settle an API-key reservation.
             # Release it before handing the synthetic terminal event to the

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -4431,6 +4431,14 @@ class _HTTPBridgeStreamingMixin:
                 request_state.request_id,
                 retry_cooldown_seconds,
             )
+            # Session creation precedes this startup admission check.  Mark
+            # the opened bridge as retiring before returning the terminal
+            # cooldown result so no later request can reuse its socket.  The
+            # bounded helper closes immediately when idle and otherwise waits
+            # for existing owners to drain.
+            session.upstream_control.reconnect_requested = True
+            session.upstream_control.retire_after_drain = True
+            await self._retire_http_bridge_after_drain_if_ready(session)
             # This path returns before the request is submitted, so the normal
             # detach/finally cleanup cannot settle an API-key reservation.
             # Release it before handing the synthetic terminal event to the

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1084,6 +1084,12 @@ class _WebSocketRequestState:
     # it claimed none); released by the submit finalizer whenever the probe
     # was never dispatched, so no pre-dispatch exit can strand the lease.
     claimed_half_open_until: float = 0.0
+    # True while the submit owns an admission-waiter registration taken at
+    # submit entry, before the retry-circuit gate, that the dispatch path has
+    # not yet taken over. It keeps the turn visible to a concurrent
+    # cooldown-suppressed sibling deciding whether the shared session is
+    # idle; every pre-dispatch exit releases it.
+    admission_waiter_preregistered: bool = False
     # Stable fingerprint used by the durable recovery-attempt journal. It is
     # populated only for a proof-gated fresh replay candidate.
     recovery_attempt_fingerprint: str | None = None

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/context.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/context.md
@@ -1,0 +1,24 @@
+# Context
+
+The bridge opens or reuses a session before the request-specific pre-created
+retry decision. That ordering is required for continuity and account routing,
+but it means a cooldown decision can arrive after a WebSocket has already been
+registered. Returning an error alone is insufficient: the session remains in
+the registry and may be selected by a later request.
+
+The existing `_retire_http_bridge_after_drain_if_ready` helper is the correct
+lifecycle owner. Setting both control flags makes `_http_bridge_session_reusable_for_request`
+reject new work immediately. The helper closes only when there is no visible
+pending request, queue count, unanchored reservation, or competing close, and
+otherwise leaves the session marked for retirement until the remaining owner
+settles it.
+
+The startup terminal path is equivalent to late suppression from a lifecycle
+perspective: it has an already-created session but no upstream `response.create`
+dispatch. It must use the same flags and helper so both paths are idempotent
+and share registry detachment, alias cleanup, lease settlement, and bounded
+socket close behavior.
+
+Replay exceptions remain intentionally unchanged. A proof-gated full resend or
+an operation-fenced continuity replay is an explicitly authorized dispatch;
+those paths must not be retired by the generic cooldown suppression branch.

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/context.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/context.md
@@ -8,10 +8,19 @@ the registry and may be selected by a later request.
 
 The existing `_retire_http_bridge_after_drain_if_ready` helper is the correct
 lifecycle owner. Setting both control flags makes `_http_bridge_session_reusable_for_request`
-reject new work immediately. The helper closes only when there is no visible
-pending request, queue count, unanchored reservation, or competing close, and
-otherwise leaves the session marked for retirement until the remaining owner
-settles it.
+reject new work immediately. The flags are set only when the session is
+unowned under `pending_lock` (no visible pending request, queue count,
+admission waiter, foreign unanchored reservation, or competing close); an
+owned session is left unmarked because the pre-dispatch fence fails any
+non-owner submit on a marked session, and the one submit a cooldown admits —
+the half-open probe — is exactly the turn a concurrent suppression would
+otherwise fence off.
+
+That probe is visible only if admission ownership starts before the dispatch
+registration: the submit counts itself as an admission waiter at entry, the
+dispatch registration takes the count over, and every pre-dispatch exit
+(interruption cleanup, retiring fence, submit finalizer) releases it and
+re-runs the retirement it deferred.
 
 The startup terminal path is equivalent to late suppression from a lifecycle
 perspective: it has an already-created session but no upstream `response.create`

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/proposal.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/proposal.md
@@ -1,0 +1,41 @@
+# Retire Cooldown-Suppressed HTTP Bridge Sessions
+
+## Why
+
+Issue #1943 exposes a lifecycle leak in the HTTP Responses bridge. A request
+can create and register an upstream WebSocket before the late retry-circuit
+admission check runs. When hard-key cooldown suppresses that request, the proxy
+returns the expected 503 but leaves the newly created session reusable. The
+orphaned socket can then be selected by a later half-open probe and keep the
+key in a repeated failure loop.
+
+The same leak exists in the startup pre-submit cooldown path used for
+continuity-bound requests: it returns a synthetic 503 before submit without
+retiring the session that was already opened.
+
+## What Changes
+
+- Mark a session as `reconnect_requested` and `retire_after_drain` whenever a
+  hard-key cooldown rejects a request before upstream dispatch.
+- Invoke the existing bounded drain-retirement helper immediately so an idle
+  session is detached and closed; sessions with other pending work remain
+  non-reusable until that work drains.
+- Cover both late submit suppression and startup pre-submit terminal paths.
+- Preserve proof-gated and operation-fenced replay bypasses, durable retry
+  circuit state, reservation settlement, and the existing 503 envelope.
+
+## Impact
+
+- Cooldown-suppressed bridge sessions cannot be reused for later requests.
+- Newly opened but never-dispatched WebSockets are closed and removed from the
+  registry when no other work owns the session.
+- Shared sessions with pending work drain through the existing lifecycle and
+  are not force-closed or double-settled.
+- No new setting, schema, migration, retry threshold, or cooldown duration is
+  introduced.
+
+## Source
+
+- GitHub issue: Soju06/codex-lb#1943
+- Feasibility analysis: Fable5 response `msg_l4vLQ0i8RzQiFjCGE2W7cOiE`
+- Source sidechat: 01a04718-7322-72d0-b4b3-8f5bb4581157

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/proposal.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/proposal.md
@@ -18,8 +18,12 @@ retiring the session that was already opened.
 - Mark a session as `reconnect_requested` and `retire_after_drain` whenever a
   hard-key cooldown rejects a request before upstream dispatch.
 - Invoke the existing bounded drain-retirement helper immediately so an idle
-  session is detached and closed; sessions with other pending work remain
-  non-reusable until that work drains.
+  session is detached and closed; a session another turn owns (pending work,
+  a registered admission waiter such as the admitted half-open probe, or a
+  foreign unanchored handoff) is left to that owner and is not marked.
+- Count a submit as an admission waiter from submit entry, so a turn between
+  its admission decision and its dispatch registration is visible to a
+  concurrent suppression instead of being fenced off its own session.
 - Cover both late submit suppression and startup pre-submit terminal paths.
 - Preserve proof-gated and operation-fenced replay bypasses, durable retry
   circuit state, reservation settlement, and the existing 503 envelope.
@@ -29,8 +33,8 @@ retiring the session that was already opened.
 - Cooldown-suppressed bridge sessions cannot be reused for later requests.
 - Newly opened but never-dispatched WebSockets are closed and removed from the
   registry when no other work owns the session.
-- Shared sessions with pending work drain through the existing lifecycle and
-  are not force-closed or double-settled.
+- Sessions owned by other work are neither marked nor closed by a concurrent
+  suppression; the half-open probe the cooldown admits keeps its session.
 - No new setting, schema, migration, retry threshold, or cooldown duration is
   introduced.
 

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/specs/responses-api-compat/spec.md
@@ -1,0 +1,142 @@
+## MODIFIED Requirements
+
+### Requirement: Durable retry-circuit state protects repeated hard-affinity failures
+
+For a hard-affinity bridge key, the proxy MUST scope retry-circuit state by
+affinity kind, affinity key, and API-key scope (using a stable anonymous scope
+when no API key is present). The proxy MUST record only the documented
+pre-response failure classes (`stream_incomplete`, `clean_close`, and
+`stream_idle_timeout`).
+
+A bridge retirement MUST record one of those failures only when the retiring
+session still owns at least one pending request and no response event has been
+observed for that request lifecycle. Retiring an idle upstream bridge with no
+pending request MUST NOT advance the circuit or cause a later request to be
+treated as a repeated failure. A pending request that has already emitted a
+response event MUST remain excluded from this pre-response circuit.
+
+When hard-key retry-circuit cooldown suppresses a request after its bridge
+session has been created but before `response.create` is dispatched, the proxy
+MUST mark that session `reconnect_requested` and `retire_after_drain`, then
+MUST invoke the bounded drain-retirement path before returning the suppression
+error. The session MUST become ineligible for new reuse immediately. If other
+pending work or an unanchored handoff still owns the session, closure MAY wait
+for that work to drain, but the retirement marker MUST remain set and the
+session MUST NOT accept new requests. This applies to both late submit
+suppression and startup pre-submit cooldown terminal handling.
+
+Proof-gated full-resend replay and operation-fenced continuity replay remain
+eligible bypasses and MUST NOT be retired by this suppression requirement.
+
+The default circuit MUST open after two consecutive recorded failures. Once
+open, it MUST suppress pre-created replay until the persisted cooldown expires,
+using exponential backoff from sixty seconds up to ten minutes. Clean-close
+failures MUST cap their cooldown at thirty seconds. The proxy MUST persist
+failure count, cooldown deadline, last failure detail, and update time in the
+`http_bridge_retry_circuits` table and MUST merge conflict updates so concurrent
+replicas cannot shorten an existing cooldown.
+
+The clean-close retry jitter maximum MUST be read from the
+`http_responses_session_bridge_clean_close_retry_jitter_max_seconds` runtime
+setting and MUST be bounded to the inclusive range 0–30 seconds.
+
+The proxy MUST evict process-local circuit entries and their loaded/persisted
+markers after one hour without use, independently of durable-row cleanup, so
+one-shot hard-affinity keys cannot grow the worker's memory without bound.
+
+Before every hard-affinity retry decision, the proxy MUST refresh the durable
+row so a cooldown opened by another replica is observed even when this process
+has already loaded the key. A durable lookup or persistence failure MUST NOT
+crash the request; the proxy MUST continue using available local state and
+record the failure for observability. Rows older than one hour MUST be treated
+as expired and removed. A successful terminal response MUST clear the local
+and durable circuit state.
+
+#### Scenario: idle bridge retirement does not consume a circuit strike
+
+- **GIVEN** a hard-affinity HTTP bridge has no pending requests
+- **WHEN** its upstream WebSocket closes and the idle bridge is retired
+- **THEN** the retry-circuit failure count for that key remains unchanged
+- **AND** a later request is not placed in cooldown because of the idle close
+
+#### Scenario: eventless pending retirement consumes exactly one strike
+
+- **GIVEN** a hard-affinity HTTP bridge owns a pending request with no observed response event
+- **WHEN** the bridge retires because the upstream fails before acknowledging the request
+- **THEN** the retry circuit records exactly one failure for that request lifecycle
+
+#### Scenario: midstream retirement does not consume a pre-response strike
+
+- **GIVEN** a hard-affinity HTTP bridge owns a pending request with an observed response event
+- **WHEN** the bridge retires before completion
+- **THEN** the pre-response retry-circuit failure count remains unchanged
+
+#### Scenario: the second hard-key failure opens a durable circuit
+
+- **GIVEN** a hard-affinity key has one recorded pre-response failure
+- **WHEN** a second eligible failure is recorded
+- **THEN** the proxy opens the retry circuit
+- **AND** persists at least two consecutive failures and a cooldown deadline
+- **AND** subsequent pre-created replay is suppressed until that deadline
+
+#### Scenario: retry decisions observe a cooldown opened by another replica
+
+- **GIVEN** this replica previously looked up a hard-affinity key with no row
+- **AND** another replica persists an open cooldown for that same key and API-key scope
+- **WHEN** this replica evaluates the next pre-created retry
+- **THEN** it refreshes durable state before deciding
+- **AND** suppresses the retry for the persisted cooldown
+
+#### Scenario: circuit state remains isolated by key and API-key scope
+
+- **GIVEN** one hard-affinity key has an open circuit
+- **WHEN** a different affinity key or API-key scope evaluates a retry
+- **THEN** that request is not suppressed by the first key's circuit
+
+#### Scenario: durable circuit lookup failure does not fail the request
+
+- **GIVEN** durable retry-circuit lookup or persistence is unavailable
+- **WHEN** the proxy evaluates or records a retry-circuit event
+- **THEN** the request continues using any available local circuit state
+- **AND** the failure is logged and exposed through retry-circuit observability
+
+#### Scenario: late cooldown suppression retires the newly created session
+
+- **GIVEN** a hard-key request has created or selected an HTTP bridge session
+- **AND** the retry circuit is still in cooldown when late pre-created
+  admission runs
+- **WHEN** the request is suppressed before `response.create` is dispatched
+- **THEN** the proxy returns the existing HTTP 503 cooldown error
+- **AND** marks the session for reconnect and retirement after drain
+- **AND** invokes bounded retirement
+- **AND** does not send `response.create` upstream
+- **AND** the session is not reusable for a later request
+
+#### Scenario: startup cooldown terminal handling retires its session
+
+- **GIVEN** a hard continuity-bound request has an already-created bridge
+  session but no safe replay bypass
+- **AND** the retry circuit is in cooldown before the startup submit attempt
+- **WHEN** startup terminal handling returns the cooldown failure
+- **THEN** the existing 503 or synthetic `stream_idle_timeout` envelope is
+  preserved
+- **AND** the session is marked for reconnect and retirement after drain
+- **AND** bounded retirement is invoked
+- **AND** submit is not attempted
+
+#### Scenario: cooldown replay bypass does not retire the session
+
+- **GIVEN** a hard-key request is in cooldown
+- **AND** proof-gated or operation-fenced continuity replay is allowed
+- **WHEN** the retry decision runs
+- **THEN** the request remains eligible for that authorized replay
+- **AND** the generic cooldown suppression retirement is not triggered
+
+#### Scenario: shared pending work drains before close
+
+- **GIVEN** cooldown suppression marks a session that owns other visible
+  pending work or an unanchored handoff
+- **WHEN** bounded retirement runs
+- **THEN** it does not force-close or double-settle the active work
+- **AND** new requests cannot reuse the session
+- **AND** the existing owner settlement path may close it after drain

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/specs/responses-api-compat/spec.md
@@ -16,14 +16,27 @@ treated as a repeated failure. A pending request that has already emitted a
 response event MUST remain excluded from this pre-response circuit.
 
 When hard-key retry-circuit cooldown suppresses a request after its bridge
-session has been created but before `response.create` is dispatched, the proxy
-MUST mark that session `reconnect_requested` and `retire_after_drain`, then
-MUST invoke the bounded drain-retirement path before returning the suppression
-error. The session MUST become ineligible for new reuse immediately. If other
-pending work or an unanchored handoff still owns the session, closure MAY wait
-for that work to drain, but the retirement marker MUST remain set and the
-session MUST NOT accept new requests. This applies to both late submit
-suppression and startup pre-submit cooldown terminal handling.
+session has been created but before `response.create` is dispatched, and no
+other turn owns that session (no visible pending or queued request, no
+registered admission waiter, no unanchored handoff held by another request),
+the proxy MUST mark the session `reconnect_requested` and `retire_after_drain`
+and MUST invoke the bounded drain-retirement path before returning the
+suppression error, so the never-dispatched socket is closed and detached rather
+than left reusable. If another turn owns the session — in particular the
+half-open probe the cooldown admitted, which may still sit between its
+admission decision and its dispatch registration — the suppressed request MUST
+leave the session unmarked and MUST NOT close it; that owner's own lifecycle
+governs retirement, and the admitted turn MUST proceed. If the suppressed
+request itself holds the session's unanchored handoff, the session counts as
+unowned and its submit finalizer completes the retirement after releasing the
+handoff. This applies to both late submit suppression and startup pre-submit
+cooldown terminal handling.
+
+So that a concurrent suppression can see it, a submit MUST count as a
+registered admission waiter on its session from submit entry, before the
+retry-circuit admission decision, until the dispatch path takes that
+registration over; every pre-dispatch exit MUST release it, and the release
+MUST re-run any retirement the registration was deferring.
 
 Proof-gated full-resend replay and operation-fenced continuity replay remain
 eligible bypasses and MUST NOT be retired by this suppression requirement.
@@ -132,11 +145,30 @@ and durable circuit state.
 - **THEN** the request remains eligible for that authorized replay
 - **AND** the generic cooldown suppression retirement is not triggered
 
-#### Scenario: shared pending work drains before close
+#### Scenario: a concurrently admitted probe keeps its session
 
-- **GIVEN** cooldown suppression marks a session that owns other visible
-  pending work or an unanchored handoff
-- **WHEN** bounded retirement runs
-- **THEN** it does not force-close or double-settle the active work
-- **AND** new requests cannot reuse the session
-- **AND** the existing owner settlement path may close it after drain
+- **GIVEN** a hard-key retry circuit at cooldown expiry
+- **AND** request A passes admission as the half-open probe and has not yet
+  reached its dispatch registration
+- **WHEN** request B on the same session is suppressed by A's probe lease
+- **THEN** B returns the existing HTTP 503 cooldown error
+- **AND** the session is not marked for reconnect or retirement and is not
+  closed
+- **AND** A proceeds past the pre-dispatch retiring fence to dispatch
+
+#### Scenario: a session owned by other work is left to its owner
+
+- **GIVEN** cooldown suppression rejects a request on a session that owns
+  visible pending work, a registered admission waiter, or another request's
+  unanchored handoff
+- **WHEN** the suppression returns
+- **THEN** the session is not marked for retirement and is not closed
+- **AND** the owning work's own settlement path governs the session
+
+#### Scenario: a suppressed request releases only its own admission registration
+
+- **GIVEN** a submit counted itself as an admission waiter at entry
+- **WHEN** the retry circuit suppresses it or any other pre-dispatch exit fails it
+- **THEN** its registration is released without disturbing other waiters
+- **AND** a retirement that registration was deferring runs once the session
+  is unowned

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+## Specification
+
+- [x] Add the `responses-api-compat` delta for retiring sessions rejected by
+      hard-key retry-circuit cooldown before upstream dispatch.
+- [x] Record the late-submit and startup pre-submit scenarios, including the
+      replay bypass and shared-pending-work safeguards.
+
+## Implementation
+
+- [x] Mark and retire the session in the late submit suppression branch.
+- [x] Mark and retire the session in the startup continuity cooldown terminal
+      branch.
+- [x] Keep proof-gated and operation-fenced bypasses unchanged.
+
+## Regression coverage
+
+- [x] Assert late suppression returns the same 503, marks the session retiring,
+      invokes the bounded retire helper, and never sends upstream.
+- [x] Assert startup pre-submit suppression marks the session retiring, invokes
+      the helper, preserves the 503 envelope, and never submits.
+- [x] Assert the replay bypass path does not retire the session.
+
+## Verification
+
+- [x] Run focused and full HTTP bridge unit/integration tests and Ruff on
+      changed files.
+- [x] Run strict OpenSpec validation and inspect the final diff/status.
+
+Validation note: the change passes strict OpenSpec validation. The repository's
+non-strict full spec scan reports one pre-existing `model-source-routing`
+failure; the affected `responses-api-compat` and `proxy-admission-control`
+specs pass.

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
@@ -5,13 +5,18 @@
 - [x] Add the `responses-api-compat` delta for retiring sessions rejected by
       hard-key retry-circuit cooldown before upstream dispatch.
 - [x] Record the late-submit and startup pre-submit scenarios, including the
-      replay bypass and shared-pending-work safeguards.
+      replay bypass and the owned-session safeguards (concurrent admitted
+      probe, pending work, foreign handoff).
 
 ## Implementation
 
-- [x] Mark and retire the session in the late submit suppression branch.
+- [x] Mark and retire the session in the late submit suppression branch when
+      no other turn owns it (shared idle check under `pending_lock`).
 - [x] Mark and retire the session in the startup continuity cooldown terminal
-      branch.
+      branch under the same ownership check.
+- [x] Register the submit as an admission waiter from submit entry, hand the
+      registration over at dispatch, and release it on every pre-dispatch
+      exit (re-running deferred retirement).
 - [x] Keep proof-gated and operation-fenced bypasses unchanged.
 
 ## Regression coverage
@@ -23,6 +28,14 @@
 - [x] Assert the replay bypass path does not retire the session.
 - [x] Assert late suppression of an idle, never-dispatched session closes it
       through the real drain-retirement helper (`retire_after_drain` bounded close).
+- [x] Assert a deterministic A/B interleaving (A admitted as the half-open
+      probe and suspended in the gate, B suppressed by A's lease) leaves the
+      session unmarked and unclosed and lets A reach dispatch.
+- [x] Assert late and startup suppression leave a session owned by a
+      registered admission waiter unmarked.
+- [x] Assert a submit is counted as an admission waiter inside the gate and
+      releases that registration on a pre-dispatch failure, running the
+      retirement it deferred exactly once.
 
 ## Verification
 

--- a/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
+++ b/openspec/changes/retire-cooldown-suppressed-http-bridge-session/tasks.md
@@ -21,6 +21,8 @@
 - [x] Assert startup pre-submit suppression marks the session retiring, invokes
       the helper, preserves the 503 envelope, and never submits.
 - [x] Assert the replay bypass path does not retire the session.
+- [x] Assert late suppression of an idle, never-dispatched session closes it
+      through the real drain-retirement helper (`retire_after_drain` bounded close).
 
 ## Verification
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -31159,6 +31159,56 @@ async def test_http_bridge_submit_cooldown_suppression_retires_session_before_se
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_submit_cooldown_suppression_closes_idle_undispatched_session() -> None:
+    # Issue #1943: the suppressed request never dispatched response.create and
+    # nothing else owns the session, so the real (unmocked) drain-retirement
+    # helper must close the socket immediately instead of leaving it in the
+    # reuse pool for the next half-open probe.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-submit-cooldown-closes-idle")
+    now = time.monotonic()
+    cast(Any, service)._http_bridge_retry_circuits[hard_session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=2,
+            cooldown_until=now + 60.0,
+            last_detail="stream_idle_timeout",
+            last_touched_monotonic=now,
+        )
+    )
+    service._durable_bridge = SimpleNamespace(lookup_retry_circuit=AsyncMock(return_value=None))
+    close_bounded = AsyncMock()
+    service._close_http_bridge_session_bounded = close_bounded
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-submit-cooldown-closes-idle",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"hello"}',
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request_with_handoff(
+            hard_session,
+            request_state=request_state,
+            text_data=request_state.request_text or "",
+            queue_limit=8,
+            request_scope_id="scope-submit-cooldown-closes-idle",
+            owned_unanchored_handoff=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert hard_session.upstream_close_attempted is True
+    assert hard_session.queued_request_count == 0
+    assert len(hard_session.pending_requests) == 0
+    close_bounded.assert_awaited_once_with(hard_session, reason="retire_after_drain")
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_retry_circuit_ignores_soft_affinity_and_other_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7020,6 +7020,62 @@ async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_startup_cooldown_terminal_spares_session_owned_by_admitted_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The startup pre-submit cooldown rejection must not flag or close a
+    # shared session another admitted turn (for example the half-open probe
+    # between its gate and dispatch registration) already owns.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-hard-turn-cooldown-owned")
+    session.admission_waiter_count = 1
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-turn-cooldown-owned",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        session_id="turn-state-cooldown-owned",
+        hard_continuity_anchor=True,
+    )
+    submit = AsyncMock()
+    retire = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once",
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", retire)
+    monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=8,
+            propagate_http_errors=True,
+            downstream_turn_state="turn-state-cooldown-owned",
+        ):
+            pass
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
+    submit.assert_not_awaited()
+    assert session.upstream_control.reconnect_requested is False
+    assert session.upstream_control.retire_after_drain is False
+    retire.assert_not_awaited()
+    assert session.admission_waiter_count == 1
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_one_shot_hard_turn_requires_operation_ledger_for_cooldown_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -31206,6 +31262,200 @@ async def test_http_bridge_submit_cooldown_suppression_closes_idle_undispatched_
     assert hard_session.queued_request_count == 0
     assert len(hard_session.pending_requests) == 0
     close_bounded.assert_awaited_once_with(hard_session, reason="retire_after_drain")
+
+
+def _make_cooldown_suppression_request_state(request_id: str) -> proxy_service._WebSocketRequestState:
+    return proxy_service._WebSocketRequestState(
+        request_id=request_id,
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"hello"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_cooldown_suppression_spares_session_owned_by_concurrent_admitted_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Two submits race on one shared hard-key session at cooldown expiry.
+    # Request A claims the half-open probe lease inside the retry-circuit
+    # gate and is suspended there; request B then runs to completion, is
+    # suppressed by A's lease, and must NOT retire the session: A owns it
+    # from submit entry even though it has not reached the dispatch
+    # registration, so A must proceed past the pre-dispatch retiring fence.
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-cooldown-probe-race")
+    now = time.monotonic()
+    cast(Any, service)._http_bridge_retry_circuits[session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=2,
+            cooldown_until=now - 1.0,
+            last_detail="stream_idle_timeout",
+            last_touched_monotonic=now,
+        )
+    )
+    service._durable_bridge = SimpleNamespace(lookup_retry_circuit=AsyncMock(return_value=None))
+    close_bounded = AsyncMock()
+    service._close_http_bridge_session_bounded = close_bounded
+    real_gate = service._http_bridge_precreated_retry_allowed
+    probe_in_gate = asyncio.Event()
+    suppressed_done = asyncio.Event()
+    gate_calls = 0
+    probe_claimed_leases: list[float] = []
+
+    async def gate(target: Any, **kwargs: Any) -> bool:
+        nonlocal gate_calls
+        gate_calls += 1
+        allowed = await real_gate(target, **kwargs)
+        if gate_calls == 1:
+            # A: lease claimed, decision made, still inside the gate.
+            probe_claimed_leases.extend(kwargs.get("claimed_lease_out") or [])
+            probe_in_gate.set()
+            await suppressed_done.wait()
+        return allowed
+
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", gate)
+    monkeypatch.setattr(service, "_http_bridge_fair_share_threshold_pct", AsyncMock(return_value=0))
+    monkeypatch.setattr(
+        service,
+        "_ensure_http_bridge_session_stream_lease_locked",
+        AsyncMock(side_effect=RuntimeError("probe reached dispatch registration")),
+    )
+    probe_state = _make_cooldown_suppression_request_state("req-cooldown-probe")
+    suppressed_state = _make_cooldown_suppression_request_state("req-cooldown-suppressed")
+
+    async def run_probe() -> None:
+        token = set_request_scope_id("scope-cooldown-probe")
+        try:
+            await service._submit_http_bridge_request(
+                session,
+                request_state=probe_state,
+                text_data=probe_state.request_text or "",
+                queue_limit=8,
+            )
+        finally:
+            reset_request_scope_id(token)
+
+    async def run_suppressed() -> None:
+        await probe_in_gate.wait()
+        token = set_request_scope_id("scope-cooldown-suppressed")
+        try:
+            await service._submit_http_bridge_request(
+                session,
+                request_state=suppressed_state,
+                text_data=suppressed_state.request_text or "",
+                queue_limit=8,
+            )
+        finally:
+            reset_request_scope_id(token)
+            suppressed_done.set()
+
+    probe_result, suppressed_result = await asyncio.gather(run_probe(), run_suppressed(), return_exceptions=True)
+
+    assert isinstance(suppressed_result, ProxyResponseError)
+    assert suppressed_result.status_code == 503
+    assert suppressed_result.payload["error"]["code"] == "upstream_request_timeout"
+    # The admitted probe was never fenced off its own session.
+    assert isinstance(probe_result, RuntimeError)
+    assert str(probe_result) == "probe reached dispatch registration"
+    assert len(probe_claimed_leases) == 1
+    # The undispatched probe handed its lease back, as on any pre-send exit.
+    assert probe_state.claimed_half_open_until == 0.0
+    assert session.upstream_control.reconnect_requested is False
+    assert session.upstream_control.retire_after_drain is False
+    assert session.upstream_close_attempted is False
+    close_bounded.assert_not_awaited()
+    assert session.admission_waiter_count == 0
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_cooldown_suppression_defers_to_registered_admission_waiter() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-cooldown-foreign-waiter")
+    now = time.monotonic()
+    cast(Any, service)._http_bridge_retry_circuits[session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=2,
+            cooldown_until=now + 60.0,
+            last_detail="stream_idle_timeout",
+            last_touched_monotonic=now,
+        )
+    )
+    service._durable_bridge = SimpleNamespace(lookup_retry_circuit=AsyncMock(return_value=None))
+    close_bounded = AsyncMock()
+    service._close_http_bridge_session_bounded = close_bounded
+    # Another turn owns the session between its gate and dispatch.
+    session.admission_waiter_count = 1
+    request_state = _make_cooldown_suppression_request_state("req-cooldown-foreign-waiter")
+
+    token = set_request_scope_id("scope-cooldown-foreign-waiter")
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await service._submit_http_bridge_request(
+                session,
+                request_state=request_state,
+                text_data=request_state.request_text or "",
+                queue_limit=8,
+            )
+    finally:
+        reset_request_scope_id(token)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert session.upstream_control.reconnect_requested is False
+    assert session.upstream_control.retire_after_drain is False
+    close_bounded.assert_not_awaited()
+    # The suppressed submit released only its own entry registration.
+    assert session.admission_waiter_count == 1
+    assert request_state.admission_waiter_preregistered is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_owns_admission_from_entry_and_releases_on_pre_dispatch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-admission-from-entry")
+    session.upstream_control.reconnect_requested = True
+    session.upstream_control.retire_after_drain = True
+    close_bounded = AsyncMock()
+    service._close_http_bridge_session_bounded = close_bounded
+    waiter_count_in_gate: list[int] = []
+
+    async def gate(target: Any, **kwargs: Any) -> bool:
+        waiter_count_in_gate.append(target.admission_waiter_count)
+        return True
+
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_allowed", gate)
+    request_state = _make_cooldown_suppression_request_state("req-admission-from-entry")
+
+    token = set_request_scope_id("scope-admission-from-entry")
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await service._submit_http_bridge_request(
+                session,
+                request_state=request_state,
+                text_data=request_state.request_text or "",
+                queue_limit=8,
+            )
+    finally:
+        reset_request_scope_id(token)
+
+    # Visible to concurrent retirement decisions while still inside the gate.
+    assert waiter_count_in_gate == [1]
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["message"] == "HTTP responses session bridge is retiring"
+    # The fenced-off turn hands its registration back, and the retirement it
+    # was deferring runs exactly once.
+    assert session.admission_waiter_count == 0
+    assert request_state.admission_waiter_preregistered is False
+    assert session.upstream_close_attempted is True
+    close_bounded.assert_awaited_once_with(session, reason="retire_after_drain")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6924,6 +6924,7 @@ async def test_http_bridge_previous_response_anchor_bypasses_hard_turn_cooldown_
     cooldown = AsyncMock(return_value=30.0)
     submit = AsyncMock(side_effect=RuntimeError("submitted without cooldown wait"))
     sleep = AsyncMock()
+    retire = AsyncMock(return_value=False)
 
     monkeypatch.setattr(
         proxy_service,
@@ -6934,6 +6935,7 @@ async def test_http_bridge_previous_response_anchor_bypasses_hard_turn_cooldown_
     )
     monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", cooldown)
     monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", retire)
     monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
 
     with pytest.raises(RuntimeError, match="submitted without cooldown wait"):
@@ -6950,6 +6952,9 @@ async def test_http_bridge_previous_response_anchor_bypasses_hard_turn_cooldown_
     cooldown.assert_not_awaited()
     sleep.assert_not_awaited()
     submit.assert_awaited_once()
+    retire.assert_not_awaited()
+    assert session.upstream_control.reconnect_requested is False
+    assert session.upstream_control.retire_after_drain is False
 
 
 @pytest.mark.asyncio
@@ -6972,6 +6977,7 @@ async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed
     )
     submit = AsyncMock()
     sleep = AsyncMock()
+    retire = AsyncMock(return_value=False)
     monkeypatch.setattr(
         proxy_service,
         "get_settings",
@@ -6981,6 +6987,7 @@ async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed
     )
     monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
     monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", retire)
     monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
 
     with pytest.raises(ProxyResponseError) as exc_info:
@@ -6998,6 +7005,18 @@ async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed
     assert exc_info.value.payload["error"]["code"] == HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE
     submit.assert_not_awaited()
     sleep.assert_not_awaited()
+    assert session.upstream_control.reconnect_requested is True
+    assert session.upstream_control.retire_after_drain is True
+    retire.assert_awaited_once_with(session)
+    assert (
+        http_bridge_helpers_module._http_bridge_session_reusable_for_request(
+            session=session,
+            key=session.key,
+            incoming_turn_state=None,
+            previous_response_id=None,
+        )
+        is False
+    )
 
 
 @pytest.mark.asyncio
@@ -31083,6 +31102,60 @@ async def test_http_bridge_submit_suppresses_hard_key_during_retry_cooldown() ->
     assert exc_info.value.retry_after_seconds is not None
     assert exc_info.value.retry_after_seconds >= 60
     assert hard_session.queued_request_count == 0
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_cooldown_suppression_retires_session_before_send() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    hard_session = _make_bridge_session(key_value="bridge-submit-cooldown-retires")
+    now = time.monotonic()
+    cast(Any, service)._http_bridge_retry_circuits[hard_session.key] = (
+        http_bridge_retry_circuit_module._HTTPBridgeRetryCircuitState(
+            consecutive_failures=2,
+            cooldown_until=now + 60.0,
+            last_detail="stream_idle_timeout",
+            last_touched_monotonic=now,
+        )
+    )
+    service._durable_bridge = SimpleNamespace(lookup_retry_circuit=AsyncMock(return_value=None))
+    retire = AsyncMock(return_value=False)
+    service._retire_http_bridge_after_drain_if_ready = retire
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-submit-cooldown-retires",
+        model="gpt-5.6-luna",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"hello"}',
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request_with_handoff(
+            hard_session,
+            request_state=request_state,
+            text_data=request_state.request_text or "",
+            queue_limit=8,
+            request_scope_id="scope-submit-cooldown-retires",
+            owned_unanchored_handoff=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    assert hard_session.upstream_control.reconnect_requested is True
+    assert hard_session.upstream_control.retire_after_drain is True
+    retire.assert_awaited_once_with(hard_session)
+    assert (
+        http_bridge_helpers_module._http_bridge_session_reusable_for_request(
+            session=hard_session,
+            key=hard_session.key,
+            incoming_turn_state=None,
+            previous_response_id=None,
+        )
+        is False
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Takeover of #1947 by @hongzexin (their commit `fix(proxy): retire cooldown-suppressed HTTP bridge sessions` is preserved verbatim with its original authorship as the first commit of this branch). **Supersedes #1947.**

Issue #1943: the bridge opens or selects an upstream WebSocket before the hard-key retry-circuit admission check runs, so a request suppressed by cooldown returned the expected 503 but left a never-dispatched socket registered and reusable; the next half-open probe then picked that socket up and struck the circuit again. Both pre-dispatch rejection sites — late submit suppression (`request_submit.py`, now anchored to #1891's `_http_bridge_precreated_retry_block` primitive) and the startup continuity cooldown terminal path (`streaming.py`) — now mark the session `reconnect_requested` + `retire_after_drain` and run the bounded drain-retirement helper, so an idle suppressed socket is closed and detached immediately.

On top of the original change, this PR fixes a concurrency defect found during adversarial verification of the takeover (also flagged by a local `codex review`): the original flagged the **shared** session unconditionally. A half-open probe admitted on the same session is invisible between passing the gate and its dispatch registration (`admission_waiter_count += 1` / pending append — ~20 awaits incl. durable lookups), so a concurrently suppressed sibling saw an idle session, closed the socket, and left flags that failed the probe at the pre-dispatch retiring fence with `502 upstream_unavailable "HTTP responses session bridge is retiring"` — each retry-storm round killing the one submission the cooldown permits. Proven with a deterministic interleaving test that fails on the original approach and passes here.

## Changes

- `request_submit.py` / `streaming.py`: both suppression sites call one mixin method, `_retire_idle_http_bridge_session_on_cooldown_suppression`, which computes ownership under `pending_lock` (visible pending, queue count, registered admission waiters, a foreign unanchored handoff, competing close) and only then sets the two flags and runs `_retire_http_bridge_after_drain_if_ready`. An owned session is left unflagged; its owner's lifecycle governs it. The drain helper's own predicate is extracted into `_http_bridge_session_unowned_locked` and shared, so "idle" means exactly "the helper would close it now".
- `request_submit.py`: a submit counts as an admission waiter **from submit entry**, before the retry-circuit decision (`request_state.admission_waiter_preregistered`). The existing dispatch registration takes that count over instead of incrementing again; the interruption cleanup, the retiring fence and the submit finalizer release it on every pre-dispatch exit, and the release re-runs the retirement it was deferring (mirroring the registered-waiter cleanup: a closed and unowned session is retired as `last_admission_waiter_cancelled`; an idle lease is let go). This is what makes the admitted probe visible to a concurrent suppression.
- `support.py`: the new `_WebSocketRequestState.admission_waiter_preregistered` field. `protocol.py`: declarations for the two new mixin methods.
- `.all-contributorsrc` + README table: `hongzexin` added (owner blocker on #1947).
- OpenSpec change `retire-cooldown-suppressed-http-bridge-session` (`responses-api-compat` delta): ownership rule, admission-ownership-from-entry rule, and three new scenarios (concurrent admitted probe keeps its session; owned session left to its owner; suppressed request releases only its own registration). `openspec validate --strict` passes.

## Owner blockers from #1947, addressed

1. **Contributors attribution** — `hongzexin` (Jason HONG, id 136784169) added to `.all-contributorsrc` with `["code"]` and the matching README cell; `.github/scripts/check_all_contributors.py --repo Soju06/codex-lb` passes (107 contributors covered).
2. **Rebase + semantic re-verification against #1891** — rebased onto today's main; the retirement now sits inside the `if not retry_allowed:` branch right after `_http_bridge_precreated_retry_block(session)` and inside `startup_continuity_cooldown_terminal_event` before the reservation release. #1891's key quarantine does **not** retire or close these sessions: the original's defect-pinning tests fail on `origin/main` (`reconnect_requested False` / `upstream_close_attempted False`) and pass here. The third retry-block site (post-submit refresh in `streaming.py`) already goes through `_detach_http_bridge_request`, which sets the same flags and runs the helper, so no extra coverage is needed there.

## Verification

- Fails-before (original defect) on `origin/main`: `test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed`, `test_http_bridge_submit_cooldown_suppression_retires_session_before_send`, `test_http_bridge_submit_cooldown_suppression_closes_idle_undispatched_session` fail on main, pass here.
- Fails-before (concurrency fix) on the pre-fix takeover head: `test_http_bridge_submit_cooldown_suppression_spares_session_owned_by_concurrent_admitted_probe`, `test_http_bridge_submit_cooldown_suppression_defers_to_registered_admission_waiter`, `test_http_bridge_submit_owns_admission_from_entry_and_releases_on_pre_dispatch_failure`, `test_http_bridge_startup_cooldown_terminal_spares_session_owned_by_admitted_turn` all fail there, pass here.
- `tests/unit/test_proxy_http_bridge.py`: 968 passed, 1 deselected (the known environmental `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses`), after rebase onto `a07ce563b`.
- `tests/unit/test_http_bridge_idle_leases.py`, `test_http_bridge_cancel_drain.py`, `test_http_bridge_eventless_semantics.py`, `test_http_bridge_relay_loop.py`, `test_bridge_context_blowup.py`, `test_proxy_utils.py`, `tests/integration/test_http_responses_bridge.py`: 1431 passed.
- `ruff check` / `ruff format --check`: clean. `ty check`: passed. `make architecture-check`: passed. `check_simplicity_budgets.py`: all budgets OK. `openspec validate retire-cooldown-suppressed-http-bridge-session --strict`: valid.

Fixes #1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HTTP bridge sessions remaining reusable after retry-circuit cooldown suppression.
  - Suppressed sessions are now retired and closed when no active work depends on them.
  - Preserved sessions owned by active requests or probes, preventing interruption of in-progress work.
  - Improved cleanup for both startup and pre-dispatch cooldown scenarios.
  - Added safeguards against repeated failures caused by orphaned connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->