### PR TITLE
fix(proxy): fork model-transition owner conflicts

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2016,6 +2016,7 @@ class _HTTPBridgeStreamingMixin:
             else dict(headers)
         )
         fresh_replay_excluded_account_ids: set[str] = set()
+        model_transition_owner_conflict_fork_attempted = False
         unanchored_fork_spill_attempted = False
         verified_stale_anchor_generation_captured = False
         verified_stale_anchor_circuit_key: _HTTPBridgeSessionKey | None = None
@@ -2068,6 +2069,70 @@ class _HTTPBridgeStreamingMixin:
                     durable_full_resend_fresh_payload
                 )
             return durable_full_resend_is_account_neutral
+
+        def switch_model_transition_to_account_neutral_fork(exc: ProxyResponseError) -> bool:
+            nonlocal account_neutral_recovery
+            nonlocal affinity
+            nonlocal bridge_session_key
+            nonlocal downstream_turn_state
+            nonlocal force_local_recovery_creation
+            nonlocal incoming_turn_state_header
+            nonlocal model_transition_owner_conflict_fork_attempted
+            nonlocal preferred_account_has_continuity_provenance
+            nonlocal request_state
+            nonlocal session_creation_headers
+            nonlocal session_header_fallback_key
+
+            error_code, _error_message = _proxy_error_code_message(exc)
+            if (
+                durable_model_transition_lookup is None
+                or error_code != "continuity_owner_conflict"
+                or model_transition_owner_conflict_fork_attempted
+                or forwarded_request
+                or not _http_bridge_payload_is_account_neutral_fresh_replay(effective_payload)
+                or request_state.previous_response_id is not None
+                or rewritten_file_account_id is not None
+            ):
+                return False
+            reused_parent_turn_state = (
+                incoming_turn_state_header is not None and downstream_turn_state == incoming_turn_state_header
+            )
+            failed_owner_id = request_state.preferred_account_id
+            _log_http_bridge_event(
+                "model_transition_owner_conflict_fork",
+                bridge_session_key,
+                account_id=failed_owner_id,
+                model=effective_payload.model,
+                detail="outcome=retry_without_previous_model_owner",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                owner_check_applied=True,
+            )
+            if failed_owner_id is not None:
+                fresh_replay_excluded_account_ids.add(failed_owner_id)
+            session_creation_headers = without_http_bridge_session_affinity_headers(session_creation_headers)
+            incoming_turn_state_header = None
+            session_header_fallback_key = None
+            affinity = _AffinityPolicy()
+            replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
+            bridge_session_key = _HTTPBridgeSessionKey(
+                replay_kind,
+                replay_key,
+                bridge_session_key.api_key_id,
+                strength="hard",
+            )
+            account_neutral_recovery = True
+            force_local_recovery_creation = True
+            model_transition_owner_conflict_fork_attempted = True
+            request_state.affinity_policy = affinity
+            request_state.hard_continuity_anchor = False
+            request_state.preferred_account_id = None
+            request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
+            preferred_account_has_continuity_provenance = False
+            if reused_parent_turn_state:
+                request_state.session_id = None
+                downstream_turn_state = None
+            return True
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
             return (
@@ -2279,6 +2344,8 @@ class _HTTPBridgeStreamingMixin:
                 # carries its own continuity is a safe fresh raw-HTTP replay.
                 if effective_payload.previous_response_id != payload.previous_response_id:
                     setattr(exc, _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR, True)
+                if switch_model_transition_to_account_neutral_fork(exc):
+                    continue
                 if not owner_unavailable_allows_account_neutral_replay(exc):
                     exc_code, _exc_message = _proxy_error_code_message(exc)
                     if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(

--- a/openspec/changes/fork-model-transition-owner-conflict/.openspec.yaml
+++ b/openspec/changes/fork-model-transition-owner-conflict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/fork-model-transition-owner-conflict/.openspec.yaml
+++ b/openspec/changes/fork-model-transition-owner-conflict/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: spec-driven
-created: 2026-09-05
+created: 2026-09-04

--- a/openspec/changes/fork-model-transition-owner-conflict/proposal.md
+++ b/openspec/changes/fork-model-transition-owner-conflict/proposal.md
@@ -1,0 +1,18 @@
+# Fork Model-Transition Owner Conflicts
+
+## Why
+
+A durable hard continuity lookup can still identify the old model owner's
+account when the client starts a fresh request on an incompatible model. If
+bridge creation reports `continuity_owner_conflict`, the current path surfaces
+the 502 even when the payload is account-neutral and can safely start a new
+local lane.
+
+## What Changes
+
+- Fork eligible local model-transition owner conflicts onto one new
+  account-neutral HTTP bridge lane.
+- Exclude the conflicting owner, force local creation, and keep the child lane
+  hard once selected.
+- Clear parent-derived request state so the child lane cannot rebind the old
+  turn alias.

--- a/openspec/changes/fork-model-transition-owner-conflict/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fork-model-transition-owner-conflict/specs/responses-api-compat/spec.md
@@ -1,0 +1,28 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: HTTP bridge model-transition owner conflicts fork a guarded child lane
+
+When a hard continuity lookup identifies a durable owner for an incompatible model and HTTP bridge creation returns `continuity_owner_conflict`, the service MUST retry at most once on a new account-neutral child lane when the request is local, has no `previous_response_id`, has no resolved file owner, and the effective payload passes the account-neutral fresh-replay validator. The child lane MUST exclude the conflicting owner, force local creation, use hard affinity, and clear parent-derived affinity, hard-continuity, and reused turn-state identity before submitting the request.
+
+#### Scenario: Eligible model transition conflict forks once
+
+- **GIVEN** a durable hard continuity key belongs to account A for the old model
+- **AND** the new request uses an incompatible model with account-neutral input
+- **WHEN** HTTP bridge creation returns `continuity_owner_conflict`
+- **THEN** the service retries once on a new hard account-neutral lane
+- **AND** the retry excludes account A and does not forward the request
+
+#### Scenario: Child lane does not inherit parent identity
+
+- **GIVEN** the model-transition request reuses the parent turn-state header
+- **WHEN** the service forks to the account-neutral child lane
+- **THEN** the submitted child request has no parent session id
+- **AND** it has no parent affinity policy or hard-continuity anchor
+
+#### Scenario: Second conflict remains fail-closed
+
+- **GIVEN** the service already forked once for the model-transition request
+- **WHEN** the child lane also returns `continuity_owner_conflict`
+- **THEN** the service returns that error without creating another child lane

--- a/openspec/changes/fork-model-transition-owner-conflict/tasks.md
+++ b/openspec/changes/fork-model-transition-owner-conflict/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Reproduce the current `continuity_owner_conflict` failure on the
+  model-transition path.
+- [x] 1.2 Add the guarded account-neutral child-lane fork.
+- [x] 1.3 Keep the fork single-shot and clear parent-derived request state.
+
+## 2. Validation
+
+- [x] 2.1 Run focused model-transition owner-conflict regression tests.
+- [x] 2.2 Run strict OpenSpec validation.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -26995,6 +26995,330 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_forks_account_neutral_model_transition_after_owner_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_keys.append(key)
+        creation_calls.append(kwargs)
+        if len(creation_calls) == 1:
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **_kwargs: Any,
+    ):
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(creation_calls) == 2
+    assert creation_keys[0].affinity_kind in {"session_header", "turn_state_header"}
+    assert is_http_bridge_account_neutral_replay(
+        kind=creation_keys[1].affinity_kind,
+        key=creation_keys[1].affinity_key,
+    )
+    assert creation_keys[1].strength == "hard"
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["preferred_account_has_continuity_provenance"] is False
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_limits_model_transition_owner_conflict_fork_to_one_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        _key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_calls.append(kwargs)
+        raise owner_conflict
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        ):
+            pass
+
+    assert exc_info.value is owner_conflict
+    assert len(creation_calls) == 2
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_not_rebind_parent_turn_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    stream_downstream_turn_states: list[str | None] = []
+    stream_request_states: list[Any] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        if kwargs["preferred_account_id"] == "acc-model-owner":
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **kwargs: Any,
+    ):
+        stream_downstream_turn_states.append(kwargs["downstream_turn_state"])
+        stream_request_states.append(kwargs["request_state"])
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_parent",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert stream_downstream_turn_states == [None]
+    (child_request_state,) = stream_request_states
+    assert child_request_state.session_id is None
+    assert child_request_state.hard_continuity_anchor is False
+    assert child_request_state.affinity_policy.key is None
+    assert child_request_state.affinity_policy.codex_session_source is None
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_preserves_verified_replay_kind_for_durable_model_transition(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
References original PR #1619 and the maintainer's close request on #1862 to re-offer this piece standalone.

## Summary
- reproduce the current `continuity_owner_conflict` failure on an eligible model-transition request
- retry the eligible local conflict once on a new hard account-neutral child lane
- clear parent affinity, hard-continuity, and reused turn-state identity before submitting the child lane

## Validation
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q --tb=short --disable-warnings tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_forks_account_neutral_model_transition_after_owner_conflict tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_limits_model_transition_owner_conflict_fork_to_one_retry tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_not_rebind_parent_turn_alias`
- `uv run openspec validate --strict fork-model-transition-owner-conflict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when switching models encounters a session ownership conflict.
  - Eligible requests can now retry through a fresh, account-neutral connection instead of failing immediately.
  - Retry handling prevents previous session or turn state from being carried into the new connection.
  - Conflicts remain safely limited to a single retry, preserving the original error when recovery is unsuccessful.

- **Tests**
  - Added coverage for successful recovery, conflict handling, and isolation of prior session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->