### PR TITLE
feat(cost): add GPT-6 Astra pricing

### DIFF
--- a/app/core/usage/pricing.py
+++ b/app/core/usage/pricing.py
@@ -88,6 +88,21 @@ def _normalize_usage(usage: UsageTokens | ResponseUsage | None) -> UsageTokens |
 
 
 DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
+    "gpt-6-astra": ModelPrice(
+        input_per_1m=10.0,
+        cached_input_per_1m=1.0,
+        output_per_1m=50.0,
+        priority_input_per_1m=20.0,
+        priority_cached_input_per_1m=2.0,
+        priority_output_per_1m=100.0,
+        flex_input_per_1m=5.0,
+        flex_cached_input_per_1m=0.5,
+        flex_output_per_1m=25.0,
+        long_context_threshold_tokens=272_000,
+        long_context_input_per_1m=20.0,
+        long_context_cached_input_per_1m=2.0,
+        long_context_output_per_1m=75.0,
+    ),
     "gpt-5.6-sol": ModelPrice(
         input_per_1m=5.0,
         cached_input_per_1m=0.5,
@@ -323,6 +338,7 @@ DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
 }
 
 DEFAULT_MODEL_ALIASES: dict[str, str] = {
+    "gpt-6-astra*": "gpt-6-astra",
     "gpt-5.6": "gpt-5.6-sol",
     "gpt-5.6-sol*": "gpt-5.6-sol",
     "gpt-5.6-terra*": "gpt-5.6-terra",

--- a/openspec/changes/add-gpt-6-astra-pricing/.openspec.yaml
+++ b/openspec/changes/add-gpt-6-astra-pricing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/add-gpt-6-astra-pricing/proposal.md
+++ b/openspec/changes/add-gpt-6-astra-pricing/proposal.md
@@ -1,0 +1,60 @@
+# Add GPT-6 Astra usage pricing
+
+## Why
+
+`gpt-6-astra` is now served to accounts through upstream model discovery, but it
+has no entry in the bundled cost table in `app/core/usage/pricing.py`. The newest
+priced family is still `gpt-5.6-{sol,terra,luna}`. `get_pricing_for_model` returns
+nothing for an unpriced model, so `calculate_costs` skips it entirely: API-key
+cost limits, usage reservations, request logs, and reports all record Astra
+traffic as costing nothing, and it silently escapes any configured spend cap.
+
+## What Changes
+
+- Add a `gpt-6-astra` entry with the published standard, Fast/priority, Flex, and
+  standard long-context rates.
+- Add a `gpt-6-astra*` alias so dated snapshot names resolve to the canonical
+  entry, matching the existing family patterns.
+- Keep the existing 272,000-token long-context boundary and service-tier
+  precedence unchanged.
+- Keep batch and cache-write pricing out of scope, as the previous pricing
+  changes did, because the proxy exposes no corresponding cost-accounting inputs.
+- Add regression coverage for the service tiers, the long-context rates, the
+  272,000-token boundary, and snapshot alias resolution.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Require GPT-6 Astra usage cost to be computed from the published
+  rates rather than skipped as an unpriced model.
+
+## Impact
+
+- Affected module: `app/core/usage/pricing.py` (one table entry and one alias).
+- Affected tests: `tests/unit/test_pricing.py`.
+- No API, schema, persistence, dependency, or configuration change.
+
+## Notes
+
+Rates are taken from OpenAI's published API rate card: standard
+`10 / 1 / 50` USD per 1M input / cached input / output tokens, Fast at 2x, Flex
+and Batch at 0.5x, and prompts over 272,000 input tokens at 2x input and cache
+rates with 1.5x output.
+
+Two documented divergences are deliberately **not** encoded, because the existing
+table is uniformly the API rate card and encoding surface-specific rates would
+change how every other model is read:
+
+- In ChatGPT Work and Codex, Fast for this model is charged at 2.5x standard
+  rather than the API's 2x.
+- Codex does not apply the long-context multiplier above 272,000 input tokens and
+  does not charge for cache writes.
+
+Codex-routed Astra cost will therefore read slightly high for Fast traffic and
+for prompts past the long-context boundary. Aligning the table with per-surface
+rate cards is a larger contract change and belongs in its own proposal.

--- a/openspec/changes/add-gpt-6-astra-pricing/specs/api-keys/spec.md
+++ b/openspec/changes/add-gpt-6-astra-pricing/specs/api-keys/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: GPT-6 Astra usage cost pricing matches the published rates
+
+When computing API-key usage, request-log, reservation, or aggregate cost for
+`gpt-6-astra`, the system MUST use these USD-per-1M-token rates for input,
+cached input, and output:
+
+| Model | Standard | Fast/priority | Flex | Standard long context |
+| --- | --- | --- | --- | --- |
+| `gpt-6-astra` | `10 / 1 / 50` | `20 / 2 / 100` | `5 / 0.50 / 25` | `20 / 2 / 75` |
+
+The existing `priority` and `fast` service-tier aliases MUST use the
+Fast/priority rates. Standard long-context rates MUST apply only when input
+tokens exceed 272,000. Model aliases with a version or snapshot suffix MUST
+resolve to the canonical `gpt-6-astra` entry.
+
+Batch rates and cache-write rates MUST NOT be introduced into this contract
+without corresponding proxy request and usage fields.
+
+#### Scenario: Standard usage uses the published rate
+
+- **WHEN** a standard-tier `gpt-6-astra` request has 200,000 input tokens,
+  100,000 of them cached, and 1,000,000 output tokens
+- **THEN** the token cost is `$51.10`
+
+#### Scenario: Fast and Flex usage use their tier rates
+
+- **WHEN** that same request is billed at the `fast` or `priority` tier
+- **THEN** the token cost is `$102.20`
+- **WHEN** it is billed at the `flex` tier
+- **THEN** the token cost is `$25.55`
+
+#### Scenario: Long context applies above the 272,000-token boundary
+
+- **WHEN** a standard-tier `gpt-6-astra` request has 300,000 input tokens,
+  50,000 of them cached, and 100,000 output tokens
+- **THEN** the token cost is `$12.60`
+- **AND** the same request billed at the `flex` tier costs `$6.30`
+
+#### Scenario: The boundary itself stays on standard rates
+
+- **WHEN** a request has exactly 272,000 input tokens
+- **THEN** input is charged at the standard rate
+- **WHEN** a request has 272,001 input tokens
+- **THEN** input is charged at the long-context rate
+
+#### Scenario: Snapshot names resolve to the canonical entry
+
+- **WHEN** usage is reported for `gpt-6-astra-2026-04-30`
+- **THEN** it resolves to the canonical `gpt-6-astra` pricing entry

--- a/openspec/changes/add-gpt-6-astra-pricing/tasks.md
+++ b/openspec/changes/add-gpt-6-astra-pricing/tasks.md
@@ -1,0 +1,22 @@
+## 1. Pricing table
+
+- [x] 1.1 Add the `gpt-6-astra` entry with standard, Fast/priority, Flex, and standard long-context rates.
+- [x] 1.2 Add the `gpt-6-astra*` alias so dated snapshots resolve to the canonical entry.
+
+## 2. Regression coverage
+
+- [x] 2.1 Cover the standard, Fast, priority, and Flex tiers.
+- [x] 2.2 Cover the standard and Flex long-context rates.
+- [x] 2.3 Cover the 272,000-token boundary on both sides.
+- [x] 2.4 Cover snapshot alias resolution.
+
+## 3. Verification
+
+- [x] 3.1 Run `tests/unit/test_pricing.py`.
+- [x] 3.2 Run `ruff` and `ty`.
+- [x] 3.3 Validate the scoped OpenSpec change with strict validation.
+
+## 4. Out of scope
+
+- [ ] 4.1 Per-surface rate cards. Codex charges Fast at 2.5x rather than 2x for this model, applies no long-context multiplier, and does not bill cache writes. The bundled table is uniformly the API rate card, so encoding surface-specific rates is a separate contract change.
+- [ ] 4.2 `_GPT5_ALIAS_BASE_MODELS` in `app/modules/proxy/request_policy.py` is scoped to GPT-5 slugs for stripping Cursor-style UI suffixes; whether GPT-6 needs the same treatment is a routing question, not a pricing one.

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -78,6 +78,19 @@ def test_get_pricing_for_model_gpt_5_4_alias():
 )
 def test_get_pricing_for_model_gpt_5_6_aliases(requested_model: str, canonical_model: str) -> None:
     result = get_pricing_for_model(requested_model, DEFAULT_PRICING_MODELS, DEFAULT_MODEL_ALIASES)
