### PR TITLE
fix(http-bridge): wait for aborted bridge owner

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -909,6 +909,8 @@ async def _wait_for_http_bridge_retained_owner(
     try:
         await wait_on_shared_future(owner_task, timeout=timeout)
     except TimeoutError:
+        if owner_task.done():
+            return True
         return False
     except asyncio.CancelledError:
         current_task = asyncio.current_task()

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -707,6 +707,8 @@ _HTTP_BRIDGE_LOCAL_RESET_MESSAGE = HTTP_BRIDGE_LOCAL_RESET_MESSAGE
 T = TypeVar("T")
 
 _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
+_HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR = "_codex_lb_owner_task"
+_HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR = "_codex_lb_abort_error"
 # Provenance marker for bridge failures raised strictly before the current
 # request dispatched upstream. Only exceptions carrying this attribute are
 # safe for the streaming wrapper's raw-HTTP replay.
@@ -805,6 +807,107 @@ def _http_bridge_stale_inflight_seconds() -> float:
     )
 
 
+def _http_bridge_inflight_age_seconds(future: Any, now: float) -> float:
+    started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+    return max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+
+
+def _http_bridge_inflight_future_is_stale(
+    future: Any,
+    *,
+    now: float,
+    stale_after_seconds: float,
+) -> bool:
+    started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+    return isinstance(started_at, (int, float)) and now - started_at >= stale_after_seconds
+
+
+def _mark_http_bridge_inflight_creation_owner(future: Any, *, started_at: float) -> None:
+    owner_task = asyncio.current_task()
+    assert owner_task is not None
+    setattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, started_at)
+    setattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+
+
+def _abort_http_bridge_inflight_creation_locked(
+    service: Any,
+    key: "_HTTPBridgeSessionKey",
+    future: Any,
+    exc: BaseException,
+) -> bool:
+    if service._http_bridge_inflight_sessions.get(key) is not future:
+        return False
+    if getattr(future, "_http_bridge_handoff", False):
+        return False
+
+    owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
+    caller_is_owner = isinstance(owner_task, asyncio.Task) and owner_task is asyncio.current_task()
+    owner_running = isinstance(owner_task, asyncio.Task) and not owner_task.done()
+    owner_finished = isinstance(owner_task, asyncio.Task) and owner_task.done()
+    abort_was_signalled = hasattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR)
+
+    if not future.done():
+        setattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, exc)
+        if isinstance(exc, asyncio.CancelledError):
+            future.cancel()
+        else:
+            future.set_exception(exc)
+            future.exception()
+
+    if (
+        caller_is_owner
+        or owner_finished
+        or not isinstance(owner_task, asyncio.Task)
+        or key.affinity_kind == "turn_state_header"
+    ):
+        service._http_bridge_inflight_sessions.pop(key, None)
+    elif owner_running and not abort_was_signalled:
+        owner_task.cancel()
+    return True
+
+
+def _abort_http_bridge_inflight_creation_by_future_locked(
+    service: Any,
+    future: Any,
+    exc: BaseException,
+) -> "_HTTPBridgeSessionKey | None":
+    key = next(
+        (key for key, candidate in service._http_bridge_inflight_sessions.items() if candidate is future),
+        None,
+    )
+    if key is None:
+        return None
+    return key if _abort_http_bridge_inflight_creation_locked(service, key, future, exc) else None
+
+
+async def _wait_for_http_bridge_aborted_owner(
+    future: Any,
+    *,
+    timeout: float,
+) -> bool:
+    abort_error = getattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, None)
+    owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
+    if abort_error is None or not isinstance(owner_task, asyncio.Task):
+        return False
+    if owner_task.done():
+        return True
+    try:
+        await wait_on_shared_future(owner_task, timeout=timeout)
+    except TimeoutError:
+        return False
+    except asyncio.CancelledError:
+        if owner_task.done():
+            return True
+        raise
+    except BaseException:
+        return True
+    return True
+
+
+def _http_bridge_inflight_creation_can_register(future: Any) -> bool:
+    return not hasattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR)
+
+
 def _normalize_responses_request_payload_for_bridge(payload: ResponsesRequest) -> ResponsesRequest:
     return cast(
         Callable[[ResponsesRequest], ResponsesRequest],
@@ -893,10 +996,11 @@ def _cleanup_http_bridge_inflight_sessions_nowait(service: Any) -> dict[str, int
         if type(exc).__name__ not in {"WouldBlock", "RuntimeError"}:
             raise
         for future in service._http_bridge_inflight_sessions.values():
-            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
-            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            age_seconds = _http_bridge_inflight_age_seconds(future, now)
             oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
-            if isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+            if _http_bridge_inflight_future_is_stale(
+                future, now=now, stale_after_seconds=stale_after_seconds
+            ) and not getattr(future, "_http_bridge_handoff", False):
                 stale += 1
         return {
             "cleaned": 0,
@@ -908,17 +1012,35 @@ def _cleanup_http_bridge_inflight_sessions_nowait(service: Any) -> dict[str, int
             current_future = service._http_bridge_inflight_sessions.get(key)
             if current_future is not future:
                 continue
-            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
-            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            age_seconds = _http_bridge_inflight_age_seconds(future, now)
             oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
             cleanup_reason: str | None = None
-            is_stale = isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds
-            if is_stale:
+            is_stale = _http_bridge_inflight_future_is_stale(
+                future,
+                now=now,
+                stale_after_seconds=stale_after_seconds,
+            )
+            if is_stale and not getattr(future, "_http_bridge_handoff", False):
                 stale += 1
+            owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
+            owner_running = isinstance(owner_task, asyncio.Task) and not owner_task.done()
             if future.done():
+                if owner_running and hasattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR):
+                    continue
                 cleanup_reason = "done"
+            else:
+                if isinstance(owner_task, asyncio.Task) and owner_task.done():
+                    cleanup_reason = "owner_done"
             if cleanup_reason is None:
                 continue
+            if cleanup_reason == "owner_done" and not future.done():
+                owner_done_error = _http_bridge_startup_wait_timeout_error(
+                    "http_bridge_session_create",
+                    code="capacity_exhausted_active_sessions",
+                )
+                setattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, owner_done_error)
+                future.set_exception(owner_done_error)
+                future.exception()
             service._http_bridge_inflight_sessions.pop(key, None)
             cleaned += 1
             if future.done() and not future.cancelled():

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -930,17 +930,19 @@ async def _wait_for_http_bridge_aborted_owner(
     future: Any,
     *,
     timeout: float,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     abort_error = getattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, None)
     if abort_error is None:
         return False
-    return await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
+    return await _wait_for_http_bridge_retained_owner(future, timeout=timeout, scheduler=scheduler)
 
 
 async def _wait_for_http_bridge_retained_owner(
     future: Any,
     *,
     timeout: float,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
     if not isinstance(owner_task, asyncio.Task):
@@ -948,7 +950,7 @@ async def _wait_for_http_bridge_retained_owner(
     if owner_task.done():
         return True
     try:
-        await wait_on_shared_future(owner_task, timeout=timeout)
+        await wait_on_shared_future(owner_task, timeout=timeout, scheduler=scheduler)
     except TimeoutError:
         if owner_task.done():
             return True
@@ -979,7 +981,11 @@ async def _evict_http_bridge_retained_capacity_waiter_after_error(
     timeout = _http_bridge_owner_observation_timeout_seconds(service, timeout, request_deadline)
     retained_owner_finished = False
     if timeout > 0:
-        retained_owner_finished = await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
+        retained_owner_finished = await _wait_for_http_bridge_retained_owner(
+            future,
+            timeout=timeout,
+            scheduler=scheduler_for(service),
+        )
     if _http_bridge_inflight_owner_running(future) and not retained_owner_finished:
         raise error
     await service._evict_http_bridge_inflight_waiter(future, error)
@@ -1000,7 +1006,11 @@ async def _wait_for_http_bridge_aborted_owner_within_budget(
     request_deadline: float | None,
 ) -> bool:
     timeout_seconds = _http_bridge_owner_observation_timeout_seconds(service, wait_timeout_seconds, request_deadline)
-    return timeout_seconds > 0 and await _wait_for_http_bridge_aborted_owner(future, timeout=timeout_seconds)
+    return timeout_seconds > 0 and await _wait_for_http_bridge_aborted_owner(
+        future,
+        timeout=timeout_seconds,
+        scheduler=scheduler_for(service),
+    )
 
 
 def _http_bridge_turn_state_session_key(

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -179,6 +179,7 @@ from app.modules.proxy.affinity import (
     _AffinityPolicy,
     _codex_backend_identity,
     _extract_model_class,
+    _is_synthesized_turn_state,
     _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
 )
@@ -829,6 +830,10 @@ def _mark_http_bridge_inflight_creation_owner(future: Any, *, started_at: float)
     setattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
 
 
+def _http_bridge_key_is_synthesized_turn_state(key: "_HTTPBridgeSessionKey") -> bool:
+    return key.affinity_kind == "turn_state_header" and _is_synthesized_turn_state(key.affinity_key)
+
+
 def _abort_http_bridge_inflight_creation_locked(
     service: Any,
     key: "_HTTPBridgeSessionKey",
@@ -854,12 +859,7 @@ def _abort_http_bridge_inflight_creation_locked(
             future.set_exception(exc)
             future.exception()
 
-    if (
-        caller_is_owner
-        or owner_finished
-        or not isinstance(owner_task, asyncio.Task)
-        or key.affinity_kind == "turn_state_header"
-    ):
+    if caller_is_owner or owner_finished or not isinstance(owner_task, asyncio.Task):
         service._http_bridge_inflight_sessions.pop(key, None)
     elif owner_running and not abort_was_signalled:
         owner_task.cancel()
@@ -896,6 +896,9 @@ async def _wait_for_http_bridge_aborted_owner(
     except TimeoutError:
         return False
     except asyncio.CancelledError:
+        current_task = asyncio.current_task()
+        if isinstance(current_task, asyncio.Task) and current_task.cancelling():
+            raise
         if owner_task.done():
             return True
         raise
@@ -1609,6 +1612,7 @@ async def _settle_failed_http_bridge_creation(
     inflight_future: Any,
     created_session: "_HTTPBridgeSession | None",
     exc: BaseException,
+    retain_current_marker: bool = False,
 ) -> bool:
     """Retire a failed creation and report whether another session replaced it.
 
@@ -1621,13 +1625,14 @@ async def _settle_failed_http_bridge_creation(
         current_future = service._http_bridge_inflight_sessions.get(key)
         replacement_in_flight = current_future is not None and current_future is not inflight_future
         if current_future is inflight_future:
-            service._http_bridge_inflight_sessions.pop(key, None)
             if inflight_future is not None and not inflight_future.done():
                 if isinstance(exc, asyncio.CancelledError):
                     inflight_future.cancel()
                 else:
                     inflight_future.set_exception(exc)
                     inflight_future.exception()
+            if not retain_current_marker:
+                service._http_bridge_inflight_sessions.pop(key, None)
         registered_session = service._http_bridge_sessions.get(key)
         # A replacement that has claimed but not yet published its session is
         # just as much the winner as a registered one: releasing here would
@@ -1670,6 +1675,43 @@ async def _settle_failed_http_bridge_creation(
             ):
                 registered_session.durable_owner_epoch = claimed_epoch
         return superseded
+
+
+async def _release_failed_http_bridge_creation_marker(
+    service: Any,
+    key: "_HTTPBridgeSessionKey",
+    *,
+    inflight_future: Any,
+) -> None:
+    async with service._http_bridge_lock:
+        if service._http_bridge_inflight_sessions.get(key) is inflight_future:
+            service._http_bridge_inflight_sessions.pop(key, None)
+
+
+async def _settle_and_close_failed_http_bridge_creation(
+    service: Any,
+    key: "_HTTPBridgeSessionKey",
+    *,
+    inflight_future: Any,
+    created_session: "_HTTPBridgeSession | None",
+    session_registered: bool,
+    exc: BaseException,
+) -> None:
+    retain_marker = created_session is not None and not session_registered
+    superseded = await _settle_failed_http_bridge_creation(
+        service,
+        key,
+        inflight_future=inflight_future,
+        created_session=created_session,
+        exc=exc,
+        retain_current_marker=retain_marker,
+    )
+    try:
+        if retain_marker:
+            await service._close_http_bridge_session(created_session, release_durable_session=not superseded)
+    finally:
+        if retain_marker:
+            await _release_failed_http_bridge_creation_marker(service, key, inflight_future=inflight_future)
 
 
 async def _close_http_bridge_session_resources(

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -179,7 +179,6 @@ from app.modules.proxy.affinity import (
     _AffinityPolicy,
     _codex_backend_identity,
     _extract_model_class,
-    _is_synthesized_turn_state,
     _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
 )
@@ -836,7 +835,7 @@ def _http_bridge_inflight_owner_running(future: Any) -> bool:
 
 
 def _http_bridge_key_is_synthesized_turn_state(key: "_HTTPBridgeSessionKey") -> bool:
-    return key.affinity_kind == "turn_state_header" and _is_synthesized_turn_state(key.affinity_key)
+    return key.affinity_kind == "turn_state_header" and key.synthesized_turn_state
 
 
 def _abort_http_bridge_inflight_creation_locked(
@@ -855,8 +854,9 @@ def _abort_http_bridge_inflight_creation_locked(
     owner_running = isinstance(owner_task, asyncio.Task) and not owner_task.done()
     owner_finished = isinstance(owner_task, asyncio.Task) and owner_task.done()
     abort_was_signalled = hasattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR)
+    future_was_pending = not future.done()
 
-    if not future.done():
+    if future_was_pending:
         setattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, exc)
         if isinstance(exc, asyncio.CancelledError):
             future.cancel()
@@ -866,7 +866,7 @@ def _abort_http_bridge_inflight_creation_locked(
 
     if caller_is_owner or owner_finished or not isinstance(owner_task, asyncio.Task):
         service._http_bridge_inflight_sessions.pop(key, None)
-    elif owner_running and not abort_was_signalled:
+    elif owner_running and future_was_pending and not abort_was_signalled:
         owner_task.cancel()
     return True
 
@@ -939,6 +939,49 @@ async def _evict_http_bridge_retained_capacity_waiter_after_error(
     ):
         raise error
     await service._evict_http_bridge_inflight_waiter(future, error)
+
+
+def _http_bridge_owner_observation_timeout_seconds(
+    wait_timeout_seconds: float, request_deadline: float | None
+) -> float:
+    if request_deadline is None:
+        return max(0.0, wait_timeout_seconds)
+    return max(0.0, min(wait_timeout_seconds, request_deadline - _service_time().monotonic()))
+
+
+async def _wait_for_http_bridge_aborted_owner_within_budget(
+    future: Any,
+    wait_timeout_seconds: float,
+    request_deadline: float | None,
+) -> bool:
+    timeout_seconds = _http_bridge_owner_observation_timeout_seconds(wait_timeout_seconds, request_deadline)
+    return timeout_seconds > 0 and await _wait_for_http_bridge_aborted_owner(future, timeout=timeout_seconds)
+
+
+def _http_bridge_turn_state_session_key(
+    turn_state: str,
+    api_key_id: str | None,
+    *,
+    synthesized: bool = False,
+) -> _HTTPBridgeSessionKey:
+    return _HTTPBridgeSessionKey(
+        "turn_state_header",
+        turn_state,
+        api_key_id,
+        synthesized_turn_state=synthesized,
+    )
+
+
+def _http_bridge_turn_state_key_from(
+    source_key: _HTTPBridgeSessionKey,
+    turn_state: str,
+    api_key_id: str | None,
+) -> _HTTPBridgeSessionKey:
+    return _http_bridge_turn_state_session_key(
+        turn_state,
+        api_key_id,
+        synthesized=_http_bridge_key_is_synthesized_turn_state(source_key) and source_key.affinity_key == turn_state,
+    )
 
 
 def _http_bridge_inflight_creation_can_register(future: Any) -> bool:
@@ -2593,6 +2636,7 @@ def _make_http_bridge_session_key(
     allow_forwarded_affinity_headers: bool = False,
     forwarded_affinity_kind: str | None = None,
     forwarded_affinity_key: str | None = None,
+    synthesized_turn_state: str | None = None,
 ) -> _HTTPBridgeSessionKey:
     forwarded_key = (
         _forwarded_http_bridge_session_key(
@@ -2611,6 +2655,7 @@ def _make_http_bridge_session_key(
         affinity_key = turn_state_key
         affinity_kind = "turn_state_header"
         strength: Literal["hard", "soft"] = "hard"
+        key_synthesized_turn_state = turn_state_key == synthesized_turn_state
     elif (thread_key := _codex_backend_identity(headers).thread_selection_key) is not None:
         # prompt_cache_key is intentionally shared by current Codex root trees.
         # The thread key is canonical identity; once a bridge exists it is hard
@@ -2618,6 +2663,7 @@ def _make_http_bridge_session_key(
         affinity_key = thread_key
         affinity_kind = "thread_header"
         strength = "hard"
+        key_synthesized_turn_state = False
     else:
         session_key = _sticky_key_from_session_header(headers)
         if session_key is not None:
@@ -2633,6 +2679,7 @@ def _make_http_bridge_session_key(
             affinity_key = session_header_key.affinity_key
             affinity_kind = "session_header"
             strength = "hard"
+            key_synthesized_turn_state = False
         else:
             inferred_key = (
                 inferred_http_bridge_key(payload) if payload.conversation or explicit_prompt_cache_key is None else None
@@ -2642,11 +2689,13 @@ def _make_http_bridge_session_key(
                 "prompt_cache" if inferred_key else affinity.kind.value if affinity.kind is not None else "request"
             )
             strength = "soft"
+            key_synthesized_turn_state = False
     return _HTTPBridgeSessionKey(
         affinity_kind=affinity_kind,
         affinity_key=affinity_key,
         api_key_id=api_key.id if api_key is not None else None,
         strength=strength,
+        synthesized_turn_state=key_synthesized_turn_state,
     )
 
 

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -3783,7 +3783,6 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     # misclassify them into the ambiguous transport class below (issue #1830).
     code = _normalize_error_code(raw_code, error_type)
     if code in {
-        "bridge_drain_active",
         "bridge_owner_unreachable",
         "bridge_previous_response_not_found",
         "previous_response_not_found",

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -3886,6 +3886,16 @@ def _http_bridge_should_rollover_after_context_overflow(
     return True
 
 
+def _http_bridge_error_code(exc: ProxyResponseError) -> object:
+    payload = exc.payload
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    return error.get("code")
+
+
 def _http_bridge_should_attempt_local_bootstrap_rebind(
     exc: ProxyResponseError,
     *,
@@ -3898,6 +3908,13 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
         return False
     if previous_response_id is not None:
         return False
+    if owner_pre_dispatch and _http_bridge_error_code(exc) == "bridge_drain_active":
+        # Explicit draining-owner rejection before dispatch: the old owner never
+        # accepted this request upstream, so a bootstrap rebind is safe even
+        # under a hard turn-state anchor.
+        return True
+    if _sticky_key_from_turn_state_header(headers) is not None:
+        return False
     payload = exc.payload
     if not isinstance(payload, dict):
         return False
@@ -3905,13 +3922,6 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
     if not isinstance(error, dict):
         return False
     code = error.get("code")
-    if _sticky_key_from_turn_state_header(headers) is not None and not (
-        code == "bridge_drain_active" and owner_pre_dispatch
-    ):
-        # A hard turn-state anchor normally needs durable takeover. The safe
-        # bootstrap exception is explicit draining-owner rejection before
-        # dispatch, so the old owner did not accept this request upstream.
-        return False
     return code in {
         "bridge_drain_active",
         "bridge_owner_unreachable",

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -3773,6 +3773,7 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     # misclassify them into the ambiguous transport class below (issue #1830).
     code = _normalize_error_code(raw_code, error_type)
     if code in {
+        "bridge_drain_active",
         "bridge_owner_unreachable",
         "bridge_previous_response_not_found",
         "previous_response_not_found",
@@ -3891,12 +3892,11 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
     key: _HTTPBridgeSessionKey,
     headers: Mapping[str, str],
     previous_response_id: str | None,
+    owner_pre_dispatch: bool = False,
 ) -> bool:
-    if key.affinity_kind not in {"session_header", "thread_header"}:
+    if key.affinity_kind not in {"session_header", "thread_header", "turn_state_header"}:
         return False
     if previous_response_id is not None:
-        return False
-    if _sticky_key_from_turn_state_header(headers) is not None:
         return False
     payload = exc.payload
     if not isinstance(payload, dict):
@@ -3905,7 +3905,15 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
     if not isinstance(error, dict):
         return False
     code = error.get("code")
+    if _sticky_key_from_turn_state_header(headers) is not None and not (
+        code == "bridge_drain_active" and owner_pre_dispatch
+    ):
+        # A hard turn-state anchor normally needs durable takeover. The safe
+        # bootstrap exception is explicit draining-owner rejection before
+        # dispatch, so the old owner did not accept this request upstream.
+        return False
     return code in {
+        "bridge_drain_active",
         "bridge_owner_unreachable",
         "bridge_instance_mismatch",
     }

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -838,6 +838,47 @@ def _http_bridge_key_is_synthesized_turn_state(key: "_HTTPBridgeSessionKey") -> 
     return key.affinity_kind == "turn_state_header" and key.synthesized_turn_state
 
 
+def _http_bridge_session_knows_synthesized_turn_state(
+    session: "_HTTPBridgeSession",
+    turn_state: str,
+) -> bool:
+    return turn_state in session.synthesized_downstream_turn_state_aliases or (
+        session.downstream_turn_state == turn_state and _http_bridge_key_is_synthesized_turn_state(session.key)
+    )
+
+
+def _http_bridge_local_turn_state_alias_is_synthesized_locked(
+    service: Any,
+    turn_state: str,
+    api_key_id: str | None,
+) -> bool:
+    alias_key = _http_bridge_turn_state_alias_key(turn_state, api_key_id)
+    session_key = service._http_bridge_turn_state_index.get(alias_key)
+    if session_key is None:
+        return False
+    session = service._http_bridge_sessions.get(session_key)
+    if _http_bridge_alias_target_is_stale(session):
+        return False
+    return _http_bridge_session_knows_synthesized_turn_state(session, turn_state)
+
+
+def _http_bridge_canonical_inflight_key_locked(
+    service: Any,
+    key: "_HTTPBridgeSessionKey",
+) -> "_HTTPBridgeSessionKey":
+    future = service._http_bridge_inflight_sessions.get(key)
+    if future is None:
+        return key
+    return next(
+        (
+            candidate_key
+            for candidate_key, candidate_future in service._http_bridge_inflight_sessions.items()
+            if candidate_future is future and candidate_key == key
+        ),
+        key,
+    )
+
+
 def _abort_http_bridge_inflight_creation_locked(
     service: Any,
     key: "_HTTPBridgeSessionKey",
@@ -929,32 +970,36 @@ async def _evict_http_bridge_retained_capacity_waiter_after_error(
     future: Any,
     *,
     timeout: float,
+    request_deadline: float | None = None,
 ) -> None:
     error = _http_bridge_startup_wait_timeout_error(
         "http_bridge_capacity",
         code="capacity_exhausted_active_sessions",
     )
-    if _http_bridge_inflight_owner_running(future) and not (
-        await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
-    ):
+    timeout = _http_bridge_owner_observation_timeout_seconds(service, timeout, request_deadline)
+    retained_owner_finished = False
+    if timeout > 0:
+        retained_owner_finished = await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
+    if _http_bridge_inflight_owner_running(future) and not retained_owner_finished:
         raise error
     await service._evict_http_bridge_inflight_waiter(future, error)
 
 
 def _http_bridge_owner_observation_timeout_seconds(
-    wait_timeout_seconds: float, request_deadline: float | None
+    service: object, wait_timeout_seconds: float, request_deadline: float | None
 ) -> float:
     if request_deadline is None:
         return max(0.0, wait_timeout_seconds)
-    return max(0.0, min(wait_timeout_seconds, request_deadline - _service_time().monotonic()))
+    return max(0.0, min(wait_timeout_seconds, request_deadline - clock_for(service).monotonic()))
 
 
 async def _wait_for_http_bridge_aborted_owner_within_budget(
+    service: object,
     future: Any,
     wait_timeout_seconds: float,
     request_deadline: float | None,
 ) -> bool:
-    timeout_seconds = _http_bridge_owner_observation_timeout_seconds(wait_timeout_seconds, request_deadline)
+    timeout_seconds = _http_bridge_owner_observation_timeout_seconds(service, wait_timeout_seconds, request_deadline)
     return timeout_seconds > 0 and await _wait_for_http_bridge_aborted_owner(future, timeout=timeout_seconds)
 
 
@@ -976,11 +1021,14 @@ def _http_bridge_turn_state_key_from(
     source_key: _HTTPBridgeSessionKey,
     turn_state: str,
     api_key_id: str | None,
+    *,
+    synthesized: bool = False,
 ) -> _HTTPBridgeSessionKey:
     return _http_bridge_turn_state_session_key(
         turn_state,
         api_key_id,
-        synthesized=_http_bridge_key_is_synthesized_turn_state(source_key) and source_key.affinity_key == turn_state,
+        synthesized=synthesized
+        or (_http_bridge_key_is_synthesized_turn_state(source_key) and source_key.affinity_key == turn_state),
     )
 
 
@@ -3146,6 +3194,7 @@ async def _persist_http_bridge_turn_state_alias(
             async with service._http_bridge_lock:
                 if session.turn_state_alias_registration_generations.get(turn_state) == registration_generation:
                     session.turn_state_alias_registration_generations.pop(turn_state, None)
+                    session.synthesized_downstream_turn_state_aliases.discard(turn_state)
         return None, None
     if registered == DurableBridgeAliasRegistration.REGISTERED:
         return registered, receipt
@@ -3155,6 +3204,7 @@ async def _persist_http_bridge_turn_state_alias(
         if session.turn_state_alias_registration_generations.get(turn_state) != registration_generation:
             return None, receipt
         session.turn_state_alias_registration_generations.pop(turn_state, None)
+        session.synthesized_downstream_turn_state_aliases.discard(turn_state)
         if local_alias_was_published:
             session.downstream_turn_state_aliases.discard(turn_state)
             if session.downstream_turn_state == turn_state:
@@ -4139,6 +4189,9 @@ for _helper_name in (
     "_http_bridge_reconnect_turn_state",
     "_http_bridge_turn_state_alias_key",
     "_http_bridge_previous_response_alias_key",
+    "_http_bridge_session_knows_synthesized_turn_state",
+    "_http_bridge_local_turn_state_alias_is_synthesized_locked",
+    "_http_bridge_canonical_inflight_key_locked",
     "_http_bridge_session_allows_api_key",
     "_http_bridge_session_account_active",
     "_http_bridge_session_reusable_for_request",

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -3908,12 +3908,20 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
         return False
     if previous_response_id is not None:
         return False
+    turn_state_key = _sticky_key_from_turn_state_header(headers)
     if owner_pre_dispatch and _http_bridge_error_code(exc) == "bridge_drain_active":
         # Explicit draining-owner rejection before dispatch: the old owner never
-        # accepted this request upstream, so a bootstrap rebind is safe even
-        # under a hard turn-state anchor.
+        # accepted this request upstream. A generated turn-state-only key still
+        # has no safe local creator fallback, so preserve the owner's retryable
+        # rejection instead of turning it into a misleading local 409.
+        has_identity_fallback = (
+            _codex_backend_identity(headers).thread_selection_key is not None
+            or _sticky_key_from_session_header(headers) is not None
+        )
+        if key.affinity_kind == "turn_state_header" and str(turn_state_key or "").startswith("http_turn_"):
+            return has_identity_fallback
         return True
-    if _sticky_key_from_turn_state_header(headers) is not None:
+    if turn_state_key is not None:
         return False
     payload = exc.payload
     if not isinstance(payload, dict):
@@ -3923,7 +3931,6 @@ def _http_bridge_should_attempt_local_bootstrap_rebind(
         return False
     code = error.get("code")
     return code in {
-        "bridge_drain_active",
         "bridge_owner_unreachable",
         "bridge_instance_mismatch",
     }

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -830,6 +830,11 @@ def _mark_http_bridge_inflight_creation_owner(future: Any, *, started_at: float)
     setattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
 
 
+def _http_bridge_inflight_owner_running(future: Any) -> bool:
+    owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
+    return isinstance(owner_task, asyncio.Task) and not owner_task.done()
+
+
 def _http_bridge_key_is_synthesized_turn_state(key: "_HTTPBridgeSessionKey") -> bool:
     return key.affinity_kind == "turn_state_header" and _is_synthesized_turn_state(key.affinity_key)
 
@@ -886,8 +891,18 @@ async def _wait_for_http_bridge_aborted_owner(
     timeout: float,
 ) -> bool:
     abort_error = getattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, None)
+    if abort_error is None:
+        return False
+    return await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
+
+
+async def _wait_for_http_bridge_retained_owner(
+    future: Any,
+    *,
+    timeout: float,
+) -> bool:
     owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
-    if abort_error is None or not isinstance(owner_task, asyncio.Task):
+    if not isinstance(owner_task, asyncio.Task):
         return False
     if owner_task.done():
         return True
@@ -905,6 +920,23 @@ async def _wait_for_http_bridge_aborted_owner(
     except BaseException:
         return True
     return True
+
+
+async def _evict_http_bridge_retained_capacity_waiter_after_error(
+    service: Any,
+    future: Any,
+    *,
+    timeout: float,
+) -> None:
+    error = _http_bridge_startup_wait_timeout_error(
+        "http_bridge_capacity",
+        code="capacity_exhausted_active_sessions",
+    )
+    if _http_bridge_inflight_owner_running(future) and not (
+        await _wait_for_http_bridge_retained_owner(future, timeout=timeout)
+    ):
+        raise error
+    await service._evict_http_bridge_inflight_waiter(future, error)
 
 
 def _http_bridge_inflight_creation_can_register(future: Any) -> bool:
@@ -1028,7 +1060,7 @@ def _cleanup_http_bridge_inflight_sessions_nowait(service: Any) -> dict[str, int
             owner_task = getattr(future, _HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, None)
             owner_running = isinstance(owner_task, asyncio.Task) and not owner_task.done()
             if future.done():
-                if owner_running and hasattr(future, _HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR):
+                if owner_running:
                     continue
                 cleanup_reason = "done"
             else:
@@ -1597,8 +1629,10 @@ async def _raise_if_http_bridge_creation_superseded(
     closes this session without releasing the winner's row.
     """
     async with service._http_bridge_lock:
-        superseded = service._http_bridge_inflight_sessions.get(key) is not inflight_future
-    if superseded:
+        current_future = service._http_bridge_inflight_sessions.get(key)
+        superseded = current_future is not inflight_future
+        aborted = current_future is inflight_future and not _http_bridge_inflight_creation_can_register(inflight_future)
+    if superseded or aborted:
         raise _http_bridge_startup_wait_timeout_error(
             "http_bridge_session_registration",
             code="capacity_exhausted_active_sessions",

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -117,6 +117,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_should_wait_for_registration,
     _http_bridge_startup_wait_timeout_error,
     _http_bridge_turn_state_alias_key,
+    _http_bridge_turn_state_key_from,
     _log_http_bridge_event,
     _log_http_bridge_startup_wait_timeout,
     _mark_http_bridge_inflight_creation_owner,
@@ -133,7 +134,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _reserve_http_bridge_unanchored_handoff,
     _settle_and_close_failed_http_bridge_creation,
     _turn_keys,
-    _wait_for_http_bridge_aborted_owner,
+    _wait_for_http_bridge_aborted_owner_within_budget,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _close_http_bridge_session as _helpers_close_http_bridge_session,
@@ -421,6 +422,7 @@ class _HTTPBridgeMixin(
         settings = _service_get_settings()
         request_scope_id = ensure_request_scope_id()
         api_key_id = api_key.id if api_key is not None else None
+        requested_key = key
         incoming_turn_state = _sticky_key_from_turn_state_header(headers)
         incoming_session_key, initial_session_key = _turn_keys(headers, api_key, key, session_header_fallback_key)
         original_request_unanchored = _http_bridge_request_needs_unanchored_handoff(
@@ -561,7 +563,7 @@ class _HTTPBridgeMixin(
                                 bind_account_neutral_recovery_owner(alias_session)
                                 continue
                             self._http_bridge_turn_state_index.pop(alias_index_key, None)
-                            key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
+                            key = _http_bridge_turn_state_key_from(requested_key, incoming_turn_state, api_key_id)
                         elif not _http_bridge_models_compatible(alias_session.request_model, request_model):
                             model_transition_rebind, model_transition_parent_key = True, alias_key
                             if is_http_bridge_account_neutral_replay(
@@ -579,7 +581,7 @@ class _HTTPBridgeMixin(
                                 key = recovery_fork_key
                                 continue
                             else:
-                                key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
+                                key = _http_bridge_turn_state_key_from(requested_key, incoming_turn_state, api_key_id)
                         elif not _http_bridge_compatible(
                             alias_session, request_model, request_service_tier, True
                         ) or not _http_bridge_session_matches_preferred_account(
@@ -663,14 +665,14 @@ class _HTTPBridgeMixin(
                                 kind=key.affinity_kind,
                                 key=key.affinity_key,
                             ):
-                                key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
+                                key = _http_bridge_turn_state_key_from(requested_key, incoming_turn_state, api_key_id)
                         elif (
                             fallback_key := _alias_fallback_key(incoming_session_key, initial_session_key, api_key_id)
                         ) is not None:
                             key = fallback_key
                             used_session_header_fallback = True
                         else:
-                            key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
+                            key = _http_bridge_turn_state_key_from(requested_key, incoming_turn_state, api_key_id)
                             missing_turn_state_alias = True
                 pruned_sessions = self._prune_http_bridge_sessions_locked()
                 if pruned_sessions:
@@ -1371,9 +1373,8 @@ class _HTTPBridgeMixin(
                         pending_count=_http_bridge_session_generation_count(self),
                         inflight_count=len(self._http_bridge_inflight_sessions),
                     )
-                    if await _wait_for_http_bridge_aborted_owner(
-                        capacity_wait_future,
-                        timeout=wait_timeout_seconds,
+                    if await _wait_for_http_bridge_aborted_owner_within_budget(
+                        capacity_wait_future, wait_timeout_seconds, request_deadline
                     ):
                         continue
                     raise timeout_error from exc
@@ -1410,9 +1411,8 @@ class _HTTPBridgeMixin(
                     )
                     if _http_bridge_key_is_synthesized_turn_state(key):
                         raise timeout_error from exc
-                    if await _wait_for_http_bridge_aborted_owner(
-                        inflight_future,
-                        timeout=wait_timeout_seconds,
+                    if await _wait_for_http_bridge_aborted_owner_within_budget(
+                        inflight_future, wait_timeout_seconds, request_deadline
                     ):
                         continue
                     raise timeout_error from exc

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -74,6 +74,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _alias_fallback_key,
     _durable_bridge_lookup_active_owner,
     _durable_bridge_lookup_allows_local_reuse,
+    _evict_http_bridge_retained_capacity_waiter_after_error,
     _forwarded_http_bridge_session_key,
     _http_bridge_alias_target_is_stale,
     _http_bridge_allow_durable_takeover,
@@ -1379,7 +1380,11 @@ class _HTTPBridgeMixin(
                 except ProxyResponseError:
                     raise
                 except Exception:
-                    pass
+                    await _evict_http_bridge_retained_capacity_waiter_after_error(
+                        self,
+                        capacity_wait_future,
+                        timeout=wait_timeout_seconds,
+                    )
                 continue
             if inflight_future is not None and not owns_creation:
                 wait_timeout_seconds = _proxy_admission_wait_timeout_seconds()

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -90,6 +90,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_incompatible_model_fork_key,
     _http_bridge_inflight_creation_can_register,
     _http_bridge_inflight_creation_count,
+    _http_bridge_key_is_synthesized_turn_state,
     _http_bridge_key_strength,
     _http_bridge_locally_owned_fork_key,
     _http_bridge_models_compatible,
@@ -129,7 +130,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _register_http_bridge_turn_state_aliases_locked,
     _require_http_bridge_bound_account_not_excluded,
     _reserve_http_bridge_unanchored_handoff,
-    _settle_failed_http_bridge_creation,
+    _settle_and_close_failed_http_bridge_creation,
     _turn_keys,
     _wait_for_http_bridge_aborted_owner,
 )
@@ -1402,12 +1403,12 @@ class _HTTPBridgeMixin(
                         pending_count=_http_bridge_session_generation_count(self),
                         inflight_count=len(self._http_bridge_inflight_sessions),
                     )
+                    if _http_bridge_key_is_synthesized_turn_state(key):
+                        raise timeout_error from exc
                     if await _wait_for_http_bridge_aborted_owner(
                         inflight_future,
                         timeout=wait_timeout_seconds,
                     ):
-                        if key.affinity_kind == "turn_state_header":
-                            raise timeout_error from exc
                         continue
                     raise timeout_error from exc
                 except Exception:
@@ -1565,18 +1566,14 @@ class _HTTPBridgeMixin(
                         code="capacity_exhausted_active_sessions",
                     )
             except BaseException as exc:
-                superseded = await _settle_failed_http_bridge_creation(
+                await _settle_and_close_failed_http_bridge_creation(
                     self,
                     key,
                     inflight_future=inflight_future,
                     created_session=created_session,
+                    session_registered=session_registered,
                     exc=exc,
                 )
-                if created_session is not None and not session_registered:
-                    await self._close_http_bridge_session(
-                        created_session,
-                        release_durable_session=not superseded,
-                    )
                 raise
             assert created_session is not None
             _log_http_bridge_event(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -68,8 +68,6 @@ from app.modules.proxy._service.http_bridge.account_sessions import _HTTPBridgeA
 from app.modules.proxy._service.http_bridge.activity import _HTTPBridgeActivityMixin
 from app.modules.proxy._service.http_bridge.helpers import (
     _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
-    _abort_http_bridge_inflight_creation_by_future_locked,
-    _abort_http_bridge_inflight_creation_locked,
     _active_http_bridge_instance_ring,
     _alias_fallback_key,
     _durable_bridge_lookup_active_owner,
@@ -295,32 +293,6 @@ class _HTTPBridgeMixin(
             return False
         self._http_bridge_background_cleanup_failed |= any(isinstance(result, BaseException) for result in results)
         return not self._http_bridge_background_cleanup_failed
-
-    async def _fail_http_bridge_inflight_session_creation(
-        self,
-        key: "_HTTPBridgeSessionKey",
-        inflight_future: asyncio.Future["_HTTPBridgeSession"] | None,
-        exc: BaseException,
-    ) -> bool:
-        if inflight_future is None:
-            return False
-        async with self._http_bridge_lock:
-            return _abort_http_bridge_inflight_creation_locked(self, key, inflight_future, exc)
-
-    async def _evict_http_bridge_inflight_waiter(
-        self,
-        inflight_future: asyncio.Future["_HTTPBridgeSession"],
-        exc: BaseException,
-    ) -> "_HTTPBridgeSessionKey | None":
-        async with self._http_bridge_lock:
-            stale_key = None
-            for candidate_key, candidate_future in self._http_bridge_inflight_sessions.items():
-                if candidate_future is inflight_future:
-                    stale_key = candidate_key
-                    break
-            if stale_key is None:
-                return None
-            return _abort_http_bridge_inflight_creation_by_future_locked(self, inflight_future, exc)
 
     @overload
     async def _get_or_create_http_bridge_session(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -82,6 +82,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_can_recover_during_drain,
     _http_bridge_can_single_instance_owner_takeover_without_anchor,
     _http_bridge_can_single_instance_prompt_cache_takeover_without_anchor,
+    _http_bridge_canonical_inflight_key_locked,
     _http_bridge_capacity_after_planned_closes,
     _http_bridge_claim_allows_takeover,
     _http_bridge_compatible,
@@ -680,6 +681,10 @@ class _HTTPBridgeMixin(
                         force_durable_takeover = True
                     self._schedule_http_bridge_session_closes(pruned_sessions, reason="registry_detach")
                 existing = self._http_bridge_sessions.get(key)
+                if existing is not None:
+                    key = existing.key
+                else:
+                    key = _http_bridge_canonical_inflight_key_locked(self, key)
                 retained_handoff = bool(
                     existing and existing.closed and _http_bridge_session_has_admission_waiter(existing)
                 )
@@ -1374,7 +1379,7 @@ class _HTTPBridgeMixin(
                         inflight_count=len(self._http_bridge_inflight_sessions),
                     )
                     if await _wait_for_http_bridge_aborted_owner_within_budget(
-                        capacity_wait_future, wait_timeout_seconds, request_deadline
+                        self, capacity_wait_future, wait_timeout_seconds, request_deadline
                     ):
                         continue
                     raise timeout_error from exc
@@ -1385,6 +1390,7 @@ class _HTTPBridgeMixin(
                         self,
                         capacity_wait_future,
                         timeout=wait_timeout_seconds,
+                        request_deadline=request_deadline,
                     )
                 continue
             if inflight_future is not None and not owns_creation:
@@ -1412,7 +1418,7 @@ class _HTTPBridgeMixin(
                     if _http_bridge_key_is_synthesized_turn_state(key):
                         raise timeout_error from exc
                     if await _wait_for_http_bridge_aborted_owner_within_budget(
-                        inflight_future, wait_timeout_seconds, request_deadline
+                        self, inflight_future, wait_timeout_seconds, request_deadline
                     ):
                         continue
                     raise timeout_error from exc

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -68,7 +68,8 @@ from app.modules.proxy._service.http_bridge.account_sessions import _HTTPBridgeA
 from app.modules.proxy._service.http_bridge.activity import _HTTPBridgeActivityMixin
 from app.modules.proxy._service.http_bridge.helpers import (
     _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
-    _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
+    _abort_http_bridge_inflight_creation_by_future_locked,
+    _abort_http_bridge_inflight_creation_locked,
     _active_http_bridge_instance_ring,
     _alias_fallback_key,
     _durable_bridge_lookup_active_owner,
@@ -87,6 +88,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_endpoint_matches_current_instance,
     _http_bridge_has_durable_recovery_anchor,
     _http_bridge_incompatible_model_fork_key,
+    _http_bridge_inflight_creation_can_register,
     _http_bridge_inflight_creation_count,
     _http_bridge_key_strength,
     _http_bridge_locally_owned_fork_key,
@@ -115,6 +117,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_turn_state_alias_key,
     _log_http_bridge_event,
     _log_http_bridge_startup_wait_timeout,
+    _mark_http_bridge_inflight_creation_owner,
     _mark_http_bridge_reader_handoff_reconnect_failed,
     _persist_http_bridge_replacement_account,
     _persistent_http_bridge_affinity,
@@ -128,6 +131,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _reserve_http_bridge_unanchored_handoff,
     _settle_failed_http_bridge_creation,
     _turn_keys,
+    _wait_for_http_bridge_aborted_owner,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _close_http_bridge_session as _helpers_close_http_bridge_session,
@@ -297,20 +301,7 @@ class _HTTPBridgeMixin(
         if inflight_future is None:
             return False
         async with self._http_bridge_lock:
-            current_future = self._http_bridge_inflight_sessions.get(key)
-            if current_future is not inflight_future:
-                return False
-            if getattr(inflight_future, "_http_bridge_handoff", False):
-                return False
-            self._http_bridge_inflight_sessions.pop(key, None)
-            if inflight_future.done():
-                return True
-            if isinstance(exc, asyncio.CancelledError):
-                inflight_future.cancel()
-            else:
-                inflight_future.set_exception(exc)
-                inflight_future.exception()
-            return True
+            return _abort_http_bridge_inflight_creation_locked(self, key, inflight_future, exc)
 
     async def _evict_http_bridge_inflight_waiter(
         self,
@@ -325,13 +316,7 @@ class _HTTPBridgeMixin(
                     break
             if stale_key is None:
                 return None
-            if getattr(inflight_future, "_http_bridge_handoff", False):
-                return None
-            self._http_bridge_inflight_sessions.pop(stale_key, None)
-            if not inflight_future.done():
-                inflight_future.set_exception(exc)
-                inflight_future.exception()
-            return stale_key
+            return _abort_http_bridge_inflight_creation_by_future_locked(self, inflight_future, exc)
 
     @overload
     async def _get_or_create_http_bridge_session(
@@ -1332,10 +1317,9 @@ class _HTTPBridgeMixin(
                                 capacity_error_after_planned_closes = capacity_error
                         else:
                             inflight_future = asyncio.get_running_loop().create_future()
-                            setattr(
+                            _mark_http_bridge_inflight_creation_owner(
                                 inflight_future,
-                                _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
-                                clock_for(self).monotonic(),
+                                started_at=clock_for(self).monotonic(),
                             )
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
@@ -1385,6 +1369,11 @@ class _HTTPBridgeMixin(
                         pending_count=_http_bridge_session_generation_count(self),
                         inflight_count=len(self._http_bridge_inflight_sessions),
                     )
+                    if await _wait_for_http_bridge_aborted_owner(
+                        capacity_wait_future,
+                        timeout=wait_timeout_seconds,
+                    ):
+                        continue
                     raise timeout_error from exc
                 except ProxyResponseError:
                     raise
@@ -1413,6 +1402,13 @@ class _HTTPBridgeMixin(
                         pending_count=_http_bridge_session_generation_count(self),
                         inflight_count=len(self._http_bridge_inflight_sessions),
                     )
+                    if await _wait_for_http_bridge_aborted_owner(
+                        inflight_future,
+                        timeout=wait_timeout_seconds,
+                    ):
+                        if key.affinity_kind == "turn_state_header":
+                            raise timeout_error from exc
+                        continue
                     raise timeout_error from exc
                 except Exception:
                     raise
@@ -1553,7 +1549,9 @@ class _HTTPBridgeMixin(
                 await self._claim_durable_http_bridge_session(created_session, **claim_kwargs)
                 async with self._http_bridge_lock:
                     current_future = self._http_bridge_inflight_sessions.get(key)
-                    if current_future is inflight_future:
+                    if current_future is inflight_future and _http_bridge_inflight_creation_can_register(
+                        inflight_future
+                    ):
                         self._http_bridge_inflight_sessions.pop(key, None)
                         if original_request_unanchored:
                             _reserve_http_bridge_unanchored_handoff(created_session, request_scope_id=request_scope_id)

--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -198,6 +198,28 @@ def _owner_forward_failure_allows_local_recovery(exc: ProxyResponseError) -> boo
     }
 
 
+def _owner_forward_failure_was_pre_dispatch(exc: ProxyResponseError) -> bool:
+    """Return whether the owner failed before accepting the request upstream."""
+
+    return isinstance(exc, _OwnerForwardRequestError) and exc.outcome in {
+        _OwnerForwardOutcome.NOT_DISPATCHED,
+        _OwnerForwardOutcome.RECEIVER_REJECTED,
+    }
+
+
+def _owner_forward_outcome_for_proxy_error(
+    exc: ProxyResponseError,
+    *,
+    default: _OwnerForwardOutcome,
+) -> _OwnerForwardOutcome:
+    payload = exc.payload
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict) and error.get("code") == "bridge_drain_active":
+            return _OwnerForwardOutcome.RECEIVER_REJECTED
+    return default
+
+
 def _durable_recovery_supersedes_local_session(
     durable_lookup: DurableBridgeLookup | None,
     session: _HTTPBridgeSession,
@@ -552,7 +574,10 @@ class _HTTPBridgeOwnerForwardingMixin:
                     default_message="HTTP bridge owner request failed",
                 )
                 return
-            raise _OwnerForwardRequestError(exc, outcome=forward_outcome) from exc
+            raise _OwnerForwardRequestError(
+                exc,
+                outcome=_owner_forward_outcome_for_proxy_error(exc, default=forward_outcome),
+            ) from exc
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             if PROMETHEUS_AVAILABLE and bridge_owner_forward_total is not None:
                 bridge_owner_forward_total.labels(outcome="fail").inc()

--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -419,6 +419,7 @@ class _HTTPBridgeOwnerForwardingMixin:
         downstream_turn_state: str | None,
         request_started_at: float,
         proxy_api_authorization: str | None,
+        downstream_turn_state_synthesized: bool = False,
         file_owner_account_id: str | None = None,
         client_ip: str | None = None,
     ) -> AsyncIterator[str]:
@@ -441,6 +442,9 @@ class _HTTPBridgeOwnerForwardingMixin:
             reservation=api_key_reservation,
             codex_session_affinity=codex_session_affinity,
             downstream_turn_state=forwarded_turn_state,
+            downstream_turn_state_synthesized=(
+                downstream_turn_state_synthesized and forwarded_turn_state == downstream_turn_state
+            ),
             original_request_unanchored=(
                 recovery_forward
                 or (

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -115,6 +115,8 @@ class _HTTPBridgeServiceProtocol(Protocol):
         self,
         session: _HTTPBridgeSession,
         turn_state: str,
+        *,
+        synthesized: bool = False,
     ) -> bool: ...
     async def _register_http_bridge_turn_state_core(
         self,
@@ -122,6 +124,7 @@ class _HTTPBridgeServiceProtocol(Protocol):
         turn_state: str,
         *,
         reversible: bool,
+        synthesized: bool,
     ) -> tuple[bool, DurableBridgeAliasRegistrationReceipt | None]: ...
     async def _register_http_bridge_previous_response_id_impl(
         self,

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -232,21 +232,30 @@ class _HTTPBridgeSessionRegistryMixin:
         self: _HTTPBridgeServiceProtocol,
         session: _HTTPBridgeSession,
         turn_state: str,
+        *,
+        synthesized: bool = False,
     ) -> bool:
         if _requires_durable_recovery_alias_serialization(session):
             async with session.recovery_alias_lock:
-                return await self._register_http_bridge_turn_state_impl(session, turn_state)
-        return await self._register_http_bridge_turn_state_impl(session, turn_state)
+                return await self._register_http_bridge_turn_state_impl(
+                    session,
+                    turn_state,
+                    synthesized=synthesized,
+                )
+        return await self._register_http_bridge_turn_state_impl(session, turn_state, synthesized=synthesized)
 
     async def _register_http_bridge_turn_state_impl(
         self: _HTTPBridgeServiceProtocol,
         session: _HTTPBridgeSession,
         turn_state: str,
+        *,
+        synthesized: bool = False,
     ) -> bool:
         registered, _receipt = await self._register_http_bridge_turn_state_core(
             session,
             turn_state,
             reversible=False,
+            synthesized=synthesized,
         )
         return registered
 
@@ -261,6 +270,7 @@ class _HTTPBridgeSessionRegistryMixin:
             session,
             turn_state,
             reversible=True,
+            synthesized=False,
         )
 
     async def _register_http_bridge_turn_state_core(
@@ -269,6 +279,7 @@ class _HTTPBridgeSessionRegistryMixin:
         turn_state: str,
         *,
         reversible: bool,
+        synthesized: bool,
     ) -> tuple[bool, DurableBridgeAliasRegistrationReceipt | None]:
         defer_durable_publication = False
         deferred_live_alias_owner: _HTTPBridgeSession | None = None
@@ -303,6 +314,7 @@ class _HTTPBridgeSessionRegistryMixin:
                     deferred_live_alias_owner = live_alias_owner
                 else:
                     live_alias_owner.downstream_turn_state_aliases.discard(turn_state)
+                    live_alias_owner.synthesized_downstream_turn_state_aliases.discard(turn_state)
                     live_alias_owner.turn_state_alias_registration_generations.pop(turn_state, None)
                     if live_alias_owner.downstream_turn_state == turn_state:
                         live_alias_owner.downstream_turn_state = None
@@ -316,6 +328,8 @@ class _HTTPBridgeSessionRegistryMixin:
             registration_generation = _track_alias_registration(session, turn_state, turn_state=True)
             if not defer_durable_publication:
                 session.downstream_turn_state_aliases.add(turn_state)
+                if synthesized:
+                    session.synthesized_downstream_turn_state_aliases.add(turn_state)
                 if session.downstream_turn_state is None:
                     session.downstream_turn_state = turn_state
                 if live_alias_owner is not None:
@@ -346,6 +360,7 @@ class _HTTPBridgeSessionRegistryMixin:
             ):
                 if session.turn_state_alias_registration_generations.get(turn_state) == registration_generation:
                     session.turn_state_alias_registration_generations.pop(turn_state, None)
+                    session.synthesized_downstream_turn_state_aliases.discard(turn_state)
                 return False, receipt
             current_live_owner = _http_bridge_live_turn_state_alias_owner(self, session, turn_state)
             if (
@@ -357,10 +372,13 @@ class _HTTPBridgeSessionRegistryMixin:
                 return False, receipt
             if current_live_owner is not None:
                 current_live_owner.downstream_turn_state_aliases.discard(turn_state)
+                current_live_owner.synthesized_downstream_turn_state_aliases.discard(turn_state)
                 current_live_owner.turn_state_alias_registration_generations.pop(turn_state, None)
                 if current_live_owner.downstream_turn_state == turn_state:
                     current_live_owner.downstream_turn_state = None
             session.downstream_turn_state_aliases.add(turn_state)
+            if synthesized:
+                session.synthesized_downstream_turn_state_aliases.add(turn_state)
             if session.downstream_turn_state is None:
                 session.downstream_turn_state = turn_state
             alias_key = _http_bridge_turn_state_alias_key(turn_state, session.key.api_key_id)
@@ -592,6 +610,7 @@ class _HTTPBridgeSessionRegistryMixin:
             if self._http_bridge_turn_state_index.get(alias_key) == session.key:
                 self._http_bridge_turn_state_index.pop(alias_key, None)
         session.downstream_turn_state_aliases.clear()
+        session.synthesized_downstream_turn_state_aliases.clear()
         session.turn_state_alias_registration_generations.clear()
 
     def _unregister_http_bridge_previous_response_ids_locked(

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -20,6 +20,8 @@ from app.core.utils.time import utcnow
 from app.db.models import StickySessionKind
 from app.modules.proxy._service.http_bridge import helpers as _http_bridge_helpers
 from app.modules.proxy._service.http_bridge.helpers import (
+    _abort_http_bridge_inflight_creation_by_future_locked,
+    _abort_http_bridge_inflight_creation_locked,
     _await_task_deferring_cancellation,
     _forget_http_bridge_denied_anchor_fence_owner,
     _http_bridge_allow_durable_takeover,
@@ -84,6 +86,32 @@ def _requires_durable_recovery_alias_serialization(session: _HTTPBridgeSession) 
 
 
 class _HTTPBridgeSessionRegistryMixin:
+    async def _fail_http_bridge_inflight_session_creation(
+        self: Any,
+        key: "_HTTPBridgeSessionKey",
+        inflight_future: asyncio.Future["_HTTPBridgeSession"] | None,
+        exc: BaseException,
+    ) -> bool:
+        if inflight_future is None:
+            return False
+        async with self._http_bridge_lock:
+            return _abort_http_bridge_inflight_creation_locked(self, key, inflight_future, exc)
+
+    async def _evict_http_bridge_inflight_waiter(
+        self: Any,
+        inflight_future: asyncio.Future["_HTTPBridgeSession"],
+        exc: BaseException,
+    ) -> "_HTTPBridgeSessionKey | None":
+        async with self._http_bridge_lock:
+            stale_key = None
+            for candidate_key, candidate_future in self._http_bridge_inflight_sessions.items():
+                if candidate_future is inflight_future:
+                    stale_key = candidate_key
+                    break
+            if stale_key is None:
+                return None
+            return _abort_http_bridge_inflight_creation_by_future_locked(self, inflight_future, exc)
+
     async def prune_idle_http_bridge_sessions(self: Any) -> int:
         """Run the idle sweep off the request path (issue #1354).
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2394,8 +2394,18 @@ class _HTTPBridgeStreamingMixin:
                 owner_forward_fresh_replay = owner_unavailable_allows_account_neutral_replay(exc)
                 if owner_forward_fresh_replay:
                     switch_to_account_neutral_replay()
+                recovery_previous_response_id = effective_payload.previous_response_id
+                if (
+                    proxy_injected_previous_response_id
+                    and incoming_turn_state_header is not None
+                    and exc.failure_phase == "owner_forward"
+                    and exc.failure_detail == "owner_input_shape_upgrade_required"
+                ):
+                    # An injected anchor does not grant explicit-continuation
+                    # recovery authority. Refresh the client's turn-state lease.
+                    recovery_previous_response_id = None
                 should_attempt_previous_response_recovery = not owner_forward_fresh_replay and (
-                    effective_payload.previous_response_id is not None
+                    recovery_previous_response_id is not None
                     and _http_bridge_should_attempt_local_previous_response_recovery(exc)
                 )
                 should_attempt_bootstrap_rebind = (
@@ -2404,7 +2414,7 @@ class _HTTPBridgeStreamingMixin:
                         exc,
                         key=bridge_session_key,
                         headers=headers,
-                        previous_response_id=effective_payload.previous_response_id,
+                        previous_response_id=recovery_previous_response_id,
                         owner_pre_dispatch=_owner_forward_failure_was_pre_dispatch(exc),
                     )
                 )
@@ -2417,7 +2427,7 @@ class _HTTPBridgeStreamingMixin:
                     takeover_turn_state = _http_bridge_turn_state_anchor_for_owner_failure(
                         exc,
                         headers=headers,
-                        previous_response_id=effective_payload.previous_response_id,
+                        previous_response_id=recovery_previous_response_id,
                     )
                     if takeover_turn_state is not None:
                         # Reuse the routing lookup semantics (alias resolution
@@ -2432,7 +2442,7 @@ class _HTTPBridgeStreamingMixin:
                                 api_key_id=bridge_session_key.api_key_id,
                                 turn_state=takeover_turn_state,
                                 session_header=durable_session_header_alias,
-                                previous_response_id=effective_payload.previous_response_id,
+                                previous_response_id=recovery_previous_response_id,
                             )
                         except Exception:
                             logger.warning(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2412,10 +2412,10 @@ class _HTTPBridgeStreamingMixin:
                     not owner_forward_fresh_replay
                     and _http_bridge_should_attempt_local_bootstrap_rebind(
                         exc,
+                        owner_pre_dispatch=_owner_forward_failure_was_pre_dispatch(exc),
                         key=bridge_session_key,
                         headers=headers,
                         previous_response_id=recovery_previous_response_id,
-                        owner_pre_dispatch=_owner_forward_failure_was_pre_dispatch(exc),
                     )
                 )
                 should_attempt_turn_state_takeover = False

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -267,6 +267,7 @@ from app.modules.proxy.helpers import (
 from app.modules.proxy.replay_safety import (
     AccountNeutralReplayProjection,
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_has_response_owned_prefix_settling_output_ids,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -395,6 +396,13 @@ class _VerifiedDurableFullResend:
         ):
             return None
         input_items = cast(list[JsonValue], payload.input)
+        pending_tool_calls = durable_lookup.latest_pending_tool_calls
+        if pending_tool_calls is not None and responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+            input_items,
+            stored_count=stored_count,
+            pending_tool_calls=pending_tool_calls,
+        ):
+            return None
         replay_projection = project_responses_input_for_account_neutral_fresh_replay(
             input_items,
             stored_count=stored_count,
@@ -403,7 +411,6 @@ class _VerifiedDurableFullResend:
             # the exact-manifest check rejects response-owned messages.
             preserve_developer_message_ids=True,
         )
-        pending_tool_calls = durable_lookup.latest_pending_tool_calls
         if replay_projection is None:
             return None
         safe_fresh_context = responses_input_suffix_retains_prior_output(
@@ -1554,8 +1561,16 @@ class _HTTPBridgeStreamingMixin:
                 or not isinstance(payload.input, list)
             ):
                 return None, None, False
+            raw_input_items = cast(list[JsonValue], payload.input)
+            pending_tool_calls = lookup.latest_pending_tool_calls
+            if pending_tool_calls is not None and responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+                raw_input_items,
+                stored_count=stored_count,
+                pending_tool_calls=pending_tool_calls,
+            ):
+                return stored_count, lookup.latest_input_full_fingerprint, False
             replay_projection = project_responses_input_for_account_neutral_fresh_replay(
-                cast(list[JsonValue], payload.input),
+                raw_input_items,
                 stored_count=stored_count,
                 # Classification only: inline Responses-Lite developer IDs
                 # must remain visible until the exact-manifest check rejects

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -125,6 +125,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.owner_forwarding import (
     _owner_forward_failure_allows_local_recovery,
+    _owner_forward_failure_was_pre_dispatch,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
     _http_bridge_quarantine_clear_fence,
@@ -2404,6 +2405,7 @@ class _HTTPBridgeStreamingMixin:
                         key=bridge_session_key,
                         headers=headers,
                         previous_response_id=effective_payload.previous_response_id,
+                        owner_pre_dispatch=_owner_forward_failure_was_pre_dispatch(exc),
                     )
                 )
                 should_attempt_turn_state_takeover = False

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -868,6 +868,7 @@ class _HTTPBridgeStreamingMixin:
         api_key_reservation: ApiKeyUsageReservationData | None = None,
         suppress_text_done_events: bool = False,
         downstream_turn_state: str | None = None,
+        downstream_turn_state_synthesized: bool | None = None,
         forwarded_request: bool = False,
         forwarded_original_request_unanchored: bool = False,
         forwarded_legacy_signature: bool = False,
@@ -881,6 +882,10 @@ class _HTTPBridgeStreamingMixin:
         capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
+        if downstream_turn_state_synthesized is None:
+            downstream_turn_state_synthesized = (
+                downstream_turn_state is not None and _sticky_key_from_turn_state_header(headers) is None
+            )
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
         filtered = filter_inbound_headers(headers)
         return self._stream_http_bridge_or_retry(
@@ -893,6 +898,7 @@ class _HTTPBridgeStreamingMixin:
             api_key_reservation=api_key_reservation,
             suppress_text_done_events=suppress_text_done_events,
             downstream_turn_state=downstream_turn_state,
+            downstream_turn_state_synthesized=downstream_turn_state_synthesized,
             forwarded_request=forwarded_request,
             forwarded_original_request_unanchored=forwarded_original_request_unanchored,
             forwarded_legacy_signature=forwarded_legacy_signature,
@@ -919,6 +925,7 @@ class _HTTPBridgeStreamingMixin:
         api_key_reservation: ApiKeyUsageReservationData | None,
         suppress_text_done_events: bool,
         downstream_turn_state: str | None = None,
+        downstream_turn_state_synthesized: bool = False,
         forwarded_request: bool = False,
         forwarded_original_request_unanchored: bool = False,
         forwarded_legacy_signature: bool = False,
@@ -1041,6 +1048,7 @@ class _HTTPBridgeStreamingMixin:
                     queue_limit=runtime_config.queue_limit,
                     prompt_cache_idle_ttl_seconds=runtime_config.prompt_cache_idle_ttl_seconds,
                     downstream_turn_state=downstream_turn_state,
+                    downstream_turn_state_synthesized=downstream_turn_state_synthesized,
                     forwarded_request=forwarded_request,
                     forwarded_original_request_unanchored=forwarded_original_request_unanchored,
                     forwarded_legacy_signature=forwarded_legacy_signature,
@@ -1192,6 +1200,7 @@ class _HTTPBridgeStreamingMixin:
         queue_limit: int,
         prompt_cache_idle_ttl_seconds: float | None = None,
         downstream_turn_state: str | None = None,
+        downstream_turn_state_synthesized: bool = False,
         forwarded_request: bool = False,
         forwarded_original_request_unanchored: bool = False,
         forwarded_legacy_signature: bool = False,
@@ -1346,6 +1355,7 @@ class _HTTPBridgeStreamingMixin:
             allow_forwarded_affinity_headers=forwarded_request,
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
+            synthesized_turn_state=downstream_turn_state if downstream_turn_state_synthesized else None,
         )
         durable_lookup_turn_state = (
             downstream_turn_state

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2370,6 +2370,7 @@ class _HTTPBridgeStreamingMixin:
                     api_key_reservation=api_key_reservation,
                     codex_session_affinity=codex_session_affinity,
                     downstream_turn_state=downstream_turn_state,
+                    downstream_turn_state_synthesized=downstream_turn_state_synthesized,
                     file_owner_account_id=rewritten_file_account_id,
                     request_started_at=request_state.started_at,
                     proxy_api_authorization=proxy_api_authorization,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -93,6 +93,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_is_context_overflow_error,
     _http_bridge_is_explicit_previous_response_rejection,
     _http_bridge_is_previous_response_owner_unavailable,
+    _http_bridge_local_turn_state_alias_is_synthesized_locked,
     _http_bridge_models_compatible,
     _http_bridge_owner_lookup_unavailable_error_envelope,
     _http_bridge_payload_looks_like_full_resend,
@@ -882,10 +883,13 @@ class _HTTPBridgeStreamingMixin:
         capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
-        if downstream_turn_state_synthesized is None:
-            downstream_turn_state_synthesized = (
-                downstream_turn_state is not None and _sticky_key_from_turn_state_header(headers) is None
-            )
+        if (
+            downstream_turn_state_synthesized is None
+            and downstream_turn_state is not None
+            and not forwarded_request
+            and _sticky_key_from_turn_state_header(headers) is None
+        ):
+            downstream_turn_state_synthesized = True
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
         filtered = filter_inbound_headers(headers)
         return self._stream_http_bridge_or_retry(
@@ -925,7 +929,7 @@ class _HTTPBridgeStreamingMixin:
         api_key_reservation: ApiKeyUsageReservationData | None,
         suppress_text_done_events: bool,
         downstream_turn_state: str | None = None,
-        downstream_turn_state_synthesized: bool = False,
+        downstream_turn_state_synthesized: bool | None = None,
         forwarded_request: bool = False,
         forwarded_original_request_unanchored: bool = False,
         forwarded_legacy_signature: bool = False,
@@ -1200,7 +1204,7 @@ class _HTTPBridgeStreamingMixin:
         queue_limit: int,
         prompt_cache_idle_ttl_seconds: float | None = None,
         downstream_turn_state: str | None = None,
-        downstream_turn_state_synthesized: bool = False,
+        downstream_turn_state_synthesized: bool | None = None,
         forwarded_request: bool = False,
         forwarded_original_request_unanchored: bool = False,
         forwarded_legacy_signature: bool = False,
@@ -1316,6 +1320,21 @@ class _HTTPBridgeStreamingMixin:
 
         incoming_turn_state_header = _sticky_key_from_turn_state_header(headers) if not forwarded_request else None
         incoming_session_header = _sticky_key_from_session_header(headers) if not forwarded_request else None
+        if downstream_turn_state_synthesized is None:
+            downstream_turn_state_synthesized = (
+                downstream_turn_state is not None and not forwarded_request and incoming_turn_state_header is None
+            )
+            if (
+                downstream_turn_state is not None
+                and not downstream_turn_state_synthesized
+                and incoming_turn_state_header == downstream_turn_state
+            ):
+                async with self._http_bridge_lock:
+                    downstream_turn_state_synthesized = _http_bridge_local_turn_state_alias_is_synthesized_locked(
+                        self,
+                        downstream_turn_state,
+                        api_key.id if api_key is not None else None,
+                    )
         explicit_prompt_cache_key = _prompt_cache_key_from_request_model(payload)
         had_prompt_cache_key = explicit_prompt_cache_key is not None
         affinity = _sticky_key_for_responses_request(
@@ -1832,6 +1851,7 @@ class _HTTPBridgeStreamingMixin:
             downstream_turn_state=downstream_turn_state,
             incoming_turn_state_header=incoming_turn_state_header,
         )
+        request_state.downstream_turn_state_synthesized = downstream_turn_state_synthesized
         if previous_response_trimmed_input_count is not None:
             request_state.input_item_count = previous_response_trimmed_input_count
             request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
@@ -2130,6 +2150,7 @@ class _HTTPBridgeStreamingMixin:
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             if downstream_turn_state is not None:
                 request_state.session_id = _normalize_session_id(downstream_turn_state)
+            request_state.downstream_turn_state_synthesized = downstream_turn_state_synthesized
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
                 headers=headers,
@@ -2711,6 +2732,7 @@ class _HTTPBridgeStreamingMixin:
                         downstream_turn_state=downstream_turn_state,
                         incoming_turn_state_header=incoming_turn_state_header,
                     )
+                    retry_request_state.downstream_turn_state_synthesized = downstream_turn_state_synthesized
                     retry_request_state.transport = _REQUEST_TRANSPORT_HTTP
                     retry_request_state.request_stage = (
                         request_state.request_stage if owner_forward_fresh_replay else "reattach"
@@ -3029,6 +3051,7 @@ class _HTTPBridgeStreamingMixin:
                 downstream_turn_state=downstream_turn_state,
                 incoming_turn_state_header=incoming_turn_state_header,
             )
+            request_state.downstream_turn_state_synthesized = downstream_turn_state_synthesized
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
                 headers=headers,
@@ -3938,6 +3961,7 @@ class _HTTPBridgeStreamingMixin:
                     downstream_turn_state=downstream_turn_state,
                     incoming_turn_state_header=incoming_turn_state_header,
                 )
+                retry_request_state.downstream_turn_state_synthesized = downstream_turn_state_synthesized
                 retry_request_state.transport = _REQUEST_TRANSPORT_HTTP
                 retry_request_state.request_stage = retry_request_stage
                 retry_request_state.preferred_account_id = retry_preferred_account_id
@@ -4468,7 +4492,11 @@ class _HTTPBridgeStreamingMixin:
         idle_settlement_task: asyncio.Task[None] | None = None
         try:
             if downstream_turn_state is not None and not account_neutral_recovery:
-                await self._register_http_bridge_turn_state(session, downstream_turn_state)
+                await self._register_http_bridge_turn_state(
+                    session,
+                    downstream_turn_state,
+                    synthesized=request_state.downstream_turn_state_synthesized,
+                )
             _signal_propagated_capacity_startup_ready()
             if request_state.capacity_startup_wait_event is not None:
                 request_state.capacity_startup_wait_event.clear()

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1304,6 +1304,7 @@ class _HTTPBridgeSessionKey:
     affinity_key: str
     api_key_id: str | None
     strength: Literal["hard", "soft"] | None = None
+    synthesized_turn_state: bool = field(default=False, compare=False, hash=False)
 
     def __post_init__(self) -> None:
         strength = self.strength

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1010,6 +1010,7 @@ class _WebSocketRequestState:
     # recovery paths re-prepare request states with a fresh started_at, so
     # budget clamps must use this instead of recomputing from started_at.
     bridge_request_deadline: float | None = None
+    downstream_turn_state_synthesized: bool = False
     prewarm_status: str | None = None
     prewarm_latency_ms: int | None = None
     session_previous_gap_ms: int | None = None
@@ -1352,6 +1353,7 @@ class _HTTPBridgeSession:
     upstream_turn_state: str | None = None
     downstream_turn_state: str | None = None
     downstream_turn_state_aliases: set[str] = field(default_factory=set)
+    synthesized_downstream_turn_state_aliases: set[str] = field(default_factory=set)
     previous_response_ids: set[str] = field(default_factory=set)
     # The live session keeps only its current denial tombstone.  Historical
     # ids remain in the process-local fence ledger while prepared requests pin

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1611,6 +1611,9 @@ async def internal_bridge_responses(
         forwarded_legacy_signature=forwarded_request_context.context.signature_version is None,
         forwarded_headers=forwarded_headers,
         forwarded_downstream_turn_state=forwarded_request_context.context.downstream_turn_state,
+        forwarded_downstream_turn_state_synthesized=(
+            forwarded_request_context.context.downstream_turn_state_synthesized
+        ),
         forwarded_affinity_kind=forwarded_request_context.context.original_affinity_kind,
         forwarded_affinity_key=forwarded_request_context.context.original_affinity_key,
         forwarded_file_owner_account_id=forwarded_request_context.context.file_owner_account_id,
@@ -6496,6 +6499,7 @@ async def _stream_responses(
     forwarded_legacy_signature: bool = False,
     forwarded_headers: Mapping[str, str] | None = None,
     forwarded_downstream_turn_state: str | None = None,
+    forwarded_downstream_turn_state_synthesized: bool = False,
     forwarded_affinity_kind: str | None = None,
     forwarded_affinity_key: str | None = None,
     forwarded_file_owner_account_id: str | None = None,
@@ -6623,7 +6627,9 @@ async def _stream_responses(
         else None
     )
     downstream_turn_state_synthesized = (
-        bridge_active and downstream_turn_state is not None and not forwarded_request and client_turn_state is None
+        bridge_active
+        and downstream_turn_state is not None
+        and (forwarded_downstream_turn_state_synthesized if forwarded_request else client_turn_state is None)
     )
     turn_state_headers = (
         proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6614,12 +6614,16 @@ async def _stream_responses(
         policy_already_applied=forwarded_request,
     )
     client_ip = forwarded_client_ip if forwarded_request else resolve_request_client_host(request)
+    client_turn_state = proxy_affinity_module._sticky_key_from_turn_state_header(effective_headers)
     downstream_turn_state = (
         forwarded_downstream_turn_state
         if bridge_active and forwarded_downstream_turn_state is not None
         else proxy_affinity_module.ensure_http_downstream_turn_state(effective_headers)
         if bridge_active
         else None
+    )
+    downstream_turn_state_synthesized = (
+        bridge_active and downstream_turn_state is not None and not forwarded_request and client_turn_state is None
     )
     turn_state_headers = (
         proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state)
@@ -6739,6 +6743,7 @@ async def _stream_responses(
                 api_key_reservation=reservation,
                 suppress_text_done_events=suppress_text_done_events,
                 downstream_turn_state=downstream_turn_state,
+                downstream_turn_state_synthesized=downstream_turn_state_synthesized,
                 forwarded_request=forwarded_request,
                 forwarded_original_request_unanchored=forwarded_original_request_unanchored,
                 forwarded_legacy_signature=forwarded_legacy_signature,
@@ -6990,6 +6995,10 @@ async def _collect_responses(
     downstream_turn_state = (
         proxy_affinity_module.ensure_http_downstream_turn_state(request.headers) if bridge_active else None
     )
+    client_turn_state = proxy_affinity_module._sticky_key_from_turn_state_header(request.headers)
+    downstream_turn_state_synthesized = (
+        bridge_active and downstream_turn_state is not None and client_turn_state is None
+    )
     client_ip = resolve_request_client_host(request)
     turn_state_headers = (
         proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state)
@@ -7010,6 +7019,7 @@ async def _collect_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
             downstream_turn_state=downstream_turn_state,
+            downstream_turn_state_synthesized=downstream_turn_state_synthesized,
             client_ip=client_ip,
             http_bridge_active=bridge_active,
         )

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -50,6 +50,8 @@ HTTP_BRIDGE_INTERNAL_FORWARD_PATH = "/internal/bridge/responses"
 HTTP_BRIDGE_FORWARDED_HEADER = "x-codex-bridge-forwarded"
 HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER = "x-codex-bridge-origin-instance"
 HTTP_BRIDGE_TARGET_INSTANCE_HEADER = "x-codex-bridge-target-instance"
+HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER = "x-codex-bridge-turn-state-synthesized"
+HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER = "x-codex-bridge-turn-state-provenance-signature-v1"
 HTTP_BRIDGE_CODEX_AFFINITY_HEADER = "x-codex-bridge-codex-session-affinity"
 HTTP_BRIDGE_RESERVATION_ID_HEADER = "x-codex-bridge-reservation-id"
 HTTP_BRIDGE_RESERVATION_KEY_ID_HEADER = "x-codex-bridge-reservation-key-id"
@@ -82,6 +84,7 @@ class HTTPBridgeForwardContext:
     target_instance: str
     codex_session_affinity: bool
     downstream_turn_state: str | None
+    downstream_turn_state_synthesized: bool = False
     original_request_unanchored: bool = False
     original_affinity_kind: str | None = None
     original_affinity_key: str | None = None
@@ -358,6 +361,17 @@ def build_owner_forward_headers(
         context=context,
         signature_version=signature_version,
     )
+    if context.downstream_turn_state_synthesized:
+        # Add provenance without changing the deployed full-context signature
+        # bytes. Old owners ignore these headers and continue validating the
+        # existing signature; upgraded owners require this proof before they
+        # accept the generated-state privilege.
+        forwarded[HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER] = "1"
+        forwarded[HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER] = _bridge_forward_turn_state_provenance_signature(
+            payload=payload,
+            context=context,
+            signature_version=signature_version,
+        )
     return forwarded
 
 
@@ -389,6 +403,9 @@ def parse_forwarded_request(
     client_ip = _optional_header(headers.get(HTTP_BRIDGE_CLIENT_IP_HEADER))
     signature_version = _optional_header(headers.get(HTTP_BRIDGE_SIGNATURE_VERSION_HEADER))
     original_unanchored_value = _optional_header(headers.get(HTTP_BRIDGE_ORIGINAL_UNANCHORED_HEADER))
+    turn_state_synthesized_value = _optional_header(headers.get(HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER))
+    if turn_state_synthesized_value not in {None, "0", "1"}:
+        return None, _invalid_bridge_forward_signature_error()
     if signature_version == _HTTP_BRIDGE_SIGNATURE_VERSION_V2:
         if original_unanchored_value not in {"0", "1"}:
             return None, _invalid_bridge_forward_signature_error()
@@ -402,6 +419,7 @@ def parse_forwarded_request(
         target_instance=target_instance,
         codex_session_affinity=_bool_header(headers.get(HTTP_BRIDGE_CODEX_AFFINITY_HEADER)),
         downstream_turn_state=_optional_header(headers.get("x-codex-turn-state")),
+        downstream_turn_state_synthesized=turn_state_synthesized_value == "1",
         original_request_unanchored=original_request_unanchored,
         original_affinity_kind=_optional_header(headers.get(HTTP_BRIDGE_AFFINITY_KIND_HEADER)),
         original_affinity_key=_optional_header(headers.get(HTTP_BRIDGE_AFFINITY_KEY_HEADER)),
@@ -429,9 +447,25 @@ def parse_forwarded_request(
             signature_version=signature_version,
         ),
     )
+    if turn_state_synthesized_value == "1":
+        provenance_signature = _optional_header(headers.get(HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER))
+        provenance_valid = provenance_signature is not None and hmac.compare_digest(
+            provenance_signature,
+            _bridge_forward_turn_state_provenance_signature(
+                payload=payload,
+                context=context,
+                signature_version=signature_version,
+            ),
+        )
+        if not provenance_valid:
+            return None, _invalid_bridge_forward_signature_error()
     if tools_bound_valid:
         return HTTPBridgeForwardedRequest(context=context), None
-    if context.file_owner_account_id is not None or extract_input_file_ids(payload.input):
+    if (
+        context.file_owner_account_id is not None
+        or turn_state_synthesized_value == "1"
+        or extract_input_file_ids(payload.input)
+    ):
         # The rolling-upgrade primary signature does not bind the additive
         # file-owner proof. Never allow a stripped/forged proof to downgrade to
         # it, and never allow payloads with file references to fall back after a
@@ -628,6 +662,31 @@ def _bridge_forward_tools_bound_signature(
         include_client_ip=True,
         signature_version=signature_version,
         protocol="codex-lb-http-bridge-forward-tools-bound",
+    )
+    return _sign_bridge_payload(signing_payload)
+
+
+def _bridge_forward_turn_state_provenance_signature(
+    *,
+    payload: ResponsesRequest,
+    context: HTTPBridgeForwardContext,
+    signature_version: str | None = None,
+) -> str:
+    """Bind generated turn-state provenance without changing the old codec."""
+
+    signing_payload = json.dumps(
+        {
+            "downstream_turn_state_synthesized": context.downstream_turn_state_synthesized,
+            "protocol": "codex-lb-http-bridge-turn-state-provenance-v1",
+            "tools_bound_signature": _bridge_forward_tools_bound_signature(
+                payload=payload,
+                context=context,
+                signature_version=signature_version,
+            ),
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
     )
     return _sign_bridge_payload(signing_payload)
 

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -292,7 +292,7 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         if not _input_item_has_only_known_fields(item, item_type):
             return False
         call_id_value = item.get("call_id")
-        call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
+        call_id = cast(str, call_id_value) if _is_nonblank_string(call_id_value) else None
         if item_type in _TOOL_CALL_TYPES:
             if (
                 call_id is None
@@ -434,7 +434,15 @@ def responses_input_suffix_matches_pending_tool_calls(
         allow_historical_developer_interleave=True,
         canonical_lite_developer_index=canonical_lite_developer_index,
     )
-    if prefix_state is None or prefix_state[0] or prefix_state[1] & pending_tool_calls.keys():
+    if prefix_state is None:
+        return False
+    prefix_pending_calls, prefix_seen_call_ids = prefix_state
+    expected = dict(pending_tool_calls)
+    prefix_pending = {call_id: call_type for call_type, call_id in prefix_pending_calls}
+    if prefix_pending:
+        if prefix_pending != expected:
+            return False
+    elif prefix_seen_call_ids & pending_tool_calls.keys():
         return False
     suffix = input_items[stored_count:]
     if (
@@ -451,19 +459,78 @@ def responses_input_suffix_matches_pending_tool_calls(
         for item in suffix
     ):
         return False
-    if not responses_input_items_are_self_contained_fresh_replay(suffix):
+    if not prefix_pending and not responses_input_items_are_self_contained_fresh_replay(suffix):
         return False
     suffix_calls: dict[str, str] = {}
     suffix_outputs: dict[str, str] = {}
     for item in cast(list[dict[str, JsonValue]], suffix):
         item_type = cast(str, item["type"])
-        call_id = cast(str, item["call_id"])
+        call_id = item.get("call_id")
+        if not _is_nonblank_string(call_id):
+            return False
+        call_id_str = cast(str, call_id)
         if item_type in _TOOL_CALL_TYPES:
-            suffix_calls[call_id] = item_type
+            if call_id_str in suffix_calls:
+                return False
+            suffix_calls[call_id_str] = item_type
         else:
-            suffix_outputs[call_id] = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE[item_type]
-    expected = dict(pending_tool_calls)
+            if call_id_str in suffix_outputs:
+                return False
+            if "id" in item or set(item) - _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS[item_type]:
+                return False
+            if (
+                not _internal_chat_message_metadata_is_account_neutral(item.get(_INTERNAL_CHAT_MESSAGE_METADATA_FIELD))
+                or not _caller_is_self_contained(item)
+                or not _tool_output_is_self_contained(item_type, item)
+            ):
+                return False
+            suffix_outputs[call_id_str] = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE[item_type]
+    if prefix_pending:
+        return not suffix_calls and suffix_outputs == expected
     return suffix_calls == expected and suffix_outputs == expected
+
+
+def responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+    input_items: list[JsonValue],
+    *,
+    stored_count: int,
+    pending_tool_calls: Mapping[str, str],
+    canonical_lite_developer_index: int | None = None,
+) -> bool:
+    """Return whether raw prefix-settling outputs carry response-owned IDs."""
+
+    if stored_count <= 0 or len(input_items) <= stored_count or not pending_tool_calls:
+        return False
+    prefix_state = _direct_tool_call_prefix_state(
+        input_items[:stored_count],
+        allow_historical_developer_interleave=True,
+        canonical_lite_developer_index=canonical_lite_developer_index,
+    )
+    if prefix_state is None:
+        return False
+    prefix_pending_calls, _prefix_seen_call_ids = prefix_state
+    prefix_pending = {call_id: call_type for call_type, call_id in prefix_pending_calls}
+    expected = dict(pending_tool_calls)
+    if prefix_pending != expected:
+        return False
+    suffix = input_items[stored_count:]
+    if (
+        len(suffix) == 3
+        and isinstance(suffix[1], dict)
+        and _fresh_developer_message_is_transparent(suffix[1])
+        and _fresh_developer_interleave_is_bounded(suffix, index=1)
+    ):
+        suffix = [suffix[0], suffix[2]]
+    for item in suffix:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        call_type = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE.get(item_type if isinstance(item_type, str) else "")
+        call_id = item.get("call_id")
+        if call_type is not None and _is_nonblank_string(call_id) and expected.get(cast(str, call_id)) == call_type:
+            if "id" in item:
+                return True
+    return False
 
 
 def _direct_tool_call_prefix_state(
@@ -512,10 +579,11 @@ def _direct_tool_call_prefix_state(
             if item.get("status") not in (None, "completed"):
                 return None
             call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not call_id or call_id in seen_call_ids:
+            if not _is_nonblank_string(call_id) or call_id in seen_call_ids:
                 return None
-            seen_call_ids.add(call_id)
-            pending_calls.append((item_type, call_id))
+            call_id_str = cast(str, call_id)
+            seen_call_ids.add(call_id_str)
+            pending_calls.append((item_type, call_id_str))
             if len(pending_calls) > 1:
                 # A window that already spent its interleaved developer message must not
                 # become parallel afterwards, otherwise a batch is admitted by ordering the
@@ -529,7 +597,7 @@ def _direct_tool_call_prefix_state(
             if item.get("status") not in (None, "completed", "failed"):
                 return None
             call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not pending_calls:
+            if not _is_nonblank_string(call_id) or not pending_calls:
                 return None
             if pending_calls[0] != (call_type, call_id):
                 return None
@@ -548,8 +616,8 @@ def _direct_tool_call_prefix_state(
         # surface their IDs for collision checks: a pending call that reuses
         # one of them cannot be proven fresh.
         fallthrough_call_id = item.get("call_id")
-        if isinstance(fallthrough_call_id, str) and fallthrough_call_id:
-            seen_call_ids.add(fallthrough_call_id)
+        if _is_nonblank_string(fallthrough_call_id):
+            seen_call_ids.add(cast(str, fallthrough_call_id))
     return pending_calls, seen_call_ids
 
 

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/.openspec.yaml
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/proposal.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Account-neutral full-resend certification currently rejects a safe shape where
+the stored prefix already contains the pending tool call and the fresh suffix
+only supplies its matching output. That can force owner-bound recovery even
+when the resent input is otherwise self-contained and exactly settles the
+durable pending-tool manifest.
+
+## What Changes
+
+- Allow a suffix made only of outputs that exactly settle pending direct tool
+  calls already present in the verified stored prefix.
+- Keep replay certification fail-closed for orphan outputs, duplicate output
+  call IDs, missing call IDs, response-owned output fields, or suffix tool
+  calls when the pending calls live in the prefix.
+- Preserve the existing exact-manifest behavior for fresh suffixes that contain
+  both the direct tool calls and their outputs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: account-neutral replay certification can prove
+  prefix-settled direct tool calls without weakening malformed-output checks.

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Account-neutral replay proof may settle prefix-held direct tool calls
+
+The account-neutral full resend proof MUST accept output-only suffixes that
+settle pending direct tool calls from a verified stored prefix. The verified
+stored prefix must contain the exact direct tool calls named by the durable
+pending-tool manifest. The proof MUST reject suffix tool calls in that
+prefix-settling mode. Each suffix output MUST have exactly one nonblank
+`call_id`, MUST use the output type matching the manifest call type, MUST NOT
+duplicate another suffix output call ID, and MUST NOT carry response-owned
+fields outside the account-neutral tool-output field set.
+
+#### Scenario: Suffix settles pending calls from the stored prefix
+
+- **GIVEN** the verified stored prefix contains a supported direct tool call
+- **AND** the durable pending-tool manifest names that call ID and call type
+- **WHEN** the fresh suffix contains the matching direct tool output and no
+  fresh tool call
+- **THEN** account-neutral replay proof succeeds
+
+#### Scenario: Malformed prefix-settling output fails closed
+
+- **GIVEN** the verified stored prefix contains a supported direct tool call
+- **WHEN** the fresh suffix contains an orphan output, duplicate output, missing
+  call ID, mismatched output type, response-owned output field, or fresh tool
+  call
+- **THEN** account-neutral replay proof fails

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
@@ -8,8 +8,8 @@ stored prefix must contain the exact direct tool calls named by the durable
 pending-tool manifest. The proof MUST reject suffix tool calls in that
 prefix-settling mode. Each suffix output MUST have exactly one nonblank
 `call_id`, MUST use the output type matching the manifest call type, MUST NOT
-duplicate another suffix output call ID, and MUST NOT carry response-owned
-fields outside the account-neutral tool-output field set.
+duplicate another suffix output call ID, MUST NOT contain `id`, and MUST NOT
+carry response-owned fields outside the account-neutral tool-output field set.
 
 #### Scenario: Suffix settles pending calls from the stored prefix
 

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/tasks.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/tasks.md
@@ -1,0 +1,9 @@
+## 1. Prefix-settled tool outputs
+
+- [x] 1.1 Allow output-only suffixes that exactly settle pending direct tool calls from the verified stored prefix.
+- [x] 1.2 Reject duplicate, orphan, missing-call-id, and response-owned output items.
+
+## 2. Validation
+
+- [x] 2.1 Add focused replay-safety regression tests.
+- [x] 2.2 Validate the OpenSpec delta strictly.

--- a/openspec/changes/recover-draining-owner-forward/.openspec.yaml
+++ b/openspec/changes/recover-draining-owner-forward/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/recover-draining-owner-forward/proposal.md
+++ b/openspec/changes/recover-draining-owner-forward/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+During a blue-green drain, an HTTP bridge owner can reject an owner-forwarded
+request with `bridge_drain_active` before accepting it upstream. The origin
+already has enough context to retry locally for session/thread bootstrap
+requests, but current-main treats turn-state anchored drain rejection like any
+other hard anchor and refuses the local rebind.
+
+## What Changes
+
+- Classify explicit `bridge_drain_active` owner-forward errors as receiver
+  rejection, not ambiguous dispatch.
+- Allow local bootstrap rebind for session/thread headers with a turn-state
+  anchor only when the owner-forward failure is proven pre-dispatch.
+- Keep previous-response continuations excluded from this bootstrap path.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sticky-session-operations`: draining owner-forward rejection can recover
+  locally only when the owner did not accept the request upstream.

--- a/openspec/changes/recover-draining-owner-forward/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/recover-draining-owner-forward/specs/sticky-session-operations/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Draining owner-forward rejection can recover only before dispatch
+
+The origin MUST treat an owner-forwarded HTTP bridge `bridge_drain_active`
+failure as locally recoverable only if the target owner rejected the request
+before upstream dispatch. For session-header and thread-header bootstrap
+requests without `previous_response_id`, such pre-dispatch rejection MAY rebind
+a turn-state anchored request locally. The origin MUST NOT use this bootstrap
+rebind for previous-response continuations, for ambiguous dispatch failures, or
+for owner failures whose public error code does not prove a draining-owner
+rejection.
+
+#### Scenario: Pre-dispatch drain rejection rebinds bootstrap request
+
+- **GIVEN** a session-header or thread-header owner-forward request includes a
+  turn-state anchor
+- **AND** the target owner rejects it with `bridge_drain_active` before
+  dispatching upstream
+- **WHEN** the origin evaluates local bootstrap recovery
+- **THEN** it may create or reuse a local bridge session for the request
+
+#### Scenario: Ambiguous drain failure does not rebind
+
+- **GIVEN** a session-header or thread-header owner-forward request includes a
+  turn-state anchor
+- **AND** the target owner failure is ambiguous or already acknowledged
+- **WHEN** the origin evaluates local bootstrap recovery
+- **THEN** it does not use the local bootstrap rebind path

--- a/openspec/changes/recover-draining-owner-forward/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/recover-draining-owner-forward/specs/sticky-session-operations/spec.md
@@ -9,7 +9,11 @@ requests without `previous_response_id`, such pre-dispatch rejection MAY rebind
 a turn-state anchored request locally. The origin MUST NOT use this bootstrap
 rebind for previous-response continuations, for ambiguous dispatch failures, or
 for owner failures whose public error code does not prove a draining-owner
-rejection.
+rejection. An explicit previous-response continuation rejected with
+`bridge_drain_active` MUST preserve the owner's original error envelope and
+MUST NOT enter generic previous-response recovery. Before a locally recovered
+request is submitted, the origin MUST reuse or settle its original API-key
+reservation; it MUST NOT hold a second reservation for the same request.
 
 #### Scenario: Pre-dispatch drain rejection rebinds bootstrap request
 

--- a/openspec/changes/recover-draining-owner-forward/tasks.md
+++ b/openspec/changes/recover-draining-owner-forward/tasks.md
@@ -1,0 +1,10 @@
+## 1. Drain Recovery
+
+- [x] 1.1 Classify `bridge_drain_active` owner-forward proxy errors as receiver rejection.
+- [x] 1.2 Allow turn-state bootstrap rebind only for pre-dispatch draining-owner rejection.
+- [x] 1.3 Keep previous-response continuations out of the bootstrap rebind path.
+
+## 2. Validation
+
+- [x] 2.1 Add regression coverage for drain rejection classification and rebind bounding.
+- [x] 2.2 Validate the OpenSpec delta strictly.

--- a/openspec/changes/wait-for-aborted-bridge-owner/.openspec.yaml
+++ b/openspec/changes/wait-for-aborted-bridge-owner/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/wait-for-aborted-bridge-owner/proposal.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+An HTTP bridge admission waiter can time out while the exact creator that owns
+the shared in-flight marker is still running. Evicting the marker immediately
+lets another request start a replacement before the original creator has
+finalized, so two creators can race for the same bridge identity.
+
+## What Changes
+
+- Record the current owner task on each in-flight bridge creation marker.
+- When a bridge capacity waiter or same-key in-flight waiter reaches the
+  configured admission timeout, signal cancellation only to the exact recorded
+  owner for the current non-handoff marker.
+- Keep the aborted marker capacity-owned until that owner finalizes.
+- Wait no longer than one additional configured admission-wait interval for the
+  owner to terminate; retry admission only after it does.
+- Preserve the existing structured local-overload HTTP 429 when the owner does
+  not terminate within that bounded wait.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: HTTP bridge startup timeout recovery waits for the
+  aborted owner before retrying admission.

--- a/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
@@ -19,9 +19,10 @@ reason.
 
 For bridge capacity waiters and in-flight session creation waiters, when the
 configured proxy admission wait timeout expires the proxy MUST reject the
-request locally with HTTP 429 and an OpenAI-style `proxy_overloaded` error
-envelope unless exact-owner observation proves a retry-safe creator terminated
-inside one additional configured admission-wait interval. Timing out while
+request locally with HTTP 429 and a structured local-overload error envelope
+using `error.code = "capacity_exhausted_active_sessions"` unless exact-owner
+observation proves a retry-safe creator terminated inside one additional
+configured admission-wait interval. Timing out while
 observing another request's pending in-flight session creation MUST evict or
 abort that in-flight marker when it is still pending so later requests can
 attempt a fresh bridge session instead of waiting on the same stalled future.
@@ -65,6 +66,48 @@ MUST NOT return an unregistered bridge session to the caller.
 - **AND** the error payload uses `error.code = "response_create_gate_timeout"`
 - **AND** no response-create gate lease is recorded on that request state
 
+#### Scenario: Soft-affinity requests reroute before waiting
+
+- **GIVEN** a bridged Responses request with a soft-affinity session key and no
+  `previous_response_id`
+- **WHEN** its first gate acquisition attempt times out
+- **THEN** the proxy attempts the internal soft-affinity reroute to a fresh
+  bridge session
+- **AND** the recoverable gate wait applies only when reroute is not permitted
+
+#### Scenario: Stuck sessions are still detected between attempts
+
+- **WHEN** a gate acquisition attempt times out while a pending bridge request
+  has been stuck past the stuck-gate retirement threshold
+- **THEN** the stuck session retirement check still runs on that attempt
+
+#### Scenario: In-flight bridge session creation does not finish
+
+- **WHEN** a bridged Responses request waits on another request's in-flight
+  session creation
+- **AND** the in-flight creation does not finish before the configured proxy
+  admission wait timeout
+- **THEN** the waiter is rejected locally with HTTP 429 and
+  `error.code = "capacity_exhausted_active_sessions"`
+- **AND** the stalled in-flight marker is evicted if it is still pending
+
+#### Scenario: Bridge capacity waiter does not make progress
+
+- **WHEN** the HTTP bridge is at capacity and a request waits for in-flight
+  bridge work to free capacity
+- **AND** no capacity becomes available before the configured proxy admission
+  wait timeout
+- **THEN** the waiter is rejected locally with HTTP 429 and
+  `error.code = "capacity_exhausted_active_sessions"`
+
+#### Scenario: In-flight owner is cancelled during stale session close
+
+- **WHEN** a bridge session creation owner has published an in-flight marker
+- **AND** it is cancelled while closing a stale local bridge session before
+  creating the replacement session
+- **THEN** the in-flight marker is removed or settled
+- **AND** later requests do not remain blocked on that cancelled owner's future
+
 #### Scenario: Exact owner ends after timeout cancellation
 
 - **WHEN** a capacity or same-key admission waiter times out and its exact
@@ -85,5 +128,8 @@ MUST NOT return an unregistered bridge session to the caller.
 - **WHEN** a generated turn-state in-flight creation waiter reaches the
   configured proxy admission wait timeout
 - **THEN** the waiter returns the existing structured local-overload HTTP 429
-- **AND** if the owner later finishes creation after its marker was evicted, the
-  owner closes that unregistered session instead of returning it to the caller
+- **AND** the owner-held marker remains registered while the owner is still
+  running
+- **AND** if the owner later finishes creation after registration was aborted,
+  the owner closes that unregistered session instead of returning it to the
+  caller

--- a/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
@@ -81,15 +81,28 @@ MUST NOT return an unregistered bridge session to the caller.
   has been stuck past the stuck-gate retirement threshold
 - **THEN** the stuck session retirement check still runs on that attempt
 
-#### Scenario: In-flight bridge session creation does not finish
+#### Scenario: Ownerless in-flight bridge session creation does not finish
 
 - **WHEN** a bridged Responses request waits on another request's in-flight
-  session creation
+  session creation marker that has no exact owner task provenance
 - **AND** the in-flight creation does not finish before the configured proxy
   admission wait timeout
 - **THEN** the waiter is rejected locally with HTTP 429 and
   `error.code = "capacity_exhausted_active_sessions"`
 - **AND** the stalled in-flight marker is evicted if it is still pending
+
+#### Scenario: Exact-owner in-flight bridge session creation resists cancellation
+
+- **WHEN** a bridged Responses request waits on another request's in-flight
+  session creation marker that records an exact non-handoff owner task
+- **AND** the in-flight creation does not finish before the configured proxy
+  admission wait timeout
+- **AND** that exact owner remains running through the additional bounded owner
+  observation interval
+- **THEN** the waiter is rejected locally with HTTP 429 and
+  `error.code = "capacity_exhausted_active_sessions"`
+- **AND** the owner-held marker remains registered and capacity-owned until that
+  owner finalizes
 
 #### Scenario: Bridge capacity waiter does not make progress
 

--- a/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: HTTP bridge startup admission waits are bounded
+
+The proxy MUST apply the configured proxy admission wait timeout to each HTTP
+bridge startup wait attempt for per-session response-create gate acquisition,
+bridge capacity waiters, and in-flight session creation waiters.
+
+For per-session response-create gate acquisition by a bridged Responses request,
+an expired gate acquisition attempt MUST be treated as a recoverable capacity
+wait rather than a terminal failure: the request MUST release its queue slot and
+account lease, wait with capacity-wait progress semantics, and retry gate
+acquisition, bounded by the bridge request budget. Requests eligible for
+soft-affinity reroute MUST still attempt the reroute before entering the
+recoverable wait. When the bridge request budget is exhausted before the gate
+opens, the proxy MUST reject the request locally with HTTP 429,
+`error.code = "response_create_gate_timeout"`, and the stable local-overload
+reason.
+
+For bridge capacity waiters and in-flight session creation waiters, when the
+configured proxy admission wait timeout expires the proxy MUST reject the
+request locally with HTTP 429 and an OpenAI-style `proxy_overloaded` error
+envelope unless exact-owner observation proves a retry-safe creator terminated
+inside one additional configured admission-wait interval. Timing out while
+observing another request's pending in-flight session creation MUST evict or
+abort that in-flight marker when it is still pending so later requests can
+attempt a fresh bridge session instead of waiting on the same stalled future.
+
+If the timed-out marker records an exact non-handoff owner task, the proxy MUST
+signal only that owner and retain the aborted marker while that owner is still
+running. If that exact owner terminates within one additional configured
+admission-wait interval and the key is retry-safe, the timing-out request MUST
+retry admission. If the owner does not terminate in that interval, the proxy
+MUST return the existing structured local-overload HTTP 429 and leave the
+owner-held marker registered until that owner finalizes. The proxy MUST NOT use
+this retry path to replace generated turn-state in-flight creation; generated
+turn-state creator timeouts keep the existing structured local-overload HTTP
+429 behavior and the late owner MUST NOT return an unregistered bridge session
+to the caller.
+
+If a request owns in-flight bridge session creation and is cancelled or fails
+after publishing the in-flight marker but before registering the created
+session, the proxy MUST remove or settle that in-flight marker. If a session
+owner later finishes creation after its in-flight marker was evicted, the owner
+MUST NOT return an unregistered bridge session to the caller.
+
+#### Scenario: Gate contention queues within the bridge request budget
+
+- **GIVEN** an HTTP bridge session whose response-create gate is held by a
+  legitimate in-flight turn
+- **AND** a bridged Responses request that cannot soft-reroute (hard-affinity key
+  or `previous_response_id` continuity)
+- **WHEN** a gate acquisition attempt exceeds the configured proxy admission wait
+  timeout
+- **THEN** the request emits capacity-wait keepalive progress on streaming
+  surfaces and retries gate acquisition
+- **AND** the request completes normally once the in-flight turn releases the
+  gate before the bridge request budget expires
+
+#### Scenario: Gate contention still fails once the request budget is exhausted
+
+- **WHEN** a bridged Responses request retries response-create gate acquisition
+  until the bridge request budget is exhausted
+- **THEN** the request is rejected locally with HTTP 429
+- **AND** the error payload uses `error.code = "response_create_gate_timeout"`
+- **AND** no response-create gate lease is recorded on that request state
+
+#### Scenario: Exact owner ends after timeout cancellation
+
+- **WHEN** a capacity or same-key admission waiter times out and its exact
+  aborted owner terminates within the additional bounded wait
+- **THEN** the waiter retries admission if the key is retry-safe
+- **AND** no replacement creation begins before the owner terminates
+
+#### Scenario: Exact owner resists cancellation
+
+- **WHEN** a capacity or same-key admission waiter times out and its exact
+  aborted owner remains running beyond the additional bounded wait
+- **THEN** the waiter returns the existing structured local-overload HTTP 429
+- **AND** the owner-held marker remains registered and capacity-owned until that
+  owner finalizes
+
+#### Scenario: Generated turn-state owner is not silently replaced
+
+- **WHEN** a generated turn-state in-flight creation waiter reaches the
+  configured proxy admission wait timeout
+- **THEN** the waiter returns the existing structured local-overload HTTP 429
+- **AND** if the owner later finishes creation after its marker was evicted, the
+  owner closes that unregistered session instead of returning it to the caller

--- a/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
@@ -34,10 +34,12 @@ admission-wait interval and the key is retry-safe, the timing-out request MUST
 retry admission. If the owner does not terminate in that interval, the proxy
 MUST return the existing structured local-overload HTTP 429 and leave the
 owner-held marker registered until that owner finalizes. The proxy MUST NOT use
-this retry path to replace generated turn-state in-flight creation; generated
-turn-state creator timeouts keep the existing structured local-overload HTTP
-429 behavior and the late owner MUST NOT return an unregistered bridge session
-to the caller.
+this retry path to replace generated turn-state in-flight creation. The proxy
+MUST classify generated turn-state from recorded provenance rather than key
+text; client-supplied values matching generated prefixes MUST remain explicit
+turn-state. Generated turn-state creator timeouts keep the existing structured
+local-overload HTTP 429 behavior and the late owner MUST NOT return an
+unregistered bridge session to the caller.
 
 If a request owns in-flight bridge session creation and is cancelled or fails
 after publishing the in-flight marker but before registering the created

--- a/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/specs/proxy-admission-control/spec.md
@@ -37,7 +37,10 @@ owner-held marker registered until that owner finalizes. The proxy MUST NOT use
 this retry path to replace generated turn-state in-flight creation. The proxy
 MUST classify generated turn-state from recorded provenance rather than key
 text; client-supplied values matching generated prefixes MUST remain explicit
-turn-state. Generated turn-state creator timeouts keep the existing structured
+turn-state. Signed owner forwarding MUST preserve generated turn-state
+provenance across the origin-to-owner boundary. Missing legacy provenance and
+client-supplied headers MUST NOT upgrade explicit turn-state to generated.
+Generated turn-state creator timeouts keep the existing structured
 local-overload HTTP 429 behavior and the late owner MUST NOT return an
 unregistered bridge session to the caller.
 

--- a/openspec/changes/wait-for-aborted-bridge-owner/tasks.md
+++ b/openspec/changes/wait-for-aborted-bridge-owner/tasks.md
@@ -1,0 +1,10 @@
+## 1. Exact-owner timeout recovery
+
+- [x] 1.1 Record owner-task provenance on in-flight HTTP bridge creation markers.
+- [x] 1.2 After capacity and same-key timeouts, abort only the exact owner and retry only after it terminates.
+- [x] 1.3 Preserve the existing structured 429 when the exact owner outlives the bounded wait.
+
+## 2. Regression coverage and verification
+
+- [x] 2.1 Cover successful post-cancellation admission for same-key and capacity waiters.
+- [x] 2.2 Cover cancellation-resistant owners remaining capacity-owned while the waiter returns 429.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5378,6 +5378,97 @@ async def test_forwarded_priority_prompt_cache_mismatch_forks_on_canonical_owner
 
 
 @pytest.mark.asyncio
+async def test_signed_forward_preserves_generated_turn_state_provenance(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    from app.modules.proxy import api as proxy_api_module
+    from app.modules.proxy.http_bridge_forwarding import HTTPBridgeForwardContext, build_owner_forward_headers
+
+    target_settings = _make_app_settings(enabled=True, instance_id="instance-b")
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=target_settings,
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: target_settings)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_forwarded_generated",
+        "http-bridge-forwarded-generated@example.com",
+    )
+    account = await _get_account(account_id)
+    service = get_proxy_service_for_app(app_instance)
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline, kwargs
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    upstream = _TurnStateBridgeUpstreamWebSocket("upstream_turn_state_forwarded_generated")
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    async def fail_legacy_stream(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("legacy core_stream_responses path must not be used when HTTP bridge is enabled")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fail_legacy_stream)
+
+    session_id = "sid-forwarded-generated"
+    turn_state = "http_turn_forwarded_generated"
+    payload = proxy_module.ResponsesRequest(
+        model="gpt-5.1",
+        instructions="Return exactly OK.",
+        input="hello",
+    )
+    forward_context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance=target_settings.http_responses_session_bridge_instance_id,
+        codex_session_affinity=True,
+        downstream_turn_state=turn_state,
+        downstream_turn_state_synthesized=True,
+        original_request_unanchored=True,
+        original_affinity_kind="session_header",
+        original_affinity_key=session_id,
+    )
+    forward_headers = build_owner_forward_headers(
+        headers={"x-request-id": "forwarded-generated-request"},
+        payload=payload,
+        context=forward_context,
+    )
+
+    response = await async_client.post(
+        "/internal/bridge/responses",
+        json=payload.model_dump_for_forwarding(),
+        headers=forward_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert '"type":"response.completed"' in response.text
+    session_key = proxy_module._HTTPBridgeSessionKey("session_header", session_id, None)
+    owner_session = service._http_bridge_sessions[session_key]
+    assert turn_state in owner_session.downstream_turn_state_aliases
+    assert turn_state in owner_session.synthesized_downstream_turn_state_aliases
+
+
+@pytest.mark.asyncio
 async def test_forwarded_recovery_uses_durable_owner_and_strips_stale_affinity(
     async_client,
     app_instance,
@@ -5557,6 +5648,7 @@ async def test_forwarded_recovery_uses_durable_owner_and_strips_stale_affinity(
     recovery_session = service._http_bridge_sessions[recovery_session_key]
     assert recovery_session.account.id == account.id
     assert recovered_turn_state in recovery_session.downstream_turn_state_aliases
+    assert recovered_turn_state not in recovery_session.synthesized_downstream_turn_state_aliases
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_model_source_dispatch.py
+++ b/tests/integration/test_model_source_dispatch.py
@@ -857,6 +857,10 @@ async def test_client_leaving_after_the_stall_window_is_a_stall_abandonment(
         body=json.dumps(_request_body(model)).encode(),
     )
     runner = asyncio.create_task(stream.run())
+    deadline = time.monotonic() + 5
+    while not state.requests and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert state.requests, "the stub never received the open"
     await asyncio.sleep(0.6)
     stream.disconnect()
     await asyncio.wait_for(runner, timeout=10)

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
+import json
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,6 +14,7 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 
 from app.core.config.settings import get_settings
+from app.core.crypto import get_or_create_key
 from app.core.openai.requests import ResponsesRequest
 from app.modules.api_keys.service import ApiKeyUsageReservationData
 from app.modules.proxy.http_bridge_forwarding import (
@@ -30,6 +34,8 @@ from app.modules.proxy.http_bridge_forwarding import (
     HTTP_BRIDGE_SIGNATURE_V2_HEADER,
     HTTP_BRIDGE_SIGNATURE_VERSION_HEADER,
     HTTP_BRIDGE_TARGET_INSTANCE_HEADER,
+    HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER,
+    HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER,
     HTTPBridgeForwardContext,
     HTTPBridgeOwnerClient,
     _bridge_forward_signature,
@@ -86,6 +92,8 @@ def _use_legacy_forward_signature(
     # receiver must exercise the primary-signature fallback rather than the
     # tamper-proofing fast path.
     headers.pop(HTTP_BRIDGE_SIGNATURE_V2_HEADER, None)
+    headers.pop(HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER, None)
+    headers.pop(HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER, None)
     headers[HTTP_BRIDGE_SIGNATURE_HEADER] = _bridge_forward_signature(
         payload=payload,
         context=context,
@@ -99,6 +107,98 @@ def _use_legacy_forward_signature(
         )
 
 
+def _pre_provenance_tools_bound_signature(
+    *,
+    payload: ResponsesRequest,
+    context: HTTPBridgeForwardContext,
+    signature_version: str | None = None,
+) -> str:
+    """Frozen pre-provenance codec; intentionally independent of production helpers."""
+
+    body_json = json.dumps(
+        payload.model_dump_for_forwarding(),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    body_digest = hashlib.sha256(body_json.encode("utf-8")).hexdigest()
+    signing_payload = json.dumps(
+        {
+            "body_digest": body_digest,
+            "client_ip": context.client_ip,
+            "client_ip_present": context.client_ip is not None,
+            "codex_session_affinity": context.codex_session_affinity,
+            "downstream_turn_state": context.downstream_turn_state,
+            "file_owner_account_id": context.file_owner_account_id,
+            "include_client_ip": True,
+            "origin_instance": context.origin_instance,
+            "original_affinity_key": context.original_affinity_key,
+            "original_affinity_kind": context.original_affinity_kind,
+            "original_request_unanchored": context.original_request_unanchored,
+            "protocol": "codex-lb-http-bridge-forward-tools-bound",
+            "reservation": (
+                {
+                    "id": context.reservation.reservation_id,
+                    "key_id": context.reservation.key_id,
+                    "model": context.reservation.model,
+                }
+                if context.reservation is not None
+                else None
+            ),
+            "signature_version": signature_version,
+            "target_instance": context.target_instance,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    secret = get_or_create_key(get_settings().encryption_key_file)
+    return hmac.new(secret, signing_payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+@pytest.mark.parametrize("with_file", [False, True])
+def test_pre_provenance_codec_replays_both_directions(with_file: bool) -> None:
+    payload = _payload_with_file() if with_file else _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=True,
+        downstream_turn_state="http_turn_cross_version",
+        file_owner_account_id="acc-file-owner" if with_file else None,
+    )
+    old_signature = _pre_provenance_tools_bound_signature(payload=payload, context=context)
+
+    # New origin -> old owner: the deployed full-context signature bytes stay
+    # identical, including the file-owner proof that forbids legacy fallback.
+    new_headers = build_owner_forward_headers(headers={}, payload=payload, context=context)
+    assert new_headers[HTTP_BRIDGE_SIGNATURE_V2_HEADER] == old_signature
+    assert HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER not in new_headers
+    assert HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER not in new_headers
+
+    # Old origin -> new owner: replay the frozen old wire without calling the
+    # current encoder. The new decoder must accept its full-context signature.
+    old_headers = {
+        HTTP_BRIDGE_FORWARDED_HEADER: "1",
+        HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER: context.origin_instance,
+        HTTP_BRIDGE_TARGET_INSTANCE_HEADER: context.target_instance,
+        HTTP_BRIDGE_CODEX_AFFINITY_HEADER: "1",
+        HTTP_BRIDGE_SIGNATURE_V2_HEADER: old_signature,
+        "x-codex-turn-state": "http_turn_cross_version",
+    }
+    if context.file_owner_account_id is not None:
+        old_headers[HTTP_BRIDGE_FILE_OWNER_HEADER] = context.file_owner_account_id
+
+    forwarded, error = parse_forwarded_request(
+        old_headers,
+        payload=payload,
+        current_instance="instance-b",
+    )
+
+    assert error is None
+    assert forwarded is not None
+    assert forwarded.context == context
+
+
 def test_parse_forwarded_request_accepts_signed_internal_forward() -> None:
     payload = _payload()
     context = HTTPBridgeForwardContext(
@@ -106,6 +206,7 @@ def test_parse_forwarded_request_accepts_signed_internal_forward() -> None:
         target_instance="instance-b",
         codex_session_affinity=True,
         downstream_turn_state="http_turn_123",
+        downstream_turn_state_synthesized=True,
         reservation=ApiKeyUsageReservationData(
             reservation_id="res_123",
             key_id="key_123",
@@ -123,6 +224,12 @@ def test_parse_forwarded_request_accepts_signed_internal_forward() -> None:
     assert error is None
     assert forwarded is not None
     assert forwarded.context == context
+    assert headers[HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER] == "1"
+    assert HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER in headers
+    assert headers[HTTP_BRIDGE_SIGNATURE_V2_HEADER] == _pre_provenance_tools_bound_signature(
+        payload=payload,
+        context=context,
+    )
     assert forwarded.context.original_affinity_kind is None
     assert forwarded.context.original_affinity_key is None
 
@@ -323,6 +430,7 @@ def test_parse_forwarded_request_accepts_legacy_forward_with_spoofed_v2_header()
         downstream_turn_state=None,
     )
     headers = build_owner_forward_headers(headers={}, payload=old_origin_payload, context=context)
+    headers.pop(HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER, None)
     headers[HTTP_BRIDGE_SIGNATURE_V2_HEADER] = "spoofed-by-external-client"
 
     forwarded, error = parse_forwarded_request(
@@ -333,6 +441,7 @@ def test_parse_forwarded_request_accepts_legacy_forward_with_spoofed_v2_header()
     assert error is None
     assert forwarded is not None
     assert forwarded.context == context
+    assert forwarded.context.downstream_turn_state_synthesized is False
 
 
 def test_build_owner_forward_headers_drops_client_supplied_bridge_headers() -> None:
@@ -349,6 +458,7 @@ def test_build_owner_forward_headers_drops_client_supplied_bridge_headers() -> N
     inbound = {
         "x-codex-bridge-signature-v2": "client-spoofed",
         "x-codex-bridge-signature": "client-spoofed",
+        "x-codex-bridge-turn-state-synthesized": "1",
         "x-codex-bridge-future-unknown": "client-spoofed",
         "x-openai-client-version": "1.2.3",
     }
@@ -359,8 +469,55 @@ def test_build_owner_forward_headers_drops_client_supplied_bridge_headers() -> N
         context=context,
     )
     assert headers[HTTP_BRIDGE_SIGNATURE_HEADER] != "client-spoofed"
+    assert HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER not in headers
+    assert HTTP_BRIDGE_TURN_STATE_PROVENANCE_SIGNATURE_HEADER not in headers
     assert "x-codex-bridge-future-unknown" not in headers
     assert headers["x-openai-client-version"] == "1.2.3"
+
+
+def test_parse_forwarded_request_rejects_upgraded_turn_state_provenance() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=True,
+        downstream_turn_state="http_turn_generated",
+    )
+    headers = build_owner_forward_headers(headers={}, payload=payload, context=context)
+    headers[HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER] = "1"
+
+    forwarded, error = parse_forwarded_request(
+        headers,
+        payload=payload,
+        current_instance="instance-b",
+    )
+
+    assert forwarded is None
+    assert error is not None
+    assert error.payload["error"]["code"] == "bridge_forward_invalid"
+
+
+def test_parse_forwarded_request_missing_turn_state_provenance_stays_explicit() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=True,
+        downstream_turn_state="http_turn_generated",
+        downstream_turn_state_synthesized=True,
+    )
+    headers = build_owner_forward_headers(headers={}, payload=payload, context=context)
+    headers.pop(HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER)
+
+    forwarded, error = parse_forwarded_request(
+        headers,
+        payload=payload,
+        current_instance="instance-b",
+    )
+
+    assert error is None
+    assert forwarded is not None
+    assert forwarded.context.downstream_turn_state_synthesized is False
 
 
 def test_owner_forward_primary_signature_verifiable_by_pre_1203_owner() -> None:
@@ -408,6 +565,7 @@ def test_parse_forwarded_request_falls_back_to_legacy_signature_without_v2() -> 
     )
     headers = build_owner_forward_headers(headers={}, payload=old_origin_payload, context=context)
     del headers[HTTP_BRIDGE_SIGNATURE_V2_HEADER]
+    headers.pop(HTTP_BRIDGE_TURN_STATE_SYNTHESIZED_HEADER, None)
 
     forwarded, error = parse_forwarded_request(
         headers,

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1897,6 +1897,7 @@ async def test_internal_bridge_responses_disables_openai_sdk_contract(
         target_instance="owner-b",
         codex_session_affinity=True,
         downstream_turn_state="http_turn_generated",
+        downstream_turn_state_synthesized=True,
         original_request_unanchored=True,
         original_affinity_kind="session",
         original_affinity_key="sid-abc",
@@ -1947,6 +1948,7 @@ async def test_internal_bridge_responses_disables_openai_sdk_contract(
         f"internal_bridge_responses must pass enforce_openai_sdk_contract=False; got kwargs={kwargs!r}"
     )
     assert kwargs.get("forwarded_downstream_turn_state") == "http_turn_generated"
+    assert kwargs.get("forwarded_downstream_turn_state_synthesized") is True
     assert kwargs.get("forwarded_original_request_unanchored") is True
     assert kwargs.get("forwarded_legacy_signature") is False
     forwarded_headers = kwargs.get("forwarded_headers")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22090,6 +22090,224 @@ async def test_should_attempt_local_bootstrap_rebind_for_session_header_without_
     )
 
 
+@pytest.mark.parametrize(
+    ("owner_outcome", "error_code", "expected"),
+    [
+        ("receiver_rejected", "bridge_drain_active", True),
+        ("not_dispatched", "bridge_drain_active", True),
+        ("dispatch_ambiguous", "bridge_drain_active", False),
+        ("receiver_acknowledged", "bridge_drain_active", False),
+        ("receiver_rejected", "bridge_owner_unreachable", False),
+        ("receiver_rejected", "bridge_instance_mismatch", False),
+    ],
+)
+def test_turn_state_bootstrap_rebind_requires_explicit_draining_owner_rejection(
+    owner_outcome: str,
+    error_code: str,
+    expected: bool,
+) -> None:
+    source = ProxyResponseError(
+        503,
+        {"error": {"code": error_code, "message": "owner rejected", "type": "server_error"}},
+    )
+    outcome = http_bridge_owner_forwarding_module._OwnerForwardOutcome(owner_outcome)
+    exc = http_bridge_owner_forwarding_module._OwnerForwardRequestError(source, outcome=outcome)
+
+    assert (
+        proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
+            exc,
+            key=proxy_service._HTTPBridgeSessionKey("thread_header", "thread-123", None),
+            headers={"thread-id": "thread-123", "x-codex-turn-state": "http_turn_123"},
+            previous_response_id=None,
+            owner_pre_dispatch=http_bridge_owner_forwarding_module._owner_forward_failure_was_pre_dispatch(exc),
+        )
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_recovers_turn_state_locally_after_draining_owner_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    turn_state = "http_turn_drain_rebind"
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None)
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    started_at = time.monotonic()
+    prepared_states: list[proxy_service._WebSocketRequestState] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip
+        assert prepared_payload.previous_response_id is None
+        state = proxy_service._WebSocketRequestState(
+            request_id=f"req-drain-rebind-{len(prepared_states)}",
+            model="gpt-5.4",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=started_at,
+            event_queue=asyncio.Queue(),
+            transport="http",
+        )
+        prepared_states.append(state)
+        return state, '{"type":"response.create"}'
+
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=key,
+    )
+    recovery_session = _make_bridge_session(key=key, key_value=turn_state)
+    recovery_session.headers = {"x-codex-turn-state": turn_state}
+    captured_owner_context: dict[str, object] = {}
+    captured_local_request_state: dict[str, object] = {}
+
+    async def fake_owner_stream_responses(**kwargs: object):
+        captured_owner_context.update(kwargs)
+        raise ProxyResponseError(
+            503,
+            proxy_service.openai_error(
+                "bridge_drain_active",
+                "HTTP bridge owner is draining",
+                error_type="server_error",
+            ),
+        )
+        yield ""
+
+    async def fake_stream_http_bridge_session_events(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+        request_deadline: float | None = None,
+    ):
+        del text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
+        captured_local_request_state["session"] = session
+        captured_local_request_state["request_state"] = request_state
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    get_or_create = AsyncMock(side_effect=[owner_forward, recovery_session])
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_owner_client",
+        cast(Any, SimpleNamespace(stream_responses=fake_owner_stream_responses)),
+    )
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_http_bridge_session_events)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-turn-state": turn_state},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=900.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state=turn_state,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(prepared_states) == 2
+    owner_context = cast(proxy_service.HTTPBridgeForwardContext, captured_owner_context["context"])
+    assert owner_context.original_affinity_kind == "turn_state_header"
+    assert owner_context.original_affinity_key == turn_state
+    assert owner_context.downstream_turn_state == turn_state
+    local_state = cast(proxy_service._WebSocketRequestState, captured_local_request_state["request_state"])
+    assert local_state.session_id == turn_state
+    assert local_state.previous_response_id is None
+    assert captured_local_request_state["session"] is recovery_session
+    assert get_or_create.await_count == 2
+    assert get_or_create.await_args_list[1].kwargs["allow_bootstrap_owner_rebind"] is True
+
+
+def test_owner_forward_proxy_error_classifies_explicit_drain_as_receiver_rejected() -> None:
+    drain_error = ProxyResponseError(
+        503,
+        {"error": {"code": "bridge_drain_active", "message": "owner draining", "type": "server_error"}},
+    )
+    ambiguous_error = ProxyResponseError(
+        503,
+        {"error": {"code": "bridge_owner_unreachable", "message": "owner failed", "type": "server_error"}},
+    )
+
+    assert (
+        http_bridge_owner_forwarding_module._owner_forward_outcome_for_proxy_error(
+            drain_error,
+            default=http_bridge_owner_forwarding_module._OwnerForwardOutcome.DISPATCH_AMBIGUOUS,
+        )
+        is http_bridge_owner_forwarding_module._OwnerForwardOutcome.RECEIVER_REJECTED
+    )
+    assert (
+        http_bridge_owner_forwarding_module._owner_forward_outcome_for_proxy_error(
+            ambiguous_error,
+            default=http_bridge_owner_forwarding_module._OwnerForwardOutcome.DISPATCH_AMBIGUOUS,
+        )
+        is http_bridge_owner_forwarding_module._OwnerForwardOutcome.DISPATCH_AMBIGUOUS
+    )
+
+
+def test_turn_state_draining_owner_rejection_does_not_rebind_previous_response() -> None:
+    source = ProxyResponseError(
+        503,
+        {"error": {"code": "bridge_drain_active", "message": "owner draining", "type": "server_error"}},
+    )
+    exc = http_bridge_owner_forwarding_module._OwnerForwardRequestError(
+        source,
+        outcome=http_bridge_owner_forwarding_module._OwnerForwardOutcome.RECEIVER_REJECTED,
+    )
+
+    assert (
+        proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
+            exc,
+            key=proxy_service._HTTPBridgeSessionKey("thread_header", "thread-123", None),
+            headers={"thread-id": "thread-123", "x-codex-turn-state": "http_turn_123"},
+            previous_response_id="resp-123",
+            owner_pre_dispatch=True,
+        )
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_endpoint_missing_without_anchor(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -17865,6 +17865,7 @@ async def test_forward_http_bridge_request_to_owner_preserves_session_header_key
             api_key_reservation=None,
             codex_session_affinity=True,
             downstream_turn_state="http_turn_generated",
+            downstream_turn_state_synthesized=True,
             request_started_at=10.0,
             proxy_api_authorization=None,
         )
@@ -17873,6 +17874,7 @@ async def test_forward_http_bridge_request_to_owner_preserves_session_header_key
     assert chunks == []
     context = cast(proxy_service.HTTPBridgeForwardContext, captured["context"])
     assert context.downstream_turn_state == expected_turn_state
+    assert context.downstream_turn_state_synthesized is expected_unanchored
     assert context.original_request_unanchored is expected_unanchored
     assert context.original_affinity_kind == "session_header"
     assert context.original_affinity_key == "sid-123"
@@ -18515,6 +18517,85 @@ async def test_stream_via_http_bridge_fails_closed_on_forward_loop_prevented(
             pass
 
     assert exc_info.value.payload["error"]["code"] == "bridge_forward_loop_prevented"
+    get_or_create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_preserves_anchored_draining_owner_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp-draining-owner",
+        }
+    )
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+    )
+    owner_envelope = proxy_service.openai_error(
+        "bridge_drain_active",
+        "HTTP bridge owner is draining",
+        error_type="server_error",
+    )
+
+    async def fake_forward(**kwargs: object):
+        del kwargs
+        raise http_bridge_owner_forwarding_module._OwnerForwardRequestError(
+            ProxyResponseError(503, owner_envelope),
+            outcome=http_bridge_owner_forwarding_module._OwnerForwardOutcome.RECEIVER_REJECTED,
+        )
+        yield ""
+
+    get_or_create = AsyncMock(return_value=owner_forward)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_http_bridge_local_owner_account_id", AsyncMock(return_value="acc-owner"))
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-owner"))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_forward_http_bridge_request_to_owner", fake_forward)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            {"x-codex-session-id": "sid-123"},
+            codex_session_affinity=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            propagate_http_errors=False,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=900.0,
+            max_sessions=8,
+            queue_limit=4,
+        ):
+            pass
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload == owner_envelope
     get_or_create.assert_awaited_once()
 
 
@@ -22346,6 +22427,7 @@ def test_turn_state_draining_owner_rejection_does_not_rebind_previous_response()
         )
         is False
     )
+    assert proxy_service._http_bridge_should_attempt_local_previous_response_recovery(exc) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -36694,36 +36694,35 @@ async def test_heartbeat_maintenance_tolerates_a_missing_service_or_pass() -> No
 
 
 @pytest.mark.asyncio
-async def test_rejected_creator_does_not_release_the_registered_winners_durable_row(
+async def test_inflight_waiter_retries_after_aborted_owner_finalizes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue #1695: after an inflight evict, a replacement can register while
-    the stale creator is still claiming. The stale creator claims LAST, so its
-    epoch is current and its fenced release would succeed — closing the durable
-    row out from under the session that actually won the registry. A rejected
-    creator must not release a row that now belongs to someone else."""
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "sid-rejected-creator", None)
-    settings = _make_app_settings()
-    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
-    stale_creator_session = _make_bridge_session(key_value="sid-rejected-creator")
-    stale_creator_session.key = key
-    registered_winner = _make_bridge_session(key_value="sid-rejected-creator-winner")
-    registered_winner.key = key
-    create_started = asyncio.Event()
-    finish_create = asyncio.Event()
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-inflight-owner", None)
+    owner_create_started = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+    replacement = _make_bridge_session(key=key, key_value=key.affinity_key)
+    replacement.request_model = "gpt-5.4"
+    create_calls = 0
 
     async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
-        create_started.set()
-        await finish_create.wait()
-        return stale_creator_session
+        nonlocal create_calls
+        create_calls += 1
+        if create_calls == 1:
+            owner_create_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                owner_cancelled.set()
+                raise
+        assert owner_cancelled.is_set()
+        return replacement
 
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
-    claim_durable_session = AsyncMock()
-    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable_session)
-    close_http_bridge_session = AsyncMock()
-    monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
@@ -36736,39 +36735,171 @@ async def test_rejected_creator_does_not_release_the_registered_winners_durable_
     async def get_session() -> proxy_service._HTTPBridgeSession | proxy_service._HTTPBridgeOwnerForward:
         return await service._get_or_create_http_bridge_session(
             key,
-            headers={"x-codex-turn-state": "sid-rejected-creator"},
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key=key.affinity_key),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+            request_deadline=time.monotonic() + 1.0,
+        )
+
+    owner_task = asyncio.create_task(get_session())
+    await asyncio.wait_for(owner_create_started.wait(), timeout=1.0)
+
+    waiter_result = await asyncio.wait_for(get_session(), timeout=1.0)
+    owner_result = await asyncio.gather(owner_task, return_exceptions=True)
+
+    assert isinstance(owner_result[0], asyncio.CancelledError)
+    assert waiter_result is replacement
+    assert owner_cancelled.is_set()
+    assert create_calls == 2
+    assert service._http_bridge_sessions[key] is replacement
+    assert service._http_bridge_inflight_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_capacity_waiter_retries_after_aborted_owner_finalizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-owner", None)
+    waiter_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-waiter", None)
+    owner_create_started = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+    replacement = _make_bridge_session(key=waiter_key, key_value=waiter_key.affinity_key)
+    replacement.request_model = "gpt-5.4"
+    create_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+
+    async def create_session(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **_: object,
+    ) -> proxy_service._HTTPBridgeSession:
+        create_keys.append(key)
+        if key == owner_key:
+            owner_create_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                owner_cancelled.set()
+                raise
+        assert owner_cancelled.is_set()
+        assert key == waiter_key
+        return replacement
+
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    async def get_session(
+        key: proxy_service._HTTPBridgeSessionKey,
+    ) -> proxy_service._HTTPBridgeSession | proxy_service._HTTPBridgeOwnerForward:
+        return await service._get_or_create_http_bridge_session(
+            key,
+            headers={"x-codex-session-id": key.affinity_key},
             affinity=proxy_service._AffinityPolicy(
-                key="sid-rejected-creator",
+                key=key.affinity_key,
                 kind=proxy_service.StickySessionKind.CODEX_SESSION,
             ),
             api_key=None,
             request_model="gpt-5.4",
             idle_ttl_seconds=120.0,
+            max_sessions=1,
+            request_deadline=time.monotonic() + 1.0,
+        )
+
+    owner_task = asyncio.create_task(get_session(owner_key))
+    await asyncio.wait_for(owner_create_started.wait(), timeout=1.0)
+
+    waiter_result = await asyncio.wait_for(get_session(waiter_key), timeout=1.0)
+    owner_result = await asyncio.gather(owner_task, return_exceptions=True)
+
+    assert isinstance(owner_result[0], asyncio.CancelledError)
+    assert waiter_result is replacement
+    assert owner_cancelled.is_set()
+    assert create_keys == [owner_key, waiter_key]
+    assert service._http_bridge_sessions[waiter_key] is replacement
+    assert service._http_bridge_inflight_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_inflight_waiter_returns_429_when_aborted_owner_resists_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-resistant-owner", None)
+    owner_create_started = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+    release_owner = asyncio.Event()
+    created = _make_bridge_session(key=key, key_value=key.affinity_key)
+    create_calls = 0
+
+    async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
+        nonlocal create_calls
+        create_calls += 1
+        owner_create_started.set()
+        try:
+            await release_owner.wait()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            await release_owner.wait()
+        return created
+
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    async def get_session() -> proxy_service._HTTPBridgeSession | proxy_service._HTTPBridgeOwnerForward:
+        return await service._get_or_create_http_bridge_session(
+            key,
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key=key.affinity_key),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
             max_sessions=8,
+            request_deadline=time.monotonic() + 1.0,
         )
 
     owner_task = asyncio.create_task(get_session())
-    await asyncio.wait_for(create_started.wait(), timeout=1.0)
+    await asyncio.wait_for(owner_create_started.wait(), timeout=1.0)
 
-    # The waiter times out and evicts the inflight future; a replacement then
-    # wins the registry slot while the stale creator is still in flight.
-    with pytest.raises(ProxyResponseError):
-        await asyncio.wait_for(get_session(), timeout=1.0)
-    async with service._http_bridge_lock:
-        service._http_bridge_sessions[key] = registered_winner
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await asyncio.wait_for(get_session(), timeout=1.0)
 
-    finish_create.set()
-    with pytest.raises(ProxyResponseError):
-        await asyncio.wait_for(owner_task, timeout=1.0)
-
-    # The winner keeps the registry slot, and the rejected creator closed its
-    # own session WITHOUT releasing the durable row the winner now owns.
-    assert service._http_bridge_sessions[key] is registered_winner
-    close_http_bridge_session.assert_awaited_once_with(stale_creator_session, release_durable_session=False)
-    # It never claimed at all: claiming would have advanced the durable epoch
-    # past the registered winner, fencing the winner's own renewals out of a
-    # row it legitimately owns.
-    claim_durable_session.assert_not_awaited()
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+        assert owner_cancelled.is_set()
+        assert not owner_task.done()
+        assert service._http_bridge_inflight_sessions[key] is not None
+        activity = http_bridge_helpers_module.http_bridge_activity_snapshot_nowait(service)
+        assert activity["http_bridge_inflight_session_creates"] == 1
+        assert service._http_bridge_inflight_sessions[key] is not None
+        assert create_calls == 1
+    finally:
+        release_owner.set()
+        await asyncio.gather(owner_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -37075,7 +37206,7 @@ async def test_admission_waiters_do_not_accumulate_callbacks_on_shared_inflight_
     inflight: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
     setattr(
         inflight,
-        http_bridge_mixin_module._HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
+        http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
         time.monotonic(),
     )
     service._http_bridge_inflight_sessions[key] = inflight

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22116,7 +22116,7 @@ def test_turn_state_bootstrap_rebind_requires_explicit_draining_owner_rejection(
     assert (
         proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
             exc,
-            key=proxy_service._HTTPBridgeSessionKey("thread_header", "thread-123", None),
+            key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None),
             headers={"thread-id": "thread-123", "x-codex-turn-state": "http_turn_123"},
             previous_response_id=None,
             owner_pre_dispatch=http_bridge_owner_forwarding_module._owner_forward_failure_was_pre_dispatch(exc),
@@ -22231,7 +22231,7 @@ async def test_stream_via_http_bridge_recovers_turn_state_locally_after_draining
         chunk
         async for chunk in service._stream_via_http_bridge(
             payload,
-            headers={"x-codex-turn-state": turn_state},
+            headers={"x-codex-turn-state": turn_state, "x-codex-session-id": "sid-drain-rebind"},
             codex_session_affinity=True,
             propagate_http_errors=False,
             openai_cache_affinity=False,
@@ -22286,6 +22286,46 @@ def test_owner_forward_proxy_error_classifies_explicit_drain_as_receiver_rejecte
     )
 
 
+
+def test_turn_state_only_generated_drain_rejection_preserves_retryable_owner_error() -> None:
+    source = ProxyResponseError(
+        503,
+        {"error": {"code": "bridge_drain_active", "message": "owner draining", "type": "server_error"}},
+    )
+    exc = http_bridge_owner_forwarding_module._OwnerForwardRequestError(
+        source,
+        outcome=http_bridge_owner_forwarding_module._OwnerForwardOutcome.RECEIVER_REJECTED,
+    )
+
+    assert (
+        proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
+            exc,
+            key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None),
+            headers={"x-codex-turn-state": "http_turn_123"},
+            previous_response_id=None,
+            owner_pre_dispatch=True,
+        )
+        is False
+    )
+
+
+def test_ambiguous_drain_rejection_does_not_bootstrap_rebind_session_key() -> None:
+    exc = ProxyResponseError(
+        503,
+        {"error": {"code": "bridge_drain_active", "message": "owner draining", "type": "server_error"}},
+    )
+
+    assert (
+        proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
+            exc,
+            key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+            headers={"x-codex-session-id": "sid-123"},
+            previous_response_id=None,
+            owner_pre_dispatch=False,
+        )
+        is False
+    )
+
 def test_turn_state_draining_owner_rejection_does_not_rebind_previous_response() -> None:
     source = ProxyResponseError(
         503,
@@ -22299,7 +22339,7 @@ def test_turn_state_draining_owner_rejection_does_not_rebind_previous_response()
     assert (
         proxy_service._http_bridge_should_attempt_local_bootstrap_rebind(
             exc,
-            key=proxy_service._HTTPBridgeSessionKey("thread_header", "thread-123", None),
+            key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None),
             headers={"thread-id": "thread-123", "x-codex-turn-state": "http_turn_123"},
             previous_response_id="resp-123",
             owner_pre_dispatch=True,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -14962,6 +14962,20 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
         pytest.param(
             [
                 {
+                    "type": "function_call_output",
+                    "call_id": "call-prefix",
+                    "output": "result",
+                    "status": "completed",
+                },
+            ],
+            {"call-prefix": "function_call"},
+            True,
+            False,
+            id="prefix-settled-tool-output",
+        ),
+        pytest.param(
+            [
+                {
                     "type": "custom_tool_call",
                     "call_id": "call-1",
                     "name": "shell",
@@ -15029,14 +15043,29 @@ async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_
     forwardable_owner: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    stored_input_items: list[proxy_service.JsonValue] = [
-        {
-            "type": "additional_tools",
-            "role": "developer",
-            "tools": [{"type": "custom", "name": "shell"}],
-        },
-        {"role": "user", "content": "hello"},
-    ]
+    if pending_tool_calls == {"call-prefix": "function_call"}:
+        stored_input_items: list[proxy_service.JsonValue] = [
+            {"role": "user", "content": "look that up"},
+            {
+                "type": "function_call",
+                "call_id": "call-prefix",
+                "name": "lookup",
+                "arguments": "{}",
+                "status": "completed",
+            },
+        ]
+    else:
+        stored_input_items = cast(
+            list[proxy_service.JsonValue],
+            [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "custom", "name": "shell"}],
+                },
+                {"role": "user", "content": "hello"},
+            ],
+        )
     input_items = [*stored_input_items, *suffix_items]
     payload = proxy_service.ResponsesRequest.model_validate(
         {
@@ -15216,13 +15245,24 @@ async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_
         normalized_input_items if preserves_full_resend else normalized_input_items[-len(suffix_items) :]
     )
     assert prepared_frames[-1]["input"] == expected_input_items
-    assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
-        "true",
-    ] * len(prepared_frames)
+    if isinstance(stored_input_items[0], dict) and stored_input_items[0].get("type") == "additional_tools":
+        assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
+            "true",
+        ] * len(prepared_frames)
+    else:
+        assert all(
+            CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY not in cast(dict[str, Any], frame.get("client_metadata", {}))
+            for frame in prepared_frames
+        )
+    expected_reasoning_context = (
+        "all_turns"
+        if isinstance(stored_input_items[0], dict) and stored_input_items[0].get("type") == "additional_tools"
+        else "last_turn"
+    )
     assert all(
         frame["reasoning"]
         == {
-            "context": "all_turns",
+            "context": expected_reasoning_context,
             "effort": "high",
             "summary": "auto",
             "vendor_hint": 7,
@@ -15411,6 +15451,53 @@ def test_verified_durable_full_resend_accepts_response_bound_pending_tool_calls(
         )
         is None
     )
+
+
+def test_verified_durable_full_resend_rejects_response_owned_prefix_settling_output_id() -> None:
+    stored_input_items: list[proxy_service.JsonValue] = [
+        {"role": "user", "content": "look that up"},
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    full_input: list[proxy_service.JsonValue] = [
+        *stored_input_items,
+        {
+            "type": "function_call_output",
+            "id": "fc_output_response_owned",
+            "call_id": "call-1",
+            "output": "result",
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": full_input,
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="sess-tool-proof",
+        canonical_kind="session_header",
+        canonical_key="sid-tool-proof",
+        api_key_scope="__anonymous__",
+        account_id="acc-proof",
+        owner_instance_id=None,
+        owner_epoch=3,
+        lease_expires_at=None,
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state="http_turn_tool_proof",
+        latest_response_id="resp-tool-proof",
+        latest_input_item_count=len(stored_input_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_input_items),
+        model="gpt-5.4",
+        latest_pending_tool_calls={"call-1": "function_call"},
+    )
+
+    assert http_bridge_streaming_module._verify_durable_full_resend(payload, durable_lookup) is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22756,6 +22756,48 @@ async def test_activity_snapshot_retains_completed_failed_creation_marker_until_
 
 
 @pytest.mark.asyncio
+async def test_abort_does_not_cancel_owner_task_for_already_settled_retained_future() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-settled-retained-owner", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    inflight_future.set_exception(RuntimeError("durable claim failed"))
+    inflight_future.exception()
+    owner_started = asyncio.Event()
+    release_owner = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+
+    async def owner_cleanup() -> None:
+        owner_started.set()
+        try:
+            await release_owner.wait()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            raise
+
+    owner_task = asyncio.create_task(owner_cleanup())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    async with service._http_bridge_lock:
+        aborted = http_bridge_helpers_module._abort_http_bridge_inflight_creation_locked(
+            service,
+            key,
+            inflight_future,
+            ProxyResponseError(429, openai_error("capacity_exhausted_active_sessions", "overloaded")),
+        )
+
+    assert aborted is True
+    await asyncio.sleep(0)
+    assert owner_cancelled.is_set() is False
+    assert owner_task.done() is False
+    assert service._http_bridge_inflight_sessions[key] is inflight_future
+
+    release_owner.set()
+    await asyncio.wait_for(owner_task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_aborted_creator_rejects_before_durable_claim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -22928,7 +22970,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     turn_state = "http_turn_" + "a" * 32
-    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None)
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None, synthesized_turn_state=True)
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     owner_started = asyncio.Event()
     owner_release = asyncio.Event()
@@ -22954,7 +22996,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
-    monkeypatch.setattr(http_bridge_mixin_module, "_wait_for_http_bridge_aborted_owner", wait_for_owner)
+    monkeypatch.setattr(http_bridge_mixin_module, "_wait_for_http_bridge_aborted_owner_within_budget", wait_for_owner)
     monkeypatch.setattr(
         proxy_service,
         "_active_http_bridge_instance_ring",
@@ -22986,6 +23028,57 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
     finally:
         owner_release.set()
         await asyncio.gather(owner_task, return_exceptions=True)
+
+
+def test_http_bridge_turn_state_synthesis_requires_provenance() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    turn_state = "http_turn_" + "b" * 32
+
+    explicit_key = http_bridge_helpers_module._make_http_bridge_session_key(
+        payload,
+        headers={"x-codex-turn-state": turn_state},
+        affinity=proxy_service._AffinityPolicy(key=turn_state, kind=proxy_service.StickySessionKind.CODEX_SESSION),
+        api_key=None,
+        request_id="req-explicit",
+    )
+    synthesized_key = http_bridge_helpers_module._make_http_bridge_session_key(
+        payload,
+        headers={"x-codex-turn-state": turn_state},
+        affinity=proxy_service._AffinityPolicy(key=turn_state, kind=proxy_service.StickySessionKind.CODEX_SESSION),
+        api_key=None,
+        request_id="req-synthesized",
+        synthesized_turn_state=turn_state,
+    )
+
+    assert explicit_key == synthesized_key
+    assert http_bridge_helpers_module._http_bridge_key_is_synthesized_turn_state(explicit_key) is False
+    assert http_bridge_helpers_module._http_bridge_key_is_synthesized_turn_state(synthesized_key) is True
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_aborted_owner_wait_clamps_to_remaining_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, RuntimeError("aborted"))
+    wait_for_owner = AsyncMock(return_value=False)
+    monkeypatch.setattr(http_bridge_helpers_module, "_wait_for_http_bridge_aborted_owner", wait_for_owner)
+    monkeypatch.setattr(http_bridge_helpers_module, "_service_time", lambda: SimpleNamespace(monotonic=lambda: 10.0))
+
+    waited = await http_bridge_helpers_module._wait_for_http_bridge_aborted_owner_within_budget(
+        inflight_future,
+        5.0,
+        11.25,
+    )
+    exhausted = await http_bridge_helpers_module._wait_for_http_bridge_aborted_owner_within_budget(
+        inflight_future,
+        5.0,
+        10.0,
+    )
+
+    assert waited is False
+    assert exhausted is False
+    wait_for_owner.assert_awaited_once_with(inflight_future, timeout=pytest.approx(1.25))
 
 
 @pytest.mark.asyncio
@@ -37260,7 +37353,12 @@ async def test_abort_inflight_creation_cancels_explicit_turn_state_owner() -> No
 @pytest.mark.asyncio
 async def test_abort_inflight_creation_retains_synthesized_turn_state_until_owner_finishes() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_" + "b" * 32, None)
+    key = proxy_service._HTTPBridgeSessionKey(
+        "turn_state_header",
+        "http_turn_" + "b" * 32,
+        None,
+        synthesized_turn_state=True,
+    )
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     owner_started = asyncio.Event()
     owner_release = asyncio.Event()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -42,7 +42,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketTransportError,
     WebsocketsUpstreamWebSocket,
 )
-from app.core.clock import REAL_SCHEDULER, RealScheduler
+from app.core.clock import REAL_SCHEDULER, RealScheduler, Scheduler
 from app.core.config.dashboard_overrides import dashboard_overrides_bound, with_dashboard_overrides
 from app.core.config.settings import Settings
 from app.core.errors import HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE, openai_error
@@ -22286,7 +22286,6 @@ def test_owner_forward_proxy_error_classifies_explicit_drain_as_receiver_rejecte
     )
 
 
-
 def test_turn_state_only_generated_drain_rejection_preserves_retryable_owner_error() -> None:
     source = ProxyResponseError(
         503,
@@ -22325,6 +22324,7 @@ def test_ambiguous_drain_rejection_does_not_bootstrap_rebind_session_key() -> No
         )
         is False
     )
+
 
 def test_turn_state_draining_owner_rejection_does_not_rebind_previous_response() -> None:
     source = ProxyResponseError(
@@ -23463,7 +23463,11 @@ async def test_http_bridge_aborted_owner_wait_clamps_to_remaining_request_budget
 
     assert waited is False
     assert exhausted is False
-    wait_for_owner.assert_awaited_once_with(inflight_future, timeout=pytest.approx(1.25))
+    wait_for_owner.assert_awaited_once_with(
+        inflight_future,
+        timeout=pytest.approx(1.25),
+        scheduler=http_bridge_helpers_module.REAL_SCHEDULER,
+    )
 
 
 @pytest.mark.asyncio
@@ -23498,7 +23502,11 @@ async def test_http_bridge_retained_owner_cleanup_clamps_to_remaining_request_bu
                 request_deadline=11.25,
             )
         assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
-        wait_for_owner.assert_awaited_once_with(retained_future, timeout=pytest.approx(1.25))
+        wait_for_owner.assert_awaited_once_with(
+            retained_future,
+            timeout=pytest.approx(1.25),
+            scheduler=http_bridge_helpers_module.REAL_SCHEDULER,
+        )
         evict_waiter.assert_not_awaited()
 
         wait_for_owner.reset_mock()
@@ -37933,7 +37941,12 @@ async def test_wait_for_aborted_owner_preserves_observer_cancellation(
     )
     setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
 
-    async def observer_cancelled_wait(shared: asyncio.Future[Any], *, timeout: float | None = None) -> Any:
+    async def observer_cancelled_wait(
+        shared: asyncio.Future[Any],
+        *,
+        timeout: float | None = None,
+        scheduler: Scheduler | None = None,
+    ) -> Any:
         assert shared is owner_task
         owner_task.cancel()
         await asyncio.gather(owner_task, return_exceptions=True)
@@ -37969,7 +37982,12 @@ async def test_wait_for_aborted_owner_accepts_owner_timeout_completion(
     )
     setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
 
-    async def owner_timeout_wait(shared: asyncio.Future[Any], *, timeout: float | None = None) -> Any:
+    async def owner_timeout_wait(
+        shared: asyncio.Future[Any],
+        *,
+        timeout: float | None = None,
+        scheduler: Scheduler | None = None,
+    ) -> Any:
         assert shared is owner_task
         await shared
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22642,6 +22642,87 @@ async def test_get_or_create_http_bridge_session_does_not_publish_before_durable
 
 
 @pytest.mark.asyncio
+async def test_failed_creator_retains_marker_until_created_session_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-cleanup-retention", None)
+    created_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+    settings = _make_app_settings()
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+    create_calls = 0
+    create_started = asyncio.Event()
+    claim_started = asyncio.Event()
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
+        nonlocal create_calls
+        create_calls += 1
+        create_started.set()
+        return created_session
+
+    async def claim_durable_session(*_: object, **__: object) -> None:
+        claim_started.set()
+        await asyncio.Event().wait()
+
+    async def close_session(session: proxy_service._HTTPBridgeSession, **_: object) -> None:
+        assert session is created_session
+        close_started.set()
+        await release_close.wait()
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable_session)
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    async def get_session() -> proxy_service._HTTPBridgeSession | proxy_service._HTTPBridgeOwnerForward:
+        return await service._get_or_create_http_bridge_session(
+            key,
+            headers={},
+            affinity=proxy_service._AffinityPolicy(
+                key=key.affinity_key,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+            request_deadline=time.monotonic() + 1.0,
+        )
+
+    owner_task = asyncio.create_task(get_session())
+    await asyncio.wait_for(create_started.wait(), timeout=1.0)
+    await asyncio.wait_for(claim_started.wait(), timeout=1.0)
+
+    with pytest.raises(ProxyResponseError):
+        await asyncio.wait_for(get_session(), timeout=1.0)
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+
+    assert service._http_bridge_inflight_sessions.get(key) is not None
+    third_waiter = asyncio.create_task(get_session())
+    try:
+        await asyncio.sleep(0.05)
+        assert create_calls == 1
+        assert service._http_bridge_inflight_sessions.get(key) is not None
+    finally:
+        third_waiter.cancel()
+        await asyncio.gather(third_waiter, return_exceptions=True)
+        release_close.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(owner_task, timeout=1.0)
+    assert key not in service._http_bridge_inflight_sessions
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_waiter_propagates_terminal_inflight_proxy_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -22740,6 +22821,72 @@ async def test_get_or_create_http_bridge_session_inflight_wait_times_out(
         await inflight_future
     assert future_exc_info.value.status_code == 429
     assert future_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+
+
+@pytest.mark.asyncio
+async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    turn_state = "http_turn_" + "a" * 32
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    owner_started = asyncio.Event()
+    owner_release = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+
+    async def owner() -> None:
+        try:
+            owner_started.set()
+            await owner_release.wait()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            await owner_release.wait()
+
+    owner_task = asyncio.create_task(owner())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+    settings = _make_app_settings()
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+    wait_for_owner = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(http_bridge_mixin_module, "_wait_for_http_bridge_aborted_owner", wait_for_owner)
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await service._get_or_create_http_bridge_session(
+                key,
+                headers={"x-codex-turn-state": turn_state},
+                affinity=proxy_service._AffinityPolicy(
+                    key=turn_state,
+                    kind=proxy_service.StickySessionKind.CODEX_SESSION,
+                ),
+                api_key=None,
+                request_model="gpt-5.4",
+                idle_ttl_seconds=120.0,
+                max_sessions=8,
+                allow_forward_to_owner=True,
+            )
+
+        assert exc_info.value.status_code == 429
+        await asyncio.wait_for(owner_cancelled.wait(), timeout=1.0)
+        assert owner_cancelled.is_set()
+        assert not owner_task.done()
+        assert service._http_bridge_inflight_sessions[key] is inflight_future
+        wait_for_owner.assert_not_awaited()
+    finally:
+        owner_release.set()
+        await asyncio.gather(owner_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -27768,7 +27915,6 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
     # relying on an earlier module having reset the shared test database.
     del db_setup
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    await service._pin_file_account("file_from_other_account", "acc-file")
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.4",
@@ -27786,6 +27932,7 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
         }
     )
     get_or_create = AsyncMock()
+    resolve_file_account = AsyncMock(return_value="acc-file")
 
     monkeypatch.setattr(
         proxy_service,
@@ -27808,6 +27955,7 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_http_bridge_local_owner_account_id", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_resolve_forwarded_file_account_for_responses", resolve_file_account)
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
 
     with pytest.raises(ProxyResponseError) as exc_info:
@@ -27829,6 +27977,7 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
 
     assert exc_info.value.status_code == 502
     assert exc_info.value.payload["error"]["code"] == "previous_response_owner_unavailable"
+    resolve_file_account.assert_not_awaited()
     get_or_create.assert_not_awaited()
 
 
@@ -36900,6 +37049,125 @@ async def test_inflight_waiter_returns_429_when_aborted_owner_resists_cancellati
     finally:
         release_owner.set()
         await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_abort_inflight_creation_cancels_explicit_turn_state_owner() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "turn-client-provided", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    owner_started = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+    owner_release = asyncio.Event()
+
+    async def owner() -> None:
+        try:
+            owner_started.set()
+            await owner_release.wait()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            raise
+
+    owner_task = asyncio.create_task(owner())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    try:
+        aborted = http_bridge_helpers_module._abort_http_bridge_inflight_creation_locked(
+            service,
+            key,
+            inflight_future,
+            ProxyResponseError(429, openai_error("proxy_overloaded", "overloaded")),
+        )
+        await asyncio.sleep(0)
+
+        assert aborted is True
+        assert service._http_bridge_inflight_sessions.get(key) is inflight_future
+        assert owner_cancelled.is_set()
+    finally:
+        owner_release.set()
+        await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_abort_inflight_creation_retains_synthesized_turn_state_until_owner_finishes() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_" + "b" * 32, None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    owner_started = asyncio.Event()
+    owner_release = asyncio.Event()
+    owner_cancelled = asyncio.Event()
+
+    async def owner() -> None:
+        try:
+            owner_started.set()
+            await owner_release.wait()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            await owner_release.wait()
+
+    owner_task = asyncio.create_task(owner())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    try:
+        aborted = http_bridge_helpers_module._abort_http_bridge_inflight_creation_locked(
+            service,
+            key,
+            inflight_future,
+            ProxyResponseError(429, openai_error("proxy_overloaded", "overloaded")),
+        )
+        await asyncio.sleep(0)
+
+        assert aborted is True
+        assert owner_cancelled.is_set()
+        assert not owner_task.done()
+        assert service._http_bridge_inflight_sessions[key] is inflight_future
+        activity = http_bridge_helpers_module.http_bridge_activity_snapshot_nowait(service)
+        assert activity["http_bridge_inflight_session_creates"] == 1
+        assert activity["http_bridge_cleaned_inflight_session_creates"] == 0
+        assert service._http_bridge_inflight_sessions[key] is inflight_future
+    finally:
+        owner_release.set()
+        await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_aborted_owner_preserves_observer_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+
+    async def owner() -> None:
+        await asyncio.Event().wait()
+
+    owner_task = asyncio.create_task(owner())
+    setattr(
+        inflight_future,
+        http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR,
+        ProxyResponseError(429, openai_error("proxy_overloaded", "overloaded")),
+    )
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+
+    async def observer_cancelled_wait(shared: asyncio.Future[Any], *, timeout: float | None = None) -> Any:
+        assert shared is owner_task
+        owner_task.cancel()
+        await asyncio.gather(owner_task, return_exceptions=True)
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        current_task.cancel()
+        await asyncio.sleep(0)
+        raise AssertionError("observer cancellation did not propagate")
+
+    monkeypatch.setattr(http_bridge_helpers_module, "wait_on_shared_future", observer_cancelled_wait)
+
+    observer = asyncio.create_task(
+        http_bridge_helpers_module._wait_for_http_bridge_aborted_owner(inflight_future, timeout=1.0)
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await observer
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -23162,6 +23162,7 @@ async def test_aborted_creator_rejects_before_durable_claim(
         raise AssertionError("create_session should be cancelled by the aborting waiter")
 
     settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
@@ -37619,6 +37620,7 @@ async def test_inflight_waiter_retries_after_aborted_owner_finalizes(
         return replacement
 
     settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22723,6 +22723,105 @@ async def test_failed_creator_retains_marker_until_created_session_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_activity_snapshot_retains_completed_failed_creation_marker_until_owner_finishes() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-retain-running-owner", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    inflight_future.set_exception(RuntimeError("durable claim failed"))
+    inflight_future.exception()
+    owner_started = asyncio.Event()
+    release_owner = asyncio.Event()
+
+    async def owner_cleanup() -> None:
+        owner_started.set()
+        await release_owner.wait()
+
+    owner_task = asyncio.create_task(owner_cleanup())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    snapshot = http_bridge_helpers_module.http_bridge_activity_snapshot_nowait(service)
+
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_inflight_session_creates"] == 1
+    assert service._http_bridge_inflight_sessions[key] is inflight_future
+
+    release_owner.set()
+    await asyncio.wait_for(owner_task, timeout=1.0)
+    snapshot = http_bridge_helpers_module.http_bridge_activity_snapshot_nowait(service)
+
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 1
+    assert key not in service._http_bridge_inflight_sessions
+
+
+@pytest.mark.asyncio
+async def test_aborted_creator_rejects_before_durable_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-aborted-before-claim", None)
+    created_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+    create_started = asyncio.Event()
+    claim_durable = AsyncMock()
+    close_session = AsyncMock()
+
+    async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
+        create_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            return created_session
+        raise AssertionError("create_session should be cancelled by the aborting waiter")
+
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    owner_task = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            key,
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key=key.affinity_key),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+            request_deadline=time.monotonic() + 1.0,
+        )
+    )
+    await asyncio.wait_for(create_started.wait(), timeout=1.0)
+    async with service._http_bridge_lock:
+        inflight_future = service._http_bridge_inflight_sessions[key]
+        http_bridge_helpers_module._abort_http_bridge_inflight_creation_locked(
+            service,
+            key,
+            inflight_future,
+            ProxyResponseError(429, openai_error("capacity_exhausted_active_sessions", "overloaded")),
+        )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await asyncio.wait_for(owner_task, timeout=1.0)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+    claim_durable.assert_not_awaited()
+    close_session.assert_awaited_once_with(created_session, release_durable_session=True)
+    assert key not in service._http_bridge_sessions
+    assert key not in service._http_bridge_inflight_sessions
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_waiter_propagates_terminal_inflight_proxy_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -23221,6 +23320,74 @@ async def test_get_or_create_http_bridge_session_capacity_wait_times_out(
     assert future_exc_info.value.status_code == 429
     assert future_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capacity_waiter_waits_for_retained_failed_owner_before_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-retained-failed-owner", None)
+    waiter_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-retained-capacity-waiter", None)
+    retained_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    retained_future.set_exception(RuntimeError("durable claim failed"))
+    retained_future.exception()
+    owner_started = asyncio.Event()
+    release_owner = asyncio.Event()
+    replacement = _make_bridge_session(key=waiter_key, key_value=waiter_key.affinity_key)
+    replacement.request_model = "gpt-5.4"
+
+    async def owner_cleanup() -> None:
+        owner_started.set()
+        await release_owner.wait()
+
+    owner_task = asyncio.create_task(owner_cleanup())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(retained_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    service._http_bridge_inflight_sessions[owner_key] = retained_future
+
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.2)
+    create_http_bridge_session = AsyncMock(return_value=replacement)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    waiter = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            waiter_key,
+            headers={"x-codex-session-id": waiter_key.affinity_key},
+            affinity=proxy_service._AffinityPolicy(
+                key=waiter_key.affinity_key,
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=1,
+            request_deadline=time.monotonic() + 1.0,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert create_http_bridge_session.await_count == 0
+    assert service._http_bridge_inflight_sessions[owner_key] is retained_future
+
+    release_owner.set()
+    await asyncio.wait_for(owner_task, timeout=1.0)
+    resolved = await asyncio.wait_for(waiter, timeout=1.0)
+
+    assert resolved is replacement
+    assert owner_key not in service._http_bridge_inflight_sessions
+    assert service._http_bridge_sessions[waiter_key] is replacement
+    create_http_bridge_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -37338,6 +37338,38 @@ async def test_wait_for_aborted_owner_preserves_observer_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_wait_for_aborted_owner_accepts_owner_timeout_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+
+    async def owner() -> None:
+        raise TimeoutError("owner creation timed out")
+
+    owner_task = asyncio.create_task(owner())
+    setattr(
+        inflight_future,
+        http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR,
+        ProxyResponseError(429, openai_error("proxy_overloaded", "overloaded")),
+    )
+    setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+
+    async def owner_timeout_wait(shared: asyncio.Future[Any], *, timeout: float | None = None) -> Any:
+        assert shared is owner_task
+        await shared
+
+    monkeypatch.setattr(http_bridge_helpers_module, "wait_on_shared_future", owner_timeout_wait)
+
+    assert (
+        await http_bridge_helpers_module._wait_for_http_bridge_aborted_owner(
+            inflight_future,
+            timeout=1.0,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
 async def test_superseded_creator_hands_its_claimed_epoch_to_the_registered_winner() -> None:
     """Eviction can land DURING the claim, so a creator may advance the shared
     row's epoch past the session that won the registry slot — fencing the

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22994,7 +22994,7 @@ async def test_failed_creator_retains_marker_until_created_session_cleanup(
     key = proxy_service._HTTPBridgeSessionKey("prompt_cache_key", "sid-cleanup-retention", None)
     created_session = _make_bridge_session(key=key, key_value=key.affinity_key)
     settings = _make_app_settings()
-    settings.proxy_admission_wait_timeout_seconds = 0.01
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     create_calls = 0
     create_started = asyncio.Event()
     claim_started = asyncio.Event()
@@ -23040,7 +23040,7 @@ async def test_failed_creator_retains_marker_until_created_session_cleanup(
             request_model="gpt-5.4",
             idle_ttl_seconds=120.0,
             max_sessions=8,
-            request_deadline=time.monotonic() + 1.0,
+            request_deadline=http_bridge_helpers_module.clock_for(service).monotonic() + 1.0,
         )
 
     owner_task = asyncio.create_task(get_session())
@@ -23341,7 +23341,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
     setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
     service._http_bridge_inflight_sessions[synthesized_key] = inflight_future
     settings = _make_app_settings()
-    settings.proxy_admission_wait_timeout_seconds = 0.01
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     wait_for_owner = AsyncMock(return_value=True)
 
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
@@ -23873,7 +23873,13 @@ async def test_capacity_waiter_waits_for_retained_failed_owner_before_retry(
     setattr(retained_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
     service._http_bridge_inflight_sessions[owner_key] = retained_future
 
-    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.2)
+    admission_wait_timeout_seconds = 0.2
+    settings = _make_app_settings()
+    monkeypatch.setattr(
+        http_bridge_mixin_module,
+        "_proxy_admission_wait_timeout_seconds",
+        lambda: admission_wait_timeout_seconds,
+    )
     create_http_bridge_session = AsyncMock(return_value=replacement)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
@@ -23936,7 +23942,13 @@ async def test_capacity_waiter_passes_request_deadline_to_retained_failed_owner_
     )
     service._http_bridge_inflight_sessions[owner_key] = retained_future
 
-    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.2)
+    admission_wait_timeout_seconds = 0.2
+    settings = _make_app_settings()
+    monkeypatch.setattr(
+        http_bridge_mixin_module,
+        "_proxy_admission_wait_timeout_seconds",
+        lambda: admission_wait_timeout_seconds,
+    )
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock())
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -23970,7 +23982,7 @@ async def test_capacity_waiter_passes_request_deadline_to_retained_failed_owner_
     cleanup.assert_awaited_once_with(
         service,
         retained_future,
-        timeout=pytest.approx(settings.proxy_admission_wait_timeout_seconds),
+        timeout=pytest.approx(admission_wait_timeout_seconds),
         request_deadline=pytest.approx(request_deadline),
     )
 
@@ -24510,7 +24522,12 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "sid-late-owner", None)
     settings = _make_app_settings()
-    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
+    monkeypatch.setattr(
+        http_bridge_mixin_module,
+        "_wait_for_http_bridge_aborted_owner_within_budget",
+        AsyncMock(return_value=False),
+    )
     created = _make_bridge_session(key_value="sid-late-owner")
     created.key = key
     create_started = asyncio.Event()
@@ -24518,7 +24535,10 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
 
     async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
         create_started.set()
-        await finish_create.wait()
+        try:
+            await finish_create.wait()
+        except asyncio.CancelledError:
+            await finish_create.wait()
         return created
 
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
@@ -24547,6 +24567,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
             request_model="gpt-5.4",
             idle_ttl_seconds=120.0,
             max_sessions=8,
+            request_deadline=http_bridge_helpers_module.clock_for(service).monotonic() + 1.0,
         )
 
     owner_task = asyncio.create_task(get_session())
@@ -24558,7 +24579,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
 
     assert waiter_exc_info.value.status_code == 429
     assert waiter_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
-    assert key not in service._http_bridge_inflight_sessions
+    assert service._http_bridge_inflight_sessions[key].done()
 
     finish_create.set()
     with pytest.raises(ProxyResponseError) as owner_exc_info:
@@ -24566,6 +24587,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
 
     assert owner_exc_info.value.status_code == 429
     assert owner_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+    assert key not in service._http_bridge_inflight_sessions
     assert key not in service._http_bridge_sessions
     close_http_bridge_session.assert_awaited_once_with(created, release_durable_session=True)
 
@@ -37619,8 +37641,8 @@ async def test_inflight_waiter_retries_after_aborted_owner_finalizes(
         assert owner_cancelled.is_set()
         return replacement
 
-    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
-    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
+    settings = _make_app_settings()
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -37689,7 +37711,8 @@ async def test_capacity_waiter_retries_after_aborted_owner_finalizes(
         assert key == waiter_key
         return replacement
 
-    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    settings = _make_app_settings()
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -37757,7 +37780,8 @@ async def test_inflight_waiter_returns_429_when_aborted_owner_resists_cancellati
             await release_owner.wait()
         return created
 
-    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.01)
+    settings = _make_app_settings()
+    monkeypatch.setattr(http_bridge_mixin_module, "_proxy_admission_wait_timeout_seconds", lambda: 0.01)
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22970,7 +22970,13 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     turn_state = "http_turn_" + "a" * 32
-    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None, synthesized_turn_state=True)
+    synthesized_key = proxy_service._HTTPBridgeSessionKey(
+        "turn_state_header",
+        turn_state,
+        None,
+        synthesized_turn_state=True,
+    )
+    echoed_key = proxy_service._HTTPBridgeSessionKey("turn_state_header", turn_state, None)
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     owner_started = asyncio.Event()
     owner_release = asyncio.Event()
@@ -22987,7 +22993,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
     owner_task = asyncio.create_task(owner())
     await asyncio.wait_for(owner_started.wait(), timeout=1.0)
     setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
-    service._http_bridge_inflight_sessions[key] = inflight_future
+    service._http_bridge_inflight_sessions[synthesized_key] = inflight_future
     settings = _make_app_settings()
     settings.proxy_admission_wait_timeout_seconds = 0.01
     wait_for_owner = AsyncMock(return_value=True)
@@ -23006,7 +23012,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
     try:
         with pytest.raises(ProxyResponseError) as exc_info:
             await service._get_or_create_http_bridge_session(
-                key,
+                echoed_key,
                 headers={"x-codex-turn-state": turn_state},
                 affinity=proxy_service._AffinityPolicy(
                     key=turn_state,
@@ -23023,7 +23029,7 @@ async def test_generated_turn_state_inflight_timeout_skips_owner_observation(
         await asyncio.wait_for(owner_cancelled.wait(), timeout=1.0)
         assert owner_cancelled.is_set()
         assert not owner_task.done()
-        assert service._http_bridge_inflight_sessions[key] is inflight_future
+        assert service._http_bridge_inflight_sessions[synthesized_key] is inflight_future
         wait_for_owner.assert_not_awaited()
     finally:
         owner_release.set()
@@ -23056,21 +23062,54 @@ def test_http_bridge_turn_state_synthesis_requires_provenance() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_registered_turn_state_alias_preserves_synthesis_provenance() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    turn_state = "http_turn_" + "c" * 32
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey(
+            "turn_state_header",
+            turn_state,
+            None,
+            synthesized_turn_state=True,
+        ),
+        key_value=turn_state,
+    )
+    service._http_bridge_sessions[session.key] = session
+
+    assert await service._register_http_bridge_turn_state(session, turn_state, synthesized=True) is True
+
+    assert turn_state in session.downstream_turn_state_aliases
+    assert turn_state in session.synthesized_downstream_turn_state_aliases
+    assert http_bridge_helpers_module._http_bridge_local_turn_state_alias_is_synthesized_locked(
+        service,
+        turn_state,
+        None,
+    )
+
+    service._unregister_http_bridge_turn_states_locked(session)
+
+    assert turn_state not in session.downstream_turn_state_aliases
+    assert turn_state not in session.synthesized_downstream_turn_state_aliases
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_aborted_owner_wait_clamps_to_remaining_request_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     setattr(inflight_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_ABORT_ERROR_ATTR, RuntimeError("aborted"))
     wait_for_owner = AsyncMock(return_value=False)
+    service = SimpleNamespace(_clock=VirtualClock(monotonic_value=10.0))
     monkeypatch.setattr(http_bridge_helpers_module, "_wait_for_http_bridge_aborted_owner", wait_for_owner)
-    monkeypatch.setattr(http_bridge_helpers_module, "_service_time", lambda: SimpleNamespace(monotonic=lambda: 10.0))
 
     waited = await http_bridge_helpers_module._wait_for_http_bridge_aborted_owner_within_budget(
+        service,
         inflight_future,
         5.0,
         11.25,
     )
     exhausted = await http_bridge_helpers_module._wait_for_http_bridge_aborted_owner_within_budget(
+        service,
         inflight_future,
         5.0,
         10.0,
@@ -23079,6 +23118,55 @@ async def test_http_bridge_aborted_owner_wait_clamps_to_remaining_request_budget
     assert waited is False
     assert exhausted is False
     wait_for_owner.assert_awaited_once_with(inflight_future, timeout=pytest.approx(1.25))
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retained_owner_cleanup_clamps_to_remaining_request_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retained_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    owner_started = asyncio.Event()
+    release_owner = asyncio.Event()
+
+    async def owner_cleanup() -> None:
+        owner_started.set()
+        await release_owner.wait()
+
+    owner_task = asyncio.create_task(owner_cleanup())
+    await asyncio.wait_for(owner_started.wait(), timeout=1.0)
+    setattr(retained_future, http_bridge_helpers_module._HTTP_BRIDGE_INFLIGHT_OWNER_TASK_ATTR, owner_task)
+    wait_for_owner = AsyncMock(return_value=False)
+    evict_waiter = AsyncMock()
+    service = SimpleNamespace(
+        _clock=VirtualClock(monotonic_value=10.0),
+        _evict_http_bridge_inflight_waiter=evict_waiter,
+    )
+    monkeypatch.setattr(http_bridge_helpers_module, "_wait_for_http_bridge_retained_owner", wait_for_owner)
+
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await http_bridge_helpers_module._evict_http_bridge_retained_capacity_waiter_after_error(
+                service,
+                retained_future,
+                timeout=5.0,
+                request_deadline=11.25,
+            )
+        assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+        wait_for_owner.assert_awaited_once_with(retained_future, timeout=pytest.approx(1.25))
+        evict_waiter.assert_not_awaited()
+
+        wait_for_owner.reset_mock()
+        with pytest.raises(ProxyResponseError):
+            await http_bridge_helpers_module._evict_http_bridge_retained_capacity_waiter_after_error(
+                service,
+                retained_future,
+                timeout=5.0,
+                request_deadline=10.0,
+            )
+        wait_for_owner.assert_not_awaited()
+    finally:
+        release_owner.set()
+        await owner_task
 
 
 @pytest.mark.asyncio
@@ -23481,6 +23569,64 @@ async def test_capacity_waiter_waits_for_retained_failed_owner_before_retry(
     assert owner_key not in service._http_bridge_inflight_sessions
     assert service._http_bridge_sessions[waiter_key] is replacement
     create_http_bridge_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capacity_waiter_passes_request_deadline_to_retained_failed_owner_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-retained-deadline-owner", None)
+    waiter_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-retained-deadline-waiter", None)
+    retained_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    retained_future.set_exception(RuntimeError("durable claim failed"))
+    retained_future.exception()
+    request_deadline = time.monotonic() + 0.05
+    cleanup = AsyncMock(
+        side_effect=http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+            "http_bridge_capacity",
+            code="capacity_exhausted_active_sessions",
+        )
+    )
+    service._http_bridge_inflight_sessions[owner_key] = retained_future
+
+    settings = _make_app_settings(proxy_admission_wait_timeout_seconds=0.2)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+    monkeypatch.setattr(http_bridge_mixin_module, "_evict_http_bridge_retained_capacity_waiter_after_error", cleanup)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._get_or_create_http_bridge_session(
+            waiter_key,
+            headers={"x-codex-session-id": waiter_key.affinity_key},
+            affinity=proxy_service._AffinityPolicy(
+                key=waiter_key.affinity_key,
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=1,
+            request_deadline=request_deadline,
+        )
+
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+    cleanup.assert_awaited_once_with(
+        service,
+        retained_future,
+        timeout=pytest.approx(settings.proxy_admission_wait_timeout_seconds),
+        request_deadline=pytest.approx(request_deadline),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_has_response_owned_prefix_settling_output_ids,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -712,6 +713,213 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
             pending_tool_calls=pending_tool_calls,
         )
         is expected
+    )
+
+
+def test_full_resend_suffix_accepts_outputs_for_pending_calls_in_stored_prefix() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_current", "output": "result"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
+    )
+
+
+def test_full_resend_suffix_rejects_outputs_without_matching_pending_prefix_call() -> None:
+    stored_input: list[JsonValue] = [{"role": "user", "content": "first question"}]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_current", "output": "orphan"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param(
+            [
+                {"type": "function_call_output", "call_id": "call_current", "output": "wrong"},
+                {"type": "function_call_output", "call_id": "call_current", "output": "right"},
+            ],
+            id="duplicate-output-overwrite",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_current",
+                    "output": "result",
+                    "id": "response-owned-output-id",
+                },
+            ],
+            id="response-owned-output-field",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "output": "result"}],
+            id="missing-call-id",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "call_id": "call_current"}],
+            id="missing-output",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "call_id": "call_current", "output": []}],
+            id="malformed-output",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_current",
+                    "output": "result",
+                    "internal_chat_message_metadata_passthrough": {"turn_id": ""},
+                }
+            ],
+            id="malformed-internal-metadata",
+        ),
+    ],
+)
+def test_full_resend_suffix_validates_prefix_settling_outputs(suffix: list[JsonValue]) -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("status", ["completed", "failed"])
+def test_full_resend_suffix_accepts_prefix_settling_output_status(status: str) -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "apply this patch"},
+        {
+            "type": "apply_patch_call",
+            "call_id": "call_current",
+            "input": "*** Begin Patch\n*** End Patch\n",
+            "status": "completed",
+            "caller": {"type": "direct"},
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {
+            "type": "apply_patch_call_output",
+            "call_id": "call_current",
+            "output": None,
+            "status": status,
+            "caller": {"type": "direct"},
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn_current"},
+        }
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "apply_patch_call"},
+        )
+        is True
+    )
+
+
+def test_full_resend_suffix_rejects_whitespace_prefix_settling_call_ids() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "   ",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "   ", "output": "result"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"   ": "function_call"},
+        )
+        is False
+    )
+
+
+def test_full_resend_raw_suffix_preserves_prefix_settling_output_id_evidence() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "id": "fc_old",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {
+            "type": "function_call_output",
+            "id": "response-owned-output-id",
+            "call_id": "call_current",
+            "output": "result",
+        },
+    ]
+    projection = project_responses_input_for_account_neutral_fresh_replay(
+        [*stored_input, *suffix],
+        stored_count=len(stored_input),
+    )
+
+    assert projection is not None
+    assert (
+        responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
+    )
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            projection.input_items,
+            stored_count=projection.stored_prefix_count,
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
     )
 
 


### PR DESCRIPTION
Consolidated into [Soju06/codex-lb PR 2088](https://github.com/Soju06/codex-lb/pull/2088), which carries the owner lifecycle changes together with their draining-owner recovery consumer. The survivor preserves all 17 original owner-lifecycle regression tests and the original change authorship; its full bridge/forwarding contract suite passes. Closing this duplicate review surface.
