### PR TITLE
fix(http-bridge): treat usage_limit_reached as a terminal in the account capacity wait (#2123 WP-E)

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -269,6 +269,7 @@ from app.modules.proxy.replay_safety import (
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
 )
+from app.modules.proxy.selection_errors import USAGE_LIMIT_REACHED
 
 logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
@@ -605,6 +606,10 @@ def _http_bridge_error_is_ambiguous_transport(exc: ProxyResponseError) -> bool:
 def _http_bridge_account_capacity_wait_seconds(exc: ProxyResponseError) -> float | None:
     code, message = _proxy_error_code_message(exc)
     if code == "capacity_exhausted_active_sessions":
+        return None
+    if code == USAGE_LIMIT_REACHED:
+        # Pool-wide usage exhaustion is terminal: never re-derive a recovery
+        # wait from the selector's capped retry hint that accompanies it.
         return None
     if code == "response_create_gate_timeout":
         # Per-session response-create gate contention is recoverable: the

--- a/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/proposal.md
+++ b/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The `responses-api-compat` spec already requires `usage_limit_reached`
+selection failures to be terminal on the HTTP-bridge path, and bridge session
+creation does raise the structured `429` without a recovery sleep. The bridge
+streaming retry loops then re-derive a recovery wait from the error *message*:
+whenever the exhausted pool's earliest reset is known, the selector's message is
+`Rate limit exceeded. Try again in Ns` (capped at 300 s), which matches the
+account-capacity recovery-hint pattern. The loop therefore emits
+`codex.keepalive waiting_for_account_capacity` frames (or stalls silently when
+HTTP errors are propagated) and retries session creation until the bridge
+request budget (default 7200 s) is exhausted before returning the very same
+`429`. Only the no-reset-known message `Usage limit reached` is terminal today.
+
+## What Changes
+
+- `_http_bridge_account_capacity_wait_seconds` returns no wait for
+  `usage_limit_reached`, keyed on the structured error code rather than the
+  message, so every bridge session-creation and submit retry loop reports the
+  `429` immediately with `error.resets_at` intact.
+- Client-visible: HTTP-bridge clients whose pool is exhausted with a known
+  reset now receive the immediate `429 usage_limit_reached` (no `Retry-After`,
+  which stays reserved for local overload codes) instead of up to a full
+  request budget of capacity-wait keepalives followed by the same `429`.
+- Unchanged: local caps (`account_stream_cap`, `account_response_create_cap`,
+  `api_key_stream_fair_share`), `response_create_gate_timeout`, workspace
+  spend-cap and upstream `rate_limit_exceeded` hints keep waiting within the
+  bridge request budget; the post-submit `response.failed usage_limit_reached`
+  retry path is untouched. The shared `_account_selection_recovery_sleep_seconds_from_message`
+  helper is not changed, so the SSE and WebSocket paths keep their own guards.
+- No overflow or fallback routing behaviour is introduced; this is the
+  standalone D4 fix tracked under #2123.
+
+## Impact
+
+- `app/modules/proxy/_service/http_bridge/streaming.py` (helper module; no
+  architecture ceiling touched, `http_bridge/mixin.py` unchanged).
+- `responses-api-compat` requirement "Pool usage exhaustion is reported as a
+  usage-limit error" gains an explicit bridge-retry-loop scenario.

--- a/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/specs/responses-api-compat/spec.md
+++ b/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/specs/responses-api-compat/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Pool usage exhaustion is reported as a usage-limit error
+
+The proxy MUST report pool-wide Responses usage exhaustion as a usage-limit
+error. When every account eligible for a Responses request is exhausted by known
+usage windows, the proxy MUST reject the request with HTTP `429` and an
+OpenAI-style error envelope whose `error.code` and `error.type` are both
+`usage_limit_reached`. If account selection has an authoritative upstream reset
+timestamp for the exhausted pool, the response envelope MUST include that
+timestamp as `error.resets_at`; the proxy MUST NOT expose the capped
+human-facing retry hint or a synthesized fallback as `error.resets_at`. The
+proxy MUST NOT collapse this condition into generic `no_accounts`,
+`server_error`, or HTTP `503` semantics. Exhaustion classification MUST be
+based on structured account state after the same eligibility filtering as
+ordinary selection, and MUST NOT reclassify local capacity or overload codes
+(account caps, admission gates, fair-share throttles) as usage exhaustion.
+
+#### Scenario: Public Responses request exhausts the eligible usage pool
+
+- **WHEN** account selection for a public `/v1/responses` or
+  `/backend-api/codex/responses` request finds only usage-exhausted eligible
+  accounts
+- **THEN** the response status is HTTP `429`
+- **AND** the response body has `error.code = "usage_limit_reached"`
+- **AND** the response body has `error.type = "usage_limit_reached"`
+- **AND** any selected pool reset timestamp is surfaced as `error.resets_at`
+
+#### Scenario: Streaming selection failure preserves usage-limit semantics
+
+- **WHEN** a streaming Responses request cannot select an account because every
+  eligible account is usage-exhausted before downstream-visible output
+- **THEN** the terminal error event uses `usage_limit_reached`
+- **AND** clients do not receive a generic no-account/server-unavailable error
+
+#### Scenario: Usage-limit selection failures are terminal, not waitable
+
+- **WHEN** account selection fails with `usage_limit_reached` on a streaming,
+  HTTP-bridge, or WebSocket Responses path
+- **THEN** the proxy reports the structured usage-limit failure immediately
+- **AND** it does not enter an account-capacity recovery wait for the
+  remaining request budget before reporting it
+
+#### Scenario: HTTP bridge retry loops do not wait on the usage-limit retry hint
+
+- **GIVEN** HTTP bridge session creation or submission fails with
+  `usage_limit_reached` whose message carries the selector's capped retry hint
+  (`Rate limit exceeded. Try again in Ns`) because the exhausted pool's
+  earliest reset is known
+- **WHEN** the bridge retry loop evaluates its account-capacity wait plan
+- **THEN** it derives no wait from that hint, keyed on the structured error
+  code rather than the message text
+- **AND** it emits no `codex.keepalive` with status
+  `waiting_for_account_capacity` and consumes none of the bridge request budget
+- **AND** it returns the HTTP `429` `usage_limit_reached` envelope immediately
+  with `error.resets_at` and without a `Retry-After` header
+- **AND** recoverable codes such as upstream `rate_limit_exceeded`, local
+  account caps, and `response_create_gate_timeout` keep their bounded
+  account-capacity wait
+
+#### Scenario: Local capacity codes keep their rate-limit contract
+
+- **WHEN** account selection fails with a local capacity or overload code such
+  as `account_stream_cap` or `account_response_create_cap`
+- **THEN** the response keeps HTTP `429` with `error.type = "rate_limit_error"`
+  and the stable local error code
+- **AND** the response is not reported as `usage_limit_reached`
+
+#### Scenario: Unusable non-exhausted pools keep existing semantics
+
+- **WHEN** every account is paused, deactivated, or requires re-authentication
+  and no eligible account is exhausted by a known usage window
+- **THEN** the pre-existing `no_accounts` failure semantics are preserved
+
+#### Scenario: Owner-scoped exhaustion preserves continuity semantics
+
+- **WHEN** a request is pinned to a previous-response or file owner account and
+  only that owner is usage-exhausted while the wider eligible pool is usable
+- **THEN** the proxy keeps the existing continuity-owner failure semantics
+- **AND** it does not report pool-wide `usage_limit_reached`

--- a/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/tasks.md
+++ b/openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Treat `usage_limit_reached` as terminal in
+  `_http_bridge_account_capacity_wait_seconds` (structured code, not message).
+
+## 2. Verification
+
+- [x] 2.1 Unit: the capacity-wait helper and wait plan return no wait for both
+  selector message shapes; `rate_limit_exceeded` with the same hint still waits.
+- [x] 2.2 Unit (virtual time): the bridge session-creation loop raises the `429`
+  immediately with `resets_at`, no keepalives, no time consumed, one attempt.
+- [x] 2.3 Integration: `/backend-api/codex/responses` returns `429`
+  `usage_limit_reached` with `resets_at`, no `Retry-After`, no
+  `codex.keepalive`, and never enters `_iter_account_capacity_wait_sse`.
+- [x] 2.4 `ruff check`, `ruff format --check`, `ty check`,
+  `scripts/check_proxy_architecture.py`, the bridge unit and integration
+  suites, and `openspec validate terminate-http-bridge-usage-limit-capacity-wait --strict`.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7366,6 +7366,59 @@ async def test_backend_responses_http_bridge_pool_usage_exhaustion_returns_429(a
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_http_bridge_pool_usage_exhaustion_with_retry_hint_is_terminal(
+    async_client, monkeypatch
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    select_calls = 0
+
+    async def fake_select_account_with_budget(*_args, **_kwargs):
+        nonlocal select_calls
+        select_calls += 1
+        # The exhausted pool's earliest reset is known, so the selector attaches
+        # its capped human-facing retry hint alongside the structured reset.
+        return proxy_module.AccountSelection(
+            account=None,
+            error_message="Rate limit exceeded. Try again in 300s",
+            error_code="usage_limit_reached",
+            resets_at=1_700_003_600,
+        )
+
+    def fail_capacity_wait(**kwargs):
+        raise AssertionError(f"usage_limit_reached must not enter the bridge capacity wait: {kwargs!r}")
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget",
+        fake_select_account_with_budget,
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_iter_account_capacity_wait_sse", fail_capacity_wait)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 429
+    error = response.json()["error"]
+    assert error["code"] == "usage_limit_reached"
+    assert error["type"] == "usage_limit_reached"
+    assert error["resets_at"] == 1_700_003_600
+    # Pool exhaustion is not a local overload, so no Retry-After is synthesized;
+    # clients read the structured resets_at instead.
+    assert "retry-after" not in response.headers
+    assert "codex.keepalive" not in response.text
+    assert "waiting_for_account_capacity" not in response.text
+    assert "x-codex-turn-state" not in response.headers
+    assert select_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_startup_error_omits_turn_state_header(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4396,6 +4396,61 @@ def test_http_bridge_account_capacity_wait_keeps_active_session_capacity_fail_fa
     assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) is None
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Selector shape when the exhausted pool's earliest reset is known: the
+        # capped human-facing hint matches the recovery-wait regex.
+        "Rate limit exceeded. Try again in 300s",
+        # Selector shape when no reset timestamp is known.
+        "Usage limit reached",
+    ],
+)
+def test_http_bridge_account_capacity_wait_treats_usage_limit_as_terminal(message: str) -> None:
+    exc = ProxyResponseError(
+        429,
+        openai_error(
+            "usage_limit_reached",
+            message,
+            error_type="usage_limit_reached",
+            resets_at=1_700_003_600,
+        ),
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) is None
+
+
+def test_http_bridge_account_capacity_wait_keeps_rate_limit_hint_waitable_for_selector_message_shape() -> None:
+    # Negative control: the terminal branch keys on the structured code, not on
+    # the selector message, so a transient upstream throttle carrying the same
+    # capped hint still waits.
+    exc = ProxyResponseError(
+        429,
+        openai_error("rate_limit_exceeded", "Rate limit exceeded. Try again in 300s"),
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) == 300.0
+
+
+def test_http_bridge_capacity_wait_plan_is_none_for_usage_limit() -> None:
+    exc = ProxyResponseError(
+        429,
+        openai_error(
+            "usage_limit_reached",
+            "Rate limit exceeded. Try again in 300s",
+            error_type="usage_limit_reached",
+            resets_at=1_700_003_600,
+        ),
+    )
+
+    assert (
+        http_bridge_streaming_module._http_bridge_capacity_wait_plan(
+            exc, request_deadline=time.monotonic() + 120.0, now=time.monotonic()
+        )
+        is None
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("propagate_http_errors", "expected_event_types"),
@@ -9619,6 +9674,124 @@ async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_
     assert keepalive["type"] == "codex.keepalive"
     assert keepalive["status"] == "waiting_for_account_capacity"
     assert get_or_create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_usage_limit_session_creation_failure_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    settings = SimpleNamespace(
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=1800,
+        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+        http_responses_session_bridge_gateway_safe_mode=False,
+    )
+    # Pool-wide usage exhaustion with a known earliest reset: the selector
+    # attaches its capped retry hint, which matches the recovery-wait regex
+    # but must never become a bridge capacity wait.
+    get_or_create = AsyncMock(
+        side_effect=ProxyResponseError(
+            429,
+            openai_error(
+                "usage_limit_reached",
+                "Rate limit exceeded. Try again in 300s",
+                error_type="usage_limit_reached",
+                resets_at=1_700_003_600,
+            ),
+        )
+    )
+    now = 100.0
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-usage-limit-create-terminal",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=now,
+        transport="http",
+    )
+
+    def fake_prepare(
+        _prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip
+        return request_state, '{"type":"response.create"}'
+
+    clock = VirtualClock(monotonic_value=now)
+    service._clock = clock
+
+    async def fake_sleep(seconds: float) -> None:
+        clock.advance(seconds)
+
+    capacity_waits: list[dict[str, object]] = []
+    real_capacity_wait = http_bridge_streaming_module._iter_account_capacity_wait_sse
+
+    def recording_capacity_wait(**kwargs: Any) -> AsyncIterator[str]:
+        capacity_waits.append(dict(kwargs))
+        return real_capacity_wait(**kwargs)
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=settings)),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            proxy_request_budget_seconds=600.0,
+            http_responses_session_bridge_request_budget_seconds=600.0,
+        ),
+    )
+    service._scheduler = _SleepThroughScheduler(fake_sleep)
+    monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 120.0)
+    monkeypatch.setattr(http_bridge_streaming_module, "_iter_account_capacity_wait_sse", recording_capacity_wait)
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True}
+    )
+    chunks: list[str] = []
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"session_id": "sid-usage-limit-create-terminal"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        ):
+            chunks.append(chunk)
+
+    # Terminal: no waiting_for_account_capacity keepalives, no virtual time
+    # consumed, and exactly one session-creation attempt.
+    assert chunks == []
+    assert capacity_waits == []
+    assert clock.monotonic() == 100.0
+    assert get_or_create.await_count == 1
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "usage_limit_reached"
+    assert exc_info.value.payload["error"]["type"] == "usage_limit_reached"
+    assert exc_info.value.payload["error"]["resets_at"] == 1_700_003_600
+    assert exc_info.value.retry_after_seconds is None
+    assert exc_info.value.retry_after_header is None
 
 
 def test_http_bridge_session_key_infers_strength_from_affinity_kind() -> None:


