### PR TITLE
fix(logging): bound secret patterns to the current line

### DIFF
--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -37,7 +37,7 @@ _BASIC_TOKEN_PRECHECKS = ("Basic ", "basic ", "BASIC ")
 _REDACTION_FAILED_PLACEHOLDER = "[REDACTED: log redaction failed]"
 _JSON_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
     r'(?i)("(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)"\s*:\s*")'
-    r'(?:\\.|[^"\\])*("|(?=\Z))'
+    r'(?:\\.|[^"\\])*(?:\\(?=\Z))?("|(?=\Z))'
 )
 # ``scheme://user:pass@`` userinfo, e.g. aiohttp ConnectionKey proxy URL reprs.
 # RFC 3986 userinfo never contains ``/``, ``?`` or ``#``, so a bare host
@@ -99,13 +99,18 @@ def _redact_secret_patterns_on_line(text: str) -> str:
     return _PYTHON_REPR_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_python_repr_secret, redacted)
 
 
-def _redact_secret_patterns(text: str) -> str:
+def _map_log_lines(text: str, transform: Callable[[str], str]) -> str:
     if "\n" not in text and "\r" not in text:
-        return _redact_secret_patterns_on_line(text)
-    return "".join(
-        _redact_secret_patterns_on_line(part) if index % 2 == 0 else part
-        for index, part in enumerate(_LINE_BREAKS.split(text))
-    )
+        return transform(text)
+    return "".join(transform(part) if index % 2 == 0 else part for index, part in enumerate(_LINE_BREAKS.split(text)))
+
+
+def _redact_secret_patterns(text: str) -> str:
+    return _map_log_lines(text, _redact_secret_patterns_on_line)
+
+
+def _redact_basic_tokens_on_line(text: str) -> str:
+    return _BASIC_TOKEN_PATTERN.sub(_redact_bearer_token, text)
 
 
 def redact_rendered_log_text(text: str, *, keyed_secrets: bool = True) -> str:
@@ -124,7 +129,7 @@ def redact_rendered_log_text(text: str, *, keyed_secrets: bool = True) -> str:
         if "@" in text and "://" in text:
             redacted = _USERINFO_PATTERN.sub(_redact_userinfo, redacted)
         if any(precheck in text for precheck in _BASIC_TOKEN_PRECHECKS):
-            redacted = _BASIC_TOKEN_PATTERN.sub(_redact_bearer_token, redacted)
+            redacted = _map_log_lines(redacted, _redact_basic_tokens_on_line)
         if not keyed_secrets:
             return redacted
         folded = text.casefold()

--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -19,9 +19,10 @@ from app.core.utils.request_id import get_request_id
 
 _SENSITIVE_LOG_VALUE_PATTERNS = (
     re.compile(r"(?i)(password|passwd|pwd|token|secret|api[_-]?key)(\s*[=:]\s*)([^\s,&]+)"),
-    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=:-]+"),
     re.compile(r"(?i)(authorization\s*[=:]\s*)(?!\s*bearer\b)([^,&]+)"),
 )
+_LINE_BREAKS = re.compile(r"(\r\n|\n|\r)")
 # RFC 7617 ``Basic <base64>`` token: a reversible encoding of ``user:password``
 # that aiohttp reprs verbatim (``ClientHttpProxyError.request_info.headers``
 # carries the CONNECT ``Proxy-Authorization`` header). Applied to every record
@@ -36,7 +37,7 @@ _BASIC_TOKEN_PRECHECKS = ("Basic ", "basic ", "BASIC ")
 _REDACTION_FAILED_PLACEHOLDER = "[REDACTED: log redaction failed]"
 _JSON_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
     r'(?i)("(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)"\s*:\s*")'
-    r'(?:\\.|[^"\\])*(")'
+    r'(?:\\.|[^"\\])*("|(?=\Z))'
 )
 # ``scheme://user:pass@`` userinfo, e.g. aiohttp ConnectionKey proxy URL reprs.
 # RFC 3986 userinfo never contains ``/``, ``?`` or ``#``, so a bare host
@@ -87,7 +88,7 @@ def _redact_log_value(value: str | None) -> str | None:
     return _redact_secret_patterns(_USERINFO_PATTERN.sub(_redact_userinfo, collapsed))
 
 
