### PR TITLE
fix(proxy): recover tool-complete goal followups from unavailable owners

### DIFF
--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -422,6 +422,16 @@ def responses_input_suffix_matches_pending_tool_calls(
         and _fresh_developer_interleave_is_bounded(suffix, index=1)
     ):
         suffix = [suffix[0], suffix[2]]
+    # A goal restart or steer can append user input after a fully settled
+    # prior-response tool batch. Prove that batch independently: new input
+    # must not stand in for a missing parallel call or interrupt its results.
+    first_followup = next(
+        (index for index, item in enumerate(suffix) if isinstance(item, dict) and _is_fresh_followup_input(item)),
+        len(suffix),
+    )
+    if not all(isinstance(item, dict) and _is_fresh_followup_input(item) for item in suffix[first_followup:]):
+        return False
+    suffix = suffix[:first_followup]
     if not all(
         isinstance(item, dict)
         and isinstance(item.get("type"), str)
@@ -612,7 +622,7 @@ def _is_retained_response_message(item: Mapping[str, JsonValue]) -> bool:
 
 def _is_fresh_followup_input(item: Mapping[str, JsonValue]) -> bool:
     item_type = item.get("type")
-    if item_type in {"input_file", "input_image", "input_text"}:
+    if item_type in ("input_file", "input_image", "input_text"):
         return _input_content_part_is_self_contained(item, allow_output=False)
     return (
         item_type in (None, "message")

--- a/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/proposal.md
+++ b/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+A client can resend a complete response's tool calls and matching results, then
+append a user instruction when continuing a stopped goal. The durable pending
+call manifest proves that no parallel call was omitted, but the existing proof
+rejects every user follow-up after that complete batch. The HTTP bridge can then
+inject its old response anchor and fail on an unavailable owner, despite having
+a replayable full request. This is a bounded part of issue #1707, not a claim
+that opaque compaction checkpoints can move between accounts.
+
+## What Changes
+
+- Accept a trailing self-contained user-input suffix after exact settlement of
+  the durable prior-response tool manifest.
+- Keep all retained calls, results, and fresh input in the replay body.
+- Preserve existing durable-prefix, account-neutrality, file ownership, account
+  scope, and pre-dispatch recovery checks.
+- Preserve the tighter existing developer-interleave contract; this change does
+  not combine that exception with a new trailing input suffix.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: full-resend context proof after a complete tool batch.
+
+## Impact
+
+One replay-proof helper and focused helper/HTTP-bridge regression tests. No new
+settings, schema, migrations, or dashboard changes. No production deployment.
+

--- a/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/specs/responses-api-compat/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Exact tool-manifest replay preserves fresh user follow-up
+
+When a fingerprint-verified durable input prefix is followed by every call and
+matching output in the durable prior-response pending-tool manifest, the
+full-resend context proof SHALL permit trailing self-contained user input after
+that complete batch. The proof MUST require exact call IDs and call types,
+complete settlement, no duplicate or orphan result, and no call-ID collision
+with the stored prefix. It MUST reject user input interleaved with the batch or
+any later call, output, or instruction-role message after the fresh-input suffix
+begins. The existing bounded developer-interleave exception MUST NOT gain a
+trailing-input extension.
+
+Account switching MUST still require the complete projected request to pass
+account-neutral replay classification, the durable prefix to match, and the
+existing pre-dispatch recovery and account-scope checks. A qualifying replay
+MUST retain the complete calls, outputs, and fresh input. This proof MUST NOT
+authorize transferring encrypted compaction, account-owned files, conversation
+references, or an unverified input prefix.
+
+#### Scenario: Goal follow-up after completed tool batch can leave exhausted owner
+
+- **GIVEN** the input contains a verified stored prefix and exactly settles its durable pending-tool manifest
+- **AND** a self-contained goal-continuation user message follows the complete tool batch
+- **WHEN** the previous owner is unavailable before dispatch and the complete projected body is account-neutral
+- **THEN** the bridge can use its existing fresh replay path on another eligible account
+- **AND** it retains the calls, results, and goal instruction without the old response anchor
+
+#### Scenario: Fresh input does not conceal a missing parallel result
+
+- **GIVEN** a durable manifest contains multiple calls
+- **WHEN** a resend appends user input after only part of the recorded batch
+- **THEN** context proof fails and cross-account replay remains forbidden
+
+#### Scenario: New input does not relax developer-interleave bounds
+
+- **GIVEN** a suffix uses the existing three-item custom-call/developer/output exception
+- **WHEN** additional user input follows that suffix
+- **THEN** this exception remains ineligible for exact-manifest proof
+

--- a/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/tasks.md
+++ b/openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/tasks.md
@@ -1,0 +1,11 @@
+## 1. Regression and implementation
+
+- [x] Reproduce rejection of a complete tool batch followed by fresh user input.
+- [x] Extend exact-manifest proof without weakening incomplete/tool-owner fences.
+- [x] Verify HTTP bridge recovery away from paused and quota-exhausted owners and preserve input.
+- [x] Cover altered manifests, partial batches, interleaving, files, and opaque state.
+
+## 2. Verification and publication
+
+- [x] Run affected replay, bridge, and transport tests, lint, types, and OpenSpec validation.
+- [x] Sync the specification and archive the verified change.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Define Responses API compatibility contracts so Codex, OpenCode, and OpenAI-style clients preserve expected behavior.
+
 ## Requirements
+
 ### Requirement: Use prompt_cache_key as OpenAI cache affinity
 For OpenAI-style `/v1/responses`, `/v1/responses/compact`, and chat-completions requests mapped onto Responses, the service MUST treat a non-empty `prompt_cache_key` as the bounded upstream account affinity key for prompt-cache correctness even when a `session_id` header is present. OpenAI-style route wiring MUST NOT upgrade those requests to durable `CODEX_SESSION` affinity by default. This affinity MUST apply even when dashboard `sticky_threads_enabled` is disabled, the service MUST continue forwarding the same `prompt_cache_key` upstream unchanged, and the stored affinity MUST expire after the configured freshness window so older keys can rebalance. The freshness window MUST come from dashboard settings so operators can adjust it without restart.
 
@@ -5536,6 +5538,7 @@ captured when the connection began.
 - **GIVEN** `prohibitFastMode` is enabled
 - **WHEN** an internal owner-forwarded payload carries a priority service tier
 - **THEN** the receiving preparation boundary omits `service_tier` before upstream forwarding
+
 ### Requirement: Native direct HTTP egress preserves Responses streaming semantics
 
 Direct Responses HTTP/SSE requests sent through native egress MUST preserve the existing normalized upstream payload and headers, rate-limit header ingestion, maximum SSE event size, idle and total request deadlines, terminal-event requirements, downstream event normalization, archives, and error envelope behavior. Downstream cancellation MUST cancel and await only the owned native request task, unregister its event stream, and leave unrelated multiplexed requests usable. Native transport selection MUST NOT change the public HTTP status or SSE framing contract.
@@ -5731,3 +5734,42 @@ rule. A missing or invalid value MUST remain absent.
 - **WHEN** an upstream retry hint contains a line break or exceeds the bounded
   field length
 - **THEN** codex-lb does not copy that value downstream
+
+### Requirement: Exact tool-manifest replay preserves fresh user follow-up
+
+When a fingerprint-verified durable input prefix is followed by every call and
+matching output in the durable prior-response pending-tool manifest, the
+full-resend context proof SHALL permit trailing self-contained user input after
+that complete batch. The proof MUST require exact call IDs and call types,
+complete settlement, no duplicate or orphan result, and no call-ID collision
+with the stored prefix. It MUST reject user input interleaved with the batch or
+any later call, output, or instruction-role message after the fresh-input suffix
+begins. The existing bounded developer-interleave exception MUST NOT gain a
+trailing-input extension.
+
+Account switching MUST still require the complete projected request to pass
+account-neutral replay classification, the durable prefix to match, and the
+existing pre-dispatch recovery and account-scope checks. A qualifying replay
+MUST retain the complete calls, outputs, and fresh input. This proof MUST NOT
+authorize transferring encrypted compaction, account-owned files, conversation
+references, or an unverified input prefix.
+
+#### Scenario: Goal follow-up after completed tool batch can leave exhausted owner
+
+- **GIVEN** the input contains a verified stored prefix and exactly settles its durable pending-tool manifest
+- **AND** a self-contained goal-continuation user message follows the complete tool batch
+- **WHEN** the previous owner is unavailable before dispatch and the complete projected body is account-neutral
+- **THEN** the bridge can use its existing fresh replay path on another eligible account
+- **AND** it retains the calls, results, and goal instruction without the old response anchor
+
+#### Scenario: Fresh input does not conceal a missing parallel result
+
+- **GIVEN** a durable manifest contains multiple calls
+- **WHEN** a resend appends user input after only part of the recorded batch
+- **THEN** context proof fails and cross-account replay remains forbidden
+
+#### Scenario: New input does not relax developer-interleave bounds
+
+- **GIVEN** a suffix uses the existing three-item custom-call/developer/output exception
+- **WHEN** additional user input follows that suffix
+- **THEN** this exception remains ineligible for exact-manifest proof

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8986,6 +8986,107 @@ async def test_backend_responses_http_bridge_real_selector_recovers_full_resend_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.parametrize("owner_status", [AccountStatus.PAUSED, AccountStatus.QUOTA_EXCEEDED])
+@pytest.mark.parametrize("owned_file", [False, True], ids=["account-neutral", "file-pinned"])
+async def test_http_bridge_goal_followup_after_complete_tool_batch_leaves_unavailable_owner(
+    async_client, app_instance, monkeypatch, path, owner_status, owned_file
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    owner_id = await _import_account(async_client, "acc_goal_tool_owner", "goal-tool-owner@example.com")
+    owner = await _get_account(owner_id)
+    owner_upstream = _ClosingInterruptedCustomToolUpstreamWebSocket()
+    replacement_upstream = _FakeBridgeUpstreamWebSocket("resp_goal_replacement")
+    connected = []
+
+    async def ensure_fresh(self, account, *, force=False, timeout_seconds):
+        return account
+
+    async def connect(headers, access_token, account_id_header, *, base_url=None, session=None):
+        connected.append(account_id_header)
+        return owner_upstream if account_id_header == owner.chatgpt_account_id else replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", connect)
+    session_id = "goal-tool-followup-session"
+    history = [{"role": "user", "content": [{"type": "input_text", "text": "Inspect the workspace"}]}]
+    body = {"model": "gpt-5.1", "instructions": "Continue the diagnostic", "input": history, "stream": True}
+    first = await _collect_sse_events(async_client, path, json_body=body, headers={"session_id": session_id})
+    call = next(event["item"] for event in first if event["type"] == "response.output_item.done")
+    service = get_proxy_service_for_app(app_instance)
+    lookup = await service._durable_bridge.lookup_request_targets(
+        session_key_kind="session_header",
+        session_key_value=session_id,
+        api_key_id=None,
+        turn_state=None,
+        session_header=session_id,
+        previous_response_id=None,
+    )
+    assert lookup is not None
+    assert lookup.latest_pending_tool_calls == {call["call_id"]: "custom_tool_call"}
+
+    replacement_id = await _import_account(
+        async_client, "acc_goal_tool_replacement", "goal-tool-replacement@example.com"
+    )
+    replacement = await _get_account(replacement_id)
+    async with SessionLocal() as session:
+        await session.execute(update(Account).where(Account.id == owner_id).values(status=owner_status))
+        await session.commit()
+    full_resend = [
+        *history,
+        call,
+        {"type": "custom_tool_call_output", "call_id": call["call_id"], "output": "/workspace"},
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": '<codex_internal_context source="goal">Continue the goal.</codex_internal_context>',
+                }
+            ],
+        },
+    ]
+    if owned_file:
+        await service._pin_file_account("file_goal_owner", owner_id)
+        fresh_content = full_resend[-1]["content"]
+        assert isinstance(fresh_content, list)
+        fresh_content.append({"type": "input_file", "file_id": "file_goal_owner"})
+        rejected = await async_client.post(
+            path, json={**body, "input": full_resend}, headers={"session_id": session_id}
+        )
+        assert rejected.status_code in (502, 503)
+        assert connected == [owner.chatgpt_account_id]
+        assert not replacement_upstream.sent_text
+        return
+    second = await _collect_sse_events(
+        async_client,
+        path,
+        json_body={**body, "input": full_resend},
+        headers={"session_id": session_id},
+    )
+    assert second[-1]["response"]["id"] == "resp_goal_replacement_1"
+    assert connected == [owner.chatgpt_account_id, replacement.chatgpt_account_id]
+    assert len(owner_upstream.sent_text) == 1
+    assert len(replacement_upstream.sent_text) == 1
+    replay = json.loads(replacement_upstream.sent_text[0])
+    assert "previous_response_id" not in replay
+    assert replay["input"] == [{k: v for k, v in item.items() if k != "id"} for item in full_resend]
+    third = await _collect_sse_events(
+        async_client,
+        path,
+        json_body={
+            **body,
+            "input": [{"role": "user", "content": "Continue on the replacement"}],
+            "previous_response_id": second[-1]["response"]["id"],
+        },
+        headers={"session_id": session_id},
+    )
+    assert third[-1]["response"]["id"] == "resp_goal_replacement_2"
+    assert connected == [owner.chatgpt_account_id, replacement.chatgpt_account_id]
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_declines_cross_account_anchor_and_settles(
     async_client, app_instance, monkeypatch
 ):

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -715,6 +715,95 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
     )
 
 