### PR DESCRIPTION
## Summary

HTTP-bridge session-creation retry loops treated the selector's `usage_limit_reached` error as a waitable account-capacity condition whenever its message carried the capped `Rate limit exceeded. Try again in Ns` hint, so bridge clients whose pool was usage-exhausted with a known reset got up to a full bridge request budget (default 7200 s) of `waiting_for_account_capacity` keepalives (or a silent stall) before receiving the same 429. `_http_bridge_account_capacity_wait_seconds` now treats the structured `usage_limit_reached` code as terminal, so the bridge returns the `429 usage_limit_reached` envelope with `error.resets_at` immediately, exactly like the SSE and WebSocket paths.

**Motivation.** This is a pre-existing gap, independent of any overflow behaviour: `pool_usage_exhaustion` (app/core/balancer/logic.py) emits `usage_limit_reached` with `_format_retry_hint(...)` whenever the earliest reset is known, and the bridge wait helper (app/modules/proxy/_service/support.py `try again in Ns` matcher) only exempted `no_accounts`, so the bridge retried an unrecoverable condition. It was surfaced while reviewing the Model Source overflow design and split out as its own package: **#2123 WP-E (D4)** — DESIGN.md §5 (D4 row), §7.3/§7.4 (bridge column "unchanged (429 after D4)"), §14 (P17: release note + `Retry-After` absence test), §16 WP-E. No overflow routing is introduced.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Part of #2123 (WP-E / D4)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (SSE framing on the HTTP bridge) and preserves upstream-equivalent behavior — the 429 envelope is the same one the SSE/WS paths already emit; only the pre-429 capacity-wait keepalives disappear.

