### PR TITLE
fix(docker): isolate host OAuth callback port by default

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,6 +11,17 @@
   "commitConvention": "angular",
   "contributors": [
     {
+      "login": "shuhulx",
+      "name": "Shuhul",
+      "avatar_url": "https://avatars.githubusercontent.com/u/106345809?v=4",
+      "profile": "https://github.com/shuhulx",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
+    },
+    {
       "login": "Soju06",
       "name": "Soju06",
       "avatar_url": "https://avatars.githubusercontent.com/u/34199905?v=4",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker volume create codex-lb-data
 docker network inspect codex-lb-net >/dev/null 2>&1 || docker network create codex-lb-net
 docker run -d --name codex-lb \
   --network codex-lb-net \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 
@@ -54,6 +54,8 @@ nix run github:Soju06/codex-lb
 ```
 
 Open [localhost:2455](http://localhost:2455) → Add account → Done.
+
+With Docker, use device-code sign-in (recommended) or paste the final localhost callback URL into the dialog when adding or reauthenticating an account. Port 1455 is intentionally not published so it remains available to Codex Desktop.
 
 Accessing the dashboard remotely for the first time? You need a one-time bootstrap token —
 see [Getting started](https://soju06.github.io/codex-lb/getting-started/).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ ChatGPT 账户负载均衡器。聚合多个账户、追踪用量、管理 API K
 # Docker（推荐）
 docker volume create codex-lb-data
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 
@@ -62,6 +62,8 @@ uvx codex-lb
 ```
 
 打开 [localhost:2455](http://localhost:2455) → 添加账户 → 完成。
+
+使用 Docker 添加或重新认证账户时，建议选择设备代码登录，或者将浏览器最终跳转到的 localhost 回调 URL 粘贴到对话框中。默认不会发布 1455 端口，以避免与 Codex Desktop 登录冲突。
 
 ## 远程访问初始化
 
@@ -84,7 +86,7 @@ docker logs codex-lb
 ```bash
 docker run -d --name codex-lb \
   -e CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN=your-secret-token \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 ```
@@ -394,7 +396,7 @@ CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER=Remote-User
 
 ```bash
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -e CODEX_LB_DASHBOARD_AUTH_MODE=trusted_header \
   -e CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER=Remote-User \
   -e CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS=true \
@@ -407,7 +409,7 @@ docker run -d --name codex-lb \
 
 ```bash
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -e CODEX_LB_DASHBOARD_AUTH_MODE=disabled \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,6 @@ services:
       - .env.local
     ports:
       - "2455:2455"
-      - "1455:1455"
     volumes:
       - codex-lb-data:/var/lib/codex-lb
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - .env.local
     ports:
       - "2455:2455"
-      - "1455:1455"
     command:
       # Keep development on the same pre-connection drain launcher as
       # production. Compose watch restarts the service after source sync.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -7,7 +7,7 @@ docker volume create codex-lb-data
 docker network inspect codex-lb-net >/dev/null 2>&1 || docker network create codex-lb-net
 docker run -d --name codex-lb \
   --network codex-lb-net \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 ```
@@ -15,7 +15,19 @@ docker run -d --name codex-lb \
 Ports:
 
 - `2455` — dashboard + proxy API
-- `1455` — OAuth login callback (needed while adding accounts)
+- `1455` — OAuth login callback inside the container; deliberately not published to the host by default
+
+### OAuth sign-in from Docker
+
+Codex Desktop also uses host port 1455 for its own ChatGPT login. Docker reserves every published port for the container's entire lifetime, even while no process is listening inside the container, so the portable setup leaves host port 1455 free.
+
+When adding or reauthenticating a codex-lb account from Docker, choose the device-code method (recommended). Browser OAuth also works through the manual callback field: after authorization, copy the complete `http://localhost:1455/auth/callback?...` URL from the browser address bar and paste it into the dashboard dialog. A browser connection-error page is expected because the port is not published. Treat that URL as a secret and do not share it.
+
+The dashboard's Windows port-forward helper is not compatible with the stock Docker mapping because server-side port 1455 is intentionally unpublished. Use device-code sign-in or the manual callback field instead; do not expose port 1455 over the network just to make that helper work.
+
+On a dedicated machine where the dashboard browser runs locally, and where Codex Desktop or another OAuth callback consumer will never run, you can opt into automatic browser callbacks by adding `-p 127.0.0.1:1455:1455` to `docker run`. That mapping reserves host port 1455 whenever the container is running, even when no codex-lb browser flow is active.
+
+If an existing container was created with the old `-p 1455:1455` mapping, updating its image cannot change that binding. Recreate the container without the mapping while keeping the same `codex-lb-data` volume. Compose users can update the Compose file and rerun the same `docker compose up` command with `--force-recreate`.
 
 The volume holds everything under `/var/lib/codex-lb/` (database, encryption key, archives) — back it up to preserve your data.
 
@@ -39,7 +51,7 @@ docker run -d --name codex-lb \
   ghcr.io/soju06/codex-lb:latest
 ```
 
-In the verified Docker Engine setup on Linux, host networking does not use `-p`; codex-lb still listens on ports 2455 and 1455. It also removes Docker's network-namespace isolation. The command is an opt-in path to a stable host resolver, not a DNS fix by itself.
+In the verified Docker Engine setup on Linux, host networking does not use `-p`; codex-lb listens on 2455 and can bind 1455 during browser OAuth. It also removes Docker's network-namespace isolation and can therefore conflict with Codex Desktop OAuth on the same host while that flow is active. The command is an opt-in path to a stable host resolver, not a DNS fix by itself.
 
 ## Docker Compose
 
@@ -61,7 +73,7 @@ For PostgreSQL profiles and the Postgres 16 → 18 upgrade runbook, see [Databas
 
 ```bash
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -e CODEX_LB_DASHBOARD_AUTH_MODE=trusted_header \
   -e CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER=Remote-User \
   -e CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS=true \
@@ -74,7 +86,7 @@ docker run -d --name codex-lb \
 
 ```bash
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -e CODEX_LB_DASHBOARD_AUTH_MODE=disabled \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ codex-lb runs with zero configuration — every setting has a working default, a
 # Docker (recommended)
 docker volume create codex-lb-data
 docker run -d --name codex-lb \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 
@@ -20,6 +20,8 @@ nix run github:Soju06/codex-lb
 ```
 
 Open [localhost:2455](http://localhost:2455) → Add account → Done.
+
+For Docker account setup or reauthentication, choose device-code sign-in (recommended) or paste the browser's final localhost callback URL into the dialog. Port 1455 is deliberately not published, leaving it available for Codex Desktop login.
 
 Next: point your coding agent at codex-lb — see [Client Setup](client-setup.md).
 
@@ -44,7 +46,7 @@ Open the dashboard → enter the token + new password → done. The token is sha
 ```bash
 docker run -d --name codex-lb \
   -e CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN=your-secret-token \
-  -p 2455:2455 -p 1455:1455 \
+  -p 2455:2455 \
   -v codex-lb-data:/var/lib/codex-lb \
   ghcr.io/soju06/codex-lb:latest
 ```

--- a/openspec/changes/isolate-docker-oauth-callback-port/.openspec.yaml
+++ b/openspec/changes/isolate-docker-oauth-callback-port/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/isolate-docker-oauth-callback-port/design.md
+++ b/openspec/changes/isolate-docker-oauth-callback-port/design.md
@@ -1,0 +1,31 @@
+## Context
+
+Docker port publishing is independent of the application's callback-listener lifetime. The default mapping reserves 1455 even when the listener is idle. Issue #2076 concerns that host-level collision.
+
+## Goals / Non-Goals
+
+Free the host callback port for other local applications in stock bridge-network deployments. Do not change OAuth service code, the fixed redirect URI, dashboard rendering, or host-network deployments.
+
+## Decisions
+
+Propose removing the host publication from portable launch examples and both Compose files. Keep internal callback port 1455 unchanged. Document device-code setup and manually pasted callbacks, plus a loopback-only opt-in for a dedicated machine.
+
+An optional coexistence recipe preserving current defaults is an alternative if the owner rejects this default change. Merely stopping the internal callback listener cannot free a Docker-published host port.
+
+## Risks / Trade-offs
+
+Automatic browser callback capture will no longer work out of the box. The existing Windows netsh helper targets server-side port 1455 and therefore will not work with the proposed default. Documentation states these limits explicitly; this draft needs the owner's product decision and P1 approval before it can be ready.
+
+Manual callbacks can display a browser connection error before the URL is pasted. Device-code sign-in avoids that intermediate error. The proposal does not claim to preserve the previous one-click Browser path.
+
+## Migration Plan
+
+Existing containers retain their original published ports after image updates. Recreate them without the callback mapping, preserving their data volume. Rollback restores the mapping and its original port conflict.
+
+## Open Questions
+
+Does the owner accept this default change, or prefer an optional coexistence recipe? Is documentation sufficient for the Windows helper limitation, or should a separate dashboard change guide users?
+
+## Example
+
+A laptop runs the proxy on 2455 and uses device-code account setup. Port 1455 remains free for another local application's sign-in. A dedicated host can instead opt into automatic callbacks with a loopback mapping.

--- a/openspec/changes/isolate-docker-oauth-callback-port/proposal.md
+++ b/openspec/changes/isolate-docker-oauth-callback-port/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Docker reserves published host port 1455 for the lifetime of a running container, independently of the OAuth listener inside it. This can intercept another local application's login callback, as reported in #2076.
+
+## What Changes
+
+- **BREAKING**: Stop publishing host port 1455 in portable Docker examples and shipped Compose defaults.
+- Keep device-code and manual-callback setup available, with explicit instructions and a dedicated-host opt-in mapping.
+- Document the Windows port-forward helper limitation and existing-container recreation.
+- Keep this deployment decision independent from the listener expiry fix in #2079.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: Define default host-port publication and supported account setup paths for Docker.
+
+## Impact
+
+Compose files, launch examples, deployment guidance, and port-contract tests. No application code, dashboard rendering, configuration key, or schema changes.
+
+This is a draft product-default proposal. Automatic browser callback capture and the existing Windows helper cease to work with the proposed stock mappings; owner approval under PRINCIPLES P1 is required before accepting that tradeoff.

--- a/openspec/changes/isolate-docker-oauth-callback-port/specs/deployment-installation/spec.md
+++ b/openspec/changes/isolate-docker-oauth-callback-port/specs/deployment-installation/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Default Docker deployments preserve the host OAuth callback port
+
+The documented portable Docker launch commands and shipped Docker Compose files MUST publish the dashboard and proxy port 2455 but MUST NOT publish host port 1455 by default. The container MAY continue to expose and listen on its internal callback port.
+
+Docker account-setup guidance MUST provide a path that works without host port 1455 publication, and MUST explain that Codex Desktop uses the same host callback port. Any documented opt-in host publication MUST bind to loopback, MUST be presented only for a machine without another callback consumer, and MUST state that Docker reserves the port whenever the container is running. Upgrade guidance MUST explain that an existing container retains its published ports until it is recreated.
+
+#### Scenario: Stock Docker launch keeps host port 1455 free
+
+- **WHEN** an operator follows a portable `docker run` example or starts either shipped Compose file without customization
+- **THEN** host port 2455 is published for the dashboard and proxy
+- **AND** host port 1455 remains available to Codex Desktop or another local callback consumer
+
+#### Scenario: Docker account setup without callback-port publication
+
+- **GIVEN** a stock Docker deployment does not publish host port 1455
+- **WHEN** an operator adds or reauthenticates a codex-lb account
+- **THEN** the documentation directs them to device-code sign-in or the dashboard's manual browser-callback field
+
+#### Scenario: Dedicated host opts into automatic browser callback
+
+- **GIVEN** a machine does not run Codex Desktop or another host-port-1455 consumer
+- **WHEN** an operator chooses the documented automatic browser-callback opt-in
+- **THEN** the mapping binds host port 1455 only on loopback
+- **AND** the documentation warns that the running container reserves that port even while no browser flow is active
+
+#### Scenario: Existing mapped container is upgraded
+
+- **GIVEN** an existing container was created with host port 1455 published
+- **WHEN** the operator upgrades to a release with the safer default
+- **THEN** the documentation tells them to recreate the container without that mapping while preserving its data volume

--- a/openspec/changes/isolate-docker-oauth-callback-port/tasks.md
+++ b/openspec/changes/isolate-docker-oauth-callback-port/tasks.md
@@ -1,0 +1,10 @@
+## 1. Draft Implementation
+
+- [x] 1.1 Split Docker launch mappings and guidance out of #2079.
+- [x] 1.2 Test executable publication contracts without assertions on prose.
+- [x] 1.3 Record the author in the contributor registry.
+- [x] 1.4 Validate port tests, both Compose files, and the change specification.
+
+## 2. Product Decision
+
+- [ ] 2.1 Obtain owner approval for the default change and Windows helper tradeoff before marking ready.

--- a/tests/unit/test_docker_networking.py
+++ b/tests/unit/test_docker_networking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +11,34 @@ import yaml
 pytestmark = pytest.mark.unit
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize("compose_name", ["docker-compose.yml", "docker-compose.prod.yml"])
+def test_stock_compose_keeps_host_callback_port_unpublished(compose_name: str) -> None:
+    compose = yaml.safe_load((_REPO_ROOT / compose_name).read_text(encoding="utf-8"))
+    ports = compose["services"]["server"]["ports"]
+    host_ports = {int(str(port).split(":")[-2]) for port in ports}
+    assert 2455 in host_ports
+    assert 1455 not in host_ports
+
+
+@pytest.mark.parametrize(
+    "doc_path", ["README.md", "README.zh-CN.md", "docs/getting-started.md", "docs/deployment/docker.md"]
+)
+def test_portable_docker_commands_keep_host_callback_port_unpublished(doc_path: str) -> None:
+    document = (_REPO_ROOT / doc_path).read_text(encoding="utf-8")
+    portable_commands = 0
+    for block in re.findall(r"```(?:bash|sh)?\n(.*?)```", document, flags=re.DOTALL):
+        for command in re.findall(r"docker run\b(?:[^\n]*\\\n)*[^\n]*", block):
+            tokens = shlex.split(command.replace("\\\n", " "))
+            if "--network" in tokens and tokens[tokens.index("--network") + 1] == "host":
+                continue
+            mappings = [tokens[index + 1] for index, token in enumerate(tokens[:-1]) if token in {"-p", "--publish"}]
+            host_ports = {int(mapping.split(":")[-2]) for mapping in mappings}
+            assert 2455 in host_ports
+            assert 1455 not in host_ports
+            portable_commands += 1
+    assert portable_commands > 0
 
 
 @pytest.mark.parametrize("compose_name", ["docker-compose.yml", "docker-compose.prod.yml"])


### PR DESCRIPTION
## Summary

Docker reserves published host port 1455 for the entire lifetime of a running container, even when its internal OAuth listener is stopped. This draft removes that publication from portable launch examples and both shipped Compose files, keeping dashboard/proxy port 2455 available.

Fixes #2076 if this deployment-default proposal is accepted. Split from #2079; this PR contains no listener-service changes and does not depend on that fix.

## Type of change

- [x] `fix:` — deployment port conflict
- [x] Breaking default change requiring owner decision

## Product decision / simplicity

**Draft pending owner approval under PRINCIPLES P1.** Automatic Browser callback capture will no longer work with stock mappings. Device-code or the existing manual callback field must be used instead. The Windows `netsh portproxy` helper also will not work with this proposed default; that limitation is documented explicitly.

Please evaluate whether that tradeoff is acceptable, or whether an optional coexistence recipe preserving current defaults is preferable. This draft does not claim to preserve the previous one-click Browser path. No new settings or dependencies are added.

## OpenSpec

- [x] Includes `openspec/changes/isolate-docker-oauth-callback-port/`.

## Changes

- Publish 2455 only in portable examples and stock Compose files.
- Document device-code/manual-callback setup, the Windows helper limitation, a loopback-only dedicated-host opt-in, and recreation of existing containers while preserving their data volume.
- Test parsed Docker command and Compose port mappings without new assertions on documentation prose.
- Include the author's contributor entry so this branch can be reviewed independently.

## Test plan

- Docker networking and contributor tests: **17 passed**.
- Both Compose configurations validate.
- Targeted Ruff lint/format and strict OpenSpec validation pass.
- No live installation was recreated or changed during this split.

## Screenshots / output

Not applicable: this draft does not change dashboard rendering.

## Checklist

- [x] Conventional Commit title, linked issue, scoped OpenSpec change, and port-contract coverage.
- [x] Changelog not edited; no new README section or configuration key.
- [ ] Owner approves the default and Windows helper tradeoff.
- [ ] Current GitHub checks and review complete.
