### PR TITLE
fix(compact): fail over revoked refresh accounts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1381,6 +1381,18 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "msmahdinejad",
+      "name": "Mohammad Saleh Mahdinejad",
+      "avatar_url": "https://avatars.githubusercontent.com/u/154900233?v=4",
+      "profile": "https://github.com/msmahdinejad",
+      "contributions": [
+        "code",
+        "test",
+        "bug",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hongzexin"><img src="https://avatars.githubusercontent.com/u/136784169?v=4?s=100" width="100px;" alt="Jason HONG"/><br /><sub><b>Jason HONG</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=hongzexin" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/msmahdinejad"><img src="https://avatars.githubusercontent.com/u/154900233?v=4?s=100" width="100px;" alt="Mohammad Saleh Mahdinejad"/><br /><sub><b>Mohammad Saleh Mahdinejad</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=msmahdinejad" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=msmahdinejad" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/issues?q=author%3Amsmahdinejad" title="Bug reports">🐛</a> <a href="https://github.com/Soju06/codex-lb/commits?author=msmahdinejad" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -947,6 +947,7 @@ class _CompactMixin:
         deferred_stream_health: list[tuple[Account, Any, str, int | None]] = []
         deferred_http_500_health: list[tuple[Account, ProxyResponseError, int]] = []
         deferred_proxy_health: list[tuple[Account, ProxyResponseError]] = []
+        deferred_permanent_health: list[tuple[Account, str]] = []
         settlement_attempted = False
 
         async def flush_deferred_health() -> None:
@@ -956,6 +957,8 @@ class _CompactMixin:
             deferred_http_500_health.clear()
             proxy_pending = list(deferred_proxy_health)
             deferred_proxy_health.clear()
+            permanent_pending = list(deferred_permanent_health)
+            deferred_permanent_health.clear()
             for failed_account, failed_error, failed_code, failed_status in stream_pending:
                 try:
                     await proxy._handle_stream_error(
@@ -988,6 +991,16 @@ class _CompactMixin:
                 except Exception:
                     logger.warning(
                         "Failed to flush deferred compact proxy health account_id=%s request_id=%s",
+                        failed_account.id,
+                        request_id,
+                        exc_info=True,
+                    )
+            for failed_account, failed_code in permanent_pending:
+                try:
+                    await proxy._load_balancer.mark_permanent_failure(failed_account, failed_code)
+                except Exception:
+                    logger.warning(
+                        "Failed to flush deferred compact permanent health account_id=%s request_id=%s",
                         failed_account.id,
                         request_id,
                         exc_info=True,
@@ -1077,6 +1090,15 @@ class _CompactMixin:
                 deferred_proxy_health.append((failed_account, failed_exc))
                 return
             await proxy._handle_proxy_error(failed_account, failed_exc)
+
+        async def record_or_defer_permanent_health(
+            failed_account: Account,
+            failed_code: str,
+        ) -> None:
+            if api_key is not None and api_key_reservation is not None:
+                deferred_permanent_health.append((failed_account, failed_code))
+                return
+            await proxy._load_balancer.mark_permanent_failure(failed_account, failed_code)
 
         async def record_or_defer_stream_health(
             failed_account: Account,
@@ -1752,6 +1774,22 @@ class _CompactMixin:
                             except (RefreshError, aiohttp.ClientError, asyncio.TimeoutError) as refresh_exc:
                                 if isinstance(refresh_exc, RefreshError):
                                     if refresh_exc.is_permanent:
+                                        if preferred_account_id is None:
+                                            # This compact request is not bound to an
+                                            # account-owned response, turn state, or
+                                            # file. Retire the revoked account and
+                                            # continue the same pre-visible request on
+                                            # another healthy account. For API-key
+                                            # requests the health write is deferred
+                                            # until after usage settlement.
+                                            await record_or_defer_permanent_health(
+                                                account,
+                                                refresh_exc.code,
+                                            )
+                                            last_exc = exc
+                                            excluded_account_ids.add(account.id)
+                                            transient_exhausted = True
+                                            break
                                         await settle_compact_usage(
                                             api_key=api_key,
                                             api_key_reservation=api_key_reservation,

--- a/openspec/changes/fail-over-compact-permanent-refresh/.openspec.yaml
+++ b/openspec/changes/fail-over-compact-permanent-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/fail-over-compact-permanent-refresh/proposal.md
+++ b/openspec/changes/fail-over-compact-permanent-refresh/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+An account-neutral compact request can receive an upstream authentication
+failure and then discover during forced refresh that the selected account's
+OAuth credentials are permanently revoked. The proxy marks that account for
+re-authentication but currently surfaces the original 401 instead of trying a
+healthy account from the pool, so remote compaction blocks an otherwise
+continuable Codex task.
+
+## What Changes
+
+- Treat a permanent post-401 refresh failure as an account-local compact
+  failure when another account may safely receive the request.
+- Mark and exclude the revoked account, then continue the existing bounded
+  account-selection loop.
+- Preserve fail-closed behavior for file/continuity-pinned compact requests and
+  when no replacement account is available.
+- Add product-path regressions for transparent pool failover and pin safety.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: extend compact authentication failover to permanent
+  failures discovered by the forced refresh itself.
+
+## Impact
+
+Compact retry control flow and focused proxy tests only. No schema, setting,
+dependency, dashboard, or deployment contract changes.

--- a/openspec/changes/fail-over-compact-permanent-refresh/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-over-compact-permanent-refresh/specs/responses-api-compat/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Compact auth failures fail over after forced refresh
+
+The proxy MUST recover from account-local compact authentication failures before
+surfacing them to the compact client. When a `/backend-api/codex/responses/compact`
+request receives an upstream `401 invalid_api_key` or `401 token_invalidated`
+response for the selected account, the proxy MUST attempt one forced token
+refresh and retry the compact request on that same account. If the refreshed
+retry also returns `401`, the proxy MUST classify and record the account
+failure, exclude that account from the current compact request, and try another
+eligible account when one is available. If the forced refresh itself confirms
+a permanent credential failure, the proxy MUST mark the selected account for
+re-authentication, exclude it from the current compact request, and try another
+eligible account when account ownership permits. The proxy MUST NOT surface an
+account-local `401` before exhausting eligible accounts, and MUST NOT move a
+file-pinned or continuity-pinned compact request to another account. When no
+safe replacement is available, the proxy MUST preserve the terminal auth error
+and settlement behavior.
+
+#### Scenario: Refreshed compact auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a compact request
+- **AND** the selected account returns `401 invalid_api_key` for compact before and after a forced refresh
+- **WHEN** another eligible account can complete the compact request
+- **THEN** the downstream compact response succeeds from the second account
+- **AND** the selected account is excluded from further attempts for that compact request
+
+#### Scenario: Refreshed compact token invalidation uses another account
+
+- **GIVEN** at least two accounts are eligible for a compact request
+- **AND** the selected account returns `401 token_invalidated` for compact before and after a forced refresh
+- **WHEN** another eligible account can complete the compact request
+- **THEN** the downstream compact response succeeds from the second account
+- **AND** the selected account is marked `reauth_required`
+- **AND** the selected account is excluded from further attempts for that compact request
+
+#### Scenario: Compact 401 is not a generic same-contract retry
+
+- **WHEN** low-level compact transport receives HTTP 401 from upstream
+- **THEN** the service-level auth refresh/failover path handles it
+- **AND** the low-level compact transport does not mark it as a generic same-contract transport retry
+
+#### Scenario: Permanent forced-refresh failure uses another account
+
+- **GIVEN** at least two accounts are eligible for an account-neutral compact request
+- **AND** the selected account returns an upstream authentication failure
+- **WHEN** its forced refresh reports a permanent revoked-credential failure
+- **THEN** the selected account is marked `reauth_required` and excluded
+- **AND** the compact request succeeds from another eligible account when it completes
+- **AND** the selected account's authentication error is not surfaced to the client
+
+#### Scenario: Permanent forced-refresh failure preserves an account pin
+
+- **GIVEN** a compact request is pinned to an account by file or continuity ownership
+- **AND** that account returns an upstream authentication failure
+- **WHEN** its forced refresh reports a permanent credential failure
+- **THEN** the account is marked `reauth_required`
+- **AND** the request is not sent to another account
+- **AND** the terminal authentication error is surfaced after settlement

--- a/openspec/changes/fail-over-compact-permanent-refresh/tasks.md
+++ b/openspec/changes/fail-over-compact-permanent-refresh/tasks.md
@@ -18,5 +18,5 @@
 - [x] 3.1 Run focused compact tests and the related proxy suite.
 - [x] 3.2 Run changed-file lint, formatting, type, architecture, and strict
   OpenSpec validation.
-- [ ] 3.3 Exercise the live remote-compact task after an atomic deployment with
+- [x] 3.3 Exercise the live remote-compact task after an atomic deployment with
   a pre-cutover data backup and rollback container.

--- a/openspec/changes/fail-over-compact-permanent-refresh/tasks.md
+++ b/openspec/changes/fail-over-compact-permanent-refresh/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contract and regression
+
+- [x] 1.1 Define failover for permanent authentication failure discovered by
+  compact forced refresh.
+- [x] 1.2 Add a failing two-account product-path regression matching remote
+  compact with a revoked selected account.
+- [x] 1.3 Preserve a pinned-request control that cannot cross accounts.
+
+## 2. Implementation
+
+- [x] 2.1 Mark and exclude the permanently failed account before continuing
+  bounded compact selection.
+- [x] 2.2 Preserve terminal settlement and the original error when failover is
+  unsafe or unavailable.
+
+## 3. Verification
+
+- [x] 3.1 Run focused compact tests and the related proxy suite.
+- [x] 3.2 Run changed-file lint, formatting, type, architecture, and strict
+  OpenSpec validation.
+- [ ] 3.3 Exercise the live remote-compact task after an atomic deployment with
+  a pre-cutover data backup and rollback container.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -1272,6 +1272,85 @@ async def test_proxy_compact_token_invalidated_marks_reauth_and_fails_over(async
 
 
 @pytest.mark.asyncio
+async def test_backend_compact_permanent_forced_refresh_failure_fails_over(async_client, monkeypatch):
+    from app.core.auth.refresh import RefreshError
+
+    account_ids: list[str] = []
+    upstream_account_ids: list[str | None] = []
+    for suffix in ("a", "b"):
+        email = f"compact-revoked-refresh-{suffix}@example.com"
+        raw_account_id = f"acc_compact_revoked_refresh_{suffix}"
+        response = await async_client.post(
+            "/api/accounts/import",
+            files={
+                "auth_json": (
+                    f"auth-{suffix}.json",
+                    json.dumps(_make_auth_json(raw_account_id, email)),
+                    "application/json",
+                )
+            },
+        )
+        assert response.status_code == 200
+        account_ids.append(generate_unique_account_id(raw_account_id, email))
+
+    async with SessionLocal() as session:
+        for suffix, account_id in zip(("a", "b"), account_ids, strict=True):
+            account = await session.get(Account, account_id)
+            assert account is not None
+            account.chatgpt_account_id = f"chatgpt_compact_revoked_refresh_{suffix}"
+        await session.commit()
+
+    failed_account_id: str | None = None
+    failed_upstream_account_id: str | None = None
+
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
+        del self, timeout_seconds
+        nonlocal failed_account_id
+        if failed_account_id is None:
+            failed_account_id = account.id
+        if force and account.id == failed_account_id:
+            raise RefreshError(
+                "refresh_token_invalidated",
+                "Refresh token was revoked",
+                True,
+            )
+        return account
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        nonlocal failed_upstream_account_id
+        if failed_upstream_account_id is None:
+            failed_upstream_account_id = account_id
+        upstream_account_ids.append(account_id)
+        if account_id == failed_upstream_account_id:
+            raise ProxyResponseError(
+                401,
+                openai_error(
+                    "token_revoked",
+                    "Encountered invalidated oauth token for user, failing request",
+                    error_type="authentication_error",
+                ),
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {"model": "gpt-5.6-sol", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(upstream_account_ids) == 2
+    assert upstream_account_ids[0] == failed_upstream_account_id
+    assert upstream_account_ids[1] != failed_upstream_account_id
+    assert failed_account_id is not None
+    async with SessionLocal() as session:
+        failed_account = await session.get(Account, failed_account_id)
+        assert failed_account is not None
+        assert failed_account.status == AccountStatus.REAUTH_REQUIRED
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_repeated_401_settles_reservation_if_error_recording_fails(async_client, monkeypatch):
     email = "compact-invalidated-settle@example.com"
     raw_account_id = "acc_compact_invalidated_settle"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -41770,11 +41770,72 @@ async def test_compact_permanent_refresh_settles_before_mark_permanent(monkeypat
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
-    account = _make_account("acc_compact_permanent_refresh")
+    account_a = _make_account("acc_compact_permanent_refresh_a")
+    account_b = _make_account("acc_compact_permanent_refresh_b")
+    seen_excluded_account_ids: list[set[str]] = []
     call_order: list[str] = []
     api_key = _make_api_key_data("key_compact_permanent_refresh")
     reservation = proxy_service.ApiKeyUsageReservationData(
         reservation_id="resv_compact_permanent_refresh",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def mark_permanent_failure(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("mark_permanent_failure")
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def ensure_fresh(target: Account, **kwargs: object) -> Account:
+        if target.id == account_a.id and kwargs.get("force"):
+            raise RefreshError("invalid_grant", "refresh rejected", True)
+        return target
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                401,
+                openai_error("invalid_api_key", "token expired"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=ensure_fresh))
+    monkeypatch.setattr(service._load_balancer, "mark_permanent_failure", AsyncMock(side_effect=mark_permanent_failure))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-permanent-refresh"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert call_order == ["settle_compact_api_key_usage", "mark_permanent_failure"]
+
+
+@pytest.mark.asyncio
+async def test_compact_pinned_permanent_refresh_remains_owner_bound(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_pinned_permanent_refresh")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_pinned_permanent_refresh")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_pinned_permanent_refresh",
         key_id=api_key.id,
         model="gpt-5.1",
     )
@@ -41803,25 +41864,29 @@ async def test_compact_permanent_refresh_settles_before_mark_permanent(monkeypat
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=ensure_fresh))
-    monkeypatch.setattr(
-        service,
-        "_select_account_with_budget_compatible",
-        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
-    )
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
     monkeypatch.setattr(service._load_balancer, "mark_permanent_failure", AsyncMock(side_effect=mark_permanent_failure))
     monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
     monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
 
-    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+        }
+    )
     with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
         await service.compact_responses(
             payload,
-            {"session_id": "sid-compact-permanent-refresh"},
+            {"session_id": "sid-compact-pinned-permanent-refresh"},
             api_key=api_key,
             api_key_reservation=reservation,
         )
 
     assert exc_info.value.status_code == 401
+    assert select_account.await_count == 1
     assert call_order == ["settle_compact_api_key_usage", "mark_permanent_failure"]
 
 


### PR DESCRIPTION
## Summary

- retry an account-neutral compact request on another eligible account when post-401 forced refresh confirms the selected account's OAuth credentials are permanently revoked
- defer the permanent account-health write until after API-key usage settlement
- preserve fail-closed behavior for file- and continuity-pinned compact requests
- document the behavior in OpenSpec and cover it through endpoint-level and unit regressions

Fixes #2077

## Validation

- `python -m pytest tests/integration/test_proxy_compact.py -q` — 40 passed
- `python -m pytest tests/unit/test_proxy_utils.py -k compact -q` — 101 passed
- `python -m ruff check app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py`
- `python -m ruff format --check app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py`
- `python -m ty check --python <project-venv> app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py`
- `python scripts/check_proxy_architecture.py`
- `python scripts/check_cancellation_safety.py`
- `openspec validate fail-over-compact-permanent-refresh --strict`

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- Change directory: `openspec/changes/fail-over-compact-permanent-refresh/`

## Simplicity

No new setting, dependency, schema, endpoint, or dashboard surface. The change extends the existing bounded compact account-selection loop and its established deferred-health ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact requests now automatically fail over to another healthy account when an account’s authentication is permanently revoked.
  * File- and continuity-pinned requests remain bound to their designated account and continue to surface the authentication error when recovery is unsafe or unavailable.
  * Failed accounts are excluded from subsequent selection and flagged for reauthentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->