### PR TITLE
fix(proxy): preserve anonymous output response ownership

### DIFF
--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -2599,6 +2599,7 @@ class _HTTPBridgeUpstreamEventsMixin:
             elif response_id is None:
                 matched_request_state = _match_websocket_request_state_for_anonymous_event(
                     session.pending_requests,
+                    event_type=event_type,
                     prefer_previous_response_not_found=is_previous_response_not_found_event
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1661,6 +1661,7 @@ def _match_websocket_request_state_for_anonymous_event(
     pending_requests: deque[_WebSocketRequestState],
     *,
     prefer_previous_response_not_found: bool,
+    event_type: str | None = None,
     previous_response_id_hint: str | None = None,
     error_message: str | None = None,
     allow_unanchored_previous_response_error: bool = False,
@@ -1673,6 +1674,33 @@ def _match_websocket_request_state_for_anonymous_event(
             error_message=error_message,
             allow_unanchored_previous_response_error=allow_unanchored_previous_response_error,
         )
+
+    # Output belongs to an already-created response. A younger pipelined
+    # request may still lack its response ID while the active response emits
+    # item/text/tool events without a response_id field.
+    if (
+        event_type is not None
+        and event_type.startswith("response.")
+        and event_type
+        not in {
+            "response.created",
+            "response.queued",
+            "response.in_progress",
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+        }
+    ):
+        started_requests = [
+            request_state
+            for request_state in pending_requests
+            if request_state.response_id is not None
+            and (_http_bridge_request_counts_against_queue(request_state) or request_state.draining_until_terminal)
+        ]
+        if started_requests:
+            return started_requests[0] if len(started_requests) == 1 else None
+        # Preserve supported pre-created output/reasoning preludes when no
+        # started response can own the event.
 
     visible_requests = [
         request_state for request_state in pending_requests if _http_bridge_request_counts_against_queue(request_state)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5374,6 +5374,7 @@ class _WebSocketMixin:
             elif response_id is None:
                 request_state = _match_websocket_request_state_for_anonymous_event(
                     pending_requests,
+                    event_type=event_type,
                     prefer_previous_response_not_found=is_previous_response_not_found_matching_event
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,

--- a/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/context.md
+++ b/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/context.md
@@ -1,0 +1,9 @@
+## Reproduction
+
+Two requests share an upstream connection. Response A has an ID; request B awaits response.created. Output events for A carry item_id but no response_id. The anonymous matcher chooses B because it is the only unresolved request. The final response.completed event still resolves to A by response ID, so A completes without its streamed output.
+
+The fix prefers a unique started response for output events. When none has started, supported pre-created output behavior remains unchanged. Metadata and error matching retain their existing paths. Multiple started responses remain unresolved rather than guessing ownership.
+
+## Validation
+
+On unmodified main, eight bridge-level output delivery regressions fail. With the patch, the affected HTTP bridge, cancellation, and WebSocket suites report 1,174 passing tests and one missing-table failure in the pre-existing file-affinity test. Ruff and targeted type checking pass.

--- a/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/proposal.md
+++ b/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/proposal.md
@@ -1,0 +1,10 @@
+# Preserve ownership of anonymous response output
+
+## Why
+Concurrent HTTP requests with identical prompts share a bridge. A response output event without a response ID is incorrectly assigned to a younger request awaiting response.created, leaving the active request empty.
+
+## What Changes
+Classify response output events separately from pre-created metadata and errors. Route anonymous output only to the sole started response, including a draining owner. Preserve existing metadata/error matching.
+
+## Impact
+HTTP bridge and WebSocket response matching. No database, configuration, or API changes.

--- a/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/specs/proxy-architecture/spec.md
+++ b/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/specs/proxy-architecture/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+### Requirement: Anonymous output ownership
+When a started response exists, the proxy SHALL assign response output events without a response ID only to a uniquely identified started response, including a draining response, and SHALL NOT assign them to a request awaiting response.created. When no response has started, existing pre-created output handling SHALL remain supported. Pre-created metadata and error matching SHALL retain their existing semantics.
+
+#### Scenario: Active response with a younger pending request
+- **WHEN** response A has started and request B awaits response.created on the same upstream socket
+- **THEN** anonymous text, tool, content, and reasoning output events SHALL remain owned by A
+- **AND** B SHALL receive no output belonging to A
+
+#### Scenario: Multiple started responses
+- **WHEN** more than one response has started and an output event has no response ID
+- **THEN** the matcher SHALL leave ownership unresolved rather than assigning the event to a waiting request

--- a/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/tasks.md
+++ b/openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+- [x] Distinguish response output from pre-created metadata in anonymous event matching.
+- [x] Apply ownership matching to HTTP bridge and WebSocket paths.
+- [x] Add text, tool, reasoning, draining, and ambiguous-owner regression coverage.
+
+## 2. Validation
+- [x] Reproduce eight output-delivery failures on unmodified upstream main.
+- [x] Run affected tests and static checks on the final patch.
+- [x] Validate the specification change.

--- a/openspec/specs/proxy-architecture/spec.md
+++ b/openspec/specs/proxy-architecture/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 Structural fitness gates for the proxy: ProxyService stays a stable façade and internal decomposition (selection orchestration, bridge mixins) cannot drift behavior or re-grow god-modules.
+
 ## Requirements
+
 ### Requirement: Proxy architecture fitness gates are enforced
 
 The repository SHALL enforce every accepted proxy architecture threshold during
@@ -119,3 +121,15 @@ remain outside reusable transport and domain libraries.
 - **WHEN** a future migration cutover makes Rust authoritative for a domain
 - **THEN** the prior Python owner is removed after contract verification
 - **AND** no permanent dual implementation independently makes that domain decision
+
+### Requirement: Anonymous output ownership
+When a started response exists, the proxy SHALL assign response output events without a response ID only to a uniquely identified started response, including a draining response, and SHALL NOT assign them to a request awaiting response.created. When no response has started, existing pre-created output handling SHALL remain supported. Pre-created metadata and error matching SHALL retain their existing semantics.
+
+#### Scenario: Active response with a younger pending request
+- **WHEN** response A has started and request B awaits response.created on the same upstream socket
+- **THEN** anonymous text, tool, content, and reasoning output events SHALL remain owned by A
+- **AND** B SHALL receive no output belonging to A
+
+#### Scenario: Multiple started responses
+- **WHEN** more than one response has started and an output event has no response ID
+- **THEN** the matcher SHALL leave ownership unresolved rather than assigning the event to a waiting request

--- a/tests/unit/test_http_bridge_cancel_drain.py
+++ b/tests/unit/test_http_bridge_cancel_drain.py
@@ -1198,3 +1198,100 @@ async def test_response_created_does_not_promote_in_progress_durable_anchor() ->
     assert refreshed is not None
     assert refreshed.latest_response_id == "resp_B_completed"
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "output_event",
+    [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {"type": "message", "id": "msg_A", "role": "assistant", "status": "in_progress", "content": []},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_A",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "answer A",
+        },
+        {
+            "type": "response.output_text.done",
+            "item_id": "msg_A",
+            "output_index": 0,
+            "content_index": 0,
+            "text": "answer A",
+        },
+        {
+            "type": "response.content_part.done",
+            "item_id": "msg_A",
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "answer A", "annotations": []},
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "fc_A", "output_index": 0, "delta": "{}"},
+        {"type": "response.function_call_arguments.done", "item_id": "fc_A", "output_index": 0, "arguments": "{}"},
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_A",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "reason A",
+        },
+        {
+            "type": "response.refusal.delta",
+            "item_id": "msg_A",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "refusal A",
+        },
+    ],
+)
+async def test_anonymous_output_stays_with_started_response(output_event: dict[str, Any]) -> None:
+    import json
+
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    active = _make_request_state(
+        "req-A", response_id="resp_A", awaiting_response_created=False, event_queue=asyncio.Queue()
+    )
+    waiting = _make_request_state(
+        "req-B", response_id=None, awaiting_response_created=True, event_queue=asyncio.Queue()
+    )
+    session = _make_http_bridge_session(deque([active, waiting]), queued_request_count=2)
+    await service._process_http_bridge_upstream_text(session, json.dumps(output_event))
+    assert active.event_queue is not None
+    assert waiting.event_queue is not None
+    assert active.event_queue.qsize() == 1
+    assert waiting.event_queue.empty()
+    delivered = active.event_queue.get_nowait()
+    assert delivered is not None and output_event["type"] in delivered
+
+
+@pytest.mark.parametrize("draining", [False, True])
+def test_anonymous_output_owner_excludes_waiting_requests(draining: bool) -> None:
+    active = _make_request_state("req-A", response_id="resp_A", awaiting_response_created=False)
+    active.draining_until_terminal = draining
+    waiting = _make_request_state("req-B", response_id=None, awaiting_response_created=True)
+    assert (
+        proxy_service._match_websocket_request_state_for_anonymous_event(
+            deque([active, waiting]),
+            prefer_previous_response_not_found=False,
+            event_type="response.output_text.delta",
+        )
+        is active
+    )
+
+
+def test_anonymous_output_does_not_guess_with_multiple_started_responses() -> None:
+    active = _make_request_state("req-A", response_id="resp_A", awaiting_response_created=False)
+    other = _make_request_state("req-B", response_id="resp_B", awaiting_response_created=False)
+    waiting = _make_request_state("req-C", response_id=None, awaiting_response_created=True)
+    assert (
+        proxy_service._match_websocket_request_state_for_anonymous_event(
+            deque([active, other, waiting]),
+            prefer_previous_response_not_found=False,
+            event_type="response.output_text.delta",
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

When response A is streaming and request B awaits `response.created` on the same upstream connection, A's output events may omit `response_id`. The anonymous matcher assigns those events to B because B is the sole unresolved request. A then receives its correctly identified terminal event without its answer.

Prefer the unique started response for anonymous output events in both the HTTP bridge and WebSocket paths. Preserve existing pre-created output handling when no response has started, and leave metadata/error matching unchanged.

## Type of change

- [x] `fix:` — bug fix

No linked issue; reproduced directly against current `main`.

## OpenSpec

- [x] Includes an OpenSpec change.
- [x] Preserves upstream event formats; only request ownership changes.

Change: `openspec/changes/archive/2026-09-04-fix-anonymous-output-ownership/`.

## Reproduction

```text
pending: A(response_id=resp_A), B(response_id=None)
upstream: response.output_text.delta(item_id=msg_A, delta="answer A")
before:  A receives 0 events; B receives 1
with fix: A receives 1 event; B receives 0
```

Eight bridge-level regressions cover message items, text, content parts, function-call arguments, reasoning summaries, and refusals. Additional controls cover draining owners and multiple started responses.

## Validation

- Eight new output-delivery regressions fail on unmodified main (`b2c5ffc`).
- Affected suites: **1,174 passed, 1 failed**. The failure, `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses`, also fails on unmodified main with `no such table: file_account_pins`.
- Ruff and targeted `ty` checks pass.
- OpenSpec validation: **58 passed, 0 failed**; change validated and archived.
- Full local CI passed frontend checks, Python lint/type checks, and Rust clippy, then stopped at `rust-audit` because `cargo deny` is not installed. Later full-CI stages were not run.

```bash
uv run pytest tests/unit/test_http_bridge_cancel_drain.py \
  tests/unit/test_proxy_http_bridge.py \
  tests/unit/test_websocket_terminal_cancellation.py \
  tests/integration/test_proxy_websocket_responses.py -q
```

No new settings, dependencies, database changes, or dashboard changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed routing of anonymous upstream output events so they remain associated with the uniquely identified started response, including responses that are draining.
  - Prevented output from being assigned to requests still awaiting response initialization.
  - Left ownership unresolved when multiple started responses could match, avoiding incorrect delivery.

- **Tests**
  - Added coverage for text, tool, content, reasoning, refusal, and function-call output events, including concurrent and draining scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->