### PR TITLE
fix(auth): retain unexpired access on refresh preflight failure

### DIFF
--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -36,6 +36,7 @@ from app.db.models import Account, AccountProxyBinding, AccountStatus
 from app.db.session import get_background_session
 from app.modules.accounts.refresh_claims import RefreshClaimCoordinatorPort, get_refresh_claim_coordinator
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
+from app.modules.proxy.account_eligibility import account_access_token_expires_at
 
 
 class AccountsRepositoryPort(Protocol):
@@ -164,6 +165,19 @@ _TOKEN_REFRESH_CLAIM_POLL_SECONDS = 0.25
 # token; it must fail closed and surface the terminal state instead.
 _TERMINAL_REFRESH_STATUSES = frozenset({AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED})
 
+# These describe the refresh credential, not an upstream rejection of the
+# access token or termination of the account/session. Only ordinary preflight
+# callers may try a still-unexpired access token after these failures.
+_REFRESH_CREDENTIAL_FAILURE_CODES = frozenset(
+    {
+        "refresh_token_expired",
+        "refresh_token_reused",
+        "refresh_token_invalidated",
+        "invalid_refresh_token",
+        "invalid_grant",
+    }
+)
+
 
 _RefreshSingleflightKey: TypeAlias = tuple[str, str]
 
@@ -288,10 +302,34 @@ class AuthManager:
 
     async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
         if force or (account.status != AccountStatus.REAUTH_REQUIRED and should_refresh(account.last_refresh)):
-            account = await _REFRESH_SINGLEFLIGHT.run(
-                _refresh_singleflight_key(self._encryptor, account),
-                lambda: self._run_refresh(account),
-            )
+            ordinary_active_preflight = not force and account.status == AccountStatus.ACTIVE
+            try:
+                account = await _REFRESH_SINGLEFLIGHT.run(
+                    _refresh_singleflight_key(self._encryptor, account),
+                    lambda: self._run_refresh(account),
+                )
+            except RefreshError as exc:
+                if (
+                    not ordinary_active_preflight
+                    or not exc.is_permanent
+                    or exc.code not in _REFRESH_CREDENTIAL_FAILURE_CODES
+                ):
+                    raise
+                # Keep recovery outside singleflight: a forced caller sharing
+                # this exchange must still fail after an upstream auth rejection.
+                # Re-read because the owned refresh task (or a peer) may have
+                # updated a different ORM instance. Never clear its warning.
+                latest = await self._repo.get_by_id_fresh(account.id)
+                if (
+                    latest is None
+                    or latest.status != AccountStatus.REAUTH_REQUIRED
+                    or latest.deactivation_reason != PERMANENT_FAILURE_CODES[exc.code]
+                ):
+                    raise
+                expires_at = account_access_token_expires_at(latest, self._encryptor)
+                if expires_at is None or expires_at <= time.time():
+                    raise
+                account = _adopt_account_row(account, latest)
         return await self._ensure_chatgpt_account_id(account)
 
     async def _run_refresh(self, account: Account) -> Account:

