### PR TITLE
fix(http-bridge): reject unsafe forwarded headers

### DIFF
--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -114,6 +114,54 @@ class OwnerForwardRelayFailure(Exception):
     event_block: str
 
 
+def _bridge_header_name_has_illegal_control_char(name: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in name)
+
+
+def _bridge_header_value_has_illegal_control_char(value: str) -> bool:
+    return any((ord(char) < 32 and char != "\t") or ord(char) == 127 for char in value)
+
+
+def _bridge_header_has_illegal_control_char(name: str, value: str) -> bool:
+    """Return whether reconstructed metadata is unsafe as an HTTP header."""
+
+    return _bridge_header_name_has_illegal_control_char(name) or _bridge_header_value_has_illegal_control_char(value)
+
+
+def _reject_illegal_bridge_header_value(name: str, value: str | None) -> None:
+    if value is None or not _bridge_header_has_illegal_control_char(name, value):
+        return
+    raise ProxyResponseError(
+        400,
+        openai_error(
+            "bridge_forward_invalid",
+            "Internal bridge forward metadata is not safe to forward",
+            error_type="invalid_request_error",
+        ),
+    )
+
+
+def _validate_bridge_forward_context_headers(context: HTTPBridgeForwardContext) -> None:
+    for name, value in (
+        (HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER, context.origin_instance),
+        (HTTP_BRIDGE_TARGET_INSTANCE_HEADER, context.target_instance),
+        ("x-codex-turn-state", context.downstream_turn_state),
+        (HTTP_BRIDGE_AFFINITY_KIND_HEADER, context.original_affinity_kind),
+        (HTTP_BRIDGE_AFFINITY_KEY_HEADER, context.original_affinity_key),
+        (HTTP_BRIDGE_FILE_OWNER_HEADER, context.file_owner_account_id),
+        (HTTP_BRIDGE_CLIENT_IP_HEADER, context.client_ip),
+    ):
+        _reject_illegal_bridge_header_value(name, value)
+    if context.reservation is None:
+        return
+    for name, value in (
+        (HTTP_BRIDGE_RESERVATION_ID_HEADER, context.reservation.reservation_id),
+        (HTTP_BRIDGE_RESERVATION_KEY_ID_HEADER, context.reservation.key_id),
+        (HTTP_BRIDGE_RESERVATION_MODEL_HEADER, context.reservation.model),
+    ):
+        _reject_illegal_bridge_header_value(name, value)
+
+
 class HTTPBridgeOwnerClient:
     async def stream_responses(
         self,
@@ -217,6 +265,10 @@ def build_owner_forward_headers(
     payload: ResponsesRequest,
     context: HTTPBridgeForwardContext,
 ) -> dict[str, str]:
+    # WebSocket client metadata is reconstructed as a header mapping without
+    # passing through an HTTP parser. Validate it before signing so aiohttp is
+    # never the first component to discover illegal wire bytes.
+    _validate_bridge_forward_context_headers(context)
     filtered = filter_inbound_headers(headers)
     # Per the hop-by-hop contract, also drop any header named by the inbound
     # Connection header in addition to the fixed unsafe set.
@@ -235,7 +287,9 @@ def build_owner_forward_headers(
     forwarded = {
         key: value
         for key, value in filtered.items()
-        if key.lower() not in drop and not key.lower().startswith("x-codex-bridge-")
+        if key.lower() not in drop
+        and not key.lower().startswith("x-codex-bridge-")
+        and not _bridge_header_has_illegal_control_char(key, value)
     }
     # filter_inbound_headers strips Authorization, but the owner instance
     # re-validates the client API key from this header (see
@@ -246,7 +300,7 @@ def build_owner_forward_headers(
         (value for key, value in headers.items() if key.lower() == "authorization"),
         None,
     )
-    if authorization is not None:
+    if authorization is not None and not _bridge_header_has_illegal_control_char("authorization", authorization):
         forwarded["authorization"] = authorization
     forwarded[HTTP_BRIDGE_FORWARDED_HEADER] = "1"
     forwarded[HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER] = context.origin_instance

--- a/openspec/changes/reject-illegal-bridge-forward-headers/.openspec.yaml
+++ b/openspec/changes/reject-illegal-bridge-forward-headers/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/reject-illegal-bridge-forward-headers/proposal.md
+++ b/openspec/changes/reject-illegal-bridge-forward-headers/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Owner-forwarded HTTP bridge requests reconstruct WebSocket metadata into HTTP
+headers before posting to the target owner. If reconstructed bridge metadata
+contains illegal HTTP control characters, aiohttp can reject serialization
+outside the proxy's structured error path, and reservation metadata can be
+silently lost on the wire while the origin still treats the owner as settlement
+authority.
+
+## What Changes
+
+- Reject illegal control characters in signed bridge-forward context metadata
+  before building signatures or posting to an owner.
+- Drop unsafe ordinary client headers rather than forwarding them to aiohttp.
+- Preserve reservation ownership by failing closed when reservation metadata is
+  unsafe instead of omitting only the signed reservation headers.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sticky-session-operations`: owner forwarding fails closed on illegal
+  reconstructed HTTP header metadata.

--- a/openspec/changes/reject-illegal-bridge-forward-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/reject-illegal-bridge-forward-headers/specs/sticky-session-operations/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Owner forwarding rejects illegal reconstructed header metadata
+
+Owner-forwarded HTTP bridge requests MUST validate reconstructed bridge
+metadata before building signatures or posting headers to another owner.
+Metadata values that become signed bridge headers MUST NOT contain illegal HTTP
+header control characters. If original affinity, downstream turn-state,
+file-owner, client-IP, origin/target instance, or reservation metadata contains
+such a character, the proxy MUST fail closed with the structured
+`bridge_forward_invalid` error instead of sending the owner request. Ordinary
+client headers with illegal HTTP control characters MUST be omitted from the
+forwarded header map.
+
+#### Scenario: Unsafe reservation metadata fails closed
+
+- **GIVEN** an owner-forward request carries API-key reservation metadata
+- **AND** one reservation field contains an illegal HTTP header control
+  character
+- **WHEN** the origin builds the owner-forward request
+- **THEN** it returns `bridge_forward_invalid`
+- **AND** it does not omit only the reservation headers while keeping the owner
+  as reservation-settlement authority
+
+#### Scenario: Unsafe client header is omitted
+
+- **GIVEN** an owner-forward request includes an ordinary client header with an
+  illegal HTTP header control character
+- **WHEN** the origin builds the owner-forward request
+- **THEN** that client header is not forwarded
+- **AND** the signed bridge-forward metadata remains valid

--- a/openspec/changes/reject-illegal-bridge-forward-headers/tasks.md
+++ b/openspec/changes/reject-illegal-bridge-forward-headers/tasks.md
@@ -1,0 +1,10 @@
+## 1. Header safety
+
+- [x] 1.1 Reject illegal control characters in bridge-forward context metadata.
+- [x] 1.2 Drop ordinary client headers that contain illegal control characters.
+- [x] 1.3 Preserve reservation settlement authority by failing closed on unsafe reservation metadata.
+
+## 2. Validation
+
+- [x] 2.1 Add owner-forward header safety regression tests.
+- [x] 2.2 Validate the OpenSpec delta strictly.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -53,6 +53,7 @@ from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import support as proxy_support_module
 from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
 from app.modules.proxy._service.http_bridge import mixin as http_bridge_mixin_module
+from app.modules.proxy._service.http_bridge import owner_forwarding as http_bridge_owner_forwarding_module
 from app.modules.proxy._service.http_bridge import quarantine as http_bridge_quarantine_module
 from app.modules.proxy._service.http_bridge import request_submit as http_bridge_request_submit_module
 from app.modules.proxy._service.http_bridge import retry_circuit as http_bridge_retry_circuit_module
@@ -16465,6 +16466,155 @@ async def test_recovery_forward_replaces_incoming_affinity_with_recovered_turn_s
     assert signed_headers["x-codex-turn-state"] == "http_turn_recovered"
     assert "http_turn_stale" not in signed_headers.values()
     assert signed_headers["x-request-trace"] == "keep-me"
+
+
+def test_owner_forward_headers_drop_illegal_control_char_client_headers() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    context = proxy_service.HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+
+    forwarded = http_bridge_forwarding_module.build_owner_forward_headers(
+        headers={
+            "x-request-trace": "ok\tvalue",
+            "x-bad-trace": "bad\x00value",
+            "x-bad-name\t": "bad",
+        },
+        payload=payload,
+        context=context,
+    )
+
+    assert forwarded["x-request-trace"] == "ok\tvalue"
+    assert "x-bad-trace" not in forwarded
+    assert "x-bad-name\t" not in forwarded
+
+
+def test_owner_forward_headers_allow_htab_in_signed_metadata_values() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    context = proxy_service.HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state="http_turn\tgenerated",
+        original_affinity_kind="session_header",
+        original_affinity_key="sid\t123",
+    )
+
+    forwarded = http_bridge_forwarding_module.build_owner_forward_headers(
+        headers={"authorization": "Bearer\tclient"},
+        payload=payload,
+        context=context,
+    )
+
+    assert forwarded["x-codex-turn-state"] == "http_turn\tgenerated"
+    assert forwarded["x-codex-bridge-affinity-key"] == "sid\t123"
+    assert forwarded["authorization"] == "Bearer\tclient"
+
+
+def test_owner_forward_headers_reject_illegal_control_char_affinity_metadata() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    context = proxy_service.HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+        original_affinity_kind="prompt_cache",
+        original_affinity_key="cache\x00key",
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        http_bridge_forwarding_module.build_owner_forward_headers(
+            headers={},
+            payload=payload,
+            context=context,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.payload["error"]["code"] == "bridge_forward_invalid"
+
+
+def test_owner_forward_headers_reject_illegal_control_char_reservation_metadata() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    context = proxy_service.HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+        reservation=proxy_service.ApiKeyUsageReservationData(
+            reservation_id="reservation-1",
+            key_id="key-1",
+            model="gpt-5.4\npriority",
+        ),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        http_bridge_forwarding_module.build_owner_forward_headers(
+            headers={},
+            payload=payload,
+            context=context,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.payload["error"]["code"] == "bridge_forward_invalid"
+
+
+@pytest.mark.asyncio
+async def test_forward_http_bridge_request_to_owner_rejects_unsafe_reservation_before_owner_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="reservation-1",
+        key_id="key-1",
+        model="gpt-5.4\npriority",
+    )
+    post_called = False
+
+    class FakeOwnerSession:
+        async def __aenter__(self) -> "FakeOwnerSession":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        def post(self, *_args: object, **_kwargs: object) -> object:
+            nonlocal post_called
+            post_called = True
+            raise AssertionError("unsafe reservation metadata reached owner POST")
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        http_bridge_forwarding_module.aiohttp,
+        "ClientSession",
+        lambda **_kwargs: FakeOwnerSession(),
+    )
+
+    with pytest.raises(http_bridge_owner_forwarding_module._OwnerForwardRequestError) as exc_info:
+        async for _ in service._forward_http_bridge_request_to_owner(
+            owner_forward=owner_forward,
+            payload=payload,
+            headers={"x-codex-session-id": "sid-123"},
+            api_key_reservation=reservation,
+            codex_session_affinity=True,
+            downstream_turn_state="http_turn_generated",
+            request_started_at=10.0,
+            proxy_api_authorization=None,
+        ):
+            pass
+
+    assert post_called is False
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.payload["error"]["code"] == "bridge_forward_invalid"
+    assert exc_info.value.outcome is http_bridge_owner_forwarding_module._OwnerForwardOutcome.NOT_DISPATCHED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Slice 4 of Soju06/codex-lb#1881.

- keep rejecting control characters in forwarded bridge header names
- allow legal HTAB characters in forwarded header values while still rejecting other control characters and DEL
- reject unsafe signed bridge reservation metadata before an owner POST can be attempted
- cover local header filtering, signed metadata reconstruction, and the owner-forward error/outcome path
- document the bridge forwarded-header contract in `sticky-session-operations`

## Validation

```
uv run openspec validate --strict reject-illegal-bridge-forward-headers
# Change 'reject-illegal-bridge-forward-headers' is valid

uv run pytest tests/unit/test_proxy_http_bridge.py -k 'owner_forward_headers or forward_http_bridge_request_to_owner_rejects_unsafe_reservation_before_owner_post or forward_http_bridge_request_to_owner_preserves_session_header_key'
# 9 passed, 980 deselected

uv run ty check
# All checks passed!

uv run ruff check .
# All checks passed!

uv run ruff format --check .
# 1021 files already formatted
```