+def test_full_resend_tool_manifest_accepts_goal_followup_after_all_results() -> None:
+    stored_input: list[JsonValue] = [{"role": "user", "content": "Inspect the workspace"}]
+    suffix: list[JsonValue] = [
+        {"type": "function_call", "call_id": "call_inspect", "name": "inspect", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_inspect", "output": "Inspection complete"},
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": '<codex_internal_context source="goal">Continue the goal.</codex_internal_context>',
+                }
+            ],
+        },
+    ]
+
+    assert responses_input_suffix_matches_pending_tool_calls(
+        [*stored_input, *suffix],
+        stored_count=len(stored_input),
+        pending_tool_calls={"call_inspect": "function_call"},
+    )
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        "missing-call",
+        "missing-output",
+        "wrong-call-type",
+        "duplicate-output",
+        "omitted-parallel-call",
+        "leading-user",
+        "interleaved-user",
+        "later-call",
+        "later-developer",
+        "later-assistant",
+        "developer-interleave",
+        "opaque-compaction",
+        "malformed-type",
+    ],
+)
+def test_goal_followup_keeps_exact_tool_manifest_fences(changed: str) -> None:
+    stored: list[JsonValue] = [{"role": "user", "content": "Inspect"}]
+    call: dict[str, JsonValue] = {"type": "custom_tool_call", "call_id": "call_1", "name": "shell", "input": "pwd"}
+    output: dict[str, JsonValue] = {"type": "custom_tool_call_output", "call_id": "call_1", "output": "/workspace"}
+    followup: dict[str, JsonValue] = {"role": "user", "content": [{"type": "input_text", "text": "Continue"}]}
+    developer: dict[str, JsonValue] = {
+        "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": "Follow the current task"}],
+        "internal_chat_message_metadata_passthrough": {"turn_id": "turn_current"},
+    }
+    suffix: list[JsonValue] = [call, output, followup]
+    manifest = {"call_1": "custom_tool_call"}
+    if changed == "missing-call":
+        suffix.remove(call)
+    elif changed == "missing-output":
+        suffix.remove(output)
+    elif changed == "wrong-call-type":
+        manifest["call_1"] = "function_call"
+    elif changed == "duplicate-output":
+        suffix.insert(2, output)
+    elif changed == "omitted-parallel-call":
+        manifest["call_2"] = "custom_tool_call"
+    elif changed == "leading-user":
+        suffix.insert(0, followup)
+    elif changed == "interleaved-user":
+        suffix.insert(1, followup)
+    elif changed == "later-call":
+        suffix.append({**call, "call_id": "call_2"})
+    elif changed == "later-developer":
+        suffix.append(developer)
+    elif changed == "later-assistant":
+        suffix.append({"role": "assistant", "content": "Earlier output must precede the new instruction"})
+    elif changed == "developer-interleave":
+        suffix.insert(1, developer)
+    elif changed == "opaque-compaction":
+        suffix.append({"type": "compaction", "encrypted_content": "opaque_owner_checkpoint"})
+    elif changed == "malformed-type":
+        followup["type"] = []
+
+    assert not responses_input_suffix_matches_pending_tool_calls(
+        [*stored, *suffix],
+        stored_count=len(stored),
+        pending_tool_calls=manifest,
+    )
+
+
 def test_full_resend_tool_loop_manifest_tolerates_fresh_developer_interleave_after_historical_one() -> None:
     stored_input: list[JsonValue] = [
         {"role": "user", "content": "first question"},


### PR DESCRIPTION
## Summary

Allow a complete, durable-manifest-verified tool batch to be followed by fresh user input when proving that a full resend can recover from an unavailable response owner.

Refs #1707 — **partial fix** for replayable tool-complete goal restarts. This does not make opaque encrypted compaction checkpoints portable between accounts.

## Type of change

- [x] `fix:` — bug fix

## OpenSpec

- [x] This PR includes / updates an OpenSpec change.
- [x] This PR touches a codex-faithful path and preserves request/response payloads.

Archived change: `openspec/changes/archive/2026-09-06-recover-tool-complete-goal-followup/`

## Changes

- Prove the exact prior-response call/result batch independently of a trailing self-contained user-input suffix. The helper previously rejected that suffix even when the complete batch matched its durable pending-call manifest.
- Keep the existing complete-body projection, durable-prefix fingerprint, account-neutrality, account scope, file ownership, and pre-dispatch checks. No input is dropped by this proof helper.
- Preserve rejection of missing parallel results, duplicate or mismatched calls, interleaved user input, and later tool/developer/assistant items. The existing three-item developer-interleave exception is not broadened.
- Exercise both HTTP endpoints with the real database and account selector: paused or quota-exhausted owner, fresh replay to a replacement, then anchored continuation on that replacement. Account-owned files remain pinned and cannot use this recovery.

No settings, migrations, defaults, or dashboard changes.

## Test plan

Base: current upstream `main`, `5ad638b6a4c9c094bcc8866b1d7487173fe3b54e`.

With the production helper patch removed, the new goal-recovery regression failed on **both HTTP endpoints with 502**. With the patch, it recovers without the unavailable owner's anchor and retains the complete input.

```text
uv run pytest tests/unit/test_replay_safety.py \
  tests/unit/test_durable_bridge_sessions.py \
  tests/unit/test_durable_bridge_transcript_codec.py \
  tests/integration/test_http_responses_bridge.py \
  tests/integration/test_proxy_websocket_responses.py \
  -q --tb=short --show-capture=no --timeout=120
585 passed

# Final focused run, including added file-owner rejection cases:
uv run pytest tests/unit/test_replay_safety.py \
  tests/integration/test_http_responses_bridge.py \
  -q -k goal_followup --tb=short --show-capture=no --timeout=90
22 passed, 360 deselected

make lint
uv run ty check
openspec validate responses-api-compat --type spec --strict
openspec validate --specs
git diff --check
All passed
```

An earlier broad run with a 60-second per-test timeout timed out in the existing idle-reader replacement test; the 120-second run above passed. These are local test results, not a claim about hosted CI or production deployment.

## Example behavior

The replay input contains a verified stored prefix, the prior response's complete tool call and result, and a new goal instruction. There is no client-supplied `previous_response_id`.

- Before: context proof fails; bridge restores the old anchor and returns `previous_response_owner_unavailable` when its owner cannot serve.
- After: existing account-neutral recovery removes that anchor, forwards the full projected history to an eligible replacement, and completes. The next anchored request stays on that replacement.
- If an account-owned file or opaque encrypted checkpoint is involved, this patch does not authorize cross-account recovery.

## Checklist

- [x] Conventional Commits title and related issue linked.
- [x] Regression, integration, rejection, and continuation tests added.
- [x] Relevant lint/type/test targets run locally.
- [x] OpenSpec delta verified, synchronized, archived; specs validated.
- [x] Simplicity gates reviewed; no additional setup or configuration.
- [x] CHANGELOG not edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for continuing a conversation with a fresh user message after a completed tool-call batch.
  * Full tool-call and result history is preserved when resuming interrupted goals.

* **Bug Fixes**
  * Improved recovery when the previous account is unavailable, allowing eligible conversations to continue on a replacement account.
  * Added safeguards to reject incomplete, reordered, duplicated, or interleaved tool-call sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->