--- a/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/context.md
+++ b/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/context.md
@@ -1,0 +1,45 @@
+## Context and limits
+
+An OAuth refresh failure and an access-token rejection are distinct events.
+Existing upstream routing already permits warning-state accounts to serve
+ordinary requests until known access-token expiry. This change closes the
+first-request preflight gap without changing that policy or hiding the warning.
+
+For example, a stale imported credential can have a future access-token expiry
+while its refresh token returns `refresh_token_invalidated`. The first native
+Responses request should reach upstream with the stored access token, just as
+the next request would once it observes `reauth_required`.
+
+The recovery belongs outside the shared refresh task: an ordinary caller and
+a forced-refresh caller may share the same exchange but must not share a
+successful fallback. The forced caller may have already observed an upstream
+401, so its error must remain an error. The fresh database read also avoids
+depending on mutations to another caller's ORM snapshot.
+
+The persisted warning must match the refresh error's canonical reason. The
+terminal-status guard can synthesize a refresh error for an already-invalidated
+session; checking the stored reason prevents that synthesized error from
+accidentally authorizing this narrower preflight recovery.
+
+Only explicit refresh-credential failures qualify: `refresh_token_expired`,
+`refresh_token_reused`, `refresh_token_invalidated`, `invalid_refresh_token`,
+and `invalid_grant`. Session/account invalidation and transport or persistence
+failures retain their existing handling. No extra usage or model probe is sent.
+The actual upstream request remains the authority on token acceptance; a JWT
+expiry is only a local pre-dispatch check, not proof of authentication.
+
+This does not establish that Advanced Account Security caused the reported
+refresh rejection, nor that any particular previously rejected credential
+remained valid. It cannot prevent reauthentication when OpenAI actually expires
+or revokes the access token.
+
+## Verification
+
+- The native Responses regression failed on the unmodified base with
+  `response.failed` before dispatch and passes with this change.
+- The affected auth, guardian, refresh-claim, balancer and Responses suites
+  passed: 578 passed, 3 pre-existing skips.
+- Repository lint, formatting, type, architecture and cancellation checks passed.
+- Strict change validation and ordinary all-spec validation passed (58 specs).
+  Global strict validation reports existing placeholder-purpose warnings in
+  unrelated capabilities; they are not changed by this patch.

--- a/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/proposal.md
+++ b/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Issue #1919 reports repeated reauthentication with Advanced Account Security.
+The merged `keep-reauth-required-access-routable` change already preserves
+access-token routing after a refresh warning. However, the ordinary request
+that first discovers a permanent refresh-credential failure still raises from
+its freshness preflight before trying the stored access token. A single-account
+or owner-bound request can fail even though its access token remains usable.
+
+## What Changes
+
+- Let an ordinary, non-forced freshness preflight continue on the same account
+  after a refresh-credential-only failure when the freshly persisted row is
+  `reauth_required` and its access token has a known future expiry.
+- Keep the refresh warning and credentials unchanged; upstream still validates
+  the actual request. Forced refresh after an upstream rejection still fails.
+- Preserve singleflight, cross-replica claims, guarded writes, and cancellation.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Separate the caller's preflight recovery from the
+  shared refresh result and constrain when a stored access token may be tried.
+
+## Impact
+
+Backend authentication preflight and regression tests only. No new setting,
+network probe, dependency, schema, migration, or installation step. This is a
+partial mitigation for #1919, not a way to extend or override OpenAI sessions.

--- a/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Ordinary refresh preflight may retain an unexpired access token
+
+When an ordinary non-forced freshness preflight for an active account receives
+a permanent refresh-credential-only error, it MUST re-read the persisted account
+before recovering. It MAY continue the same request using that row's stored
+access token only when the row is `reauth_required` and the access token has a
+known expiry strictly in the future. The persisted warning MUST match the
+refresh error's canonical reason; a synthesized terminal-status error MUST NOT
+mask a different session-invalidated warning. The supported refresh-only errors MUST be
+`refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`,
+`invalid_refresh_token`, and `invalid_grant`.
+
+Recovery MUST NOT clear the refresh warning, rewrite credentials or
+`last_refresh`, make an additional upstream probe, or change account ownership.
+The upstream resource request MUST still authenticate the token normally.
+Forced refresh callers MUST retain the failed refresh result, including when
+they share an exchange with a recovering ordinary caller. Transient failures,
+unknown or elapsed expiry, missing accounts, paused/deactivated state, and
+session/account invalidation MUST NOT qualify for this recovery.
+
+#### Scenario: First request uses the remaining access-token lifetime
+
+- **GIVEN** an active account with stale refresh metadata and an unexpired access token
+- **WHEN** ordinary Responses preflight receives `refresh_token_invalidated`
+- **THEN** the guarded refresh failure persists `reauth_required`
+- **AND** that same request may reach upstream with the stored access token
+- **AND** a successful upstream response is returned without changing credentials
+
+#### Scenario: Forced and ordinary callers share only the refresh result
+
+- **GIVEN** ordinary and forced callers sharing one failing refresh exchange
+- **WHEN** the ordinary caller can retain an unexpired stored access token
+- **THEN** only the ordinary caller recovers
+- **AND** the forced caller still receives the permanent refresh failure
+
+#### Scenario: No usable stored access token
+
+- **WHEN** the fresh row is absent, not `reauth_required`, or has unknown or elapsed access-token expiry
+- **THEN** the ordinary preflight propagates its original refresh failure
+
+#### Scenario: Authentication rejection remains authoritative
+
+- **WHEN** the resource endpoint rejects the retained access token
+- **THEN** forced refresh recovery MUST NOT return that token as a successful refresh
+- **AND** the existing authentication failure or safe failover path applies
+
+#### Scenario: Non-refresh-credential failures do not qualify
+
+- **WHEN** refresh fails transiently or reports account/session invalidation
+- **THEN** the preflight propagates the failure without access-token recovery

