### PR TITLE
fix(proxy): filter vendor events from public Responses streams

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -8828,12 +8828,12 @@ async def _normalize_public_responses_stream(
     Args:
         stream: the upstream SSE event blocks (post-error-conversion).
         enforce_openai_sdk_contract: when True (the default, used for /v1),
-            apply OpenAI Responses SSE contract enforcement: drop Codex
-            vendor events (codex.*), backfill terminal output from streamed
+            apply OpenAI Responses SSE contract enforcement: drop events
+            outside response.* and error, backfill terminal output from streamed
             item events, and synthesize a leading response.created event
             when the upstream stream's first standard event is not
             response.created. When False (used for /backend-api/codex/*,
-            which feeds the Codex CLI), all events including codex.* are
+            which feeds the Codex CLI), all events including vendor events are
             forwarded verbatim and no synthesis happens — the Codex CLI
             relies on the upstream's native event shape.
     """
@@ -9391,16 +9391,16 @@ def _normalize_public_stream_payload(
             normalized_payload = dict(payload)
             normalized_payload["part"] = normalized_part
             return normalized_payload, None
-    # Drop Codex-internal vendor events on the public /v1 surface only. The
-    # upstream Codex backend emits non-standard events (notably
-    # ``codex.rate_limits``, which is throttled per rate-limit window and so
-    # leaks intermittently before ``response.created``). The OpenAI Responses
-    # SSE contract does not define any ``codex.*`` event type, and the OpenAI
-    # SDK's stream parser raises ``RuntimeError`` if any other event arrives
-    # first. The Codex CLI routes under ``/backend-api/codex/*`` legitimately
-    # consume these events and pass ``enforce_openai_sdk_contract=False`` so
-    # they continue to forward unchanged.
-    if enforce_openai_sdk_contract and isinstance(event_type, str) and event_type.startswith("codex."):
+    # Public Responses streams accept the response.* and error families.
+    # Upstream diagnostics such as codex.rate_limits and
+    # responsesapi.websocket_timing break strict event deserializers.
+    # Native Codex requests disable this contract and retain vendor events.
+    if (
+        enforce_openai_sdk_contract
+        and isinstance(event_type, str)
+        and event_type != "error"
+        and not event_type.startswith("response.")
+    ):
         return None, None
     if event_type == "error" or (enforce_openai_sdk_contract and event_type == "response.failed"):
         if event_type == "error":

--- a/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/context.md
+++ b/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/context.md
@@ -1,0 +1,20 @@
+# Context
+
+Refs #1934. The issue reports two independent parser incompatibilities:
+string-valued `response.instructions`, and an unrecognized
+`responsesapi.websocket_timing` event. This change addresses only the latter.
+
+The existing public contract already specifies the `response.*` and `error`
+families. Filtering by those families avoids adding a vendor-name registry and
+continues accepting future `response.*` events. It does not validate every
+event subtype or change malformed-payload handling.
+
+For example, upstream `response.created`, `response.output_text.delta`,
+`responsesapi.websocket_timing`, `response.completed` becomes the same sequence
+without the timing diagnostic on the public surface. A native Codex request
+continues receiving the diagnostic. OpenAI-shaped requests to the backend route
+already enable public contract enforcement and therefore also filter it.
+
+Regression tests inject upstream SSE into the real application route and stream
+normalizer. They do not exercise IntelliJ, Koog, or a live ChatGPT account and
+cannot establish complete IntelliJ compatibility.

--- a/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/proposal.md
+++ b/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/proposal.md
@@ -1,0 +1,29 @@
+# Filter public Responses vendor events
+
+## Why
+
+The public Responses stream currently drops `codex.*` events but forwards
+`responsesapi.websocket_timing`. Issue #1934 reports that IntelliJ's strict
+event deserializer aborts on this upstream diagnostic before receiving
+`response.completed`.
+
+## What Changes
+
+- Apply the existing public event-family contract to all string event types:
+  allow `response.*` and `error`, and drop other types.
+- Preserve vendor events when native Codex contract enforcement is disabled.
+- Cover public and native HTTP/SSE routing with regression tests.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: clarify filtering beyond the `codex.*` namespace
+  and distinguish native requests from OpenAI-shaped backend requests.
+
+## Impact
+
+- Code: `app/modules/proxy/api.py`.
+- Tests: Responses stream contract unit tests and Responses route integration tests.
+- No new configuration, dependencies, database changes, or dashboard changes.
+- Partial coverage of #1934; `response.instructions` compatibility is out of scope.

--- a/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/specs/responses-api-compat/spec.md
@@ -1,0 +1,34 @@
+# responses-api-compat Delta
+
+## MODIFIED Requirements
+
+### Requirement: Public /v1 responses SSE stream emits only OpenAI Responses contract events
+
+When serving streaming `POST /v1/responses`, the service MUST forward a
+string-valued event type only when it is exactly `error` or begins with
+`response.`. Other string-valued event types MUST be dropped before they reach
+the public stream. OpenAI-shaped backend requests with public contract
+enforcement enabled MUST follow the same filtering rule. Native Codex requests
+with public contract enforcement disabled MUST retain upstream vendor events.
+
+#### Scenario: Codex-internal rate-limit event is dropped before response.created
+
+- **WHEN** upstream emits `codex.rate_limits` before `response.created` for a streaming `/v1/responses` request
+- **THEN** the public stream MUST NOT contain `codex.rate_limits`
+- **AND** its first event MUST be `response.created`
+
+#### Scenario: Timing diagnostics are filtered without losing text or completion
+
+- **WHEN** upstream emits `responsesapi.websocket_timing` before, between, or after standard response events
+- **THEN** a public-contract stream MUST NOT contain that diagnostic
+- **AND** standard text deltas and completion events MUST remain in order
+
+#### Scenario: OpenAI-shaped backend request filters vendor events
+
+- **WHEN** an OpenAI-shaped `/backend-api/codex/responses` request enables public contract enforcement
+- **THEN** its response stream MUST apply the public event-family filtering rule
+
+#### Scenario: Codex-internal events on the Codex CLI route are preserved
+
+- **WHEN** a native `/backend-api/codex/responses` request disables public contract enforcement
+- **THEN** the response stream MUST retain `codex.rate_limits` and `responsesapi.websocket_timing` in upstream order

--- a/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/tasks.md
+++ b/openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Reproduce vendor-event leakage on current main with regression tests (8 failures, 7 passes).
+- [x] Filter non-contract event families when public contract enforcement is enabled.
+- [x] Verify public text/completion delivery and native vendor-event preservation (15 regression cases pass).
+- [x] Run the Responses unit/integration suites and scoped formatting, lint, and type checks (171 tests pass; checks pass).
+- [x] Validate the change and specs; record any existing baseline failure separately (change and owning spec pass strict validation; all 58 specs pass CI-default validation; optional full strict validation has 22 existing failures).
+- [x] Review the diff and prepare a PR draft with partial scope and verification limits (35 additional SDK/source tests pass; no IntelliJ or live upstream verification).

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -16,6 +16,14 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 
 ## Constraints
 
+- Public-contract SSE filtering uses the `response.*` and `error` families, so
+  diagnostics such as `responsesapi.websocket_timing` cannot interrupt strict
+  client event deserializers. For example, a timing diagnostic between a text
+  delta and `response.completed` is removed while both standard events remain.
+  Native Codex requests retain vendor events; OpenAI-shaped backend requests
+  follow public filtering. This does not normalize string-valued
+  `response.instructions` or establish full IntelliJ compatibility (Refs #1934).
+
 - Upstream limitations determine available modalities, tool output, and overflow handling.
 - `store=true` is rejected; responses are not persisted.
 - `include` values must be on the documented allowlist.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -467,16 +467,35 @@ Public Responses endpoints MUST NOT return an OpenAI-shaped `previous_response_n
 - **AND** the missing `previous_response_id` is not exposed in the response body
 
 ### Requirement: Public /v1 responses SSE stream emits only OpenAI Responses contract events
-When serving streaming `POST /v1/responses`, the service MUST emit only event types defined by the OpenAI Responses SSE contract (the `response.*` and `error` families) on the public stream. The service MUST drop any vendor-internal event types — specifically, any event whose `type` begins with `codex.` (for example `codex.rate_limits`) — before they reach the public stream. The `/backend-api/codex/*` routes are NOT subject to this requirement and MUST continue forwarding these events unchanged.
+
+When serving streaming `POST /v1/responses`, the service MUST forward a
+string-valued event type only when it is exactly `error` or begins with
+`response.`. Other string-valued event types MUST be dropped before they reach
+the public stream. OpenAI-shaped backend requests with public contract
+enforcement enabled MUST follow the same filtering rule. Native Codex requests
+with public contract enforcement disabled MUST retain upstream vendor events.
 
 #### Scenario: Codex-internal rate-limit event is dropped before response.created
-- **WHEN** the upstream Codex backend emits `codex.rate_limits` before `response.created` for a streaming `/v1/responses` request
-- **THEN** the public stream MUST NOT contain the `codex.rate_limits` event
-- **AND** the first event the public stream emits MUST be `response.created`
+
+- **WHEN** upstream emits `codex.rate_limits` before `response.created` for a streaming `/v1/responses` request
+- **THEN** the public stream MUST NOT contain `codex.rate_limits`
+- **AND** its first event MUST be `response.created`
+
+#### Scenario: Timing diagnostics are filtered without losing text or completion
+
+- **WHEN** upstream emits `responsesapi.websocket_timing` before, between, or after standard response events
+- **THEN** a public-contract stream MUST NOT contain that diagnostic
+- **AND** standard text deltas and completion events MUST remain in order
+
+#### Scenario: OpenAI-shaped backend request filters vendor events
+
+- **WHEN** an OpenAI-shaped `/backend-api/codex/responses` request enables public contract enforcement
+- **THEN** its response stream MUST apply the public event-family filtering rule
 
 #### Scenario: Codex-internal events on the Codex CLI route are preserved
-- **WHEN** the upstream emits `codex.rate_limits` for a `POST /backend-api/codex/responses` request
-- **THEN** the response stream forwards the `codex.rate_limits` event to the Codex CLI client unchanged
+
+- **WHEN** a native `/backend-api/codex/responses` request disables public contract enforcement
+- **THEN** the response stream MUST retain `codex.rate_limits` and `responsesapi.websocket_timing` in upstream order
 
 ### Requirement: Streamed /v1 responses terminal output is backfilled from item events
 When serving streaming `POST /v1/responses`, if the upstream's terminal `response.completed` or `response.incomplete` event carries `output` as missing or as an empty list, the service MUST reconstruct `output` from the `response.output_item.done` events emitted earlier in the same stream before yielding the terminal SSE event. The reconstructed `output` MUST preserve the `output_index` ordering and the raw item payloads. When the terminal `response.completed` / `response.incomplete` already carries a non-empty `output`, the service MUST forward it unchanged.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -1138,6 +1138,76 @@ async def test_proxy_responses_openai_shape_custom_client_gets_sdk_sse_contract(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route", "native"),
+    [
+        ("/v1/responses", False),
+        ("/v1/responses/", False),
+        ("/backend-api/codex/responses", False),
+        ("/backend-api/codex/responses/", False),
+        ("/backend-api/codex/responses", True),
+        ("/backend-api/codex/responses/", True),
+    ],
+    ids=["v1", "v1-slash", "backend-public", "backend-public-slash", "backend-native", "backend-native-slash"],
+)
+async def test_responses_routes_filter_vendor_events_only_for_public_contract(async_client, monkeypatch, route, native):
+    auth_json = _make_auth_json("acc_vendor_events", "vendor-events@example.com")
+    response = await async_client.post(
+        "/api/accounts/import", files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    )
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'event: response.created\ndata: {"type":"response.created","sequence_number":0,'
+            '"response":{"id":"resp_vendor","object":"response","status":"in_progress",'
+            '"instructions":"Keep this string.","output":[]}}\n\n'
+        )
+        yield (
+            'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","sequence_number":1,'
+            '"item_id":"msg_vendor","output_index":0,"content_index":0,"delta":"Commit message"}\n\n'
+        )
+        yield 'event: responsesapi.websocket_timing\ndata: {"type":"responsesapi.websocket_timing","latency_ms":12}\n\n'
+        yield (
+            'event: response.completed\ndata: {"type":"response.completed","sequence_number":2,'
+            '"response":{"id":"resp_vendor","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    payload = {"model": "gpt-5.1", "input": "hi", "stream": True}
+    if native:
+        payload["instructions"] = "hi"
+    async with async_client.stream(
+        "POST",
+        route,
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "codex-cli/1.0" if native else "custom-client/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = list(_iter_sse_events(lines))
+    event_types = [event["type"] for event in events]
+    if native:
+        assert event_types == [
+            "codex.rate_limits",
+            "response.created",
+            "response.output_text.delta",
+            "responsesapi.websocket_timing",
+            "response.completed",
+        ]
+    else:
+        assert event_types == ["response.created", "response.output_text.delta", "response.completed"]
+    created = next(event for event in events if event["type"] == "response.created")
+    assert created["response"]["instructions"] == "Keep this string."
+    delta = next(event for event in events if event["type"] == "response.output_text.delta")
+    assert delta["delta"] == "Commit message"
+    assert events[-1]["response"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_null_instructions_gets_sdk_sse_contract(async_client, monkeypatch):
     email = "backend-openai-null-instructions@example.com"
     raw_account_id = "acc_backend_openai_null_instructions"

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1224,6 +1224,48 @@ async def test_normalize_public_responses_stream_drops_codex_rate_limits_prefix(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "diagnostic_position", [0, 1, 2], ids=["before-created", "before-completed", "after-completed"]
+)
+@pytest.mark.parametrize("enforce_contract", [True, False], ids=["public", "native"])
+async def test_normalize_responses_stream_filters_timing_only_for_public_contract(
+    diagnostic_position: int, enforce_contract: bool
+) -> None:
+    upstream_blocks = [
+        'data: {"type":"response.created","sequence_number":0,'
+        '"response":{"id":"resp_timing","object":"response","status":"in_progress","output":[]}}\n\n',
+        'data: {"type":"response.completed","sequence_number":1,'
+        '"response":{"id":"resp_timing","object":"response","status":"completed","output":[]}}\n\n',
+    ]
+    upstream_blocks.insert(diagnostic_position, 'data: {"type":"responsesapi.websocket_timing","latency_ms":12}\n\n')
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(*upstream_blocks), enforce_openai_sdk_contract=enforce_contract
+        )
+    ]
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    event_types = [payload["type"] for payload in payloads if payload is not None]
+    expected_types = ["response.created", "response.completed"]
+    if not enforce_contract:
+        expected_types.insert(diagnostic_position, "responsesapi.websocket_timing")
+    assert event_types == expected_types
+
+
+@pytest.mark.parametrize(
+    ("event_type", "forwarded"),
+    [("response.future_event", True), ("error", True), ("vendor.future_event", False)],
+)
+def test_public_responses_event_family_contract(event_type: str, forwarded: bool) -> None:
+    payload: dict[str, JsonValue] = {"type": event_type, "code": "server_error", "message": "test error"}
+    normalized, violation = proxy_api_module._normalize_public_stream_payload(payload)
+    assert (normalized is not None) is forwarded
+    if normalized is not None:
+        assert normalized["type"] == event_type
+    assert violation is None
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_backfills_terminal_output_from_items() -> None:
     """G3: terminal `response.completed.output` MUST be backfilled from
     `response.output_item.done` events when upstream sends empty output.


### PR DESCRIPTION
## Summary

An upstream `responsesapi.websocket_timing` event currently reaches public Responses SSE clients and can abort strict event deserializers before `response.completed`. Enforce the existing `response.*` / `error` event-family contract instead of filtering only `codex.*` events.

## Type of change

- [x] `fix:` — bug fix

Linked issue: Refs #1934 (partial). This addresses vendor-event leakage only; it does not change string-valued `response.instructions` or claim full IntelliJ compatibility.

## OpenSpec

- [x] Includes an OpenSpec change and updates the owning spec/context.
- [x] Native Codex requests retain upstream vendor events; public-contract streams intentionally filter them.

Change directory: `openspec/changes/archive/2026-09-06-filter-public-responses-vendor-events/`

Owning requirement: `openspec/specs/responses-api-compat/spec.md`, “Public /v1 responses SSE stream emits only OpenAI Responses contract events”.

## Changes

- Drop string event types outside `response.*` and `error` when public contract enforcement is enabled, including OpenAI-shaped backend requests.
- Preserve vendor events for native Codex requests, standard event ordering, text deltas, and string-valued `instructions`.
- Add 15 regression cases covering timing events before/between/after lifecycle events, event-family handling, and public/native routes with and without trailing slashes.

No settings, dependencies, migrations, or dashboard changes.

## Test plan

Validated on Windows with Python 3.13.13 against upstream main `5ad638b6a4c9c094bcc8866b1d7487173fe3b54e`, using `uv sync --locked --all-extras --dev --python 3.13`.

```text
Unmodified main: Responses contract unit + integration suites: 156 passed
New regression cases before the fix: 8 failed (vendor events leaked), 7 passed
Same regression cases after the fix: 15 passed

python -m pytest tests/unit/test_proxy_api_responses_contract.py tests/integration/test_proxy_responses.py -q --timeout=60
171 passed

python -m pytest tests/e2e/test_v1_responses_openai_sdk.py tests/integration/test_model_source_routing.py -q -k "responses or stream_success_passes_through_sse" --timeout=60
35 passed, 73 deselected

ruff check / ruff format --check / ty check
Passed for the three changed Python files
```

OpenSpec 1.11.0: change and owning spec pass strict validation; all 58 main specs pass CI-default validation. Optional whole-repository `--strict` validation has 22 pre-existing failures on the unmodified main specs (36 pass); no unrelated specs are changed here.

The tests use real app routes, stream normalization, and the OpenAI Python SDK, with injected upstream responses. They do not use IntelliJ/Koog or a live ChatGPT account. The full repository CI matrix has not been run locally.

## Output example

For streaming `POST /v1/responses` with `{"model":"gpt-5.1","input":"hi","stream":true}`, the injected upstream sequence is:

```text
codex.rate_limits
response.created
response.output_text.delta ("Commit message")
responsesapi.websocket_timing
response.completed
```

The public stream now contains `response.created`, the same text delta, and `response.completed`. Native Codex requests retain the full sequence. `response.created.response.instructions` remains a string.

## Checklist

- [x] Conventional Commit title and partial issue reference.
- [x] Regression tests observed failing before the fix and passing after it.
- [x] Relevant local tests, scoped code checks, and OpenSpec validation completed.
- [x] Simplicity principles reviewed; no new configuration or setup.
- [x] CHANGELOG not edited.
- [ ] Full cloud CI and maintainer review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Public Responses API streams now forward only `response.*` and `error` events.
  - Vendor and diagnostic events are filtered from public streams while standard response content and completion events remain available.
  - Native Codex streams continue to preserve vendor events when public contract enforcement is disabled.

- **Tests**
  - Added coverage for public and native streaming routes, event filtering, and event ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->