-def _redact_secret_patterns(text: str) -> str:
+def _redact_secret_patterns_on_line(text: str) -> str:
     redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, text)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[0].sub(_redact_keyed_secret, redacted)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[1].sub(_redact_bearer_token, redacted)
@@ -96,6 +97,15 @@ def _redact_secret_patterns(text: str) -> str:
     # Last, so ``'Proxy-Authorization': 'Basic [REDACTED]'`` keeps the scheme
     # the token passes above already exposed.
     return _PYTHON_REPR_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_python_repr_secret, redacted)
+
+
+def _redact_secret_patterns(text: str) -> str:
+    if "\n" not in text and "\r" not in text:
+        return _redact_secret_patterns_on_line(text)
+    return "".join(
+        _redact_secret_patterns_on_line(part) if index % 2 == 0 else part
+        for index, part in enumerate(_LINE_BREAKS.split(text))
+    )
 
 
 def redact_rendered_log_text(text: str, *, keyed_secrets: bool = True) -> str:
@@ -139,7 +149,8 @@ def _redact_keyed_secret(match: re.Match[str]) -> str:
 
 
 def _redact_json_secret(match: re.Match[str]) -> str:
-    return f"{match.group(1)}{_LOG_REDACTION}{match.group(2)}"
+    closer = match.group(2) or ""
+    return f"{match.group(1)}{_LOG_REDACTION}{closer}"
 
 
 def _redact_python_repr_secret(match: re.Match[str]) -> str:

--- a/openspec/changes/line-scope-log-secret-redaction/context.md
+++ b/openspec/changes/line-scope-log-secret-redaction/context.md
@@ -1,0 +1,58 @@
+# Line-scoped log secret redaction — change context
+
+## Purpose / scope
+
+Harden the existing rendered-record secret patterns so they cannot destroy
+traceback structure or leak glued Bearer / unterminated JSON tails. The
+baseline policy is `credential-safe-proxy-logging` on
+`proxy-runtime-observability`: WARNING+ keyed redaction of the fully
+rendered text and JSON exception field, INFO limited to URL userinfo and
+`Basic` tokens.
+
+## Decisions
+
+- Line-scoped application of `_redact_secret_patterns`, not a credential
+  grammar. #2009's parser did not converge.
+- Replacement PR for #2009 rather than rebasing the 18-round branch onto the
+  mixin already on `main`.
+- #2028 stays a follow-up. This change must not silently adopt fail-closed
+  end-of-line authorization redaction.
+
+## Constraints
+
+- Do not copy `LogRecord` on the format path.
+- Do not add `UtcDefaultFormatter.format` / `formatException` overrides.
+- Do not lower the keyed-secret gate below WARNING.
+
+## Failure modes
+
+- Authorization without `,`/`&` still consumes the rest of **that** line,
+  including a same-line `status=failed`. That is existing pinned behavior.
+- DEBUG/INFO `exc_info=` still skips keyed patterns. Repository DEBUG sites
+  that log exceptions remain out of this change.
+
+## Example
+
+```
+RuntimeError: authorization=Basic X
+status=failed
+api_key=Y
+Bearer abc.def:GLUEDTAIL, ok=1
+payload={"token":"abc
+```
+
+renders as
+
+```
+RuntimeError: authorization=[REDACTED]
+status=failed
+api_key=[REDACTED]
+Bearer [REDACTED], ok=1
+payload={"token":"[REDACTED]
+```
+
+## Related
+
+- Supersedes #2009.
+- Related to #2028 (deferred classes).
+- Baseline: #2053 / #2054 / `credential-safe-proxy-logging`.

--- a/openspec/changes/line-scope-log-secret-redaction/context.md
+++ b/openspec/changes/line-scope-log-secret-redaction/context.md
@@ -33,7 +33,7 @@ rendered text and JSON exception field, INFO limited to URL userinfo and
 
 ## Example
 
-```
+```text
 RuntimeError: authorization=Basic X
 status=failed
 api_key=Y
