### PR TITLE
fix(proxy): allow prefix-settled replay outputs

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -265,6 +265,7 @@ from app.modules.proxy.helpers import (
 from app.modules.proxy.replay_safety import (
     AccountNeutralReplayProjection,
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_has_response_owned_prefix_settling_output_ids,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -397,6 +398,13 @@ class _VerifiedDurableFullResend:
         ):
             return None
         input_items = cast(list[JsonValue], payload.input)
+        pending_tool_calls = durable_lookup.latest_pending_tool_calls
+        if pending_tool_calls is not None and responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+            input_items,
+            stored_count=stored_count,
+            pending_tool_calls=pending_tool_calls,
+        ):
+            return None
         replay_projection = project_responses_input_for_account_neutral_fresh_replay(
             input_items,
             stored_count=stored_count,
@@ -405,7 +413,6 @@ class _VerifiedDurableFullResend:
             # the exact-manifest check rejects response-owned messages.
             preserve_developer_message_ids=True,
         )
-        pending_tool_calls = durable_lookup.latest_pending_tool_calls
         if replay_projection is None:
             return None
         safe_fresh_context = responses_input_suffix_retains_prior_output(
@@ -1563,8 +1570,16 @@ class _HTTPBridgeStreamingMixin:
                 or not isinstance(payload.input, list)
             ):
                 return None, None, False