--- a/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/tasks.md
+++ b/openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/tasks.md
@@ -1,0 +1,18 @@
+## 1. Reproduction
+
+- [x] 1.1 Reproduce a native Responses request failing before dispatch when only
+  its refresh credential is rejected and its access token remains unexpired.
+
+## 2. Implementation
+
+- [x] 2.1 Add caller-local, non-forced preflight recovery using fresh persisted
+  state and the existing access-token expiry helper.
+- [x] 2.2 Keep forced failures, expired/unknown-expiry tokens, deactivation,
+  session invalidation, and transient errors outside the recovery path.
+
+## 3. Verification
+
+- [x] 3.1 Cover the Responses route, shared ordinary/forced refresh callers,
+  persisted credential preservation, and rejection boundaries.
+- [x] 3.2 Run relevant auth/proxy tests, lint, type and strict change validation.
+- [x] 3.3 Sync the verified requirement and archive the change.

--- a/openspec/specs/usage-refresh-policy/context.md
+++ b/openspec/specs/usage-refresh-policy/context.md
@@ -24,6 +24,17 @@ account locally; it does not globally de-route it or move owner-bound continuity
 to another account. At known expiry, selection and bridge reuse reject the
 account before upstream I/O.
 
+An ordinary freshness preflight can also discover the refresh warning itself.
+For an explicit refresh-credential-only error, it re-reads the persisted warning
+and known access-token expiry and may try the same upstream request using the
+remaining access-token lifetime. For example, a stale imported credential with
+an unexpired access token need not lose its first Responses request merely
+because the refresh token is invalidated. This recovery is caller-local:
+forced refresh after an upstream rejection still fails, even if it shared the
+exchange with an ordinary caller. Session invalidation, unknown/elapsed expiry,
+and transient failures do not qualify. No extra probe or quota-consuming warmup
+is made; the resource endpoint still decides whether the access token is valid.
+
 ## Upstream Usage Source
 
 codex-lb refreshes account usage by calling:

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 Define how background usage refresh reacts to auth-like failures without permanently hammering bad accounts.
+
 ## Requirements
+
 ### Requirement: Usage refresh cools down repeated auth-like failures
 
 Background usage refresh MUST apply a cooldown to accounts that repeatedly fail usage refresh with ambiguous `401` or `403` responses. Accounts in that cooldown window MUST be skipped until the cooldown expires or a later successful refresh clears it.
@@ -1644,3 +1646,53 @@ Auth Guardian MUST preserve stable account identities while its candidate-query 
 - **THEN** Auth Guardian refreshes the selected account without a detached-instance failure
 - **AND** the refresh worker re-reads the account in its own session before refreshing it
 