@@ -43,7 +43,7 @@ payload={"token":"abc
 
 renders as
 
-```
+```text
 RuntimeError: authorization=[REDACTED]
 status=failed
 api_key=[REDACTED]

--- a/openspec/changes/line-scope-log-secret-redaction/design.md
+++ b/openspec/changes/line-scope-log-secret-redaction/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`credential-safe-proxy-logging` already redacts the fully rendered record
+through `_RedactingFormatterMixin` and JSON `formatException`. The remaining
+gaps are pattern bounds, not formatter architecture. PR #2009 tried a
+grammar-aware RFC 9110 parser across many review rounds; that path grew
+without converging. This change uses a line-scoped invariant instead.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Secret-pattern matches must not cross CR/LF.
+- Unterminated JSON secrets on the current line must not leak.
+- `Bearer abc.def:GLUEDTAIL` must not leave `:GLUEDTAIL`.
+- Preserve existing same-line `Authorization: Basic … status=failed`
+  comma-less truncation and the WARNING+ keyed-secret gate.
+
+**Non-Goals:**
+
+- Auth-param lists, quoted Python header keys, whitespace-separated Bearer
+  tails (issue #2028).
+- Changing INFO/DEBUG keyed-secret policy.
+- Replacing the mixin with `format` / `formatException` overrides.
+- Copying `LogRecord` on the format path.
+
+## Decisions
+
+Apply `_redact_secret_patterns` independently to each CR/LF-delimited line
+and reattach the original terminator bytes. That is a structural invariant
+(`line count and terminator bytes are unchanged`; `f(f(x)) == f(x)` for the
+shipped patterns) rather than a growing credential grammar.
+
+Make the JSON closer optional at end of line so `{"token":"abc` redacts
+through `\Z` on that line.
+
+Add `:` to the Bearer token class so a glued tail is consumed up to the
+existing whitespace/comma stop.
+
+Rejected: tightening only `[^,&]` to `[^\n,&]`. That would fix authorization
+swallowing and still leave keyed `\s*` and JSON `\s*` able to cross lines.
+
+Rejected: expanding into #2028's fail-closed-to-end-of-line authorization
+policy. That drops same-line diagnostic tails and is a separate contract.

--- a/openspec/changes/line-scope-log-secret-redaction/proposal.md
+++ b/openspec/changes/line-scope-log-secret-redaction/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Rendered WARNING+ log records already redact keyed secrets, including exception
+and stack text, but the shared secret patterns run on the entire rendered
+string. An `authorization=` value can therefore consume following traceback
+lines, an unterminated JSON secret at end of line is left intact, and a Bearer
+token stops at `:` so a glued credential tail leaks.
+
+## What Changes
+
+- Apply the keyed/bearer/authorization/JSON/Python-repr secret patterns one
+  CR/LF-delimited line at a time.
+- Redact unterminated JSON secret values through the end of the current line.
+- Treat a same-line `:` tail after a Bearer token as credential material
+  (isolated from the keyed `secret=` pattern).
+- Leave the `_RedactingFormatterMixin` path, the WARNING+ keyed-secret gate,
+  and comma/`&` same-line truncation unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: Require line-bounded secret-pattern
+  application, unterminated JSON redaction through end of line, and Bearer
+  colon-tail consumption. This is a delta on the existing rendered-record
+  redaction policy from `credential-safe-proxy-logging`, not a new capability.
+
+## Impact
+
+- Code: `app/core/runtime_logging.py`.
+- Tests: `tests/unit/test_structured_logging.py`.
+- No settings, dependencies, schemas, routes, database, or frontend changes.
+- Out of scope (issue #2028): Digest/AWS auth-param lists, quoted Python header
+  keys, and whitespace-separated Bearer tails.

--- a/openspec/changes/line-scope-log-secret-redaction/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/line-scope-log-secret-redaction/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Secret-pattern redaction stays on the current line
+
+Keyed, bearer, basic, authorization, JSON, and Python-repr secret patterns
+MUST be applied independently to each CR/LF-delimited line of rendered log
+text. A match MUST NOT consume CR or LF or any text from a following line.
+Unterminated JSON secret values MUST be redacted through the end of the
+current line. A Bearer credential MUST treat a glued `:` tail on the same
+line as credential material. Same-line comma and ampersand separators MUST
+keep their existing truncation behavior. Records below WARNING MUST still
+skip these keyed patterns.
+
+#### Scenario: Authorization does not swallow the next traceback line
+
+- **GIVEN** a WARNING or higher record whose exception text contains
+  `authorization=Basic X` followed by a newline and `status=failed`
+- **WHEN** the text or JSON formatter renders the record
+- **THEN** the Basic credential is replaced with `[REDACTED]`
+- **AND** the following line still contains `status=failed`
+
+#### Scenario: Unterminated JSON secret is redacted through end of line
+
+- **GIVEN** a WARNING or higher record contains `{"token":"abc` with no
+  closing quote before the line ending, then a following `safe diagnostic line`
+- **WHEN** the text or JSON formatter renders the record
+- **THEN** the token value is replaced with `[REDACTED]`
+- **AND** `safe diagnostic line` remains
+
+#### Scenario: Bearer glued colon tail is redacted
+
+- **GIVEN** a WARNING or higher record contains
+  `Bearer abc.def:GLUEDTAIL, status=502`
+- **WHEN** the text or JSON formatter renders the record
+- **THEN** the rendered text contains `Bearer [REDACTED], status=502`
+- **AND** neither `abc.def` nor `GLUEDTAIL` appears
+
+#### Scenario: Same-line authorization truncation is unchanged
+
+- **GIVEN** a WARNING or higher record contains
+  `Authorization: Basic dXNlcjpwYXNz status=failed` on one line with no comma
+- **WHEN** the text formatter renders the record
+- **THEN** the credential is redacted
+- **AND** `status=failed` is not present on that line
+
+#### Scenario: Line terminators are preserved and redaction is idempotent
+
+- **GIVEN** rendered secret-bearing text that uses LF and CRLF separators
+- **WHEN** secret-pattern redaction is applied once and then again
+- **THEN** the terminator bytes and line count are unchanged
+- **AND** the second pass equals the first

--- a/openspec/changes/line-scope-log-secret-redaction/tasks.md
+++ b/openspec/changes/line-scope-log-secret-redaction/tasks.md
@@ -1,0 +1,19 @@
+## 1. Line-bounded secret patterns
+
+- [x] 1.1 Apply keyed/bearer/authorization/JSON/Python-repr patterns per CR/LF
+      line and preserve original terminators
+- [x] 1.2 Redact unterminated JSON secret values through end of line
+- [x] 1.3 Consume a glued `:` tail on Bearer tokens
+
+## 2. Regression coverage
+
+- [x] 2.1 Authorization does not swallow the next traceback line in text and JSON
+- [x] 2.2 Unterminated JSON secret at end of line is redacted; following line survives
+- [x] 2.3 `Bearer abc.def:GLUEDTAIL, status=502` keeps `, status=502` and drops the tail
+- [x] 2.4 Existing same-line comma-less Authorization truncation still holds
+- [x] 2.5 Idempotence and terminator-byte identity; WARNING+ gate unchanged
+
+## 3. Verification
+
+- [x] 3.1 Prove the three gaps on `upstream/main`, then the focused tests on this head
+- [x] 3.2 Run ruff, ty, and strict scoped OpenSpec validation

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -512,6 +512,78 @@ def test_authorization_midline_redaction_truncates_to_separator(text_formatter):
 
 
 @pytest.mark.parametrize("log_format", ["text", "json"])
+def test_authorization_redaction_does_not_swallow_following_traceback_line(monkeypatch, log_format):
+    import sys
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    basic = "BASICCRED"
+    keyed = "KEYEDCRED"
+    try:
+        raise RuntimeError("authorization=Basic " + basic + "\nstatus=failed\napi_key=" + keyed)
+    except RuntimeError:
+        record = _record("request failed", exc_info=sys.exc_info())
+
+    output = _render(formatter, record)
+    rendered = json.loads(output)["exception"] if log_format == "json" else output
+
+    assert basic not in rendered
+    assert "authorization=[REDACTED]" in rendered
+    assert "status=failed" in rendered
+    assert keyed not in rendered
+    assert "api_key=[REDACTED]" in rendered
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_unterminated_json_secret_redacts_through_end_of_line(monkeypatch, log_format):
+    import sys
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    token = "QAJSONSECRET"
+    try:
+        raise RuntimeError('payload={"token":"' + token + "\nsafe diagnostic line")
+    except RuntimeError:
+        record = _record("request failed", exc_info=sys.exc_info())
+
+    output = _render(formatter, record)
+    rendered = json.loads(output)["exception"] if log_format == "json" else output
+
+    assert token not in rendered
+    assert '{"token":"[REDACTED]' in rendered
+    assert "safe diagnostic line" in rendered
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
+def test_bearer_redaction_consumes_glued_colon_tail(monkeypatch, log_format):
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    output = _render(formatter, _record("upstream Bearer abc.def:GLUEDTAIL, status=502"))
+    rendered = json.loads(output)["message"] if log_format == "json" else output
+
+    assert "abc.def" not in rendered
+    assert "GLUEDTAIL" not in rendered
+    assert "Bearer [REDACTED], status=502" in rendered
+
+
+def test_secret_pattern_redaction_preserves_terminators_and_is_idempotent():
+    text = (
+        "authorization=Digest username=a\n"
+        "retrying upstream\r\n"
+        'payload={"token":"QAJSONSECRET\n'
+        "Bearer abc.def:GLUEDTAIL, status=502\n"
+    )
+
+    once = runtime_logging.redact_rendered_log_text(text)
+    twice = runtime_logging.redact_rendered_log_text(once)
+
+    assert once == twice
+    assert once.count("\n") == text.count("\n")
+    assert once.count("\r\n") == text.count("\r\n")
+    assert "retrying upstream" in once
+    assert "abc.def" not in once
+    assert "GLUEDTAIL" not in once
+    assert "QAJSONSECRET" not in once
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
 def test_bootstrap_token_output_is_byte_identical_through_redaction(monkeypatch, log_format):
     from app.core.bootstrap import log_bootstrap_token
 

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -549,14 +549,13 @@ def test_unterminated_json_secret_with_trailing_escape_redacts_through_end_of_li
     rendered = json.loads(output)["exception"] if log_format == "json" else output
 
     assert token not in rendered
-    assert '{"token":"[REDACTED]' in rendered
-    assert "safe diagnostic line" in rendered
+    assert '{"token":"[REDACTED]\nsafe diagnostic line' in rendered
 
 
 def test_basic_token_prepass_does_not_swallow_following_line():
     output = runtime_logging.redact_rendered_log_text("Authorization: Basic \nSAFE diagnostic", keyed_secrets=False)
 
-    assert output.splitlines()[-1] == "SAFE diagnostic"
+    assert output == "Authorization: Basic \nSAFE diagnostic"
 
 
 @pytest.mark.parametrize("log_format", ["text", "json"])

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import re
 
 import pytest
 
@@ -534,6 +535,31 @@ def test_authorization_redaction_does_not_swallow_following_traceback_line(monke
 
 
 @pytest.mark.parametrize("log_format", ["text", "json"])
+def test_unterminated_json_secret_with_trailing_escape_redacts_through_end_of_line(monkeypatch, log_format):
+    import sys
+
+    formatter = _formatter_from_config(monkeypatch, log_format)
+    token = "QAJSONSECRET"
+    try:
+        raise RuntimeError('payload={"token":"' + token + "\\\nsafe diagnostic line")
+    except RuntimeError:
+        record = _record("request failed", exc_info=sys.exc_info())
+
+    output = _render(formatter, record)
+    rendered = json.loads(output)["exception"] if log_format == "json" else output
+
+    assert token not in rendered
+    assert '{"token":"[REDACTED]' in rendered
+    assert "safe diagnostic line" in rendered
+
+
+def test_basic_token_prepass_does_not_swallow_following_line():
+    output = runtime_logging.redact_rendered_log_text("Authorization: Basic \nSAFE diagnostic", keyed_secrets=False)
+
+    assert output.splitlines()[-1] == "SAFE diagnostic"
+
+
+@pytest.mark.parametrize("log_format", ["text", "json"])
 def test_unterminated_json_secret_redacts_through_end_of_line(monkeypatch, log_format):
     import sys
 
@@ -567,17 +593,19 @@ def test_secret_pattern_redaction_preserves_terminators_and_is_idempotent():
     text = (
         "authorization=Digest username=a\n"
         "retrying upstream\r\n"
+        "cr-only diagnostic\r"
         'payload={"token":"QAJSONSECRET\n'
         "Bearer abc.def:GLUEDTAIL, status=502\n"
     )
+    terminators = re.compile(r"\r\n|\n|\r")
 
     once = runtime_logging.redact_rendered_log_text(text)
     twice = runtime_logging.redact_rendered_log_text(once)
 
     assert once == twice
-    assert once.count("\n") == text.count("\n")
-    assert once.count("\r\n") == text.count("\r\n")
+    assert terminators.findall(once) == terminators.findall(text)
     assert "retrying upstream" in once
+    assert "cr-only diagnostic" in once
     assert "abc.def" not in once
     assert "GLUEDTAIL" not in once
     assert "QAJSONSECRET" not in once


### PR DESCRIPTION
## Summary

Replace #2009 with a focused delta on current `main`. The original traceback leak is already fixed by #2053/#2054; what remains is pattern-bound hardening: secret patterns must not consume the next traceback line, unterminated JSON secrets must redact through end of line, and a glued Bearer `:` tail must not leak.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Related to #2009. Related to #2028 (deferred classes).

## Why this replaces the earlier PR

#2009 grew a grammar-aware authorization parser across many review rounds, then hard-conflicted with `_RedactingFormatterMixin` on `main`. Soju06 asked for a re-scoped rebase onto that mixin, or to close #2009 and fold the residual into #2028. This PR is that re-scope: one commit from current `main`, no formatter overrides, no `LogRecord` copy, WARNING+ keyed-secret gate unchanged.

## Known pre-existing gaps

Digest/AWS auth-param lists, quoted Python header keys, and whitespace-separated Bearer tails stay in #2028. They need a separate policy choice (fail-closed to end of line vs a credential grammar). This PR does not expand into that contract.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/line-scope-log-secret-redaction/`

Delta on existing `proxy-runtime-observability` (baseline: `credential-safe-proxy-logging`). Not a new capability.

## Changes

- Apply keyed/bearer/authorization/JSON/Python-repr secret patterns per CR/LF line and reattach the original terminator bytes.
- Allow an unterminated JSON secret value to close at end of line.
- Include `:` in the Bearer token class so `Bearer abc.def:GLUEDTAIL, status=502` becomes `Bearer [REDACTED], status=502`.
- Leave same-line comma-less `Authorization: Basic … status=failed` truncation pinned.

## Simplicity

No new setting, README section, dashboard nav item, or default.

## Test plan

RED on `upstream/main` `dd28d7df` (`importlib` load of `app/core/runtime_logging.py`):

- `authorization=Basic X\nstatus=failed\napi_key=Y` → `'authorization=[REDACTED]'` (following lines swallowed)
- `payload={"token":"abc\nsafe diagnostic line` → token leaks
- `Bearer abc.def:GLUEDTAIL, status=502` → `Bearer [REDACTED]:GLUEDTAIL, status=502`

GREEN on this head:

```
.venv/bin/python -m pytest tests/unit/test_structured_logging.py -q
88 passed in 0.72s

.venv/bin/python -m pytest -q -ra --timeout=180 --timeout-method=thread tests/unit
7666 passed, 97 skipped, 12 warnings in 202.70s (0:03:22)

.venv/bin/ruff check app/core/runtime_logging.py tests/unit/test_structured_logging.py
All checks passed!

.venv/bin/ruff format --check app/core/runtime_logging.py tests/unit/test_structured_logging.py
2 files already formatted

uv run ty check app/core/runtime_logging.py tests/unit/test_structured_logging.py
All checks passed!

npx --yes @fission-ai/openspec@1.11.0 validate line-scope-log-secret-redaction --strict
Change 'line-scope-log-secret-redaction' is valid
```

`git diff --numstat` vs `dd28d7df`:

```
15      4       app/core/runtime_logging.py
58      0       openspec/changes/line-scope-log-secret-redaction/context.md
44      0       openspec/changes/line-scope-log-secret-redaction/design.md
38      0       openspec/changes/line-scope-log-secret-redaction/proposal.md
51      0       openspec/changes/line-scope-log-secret-redaction/specs/proxy-runtime-observability/spec.md
19      0       openspec/changes/line-scope-log-secret-redaction/tasks.md
72      0       tests/unit/test_structured_logging.py
```

Intentionally unrun locally: `cargo deny` / `make rust-audit` (cargo-deny is not installed here; covered by CI Rust workspace). Full `make ci` stopped at that missing tool after frontend, lint, typecheck, and rust-check had already passed.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran focused ruff/ty/unit checks; full `make ci` blocked only on missing `cargo deny`.
- [x] `openspec validate line-scope-log-secret-redaction --strict` passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is **not** edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log redaction for bearer tokens containing colons and unterminated JSON-sensitive values, including trailing backslashes.
  * Prevented secrets on one log line from affecting subsequent lines, including traceback output.
  * Preserved original line breaks during redaction, including lone carriage returns.
  * Improved independent handling of Basic authentication tokens across multiline logs.
* **Tests**
  * Added coverage for multiline logs, JSON and bearer-token edge cases, line-ending preservation, and consistent repeated redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->