+            raw_input_items = cast(list[JsonValue], payload.input)
+            pending_tool_calls = lookup.latest_pending_tool_calls
+            if pending_tool_calls is not None and responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+                raw_input_items,
+                stored_count=stored_count,
+                pending_tool_calls=pending_tool_calls,
+            ):
+                return stored_count, lookup.latest_input_full_fingerprint, False
             replay_projection = project_responses_input_for_account_neutral_fresh_replay(
-                cast(list[JsonValue], payload.input),
+                raw_input_items,
                 stored_count=stored_count,
                 # Classification only: inline Responses-Lite developer IDs
                 # must remain visible until the exact-manifest check rejects

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -270,7 +270,7 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         if not _input_item_has_only_known_fields(item, item_type):
             return False
         call_id_value = item.get("call_id")
-        call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
+        call_id = cast(str, call_id_value) if _is_nonblank_string(call_id_value) else None
         if item_type in _TOOL_CALL_TYPES:
             if (
                 call_id is None
@@ -412,7 +412,15 @@ def responses_input_suffix_matches_pending_tool_calls(
         allow_historical_developer_interleave=True,
         canonical_lite_developer_index=canonical_lite_developer_index,
     )
-    if prefix_state is None or prefix_state[0] or prefix_state[1] & pending_tool_calls.keys():
+    if prefix_state is None:
+        return False
+    prefix_pending_calls, prefix_seen_call_ids = prefix_state
+    expected = dict(pending_tool_calls)
+    prefix_pending = {call_id: call_type for call_type, call_id in prefix_pending_calls}
+    if prefix_pending:
+        if prefix_pending != expected:
+            return False
+    elif prefix_seen_call_ids & pending_tool_calls.keys():
         return False
     suffix = input_items[stored_count:]
     if (
@@ -429,19 +437,78 @@ def responses_input_suffix_matches_pending_tool_calls(
         for item in suffix
     ):
         return False
-    if not responses_input_items_are_self_contained_fresh_replay(suffix):
+    if not prefix_pending and not responses_input_items_are_self_contained_fresh_replay(suffix):
         return False
     suffix_calls: dict[str, str] = {}
     suffix_outputs: dict[str, str] = {}
     for item in cast(list[dict[str, JsonValue]], suffix):
         item_type = cast(str, item["type"])
-        call_id = cast(str, item["call_id"])
+        call_id = item.get("call_id")
+        if not _is_nonblank_string(call_id):
+            return False
+        call_id_str = cast(str, call_id)
         if item_type in _TOOL_CALL_TYPES:
-            suffix_calls[call_id] = item_type
+            if call_id_str in suffix_calls:
+                return False
+            suffix_calls[call_id_str] = item_type
         else:
-            suffix_outputs[call_id] = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE[item_type]
-    expected = dict(pending_tool_calls)
+            if call_id_str in suffix_outputs:
+                return False
+            if "id" in item or set(item) - _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS[item_type]:
+                return False
+            if (
+                not _internal_chat_message_metadata_is_account_neutral(item.get(_INTERNAL_CHAT_MESSAGE_METADATA_FIELD))
+                or not _caller_is_self_contained(item)
+                or not _tool_output_is_self_contained(item_type, item)
+            ):
+                return False
+            suffix_outputs[call_id_str] = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE[item_type]
+    if prefix_pending:
+        return not suffix_calls and suffix_outputs == expected
     return suffix_calls == expected and suffix_outputs == expected
+
+
+def responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+    input_items: list[JsonValue],
+    *,
+    stored_count: int,
+    pending_tool_calls: Mapping[str, str],
+    canonical_lite_developer_index: int | None = None,
+) -> bool:
+    """Return whether raw prefix-settling outputs carry response-owned IDs."""
+
+    if stored_count <= 0 or len(input_items) <= stored_count or not pending_tool_calls:
+        return False
+    prefix_state = _direct_tool_call_prefix_state(
+        input_items[:stored_count],
+        allow_historical_developer_interleave=True,
+        canonical_lite_developer_index=canonical_lite_developer_index,
+    )
+    if prefix_state is None:
+        return False
+    prefix_pending_calls, _prefix_seen_call_ids = prefix_state
+    prefix_pending = {call_id: call_type for call_type, call_id in prefix_pending_calls}
+    expected = dict(pending_tool_calls)
+    if prefix_pending != expected:
+        return False
+    suffix = input_items[stored_count:]
+    if (
+        len(suffix) == 3
+        and isinstance(suffix[1], dict)
+        and _fresh_developer_message_is_transparent(suffix[1])
+        and _fresh_developer_interleave_is_bounded(suffix, index=1)
+    ):
+        suffix = [suffix[0], suffix[2]]
+    for item in suffix:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        call_type = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE.get(item_type if isinstance(item_type, str) else "")
+        call_id = item.get("call_id")
+        if call_type is not None and _is_nonblank_string(call_id) and expected.get(cast(str, call_id)) == call_type:
+            if "id" in item:
+                return True
+    return False
 
 
 def _direct_tool_call_prefix_state(
@@ -490,10 +557,11 @@ def _direct_tool_call_prefix_state(
             if item.get("status") not in (None, "completed"):
                 return None
             call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not call_id or call_id in seen_call_ids:
+            if not _is_nonblank_string(call_id) or call_id in seen_call_ids:
                 return None
-            seen_call_ids.add(call_id)
-            pending_calls.append((item_type, call_id))
+            call_id_str = cast(str, call_id)
+            seen_call_ids.add(call_id_str)
+            pending_calls.append((item_type, call_id_str))
             if len(pending_calls) > 1:
                 # A window that already spent its interleaved developer message must not
                 # become parallel afterwards, otherwise a batch is admitted by ordering the
@@ -507,7 +575,7 @@ def _direct_tool_call_prefix_state(
             if item.get("status") not in (None, "completed", "failed"):
                 return None
             call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not pending_calls:
+            if not _is_nonblank_string(call_id) or not pending_calls:
                 return None
             if pending_calls[0] != (call_type, call_id):
                 return None
@@ -526,8 +594,8 @@ def _direct_tool_call_prefix_state(
         # surface their IDs for collision checks: a pending call that reuses
         # one of them cannot be proven fresh.
         fallthrough_call_id = item.get("call_id")
-        if isinstance(fallthrough_call_id, str) and fallthrough_call_id:
-            seen_call_ids.add(fallthrough_call_id)
+        if _is_nonblank_string(fallthrough_call_id):
+            seen_call_ids.add(cast(str, fallthrough_call_id))
     return pending_calls, seen_call_ids
 
 

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/.openspec.yaml
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/proposal.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Account-neutral full-resend certification currently rejects a safe shape where
+the stored prefix already contains the pending tool call and the fresh suffix
+only supplies its matching output. That can force owner-bound recovery even
+when the resent input is otherwise self-contained and exactly settles the
+durable pending-tool manifest.
+
+## What Changes
+
+- Allow a suffix made only of outputs that exactly settle pending direct tool
+  calls already present in the verified stored prefix.
+- Keep replay certification fail-closed for orphan outputs, duplicate output
+  call IDs, missing call IDs, response-owned output fields, or suffix tool
+  calls when the pending calls live in the prefix.
+- Preserve the existing exact-manifest behavior for fresh suffixes that contain
+  both the direct tool calls and their outputs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: account-neutral replay certification can prove
+  prefix-settled direct tool calls without weakening malformed-output checks.

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/specs/responses-api-compat/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Account-neutral replay proof may settle prefix-held direct tool calls
+
+The account-neutral full resend proof MUST accept output-only suffixes that
+settle pending direct tool calls from a verified stored prefix. The verified
+stored prefix must contain the exact direct tool calls named by the durable
+pending-tool manifest. The proof MUST reject suffix tool calls in that
+prefix-settling mode. Each suffix output MUST have exactly one nonblank
+`call_id`, MUST use the output type matching the manifest call type, MUST NOT
+duplicate another suffix output call ID, and MUST NOT carry response-owned
+fields outside the account-neutral tool-output field set.
+
+#### Scenario: Suffix settles pending calls from the stored prefix
+
+- **GIVEN** the verified stored prefix contains a supported direct tool call
+- **AND** the durable pending-tool manifest names that call ID and call type
+- **WHEN** the fresh suffix contains the matching direct tool output and no
+  fresh tool call
+- **THEN** account-neutral replay proof succeeds
+
+#### Scenario: Malformed prefix-settling output fails closed
+
+- **GIVEN** the verified stored prefix contains a supported direct tool call
+- **WHEN** the fresh suffix contains an orphan output, duplicate output, missing
+  call ID, mismatched output type, response-owned output field, or fresh tool
+  call
+- **THEN** account-neutral replay proof fails

--- a/openspec/changes/allow-prefix-settled-tool-output-replay/tasks.md
+++ b/openspec/changes/allow-prefix-settled-tool-output-replay/tasks.md
@@ -1,0 +1,9 @@
+## 1. Prefix-settled tool outputs
+
+- [x] 1.1 Allow output-only suffixes that exactly settle pending direct tool calls from the verified stored prefix.
+- [x] 1.2 Reject duplicate, orphan, missing-call-id, and response-owned output items.
+
+## 2. Validation
+
+- [x] 2.1 Add focused replay-safety regression tests.
+- [x] 2.2 Validate the OpenSpec delta strictly.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -13612,6 +13612,20 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
         pytest.param(
             [
                 {
+                    "type": "function_call_output",
+                    "call_id": "call-prefix",
+                    "output": "result",
+                    "status": "completed",
+                },
+            ],
+            {"call-prefix": "function_call"},
+            True,
+            False,
+            id="prefix-settled-tool-output",
+        ),
+        pytest.param(
+            [
+                {
                     "type": "custom_tool_call",
                     "call_id": "call-1",
                     "name": "shell",
@@ -13679,14 +13693,29 @@ async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_
     forwardable_owner: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    stored_input_items: list[proxy_service.JsonValue] = [
-        {
-            "type": "additional_tools",
-            "role": "developer",
-            "tools": [{"type": "custom", "name": "shell"}],
-        },
-        {"role": "user", "content": "hello"},
-    ]
+    if pending_tool_calls == {"call-prefix": "function_call"}:
+        stored_input_items: list[proxy_service.JsonValue] = [
+            {"role": "user", "content": "look that up"},
+            {
+                "type": "function_call",
+                "call_id": "call-prefix",
+                "name": "lookup",
+                "arguments": "{}",
+                "status": "completed",
+            },
+        ]
+    else:
+        stored_input_items = cast(
+            list[proxy_service.JsonValue],
+            [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "custom", "name": "shell"}],
+                },
+                {"role": "user", "content": "hello"},
+            ],
+        )
     input_items = [*stored_input_items, *suffix_items]
     payload = proxy_service.ResponsesRequest.model_validate(
         {
@@ -13866,13 +13895,24 @@ async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_
         normalized_input_items if preserves_full_resend else normalized_input_items[-len(suffix_items) :]
     )
     assert prepared_frames[-1]["input"] == expected_input_items
-    assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
-        "true",
-    ] * len(prepared_frames)
+    if isinstance(stored_input_items[0], dict) and stored_input_items[0].get("type") == "additional_tools":
+        assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
+            "true",
+        ] * len(prepared_frames)
+    else:
+        assert all(
+            CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY not in cast(dict[str, Any], frame.get("client_metadata", {}))
+            for frame in prepared_frames
+        )
+    expected_reasoning_context = (
+        "all_turns"
+        if isinstance(stored_input_items[0], dict) and stored_input_items[0].get("type") == "additional_tools"
+        else "last_turn"
+    )
     assert all(
         frame["reasoning"]
         == {
-            "context": "all_turns",
+            "context": expected_reasoning_context,
             "effort": "high",
             "summary": "auto",
             "vendor_hint": 7,
@@ -14061,6 +14101,53 @@ def test_verified_durable_full_resend_accepts_response_bound_pending_tool_calls(
         )
         is None
     )
+
+
+def test_verified_durable_full_resend_rejects_response_owned_prefix_settling_output_id() -> None:
+    stored_input_items: list[proxy_service.JsonValue] = [
+        {"role": "user", "content": "look that up"},
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    full_input: list[proxy_service.JsonValue] = [
+        *stored_input_items,
+        {
+            "type": "function_call_output",
+            "id": "fc_output_response_owned",
+            "call_id": "call-1",
+            "output": "result",
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": full_input,
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="sess-tool-proof",
+        canonical_kind="session_header",
+        canonical_key="sid-tool-proof",
+        api_key_scope="__anonymous__",
+        account_id="acc-proof",
+        owner_instance_id=None,
+        owner_epoch=3,
+        lease_expires_at=None,
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state="http_turn_tool_proof",
+        latest_response_id="resp-tool-proof",
+        latest_input_item_count=len(stored_input_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_input_items),
+        model="gpt-5.4",
+        latest_pending_tool_calls={"call-1": "function_call"},
+    )
+
+    assert http_bridge_streaming_module._verify_durable_full_resend(payload, durable_lookup) is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_has_response_owned_prefix_settling_output_ids,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -712,6 +713,213 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
             pending_tool_calls=pending_tool_calls,
         )
         is expected
+    )
+
+
+def test_full_resend_suffix_accepts_outputs_for_pending_calls_in_stored_prefix() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_current", "output": "result"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
+    )
+
+
+def test_full_resend_suffix_rejects_outputs_without_matching_pending_prefix_call() -> None:
+    stored_input: list[JsonValue] = [{"role": "user", "content": "first question"}]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_current", "output": "orphan"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param(
+            [
+                {"type": "function_call_output", "call_id": "call_current", "output": "wrong"},
+                {"type": "function_call_output", "call_id": "call_current", "output": "right"},
+            ],
+            id="duplicate-output-overwrite",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_current",
+                    "output": "result",
+                    "id": "response-owned-output-id",
+                },
+            ],
+            id="response-owned-output-field",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "output": "result"}],
+            id="missing-call-id",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "call_id": "call_current"}],
+            id="missing-output",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "call_id": "call_current", "output": []}],
+            id="malformed-output",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_current",
+                    "output": "result",
+                    "internal_chat_message_metadata_passthrough": {"turn_id": ""},
+                }
+            ],
+            id="malformed-internal-metadata",
+        ),
+    ],
+)
+def test_full_resend_suffix_validates_prefix_settling_outputs(suffix: list[JsonValue]) -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("status", ["completed", "failed"])
+def test_full_resend_suffix_accepts_prefix_settling_output_status(status: str) -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "apply this patch"},
+        {
+            "type": "apply_patch_call",
+            "call_id": "call_current",
+            "input": "*** Begin Patch\n*** End Patch\n",
+            "status": "completed",
+            "caller": {"type": "direct"},
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {
+            "type": "apply_patch_call_output",
+            "call_id": "call_current",
+            "output": None,
+            "status": status,
+            "caller": {"type": "direct"},
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn_current"},
+        }
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "apply_patch_call"},
+        )
+        is True
+    )
+
+
+def test_full_resend_suffix_rejects_whitespace_prefix_settling_call_ids() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "call_id": "   ",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "   ", "output": "result"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"   ": "function_call"},
+        )
+        is False
+    )
+
+
+def test_full_resend_raw_suffix_preserves_prefix_settling_output_id_evidence() -> None:
+    stored_input: list[JsonValue] = [
+        {"role": "user", "content": "first question"},
+        {
+            "type": "function_call",
+            "id": "fc_old",
+            "call_id": "call_current",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    suffix: list[JsonValue] = [
+        {
+            "type": "function_call_output",
+            "id": "response-owned-output-id",
+            "call_id": "call_current",
+            "output": "result",
+        },
+    ]
+    projection = project_responses_input_for_account_neutral_fresh_replay(
+        [*stored_input, *suffix],
+        stored_count=len(stored_input),
+    )
+
+    assert projection is not None
+    assert (
+        responses_input_suffix_has_response_owned_prefix_settling_output_ids(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
+    )
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            projection.input_items,
+            stored_count=projection.stored_prefix_count,
+            pending_tool_calls={"call_current": "function_call"},
+        )
+        is True
     )
 
 


### PR DESCRIPTION
Consolidated into [Soju06/codex-lb PR 2088](https://github.com/Soju06/codex-lb/pull/2088), which includes the prefix-settled tool-output replay change and its tests/spec alongside the bridge recovery that consumes it. The original patch content is retained. Closing this duplicate review surface.