+### Requirement: Ordinary refresh preflight may retain an unexpired access token
+
+When an ordinary non-forced freshness preflight for an active account receives
+a permanent refresh-credential-only error, it MUST re-read the persisted account
+before recovering. It MAY continue the same request using that row's stored
+access token only when the row is `reauth_required` and the access token has a
+known expiry strictly in the future. The persisted warning MUST match the
+refresh error's canonical reason; a synthesized terminal-status error MUST NOT
+mask a different session-invalidated warning. The supported refresh-only errors MUST be
+`refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`,
+`invalid_refresh_token`, and `invalid_grant`.
+
+Recovery MUST NOT clear the refresh warning, rewrite credentials or
+`last_refresh`, make an additional upstream probe, or change account ownership.
+The upstream resource request MUST still authenticate the token normally.
+Forced refresh callers MUST retain the failed refresh result, including when
+they share an exchange with a recovering ordinary caller. Transient failures,
+unknown or elapsed expiry, missing accounts, paused/deactivated state, and
+session/account invalidation MUST NOT qualify for this recovery.
+
+#### Scenario: First request uses the remaining access-token lifetime
+
+- **GIVEN** an active account with stale refresh metadata and an unexpired access token
+- **WHEN** ordinary Responses preflight receives `refresh_token_invalidated`
+- **THEN** the guarded refresh failure persists `reauth_required`
+- **AND** that same request may reach upstream with the stored access token
+- **AND** a successful upstream response is returned without changing credentials
+
+#### Scenario: Forced and ordinary callers share only the refresh result
+
+- **GIVEN** ordinary and forced callers sharing one failing refresh exchange
+- **WHEN** the ordinary caller can retain an unexpired stored access token
+- **THEN** only the ordinary caller recovers
+- **AND** the forced caller still receives the permanent refresh failure
+
+#### Scenario: No usable stored access token
+
+- **WHEN** the fresh row is absent, not `reauth_required`, or has unknown or elapsed access-token expiry
+- **THEN** the ordinary preflight propagates its original refresh failure
+
+#### Scenario: Authentication rejection remains authoritative
+
+- **WHEN** the resource endpoint rejects the retained access token
+- **THEN** forced refresh recovery MUST NOT return that token as a successful refresh
+- **AND** the existing authentication failure or safe failover path applies
+
+#### Scenario: Non-refresh-credential failures do not qualify
+
+- **WHEN** refresh fails transiently or reports account/session invalidation
+- **THEN** the preflight propagates the failure without access-token recovery