+    assert result is not None
+    assert result[0] == canonical_model
+
+
+@pytest.mark.parametrize(
+    ("requested_model", "canonical_model"),
+    [
+        ("gpt-6-astra", "gpt-6-astra"),
+        ("gpt-6-astra-2026-04-30", "gpt-6-astra"),
+    ],
+)
+def test_get_pricing_for_model_gpt_6_astra_aliases(requested_model: str, canonical_model: str) -> None:
+    result = get_pricing_for_model(requested_model, DEFAULT_PRICING_MODELS, DEFAULT_MODEL_ALIASES)
 
     assert result == (canonical_model, DEFAULT_PRICING_MODELS[canonical_model])
 
@@ -307,6 +320,70 @@ def test_calculate_cost_from_usage_gpt_5_6_uses_272k_long_context_boundary(
 
     assert at_boundary == pytest.approx(272_000 / 1_000_000 * standard_input_rate)
     assert above_boundary == pytest.approx(272_001 / 1_000_000 * long_context_input_rate)
+
+
+@pytest.mark.parametrize(
+    ("service_tier", "expected_cost"),
+    [
+        (None, 51.1),
+        ("flex", 25.55),
+        ("priority", 102.2),
+        ("fast", 102.2),
+    ],
+)
+def test_calculate_cost_from_usage_gpt_6_astra_service_tiers(
+    service_tier: str | None,
+    expected_cost: float,
+) -> None:
+    usage = UsageTokens(
+        input_tokens=200_000.0,
+        output_tokens=1_000_000.0,
+        cached_input_tokens=100_000.0,
+    )
+
+    cost = calculate_cost_from_usage(
+        usage,
+        DEFAULT_PRICING_MODELS["gpt-6-astra"],
+        service_tier=service_tier,
+    )
+
+    assert cost == pytest.approx(expected_cost)
+
+
+@pytest.mark.parametrize(
+    ("service_tier", "expected_cost"),
+    [
+        (None, 12.6),
+        ("flex", 6.3),
+    ],
+)
+def test_calculate_cost_from_usage_gpt_6_astra_long_context(
+    service_tier: str | None,
+    expected_cost: float,
+) -> None:
+    usage = UsageTokens(
+        input_tokens=300_000.0,
+        output_tokens=100_000.0,
+        cached_input_tokens=50_000.0,
+    )
+
+    cost = calculate_cost_from_usage(
+        usage,
+        DEFAULT_PRICING_MODELS["gpt-6-astra"],
+        service_tier=service_tier,
+    )
+
+    assert cost == pytest.approx(expected_cost)
+
+
+def test_calculate_cost_from_usage_gpt_6_astra_uses_272k_long_context_boundary() -> None:
+    price = DEFAULT_PRICING_MODELS["gpt-6-astra"]
+
+    at_boundary = calculate_cost_from_usage(UsageTokens(input_tokens=272_000.0, output_tokens=0.0), price)
+    above_boundary = calculate_cost_from_usage(UsageTokens(input_tokens=272_001.0, output_tokens=0.0), price)
+
+    assert at_boundary == pytest.approx(272_000 / 1_000_000 * 10.0)
+    assert above_boundary == pytest.approx(272_001 / 1_000_000 * 20.0)
 
 
 def test_calculate_cost_from_usage_service_tier_trims_whitespace():


### PR DESCRIPTION
## Summary

`gpt-6-astra` now reaches accounts through upstream model discovery, but the bundled cost table in `app/core/usage/pricing.py` stops at the `gpt-5.6` family. `get_pricing_for_model` returns `None` for an unpriced model and `calculate_costs` then `continue`s past it, so Astra traffic is recorded as costing nothing across API-key limits, usage reservations, request logs and reports — and escapes any configured spend cap.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None found — I searched open and closed issues for GPT-6 / Astra pricing and found no existing report.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/add-gpt-6-astra-pricing/`

## Changes

- Add a `gpt-6-astra` entry to `DEFAULT_PRICING_MODELS` with standard, Fast/priority, Flex and standard long-context rates.
- Add a `gpt-6-astra*` alias to `DEFAULT_MODEL_ALIASES` so dated snapshots resolve to the canonical entry, matching the existing `gpt-5.6-*` patterns.
- Add regression coverage for the service tiers, long-context rates, the 272,000-token boundary, and snapshot alias resolution.

Rates from OpenAI's published API rate card:

| Tier | Input | Cached input | Output |
| --- | --- | --- | --- |
| Standard | `10` | `1` | `50` |
| Fast / priority (2x) | `20` | `2` | `100` |
| Flex (0.5x) | `5` | `0.50` | `25` |
| Standard long context (>272K) | `20` | `2` | `75` |

Sources: [GPT-6 Astra model page](https://developers.openai.com/api/docs/models/gpt-6-astra), [API pricing](https://developers.openai.com/api/docs/pricing).

Batch and cache-write rates stay out of scope, as in the previous pricing changes, because the proxy exposes no corresponding cost-accounting inputs.

### Deliberate divergences, flagged rather than encoded

The published rate card documents two Codex-specific differences:

- In ChatGPT Work and Codex, Fast for this model is charged at **2.5x** standard rather than the API's 2x.
- Codex applies **no** long-context multiplier above 272,000 input tokens and does not bill cache writes.

`DEFAULT_PRICING_MODELS` is uniformly the API rate card today, so encoding per-surface rates here would change how every other model is read. Codex-routed Astra cost will therefore read slightly high for Fast traffic and past the long-context boundary. Happy to follow up with a per-surface rate-card proposal if you'd prefer that contract instead — flagging rather than deciding it unilaterally.

## Simplicity

No new setting, dependency, migration, README section, `.env.example` entry or dashboard nav item; no default changed. One table entry and one alias.

## Test plan

```text
uv run pytest tests/unit/test_pricing.py -q
# 65 passed

uv run pytest tests/unit/test_pricing.py tests/unit/test_api_keys_service.py -q
# 152 passed

uv run ruff check app/core/usage/pricing.py tests/unit/test_pricing.py   # All checks passed
uv run ruff format --check app/core/usage/pricing.py tests/unit/test_pricing.py   # 2 files already formatted
uv run ty check   # no diagnostics in the touched files

bunx @fission-ai/openspec@latest validate add-gpt-6-astra-pricing --strict
# Change 'add-gpt-6-astra-pricing' is valid
```

New tests:

- `test_calculate_cost_from_usage_gpt_6_astra_service_tiers` — standard `$51.10`, flex `$25.55`, priority/fast `$102.20`.
- `test_calculate_cost_from_usage_gpt_6_astra_long_context` — standard `$12.60`, flex `$6.30`.
- `test_calculate_cost_from_usage_gpt_6_astra_uses_272k_long_context_boundary` — 272,000 stays standard, 272,001 crosses.
- `test_get_pricing_for_model_gpt_6_astra_aliases` — `gpt-6-astra-2026-04-30` resolves to `gpt-6-astra`.

## Screenshots / output

Not applicable — no user-visible surface beyond the cost figures the tests above pin.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above (none exists; searched).
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `uv run` subsets locally (see test plan).
- [x] If touching specs: scoped OpenSpec change validates strictly.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pricing support for the GPT-6 Astra model across standard, priority, flex, and long-context usage tiers.
  * Added support for resolving dated GPT-6 Astra model variants to the correct pricing.
  * Long-context pricing now applies when input usage exceeds the defined token threshold.

* **Bug Fixes**
  * GPT-6 Astra usage is now included in cost calculations, usage reservations, reports, and spending limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->