Change directory: `openspec/changes/terminate-http-bridge-usage-limit-capacity-wait/` — adds a scenario to the existing `responses-api-compat` requirement "Pool usage exhaustion is reported as a usage-limit error" (requirement text reproduced verbatim). `openspec validate terminate-http-bridge-usage-limit-capacity-wait --strict` passes.

## Changes

- `app/modules/proxy/_service/http_bridge/streaming.py` (+5): import `USAGE_LIMIT_REACHED` from `app.modules.proxy.selection_errors`; in `_http_bridge_account_capacity_wait_seconds`, `if code == USAGE_LIMIT_REACHED: return None` after the `capacity_exhausted_active_sessions` check and before the gate-timeout/message fallback. Keyed on the structured error code, not the message. `http_bridge/mixin.py` untouched (at its ceiling); `support.py` untouched.
- Behaviour: HTTP-bridge clients with an exhausted pool and a known reset now receive the immediate `429 usage_limit_reached` with `error.resets_at` and **no** `Retry-After` (reserved for local overload codes). Local caps, `response_create_gate_timeout`, workspace spend-cap and upstream `rate_limit_exceeded` hints keep waiting exactly as before; the post-submit `response.failed usage_limit_reached` retry path (`_retry_http_bridge_precreated_request`) and the shared SSE/WebSocket recovery helper are not touched.
- Tests (+226): `tests/unit/test_proxy_http_bridge.py` — `test_http_bridge_account_capacity_wait_treats_usage_limit_as_terminal` (parametrized over the retry-hint and the plain `Usage limit reached` message), negative control `test_http_bridge_account_capacity_wait_keeps_rate_limit_hint_waitable_for_selector_message_shape` (same 300 s hint with `rate_limit_exceeded` -> 300.0), `test_http_bridge_capacity_wait_plan_is_none_for_usage_limit`, and the virtual-time loop test `test_stream_via_http_bridge_usage_limit_session_creation_failure_is_terminal` (real wait helper, 600 s bridge budget, `VirtualClock`/`_SleepThroughScheduler` seams from #2103: no capacity wait entered, virtual clock unchanged, one `get_or_create` call, 429 payload with `resets_at`, `retry_after_seconds`/`retry_after_header` None). `tests/integration/test_http_responses_bridge.py` — `test_backend_responses_http_bridge_pool_usage_exhaustion_with_retry_hint_is_terminal` through `/backend-api/codex/responses`.
- Release note is the body of the `fix(proxy)` commit (release-please renders the title; the client-visible change is summarised in this PR's Summary for the squash body).

## Test plan

Branch rebased on `origin/main` @ `63ac81f34` (after #2103/#2104), head `260245e37`.

```
# branch
.venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_proxy_http_bridge.py \
  --deselect tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses
# 1002 passed, 1 deselected in 34.23s
.venv/bin/python -m pytest -p no:cacheprovider -q \
  "tests/integration/test_http_responses_bridge.py::test_backend_responses_http_bridge_pool_usage_exhaustion_with_retry_hint_is_terminal"
# 1 passed
# (pre-rebase, on 5ad638b6a: full tests/integration/test_http_responses_bridge.py 156 passed)
python scripts/check_proxy_architecture.py      # proxy architecture checks passed
python scripts/check_proxy_timing_seams.py      # proxy timing seam checks passed
ruff check / ruff format --check                # clean
openspec validate terminate-http-bridge-usage-limit-capacity-wait --strict   # valid
codex review --base origin/main                 # no findings
```

**Fail-on-main evidence** (branch tests overlaid on `origin/main` @ `63ac81f34`, worktree removed afterwards):

```
FAILED tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_treats_usage_limit_as_terminal[Rate limit exceeded. Try again in 300s]   # returns 300.0
FAILED tests/unit/test_proxy_http_bridge.py::test_http_bridge_capacity_wait_plan_is_none_for_usage_limit                                                    # returns a wait tuple
FAILED tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_usage_limit_session_creation_failure_is_terminal                                   # enters the wait and retries
3 failed, 2 passed
FAILED tests/integration/test_http_responses_bridge.py::test_backend_responses_http_bridge_pool_usage_exhaustion_with_retry_hint_is_terminal
E  AssertionError: usage_limit_reached must not enter the bridge capacity wait: {... 'reason': 'Rate limit exceeded. Try again in 300s', 'sleep_seconds': 300.0, 'emit_keepalives': False ...}
```

The two `passed` cases on main are the plain `Usage limit reached` parametrization (already terminal on main because it carries no hint) and the `rate_limit_exceeded` negative control (unchanged by design).

## Screenshots / output

Before (main): `POST /backend-api/codex/responses` with an exhausted pool and a known reset -> `codex.keepalive waiting_for_account_capacity` frames every heartbeat (or a silent 300 s sleep when HTTP errors are propagated), retried until the bridge budget, then `429 usage_limit_reached`.
After: immediate `429 {"error": {"code": "usage_limit_reached", "type": "usage_limit_reached", "resets_at": 1700003600, ...}}`, no `Retry-After`.

## Known limitations

Residual P3s from the adversarial verification (none affect correctness):

- The openspec scenario GIVEN clause and the commit body say "session creation or submission"; `_submit_http_bridge_request` never raises `usage_limit_reached` (only local/upstream bridge codes), so the guard is reachable only through the five pre-submit selection loops. The guard is shared, so this is wording only.
- DESIGN.md §10 asks for a `docs/routing.md` D4 note; `docs/routing.md` has no capacity-wait content today, so the note is deferred to WP-B, which introduces the routing section it belongs in.
- Resolved during the rebase: #2103 made `now` a required keyword of `_http_bridge_capacity_wait_plan` and replaced the `_service_time`/`asyncio.sleep` seams; the branch tests were adapted to `now=` and to `VirtualClock`/`_SleepThroughScheduler`. No production hunk overlaps #2103/#2104.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant subset locally (ruff, targeted pytest, `check_proxy_architecture.py`, `check_proxy_timing_seams.py`).
- [x] If touching specs: `openspec validate --strict` passes for the change.
- [x] Simplicity gates reviewed: no setting, no README section, no default change.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

Part of #2123

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-limit exhaustion now returns a terminal HTTP 429 response immediately instead of waiting and retrying.
  * Responses preserve the authoritative reset time and usage-limit error details without misleading retry hints or capacity-wait events.

* **Tests**
  * Added coverage for streaming, HTTP bridge, and Responses API behavior, including preservation of local capacity and account-availability error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->