--- a/tests/integration/test_auth_preflight.py
+++ b/tests/integration/test_auth_preflight.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+
+import pytest
+
+from app.core.auth.refresh import RefreshError, TokenRefreshResult
+from app.core.balancer import PERMANENT_FAILURE_CODES
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal
+from app.modules.accounts import auth_manager as auth_manager_module
+from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.repository import AccountsRepository
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def clear_refresh_state() -> None:
+    auth_manager_module._clear_refresh_singleflight_state()
+
+
+@asynccontextmanager
+async def _repo_scope() -> AsyncIterator[AccountsRepository]:
+    async with SessionLocal() as session:
+        yield AccountsRepository(session)
+
+
+async def _create_stale_account(*, access_token: str | None = None) -> Account:
+    if access_token is None:
+        payload = json.dumps({"exp": int(time.time()) + 3600}).encode()
+        access_token = f"header.{base64.urlsafe_b64encode(payload).rstrip(b'=').decode()}.sig"
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        account = Account(
+            id="preflight-account",
+            chatgpt_account_id="preflight-workspace",
+            email="preflight@example.com",
+            plan_type="plus",
+            status=AccountStatus.ACTIVE,
+            access_token_encrypted=encryptor.encrypt(access_token),
+            refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+            id_token_encrypted=encryptor.encrypt("id-old"),
+            last_refresh=utcnow() - timedelta(days=9),
+        )
+        session.add(account)
+        await session.commit()
+        return account
+
+
+@pytest.mark.asyncio
+async def test_stale_preflight_does_not_recover_a_peer_session_invalidation(db_setup):
+    snapshot = await _create_stale_account()
+    async with _repo_scope() as peer:
+        await peer.update_status(
+            snapshot.id, AccountStatus.REAUTH_REQUIRED, PERMANENT_FAILURE_CODES["app_session_terminated"]
+        )
+
+    async with _repo_scope() as repo:
+        manager = AuthManager(repo, refresh_repo_factory=_repo_scope)
+        with pytest.raises(RefreshError):
+            await manager.ensure_fresh(snapshot)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("access_token", ["opaque-token", "header.e30.sig", "header.eyJleHAiOjF9.sig"])
+async def test_preflight_does_not_recover_unknown_or_expired_access(db_setup, monkeypatch, access_token):
+    snapshot = await _create_stale_account(access_token=access_token)
+    failure = RefreshError("refresh_token_invalidated", "Refresh token revoked", True)
+
+    async def reject_refresh(_token: str, **_kwargs: object) -> TokenRefreshResult:
+        raise failure
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", reject_refresh)
+    async with _repo_scope() as repo:
+        with pytest.raises(RefreshError) as raised:
+            await AuthManager(repo, refresh_repo_factory=_repo_scope).ensure_fresh(snapshot)
+        assert raised.value is failure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("code", "permanent", "recovers"),
+    [
+        ("refresh_token_expired", True, True),
+        ("refresh_token_reused", True, True),
+        ("refresh_token_invalidated", True, True),
+        ("invalid_refresh_token", True, True),
+        ("invalid_grant", True, True),
+        ("refresh_token_invalidated", False, False),
+        ("transport_error", False, False),
+        ("status_downgrade_conflict", False, False),
+        ("token_invalidated", True, False),
+        ("token_expired", True, False),
+        ("app_session_terminated", True, False),
+        ("account_session_expired", True, False),
+        ("account_auth_invalidated", True, False),
+        ("account_deactivated", True, False),
+        ("account_suspended", True, False),
+        ("account_deleted", True, False),
+    ],
+)
+async def test_preflight_recovers_only_refresh_credential_failures(db_setup, monkeypatch, code, permanent, recovers):
+    snapshot = await _create_stale_account()
+    failure = RefreshError(code, "Upstream refresh failure", permanent)
+
+    async def reject_refresh(_token: str, **_kwargs: object) -> TokenRefreshResult:
+        raise failure
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", reject_refresh)
+    async with _repo_scope() as repo:
+        manager = AuthManager(repo, refresh_repo_factory=_repo_scope)
+        if recovers:
+            result = await manager.ensure_fresh(snapshot)
+            assert result.status == AccountStatus.REAUTH_REQUIRED
+            assert result.deactivation_reason == PERMANENT_FAILURE_CODES[code]
+        else:
+            with pytest.raises(RefreshError) as raised:
+                await manager.ensure_fresh(snapshot)
+            assert raised.value is failure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("force_first", [False, True])
+async def test_shared_refresh_failure_recovers_only_the_ordinary_caller(db_setup, monkeypatch, force_first):
+    snapshot = await _create_stale_account()
+    started = asyncio.Event()
+    second_entered = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+
+    async def reject_refresh(_token: str, **_kwargs: object) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        raise RefreshError("refresh_token_invalidated", "Refresh token revoked", True)
+
+    async def call(*, force: bool, second: bool) -> Account:
+        async with _repo_scope() as repo:
+            account = await repo.get_by_id(snapshot.id)
+            assert account is not None
+            if second:
+                second_entered.set()
+            return await AuthManager(repo, refresh_repo_factory=_repo_scope).ensure_fresh(account, force=force)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", reject_refresh)
+    first = asyncio.create_task(call(force=force_first, second=False))
+    second: asyncio.Task[Account] | None = None
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5)
+        second = asyncio.create_task(call(force=not force_first, second=True))
+        await asyncio.wait_for(second_entered.wait(), timeout=5)
+    finally:
+        release.set()
+        tasks = [first] if second is None else [first, second]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    ordinary, forced = (results[1], results[0]) if force_first else (results[0], results[1])
+    assert isinstance(ordinary, Account)
+    assert ordinary.status == AccountStatus.REAUTH_REQUIRED
+    assert isinstance(forced, RefreshError)
+    assert forced.code == "refresh_token_invalidated"
+    assert forced.is_permanent
+    assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [AccountStatus.PAUSED, AccountStatus.DEACTIVATED])
+async def test_non_active_preflight_does_not_recover(db_setup, monkeypatch, status):
+    snapshot = await _create_stale_account()
+    async with _repo_scope() as repo:
+        await repo.update_status(snapshot.id, status)
+        snapshot.status = status
+
+        async def reject_refresh(_token: str, **_kwargs: object) -> TokenRefreshResult:
+            raise RefreshError("refresh_token_invalidated", "Refresh token revoked", True)
+
+        monkeypatch.setattr(auth_manager_module, "refresh_access_token", reject_refresh)
+        with pytest.raises(RefreshError):
+            await AuthManager(repo, refresh_repo_factory=_repo_scope).ensure_fresh(snapshot)

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import time
 from collections.abc import AsyncIterator, Mapping
+from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
 
@@ -15,13 +17,16 @@ import app.core.clients.proxy as proxy_client_module
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
+from app.core.auth.refresh import RefreshError, TokenRefreshResult
 from app.core.config.settings import Settings
+from app.core.crypto import TokenEncryptor
 from app.core.openai.models import CompactResponsePayload
 from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.time import utcnow
-from app.db.models import Account, DashboardSettings, RequestLog, StickySessionKind
+from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog, StickySessionKind
 from app.db.session import SessionLocal
+from app.modules.accounts import auth_manager as auth_manager_module
 from app.modules.api_keys.service import ApiKeyUsageReservationData
 from app.modules.proxy._service.streaming import retry as streaming_retry_module
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -614,6 +619,72 @@ async def test_backend_responses_preserves_non_message_developer_directive(async
         developer_directive,
         {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.parametrize("access_accepted", [True, False], ids=["access-accepted", "access-rejected"])
+async def test_responses_preflight_retains_unexpired_access_after_refresh_failure(
+    async_client, monkeypatch, path, access_accepted
+):
+    auth_manager_module._clear_refresh_singleflight_state()
+    raw_account_id = "acc_preflight_refresh_invalidated"
+    auth_json = _make_auth_json(raw_account_id, "preflight-refresh@example.com")
+    access_token = _encode_jwt({"exp": int(time.time()) + 3600})
+    auth_json["tokens"]["accessToken"] = access_token
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    async with SessionLocal() as session:
+        account = (await session.execute(select(Account))).scalars().one()
+        account.last_refresh = utcnow() - timedelta(days=9)
+        before = (account.access_token_encrypted, account.refresh_token_encrypted, account.last_refresh)
+        await session.commit()
+
+    refresh_calls = 0
+    dispatched_tokens: list[str] = []
+
+    async def reject_refresh(_token: str, **_kwargs: object) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        raise RefreshError("refresh_token_invalidated", "Refresh token was revoked", True)
+
+    async def accept_access(payload, headers, access_token, account_id, **kwargs):
+        del payload, headers, kwargs
+        assert account_id == raw_account_id
+        dispatched_tokens.append(access_token)
+        if not access_accepted:
+            raise proxy_module.ProxyResponseError(
+                401, {"error": {"code": "invalid_api_key", "message": "Access token rejected"}}
+            )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_retained_access",'
+            '"object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", reject_refresh)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", accept_access)
+
+    response = await async_client.post(
+        path,
+        json={"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True},
+    )
+
+    assert response.status_code == 200
+    assert refresh_calls == 1
+    event = _extract_first_event(response.text.splitlines())
+    assert event["type"] == ("response.completed" if access_accepted else "response.failed")
+    assert dispatched_tokens == [access_token]
+    async with SessionLocal() as session:
+        account = (await session.execute(select(Account))).scalars().one()
+        assert account.status == AccountStatus.REAUTH_REQUIRED
+        assert account.deactivation_reason is not None
+        assert "re-login required" in account.deactivation_reason
+        assert (account.access_token_encrypted, account.refresh_token_encrypted, account.last_refresh) == before
+        assert TokenEncryptor().decrypt(account.access_token_encrypted) == access_token
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Preserve the current ordinary request when a freshness preflight discovers a
permanently invalid refresh credential but the persisted access token remains
unexpired. The actual upstream request still authenticates that token normally.

Refs #1919 — partial mitigation, not a claim to override Advanced Account
Security session expiry or eliminate all daily reauthentication. Builds on the
already-merged #1877; that change preserves subsequent request routing, while
this fixes the first request that discovers the refresh failure. The new
Responses regression fails on the unmodified current base before dispatch.

## Type of change

- [x] `fix:` — bug fix

## OpenSpec

- [x] Includes a verified, archived OpenSpec change and synchronized main spec.
- [x] Preserves upstream request/response and OAuth wire formats.

Change: `openspec/changes/archive/2026-09-06-preserve-access-on-refresh-preflight/`

## Changes

- Recover only an ordinary active-account preflight, never forced refresh.
- Require an explicit refresh-credential-only failure, fresh `reauth_required`
  row, matching canonical warning, and known future access-token expiry.
- Keep credentials, refresh timestamp and warning unchanged. No new probe.
- Keep recovery outside shared refresh work so forced callers still fail.
- Regression coverage includes native/OpenAI Responses paths, actual access
  rejection, expired/unknown tokens, account/session invalidation, and both
  ordinary-first and forced-first concurrent callers with real database sessions.

## Simplicity

- [x] Zero configuration; no new setting, dependency, schema or migration.
- [x] No required setup, README, dashboard layout or navigation changes.

## Test plan

```text
uv run pytest tests/unit/test_auth_manager.py tests/unit/test_auth_guardian.py tests/unit/test_auth_refresh.py tests/unit/test_auth.py tests/unit/test_proxy_load_balancer_refresh.py tests/unit/test_load_balancer.py tests/integration/test_token_refresh_claims.py tests/integration/test_auth_preflight.py tests/integration/test_proxy_responses.py tests/integration/test_auth_guardian_multi_replica.py -q --tb=short --show-capture=no --timeout=60
578 passed, 3 pre-existing skips

make lint
uv run ty check
git diff --check
passed (including architecture and cancellation checks)

npx --yes @fission-ai/openspec@1.11.0 validate preserve-access-on-refresh-preflight --strict
passed before archiving

npx --yes @fission-ai/openspec@1.11.0 validate --specs
58 passed
```

Global `validate --specs --strict` reports pre-existing placeholder-purpose
warnings in unrelated capabilities; the changed usage-refresh capability and
change validate strictly. The affected suites above were run, not the full
multi-platform/container CI matrix. No live account credentials or requests
were used in these tests, and no running installation was changed.

## Behavioral output

```text
Before: stale ACTIVE -> refresh_token_invalidated -> response.failed (no dispatch)
After:  stale ACTIVE -> same persisted warning -> stored access token -> response.completed
        (only when the upstream resource endpoint accepts the token)
Unchanged: actual access rejection -> failed forced refresh / existing failover
```

## Checklist

- [x] Conventional Commits title; linked related issue without overstating scope.
- [x] Regression reproduced before implementation; tests added.
- [x] Relevant local CI subsets, type checks, strict change and all-spec checks run.
- [x] Simplicity gates reviewed; CHANGELOG left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests can continue using an unexpired access token when refresh credentials fail permanently, reducing unnecessary first-request failures.
  - Accounts are marked as requiring reauthentication while preserving the existing access and refresh credentials.
  - Forced refreshes, expired or unavailable access tokens, transient errors, and upstream authentication rejections continue to fail as expected.
  - Added coverage for Responses endpoints and concurrent refresh scenarios to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->