### PR TITLE
feat(usage): coalesced on-demand account refresh after usage_limit_reached (#2123 WP-F)

### DIFF
--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -73,6 +73,11 @@ if PROMETHEUS_AVAILABLE:
         "Upstream request duration",
         registry=REGISTRY,
     )
+    upstream_reasoning_replay_400_total = Counter(
+        "codex_lb_upstream_reasoning_replay_400_total",
+        "Total upstream HTTP 400 rejections whose message references reasoning items",
+        registry=REGISTRY,
+    )
     image_requests_total = Counter(
         "codex_lb_image_requests_total",
         "Total OpenAI-compatible image route requests",
@@ -388,6 +393,7 @@ else:
     upstream_requests_total: CounterLike | None = None
     upstream_transport_decisions_total: CounterLike | None = None
     upstream_request_duration_seconds: HistogramLike | None = None
+    upstream_reasoning_replay_400_total: CounterLike | None = None
     image_requests_total: CounterLike | None = None
     image_request_duration_seconds: HistogramLike | None = None
     active_connections: GaugeLike | None = None
@@ -499,6 +505,7 @@ __all__ = [
     "requests_total",
     "stream_pool_capacity",
     "stream_pool_inflight",
+    "upstream_reasoning_replay_400_total",
     "upstream_request_duration_seconds",
     "upstream_requests_total",
     "upstream_transport_decisions_total",

--- a/app/modules/proxy/_service/observability.py
+++ b/app/modules/proxy/_service/observability.py
@@ -12,6 +12,7 @@ from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
     continuity_fail_closed_total,
     continuity_owner_resolution_total,
+    upstream_reasoning_replay_400_total,
     upstream_transport_decisions_total,
 )
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest, canonicalized_tools
@@ -55,6 +56,51 @@ def _record_upstream_transport_decision(
         sticky="true" if sticky else "false",
         status="success" if status == "success" else "error",
     ).inc()
+
+
+def _is_reasoning_replay_rejection(
+    *,
+    code: str,
+    http_status: int | None,
+    message: str | None,
+) -> bool:
+    """Return whether upstream rejected replayed reasoning items with a 400.
+
+    Observation only: a forked thread that replays reasoning ciphertext minted
+    for another account dies on ChatGPT's 400 and is undetectable from ids,
+    so this predicate feeds ``codex_lb_upstream_reasoning_replay_400_total``
+    to size that residual. It never alters classification, account health,
+    or failover. Without an HTTP status (terminal ``error`` /
+    ``response.failed`` frames) only the ``invalid_request_error`` code
+    qualifies.
+    """
+    if http_status is None:
+        if code != "invalid_request_error":
+            return False
+    elif http_status != 400:
+        return False
+    return "reasoning" in (message or "").lower()
+
+
+def _record_upstream_reasoning_replay_rejection() -> None:
+    if PROMETHEUS_AVAILABLE and upstream_reasoning_replay_400_total is not None:
+        upstream_reasoning_replay_400_total.inc()
+    logger.info("Counted upstream reasoning replay rejection request_id=%s", get_request_id())
+
+
+def _observe_terminal_stream_error_frame(code: str | None, message: str | None) -> None:
+    """Count a reasoning-replay rejection carried by a terminal ``error``/``response.failed`` frame.
+
+    Runs where the frame is classified, before and independent of any account
+    health write: ``invalid_request_error`` is never penalized, so
+    ``_handle_stream_error`` never sees these frames. HTTP status rejections
+    are counted by ``_handle_stream_error`` instead, so each upstream failure
+    is counted exactly once.
+    """
+    if code is None:
+        return
+    if _is_reasoning_replay_rejection(code=code, http_status=None, message=message):
+        _record_upstream_reasoning_replay_rejection()
 
 
 def _maybe_log_proxy_request_shape(

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -53,7 +53,6 @@ from app.core.errors import (
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
-from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, upstream_reasoning_replay_400_total
 from app.core.openai.models import OpenAIError, OpenAIEvent, OpenAIResponsePayload, ResponseUsage
 from app.core.openai.parsing import classify_event_type, parse_sse_event
 from app.core.openai.requests import ResponsesRequest
@@ -258,6 +257,9 @@ from app.modules.proxy._service.observability import (
     _interesting_header_keys as _interesting_header_keys,
 )
 from app.modules.proxy._service.observability import (
+    _is_reasoning_replay_rejection as _is_reasoning_replay_rejection,
+)
+from app.modules.proxy._service.observability import (
     _maybe_log_proxy_request_payload as _maybe_log_proxy_request_payload,
 )
 from app.modules.proxy._service.observability import (
@@ -267,10 +269,16 @@ from app.modules.proxy._service.observability import (
     _maybe_log_proxy_service_tier_trace as _maybe_log_proxy_service_tier_trace,
 )
 from app.modules.proxy._service.observability import (
+    _observe_terminal_stream_error_frame as _observe_terminal_stream_error_frame,
+)
+from app.modules.proxy._service.observability import (
     _record_continuity_fail_closed as _record_continuity_fail_closed,
 )
 from app.modules.proxy._service.observability import (
     _record_continuity_owner_resolution as _record_continuity_owner_resolution,
+)
+from app.modules.proxy._service.observability import (
+    _record_upstream_reasoning_replay_rejection as _record_upstream_reasoning_replay_rejection,
 )
 from app.modules.proxy._service.observability import (
     _summarize_input as _summarize_input,
@@ -701,6 +709,24 @@ def _raw_stream_error_code_or_upstream(
     return error_code
 
 
+def _classify_terminal_stream_error_frame(
+    event_type: str | None,
+    event_payload: dict[str, JsonValue] | None,
+    error_code: str,
+    error_message: str | None,
+) -> str:
+    """Resolve a terminal frame's error code and record its observability in one step.
+
+    ``streaming/mixin.py`` sits at its line ceiling, so the two parsed
+    terminal-frame sites resolve the code (``_raw_stream_error_code_or_upstream``)
+    and observe the frame (``_observe_terminal_stream_error_frame``) through
+    this single call instead of one statement each.
+    """
+    resolved_code = _raw_stream_error_code_or_upstream(event_type, event_payload, error_code)
+    _observe_terminal_stream_error_frame(resolved_code, error_message)
+    return resolved_code
+
+
 def _mark_stream_settlement_interrupted(
     settlement: _StreamSettlement,
     *,
@@ -1022,35 +1048,6 @@ def _is_model_scoped_rejection(
     return is_model_scoped_upstream_rejection(message)
 
 
-def _is_reasoning_replay_rejection(
-    *,
-    code: str,
-    http_status: int | None,
-    message: str | None,
-) -> bool:
-    """Return whether upstream rejected replayed reasoning items with a 400.
-
-    Observation only: a forked thread that replays reasoning ciphertext minted
-    for another account dies on ChatGPT's 400 and is undetectable from ids,
-    so this predicate feeds ``codex_lb_upstream_reasoning_replay_400_total``
-    to size that residual. It never alters classification, account health,
-    or failover. Without an HTTP status (websocket error frames) only the
-    ``invalid_request_error`` code qualifies.
-    """
-    if http_status is None:
-        if code != "invalid_request_error":
-            return False
-    elif http_status != 400:
-        return False
-    return "reasoning" in (message or "").lower()
-
-
-def _record_upstream_reasoning_replay_rejection() -> None:
-    if PROMETHEUS_AVAILABLE and upstream_reasoning_replay_400_total is not None:
-        upstream_reasoning_replay_400_total.inc()
-    _facade().logger.info("Counted upstream reasoning replay rejection request_id=%s", get_request_id())
-
-
 def _request_usage_refresh(proxy: Any, account_id: str) -> None:
     """Schedule a tracked, coalesced usage refresh after a streamed ``usage_limit_reached``.
 
@@ -1083,7 +1080,12 @@ async def _handle_stream_error(
         http_status=http_status,
         phase="first_event",
     )
-    if _is_reasoning_replay_rejection(code=code, http_status=http_status, message=error.get("message")):
+    # Terminal frames are counted where they are classified
+    # (``_observe_terminal_stream_error_frame``); only HTTP status rejections
+    # reach the counter from here, so a failure is never counted twice.
+    if http_status is not None and _is_reasoning_replay_rejection(
+        code=code, http_status=http_status, message=error.get("message")
+    ):
         _record_upstream_reasoning_replay_rejection()
     if _facade()._is_account_neutral_error_code(code):
         return classified

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -53,6 +53,7 @@ from app.core.errors import (
 from app.core.errors import (
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE as PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
 )
+from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, upstream_reasoning_replay_400_total
 from app.core.openai.models import OpenAIError, OpenAIEvent, OpenAIResponsePayload, ResponseUsage
 from app.core.openai.parsing import classify_event_type, parse_sse_event
 from app.core.openai.requests import ResponsesRequest
@@ -1021,6 +1022,35 @@ def _is_model_scoped_rejection(
     return is_model_scoped_upstream_rejection(message)
 
 
+def _is_reasoning_replay_rejection(
+    *,
+    code: str,
+    http_status: int | None,
+    message: str | None,
+) -> bool:
+    """Return whether upstream rejected replayed reasoning items with a 400.
+
+    Observation only: a forked thread that replays reasoning ciphertext minted
+    for another account dies on ChatGPT's 400 and is undetectable from ids,
+    so this predicate feeds ``codex_lb_upstream_reasoning_replay_400_total``
+    to size that residual. It never alters classification, account health,
+    or failover. Without an HTTP status (websocket error frames) only the
+    ``invalid_request_error`` code qualifies.
+    """
+    if http_status is None:
+        if code != "invalid_request_error":
+            return False
+    elif http_status != 400:
+        return False
+    return "reasoning" in (message or "").lower()
+
+
+def _record_upstream_reasoning_replay_rejection() -> None:
+    if PROMETHEUS_AVAILABLE and upstream_reasoning_replay_400_total is not None:
+        upstream_reasoning_replay_400_total.inc()
+    _facade().logger.info("Counted upstream reasoning replay rejection request_id=%s", get_request_id())
+
+
 def _request_usage_refresh(proxy: Any, account_id: str) -> None:
     """Schedule a tracked, coalesced usage refresh after a streamed ``usage_limit_reached``.
 
@@ -1053,6 +1083,8 @@ async def _handle_stream_error(
         http_status=http_status,
         phase="first_event",
     )
+    if _is_reasoning_replay_rejection(code=code, http_status=http_status, message=error.get("message")):
+        _record_upstream_reasoning_replay_rejection()
     if _facade()._is_account_neutral_error_code(code):
         return classified
     if _is_account_neutral_request_rejection(

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -405,6 +405,8 @@ from app.modules.proxy.http_bridge_forwarding import (
     OwnerForwardRelayFailure as OwnerForwardRelayFailure,
 )
 from app.modules.proxy.load_balancer import AccountSelection
+from app.modules.proxy.selection_errors import USAGE_LIMIT_REACHED
+from app.modules.usage.updater import UsageUpdater
 
 
 def _facade() -> Any:
@@ -1019,6 +1021,23 @@ def _is_model_scoped_rejection(
     return is_model_scoped_upstream_rejection(message)
 
 
+def _request_usage_refresh(proxy: Any, account_id: str) -> None:
+    """Schedule a tracked, coalesced usage refresh after a streamed ``usage_limit_reached``.
+
+    ``mark_rate_limit`` persists status only, while the pool-exhaustion
+    predicate also needs a >= 100 % usage row that would otherwise wait for
+    the next scheduler tick. The refresh runs on its own background session
+    and never touches this request's ``Account``.
+    """
+    schedule = getattr(proxy, "_schedule_cancel_safe_cleanup", None)
+    if schedule is None:
+        return
+    refresh = UsageUpdater.request_refresh(account_id)
+    if refresh is None:
+        return
+    schedule(refresh, action="request_usage_refresh", request_id=get_request_id() or "unknown")
+
+
 async def _handle_stream_error(
     proxy: Any,
     account: Account,
@@ -1061,6 +1080,8 @@ async def _handle_stream_error(
         return classified
     if classified["failure_class"] == "rate_limit":
         await proxy._load_balancer.mark_rate_limit(account, error)
+        if code == USAGE_LIMIT_REACHED:
+            _request_usage_refresh(proxy, account.id)
     elif classified["failure_class"] == "quota":
         await proxy._load_balancer.mark_quota_exceeded(account, error)
     elif code in PERMANENT_FAILURE_CODES:

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -271,15 +271,16 @@ from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
 from app.modules.proxy._service.streaming.helpers import (
-    _handle_stream_error as _handle_stream_error_helper,
-)
-from app.modules.proxy._service.streaming.helpers import (
+    _classify_terminal_stream_error_frame,
     _mark_downstream_stream_cancelled,
     _mark_upstream_stream_incomplete,
+    _observe_terminal_stream_error_frame,
     _openai_error_fields,
-    _raw_stream_error_code_or_upstream,
     _rewrite_malformed_stream_error_event,
     _stream_transport_failure_event_or_raise,
+)
+from app.modules.proxy._service.streaming.helpers import (
+    _handle_stream_error as _handle_stream_error_helper,
 )
 from app.modules.proxy._service.streaming.helpers import _raw_stream_error_fields as _raw_error_fields
 from app.modules.proxy._service.streaming.helpers import (
@@ -680,7 +681,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         error.code if error else None,
                         raw_error_type,
                     )
-                code = _raw_stream_error_code_or_upstream(event_type, first_payload, code)
+                code = _classify_terminal_stream_error_frame(event_type, first_payload, code, raw_error_message)
                 rewritten_error = _facade()._rewrite_previous_response_stream_error(
                     previous_response_id=payload.previous_response_id,
                     preferred_account_id=preferred_account_id,
@@ -840,10 +841,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                         else:
                             raw_error_code = _normalize_error_code(error.code if error else None, raw_error_type)
                             upstream_error = _upstream_error_from_openai(error)
-                        raw_error_code = _raw_stream_error_code_or_upstream(
-                            event_type,
-                            event_payload,
-                            raw_error_code,
+                        raw_error_code = _classify_terminal_stream_error_frame(
+                            event_type, event_payload, raw_error_code, raw_error_message
                         )
                         rewritten_error = _facade()._rewrite_previous_response_stream_error(
                             previous_response_id=payload.previous_response_id,
@@ -898,6 +897,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         event_type,
                         event_payload,
                     )
+                    _observe_terminal_stream_error_frame(raw_error_code, raw_error_message)
                     status = "error"
                     error_code = raw_error_code
                     error_message = raw_error_message

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -307,6 +307,7 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.observability import (
     _maybe_log_proxy_service_tier_trace as _maybe_log_proxy_service_tier_trace,
 )
+from app.modules.proxy._service.observability import _observe_terminal_stream_error_frame
 from app.modules.proxy._service.observability import (
     _record_continuity_fail_closed as _record_continuity_fail_closed,
 )
@@ -6302,6 +6303,7 @@ class _WebSocketMixin:
         if completed_empty_prewarm:
             settlement.record_success = False
         if event_type in {"response.failed", "error"}:
+            _observe_terminal_stream_error_frame(error_code, error_message)
             settlement.account_health_error = _facade()._should_penalize_stream_error(error_code) and not getattr(
                 request_state,
                 "account_health_error_handled",

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -5,10 +5,10 @@ import contextlib
 import logging
 import math
 import time
-from collections.abc import Awaitable, Callable, Collection, Hashable
+from collections.abc import Awaitable, Callable, Collection, Coroutine, Hashable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Final, Mapping, Protocol, cast
+from typing import Any, Final, Mapping, Protocol, cast
 
 from app.core import usage as usage_core
 from app.core.auth.refresh import RefreshError
@@ -151,6 +151,13 @@ class _MergedAdditionalWindow:
 # process. Updated only after a successful refresh that wrote data.
 _last_successful_refresh: dict[str, datetime] = {}
 _usage_refresh_auth_cooldowns: dict[str, float] = {}
+
+# Debounce window for request-triggered refreshes (a streamed
+# ``usage_limit_reached``): one immediate upstream fetch per account per
+# window collapses a 429 storm into a single call. Deliberately a constant
+# rather than a CODEX_LB_* setting (PRINCIPLES.md P2).
+_REQUEST_REFRESH_DEBOUNCE_SECONDS: Final[float] = 15.0
+_usage_request_refresh_deadlines: dict[str, float] = {}
 
 # Fallback for consecutive workspace-less "free" observations (issue #1456) used
 # only when persistence is explicitly disabled -- the DB-less unit-test harness.
@@ -436,6 +443,25 @@ class UsageUpdater:
             )
             return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
 
+    @staticmethod
+    def request_refresh(account_id: str) -> Coroutine[Any, Any, None] | None:
+        """Return an immediate background refresh for ``account_id``, or ``None`` when suppressed.
+
+        The caller schedules the coroutine as a tracked task. It loads the
+        account from a fresh background row (never a caller's ``Account``),
+        bypasses freshness, and joins any in-flight owned-session refresh.
+        Repeats within ``_REQUEST_REFRESH_DEBOUNCE_SECONDS`` are dropped, as
+        are disabled refresh and accounts in auth cooldown.
+        """
+        if not get_settings().usage_refresh_enabled or _is_usage_refresh_in_cooldown(account_id):
+            return None
+        now = time.monotonic()
+        deadline = _usage_request_refresh_deadlines.get(account_id)
+        if deadline is not None and deadline > now:
+            return None
+        _usage_request_refresh_deadlines[account_id] = now + _REQUEST_REFRESH_DEBOUNCE_SECONDS
+        return _run_requested_refresh(account_id)
+
     async def _refresh_account_if_stale(
         self,
         account: Account,
@@ -521,30 +547,39 @@ class UsageUpdater:
             return False
         return not await self._additional_usage_is_stale(account.id, now=now, interval_seconds=interval_seconds)
 
+    @staticmethod
+    async def _load_owned_session_updater(account_id: str) -> tuple[UsageUpdater, Account] | None:
+        """Load a fresh eligible row for ``account_id`` with repositories that own their sessions."""
+
+        @contextlib.asynccontextmanager
+        async def refresh_repo_factory():
+            yield BackgroundAccountsRepository()
+
+        accounts_repo = BackgroundAccountsRepository()
+        account = await accounts_repo.get_by_id(account_id)
+        if account is None:
+            return None
+        if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+            return None
+        updater = UsageUpdater(
+            BackgroundUsageRepository(),
+            accounts_repo,
+            BackgroundAdditionalUsageRepository(),
+            auth_manager=AuthManager(accounts_repo, refresh_repo_factory=refresh_repo_factory),
+        )
+        return updater, account
+
     async def _refresh_account_if_stale_with_owned_session(
         self,
         account_id: str,
         *,
         interval_seconds: int,
     ) -> AccountRefreshResult:
-        @contextlib.asynccontextmanager
-        async def refresh_repo_factory():
-            yield BackgroundAccountsRepository()
-
-        accounts_repo = BackgroundAccountsRepository()
-        usage_repo = BackgroundUsageRepository()
-        additional_usage_repo = BackgroundAdditionalUsageRepository()
-        account = await accounts_repo.get_by_id(account_id)
-        if account is None:
+        loaded = await self._load_owned_session_updater(account_id)
+        if loaded is None:
             return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
-        if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
-            return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
-        return await UsageUpdater(
-            usage_repo,
-            accounts_repo,
-            additional_usage_repo,
-            auth_manager=AuthManager(accounts_repo, refresh_repo_factory=refresh_repo_factory),
-        )._refresh_account_if_stale(
+        updater, account = loaded
+        return await updater._refresh_account_if_stale(
             account,
             usage_account_id=account.chatgpt_account_id,
             interval_seconds=interval_seconds,
@@ -940,6 +975,36 @@ class UsageUpdater:
         account.deactivation_reason = stored.deactivation_reason
         account.reset_at = stored.reset_at
         account.blocked_at = stored.blocked_at
+
+
+async def _run_requested_refresh(account_id: str) -> None:
+    async def refresh_factory() -> AccountRefreshResult:
+        loaded = await UsageUpdater._load_owned_session_updater(account_id)
+        if loaded is None:
+            return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+        updater, account = loaded
+        return await updater._refresh_account(account, usage_account_id=account.chatgpt_account_id)
+
+    try:
+        # The owned-session key coalesces with the scheduler's refresh of the
+        # same account; joining never queues a successor fetch.
+        result = await _USAGE_REFRESH_SINGLEFLIGHT.run(
+            _usage_refresh_singleflight_key(account_id, own_singleflight_session=True),
+            refresh_factory,
+            join_existing=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Requested usage refresh failed account_id=%s request_id=%s error=%s",
+            account_id,
+            get_request_id(),
+            exc,
+            exc_info=True,
+        )
+        return
+    if result.fetch_succeeded:
+        _last_successful_refresh[account_id] = utcnow()
+        _clear_usage_refresh_auth_cooldown(account_id)
 
 
 def build_background_usage_updater() -> UsageUpdater:
@@ -1409,6 +1474,7 @@ def _prune_usage_refresh_auth_cooldowns() -> None:
 
 def _clear_usage_refresh_state() -> None:
     _usage_refresh_auth_cooldowns.clear()
+    _usage_request_refresh_deadlines.clear()
     _last_successful_refresh.clear()
     _FALLBACK_PLAN_DOWNGRADE_OBSERVATIONS.clear_all()
     _USAGE_REFRESH_SINGLEFLIGHT.clear()

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -1023,6 +1023,12 @@ async def _run_requested_refresh(account_id: str) -> None:
     if result.fetch_succeeded:
         _last_successful_refresh[account_id] = utcnow()
         _clear_usage_refresh_auth_cooldown(account_id)
+    if result.usage_written:
+        # ``mark_rate_limit`` invalidated the selection cache before this row
+        # existed, so a selection in between repopulated it without usage
+        # evidence. Drop that entry now instead of letting the >= 100 % row
+        # wait out the cache TTL before the pool reports exhaustion.
+        get_account_selection_cache().invalidate()
 
 
 def build_background_usage_updater() -> UsageUpdater:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -233,6 +233,13 @@ class _UsageRefreshSingleflight:
         with contextlib.suppress(BaseException):
             task.exception()
 
+    def inflight(self, account_id: Hashable) -> asyncio.Task[AccountRefreshResult] | None:
+        """Return the running refresh task registered under ``account_id``, if any."""
+        task = self._inflight.get(account_id)
+        if task is None or task.done():
+            return None
+        return task
+
     def clear(self) -> None:
         self._inflight.clear()
 
@@ -449,9 +456,11 @@ class UsageUpdater:
 
         The caller schedules the coroutine as a tracked task. It loads the
         account from a fresh background row (never a caller's ``Account``),
-        bypasses freshness, and joins any in-flight owned-session refresh.
-        Repeats within ``_REQUEST_REFRESH_DEBOUNCE_SECONDS`` are dropped, as
-        are disabled refresh and accounts in auth cooldown.
+        bypasses freshness, and joins an in-flight refresh of the account on
+        either singleflight lane (the scheduler's caller-session key or the
+        owned-session key) instead of fetching again. Repeats within
+        ``_REQUEST_REFRESH_DEBOUNCE_SECONDS`` are dropped, as are disabled
+        refresh and accounts in auth cooldown.
         """
         if not get_settings().usage_refresh_enabled or _is_usage_refresh_in_cooldown(account_id):
             return None
@@ -986,13 +995,22 @@ async def _run_requested_refresh(account_id: str) -> None:
         return await updater._refresh_account(account, usage_account_id=account.chatgpt_account_id)
 
     try:
-        # The owned-session key coalesces with the scheduler's refresh of the
-        # same account; joining never queues a successor fetch.
-        result = await _USAGE_REFRESH_SINGLEFLIGHT.run(
-            _usage_refresh_singleflight_key(account_id, own_singleflight_session=True),
-            refresh_factory,
-            join_existing=True,
-        )
+        # Two singleflight lanes exist per account: the scheduler (and
+        # ``force_refresh``) run on the bare ``account_id`` key with
+        # caller-bound sessions, while the rate-limit payload and fleet paths
+        # run on the owned-session key. A request must not add a third
+        # concurrent fetch, so it joins a scheduler refresh already in flight
+        # and otherwise runs on the owned-session key, where ``join_existing``
+        # never queues a successor fetch.
+        scheduler_refresh = _USAGE_REFRESH_SINGLEFLIGHT.inflight(_usage_refresh_singleflight_key(account_id))
+        if scheduler_refresh is not None:
+            result = await wait_on_shared_future(scheduler_refresh)
+        else:
+            result = await _USAGE_REFRESH_SINGLEFLIGHT.run(
+                _usage_refresh_singleflight_key(account_id, own_singleflight_session=True),
+                refresh_factory,
+                join_existing=True,
+            )
     except Exception as exc:
         logger.warning(
             "Requested usage refresh failed account_id=%s request_id=%s error=%s",

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
@@ -46,9 +46,15 @@ reasoning items are counted.
   throttling and quota codes are excluded: throttling is transient, and quota
   codes already pin `used_percent=100` in runtime state.
 - `codex_lb_upstream_reasoning_replay_400_total` counts upstream HTTP 400
-  rejections (or code-less `invalid_request_error` frames) whose message
-  references reasoning. Observation only: classification, account health and
-  failover are unchanged, and the counter is a no-op without `prometheus_client`.
+  rejections and terminal `error` / `response.failed` frames carrying
+  `invalid_request_error` whose message references reasoning. Frames are counted
+  where they are classified (SSE streaming first-event and mid-stream sites, and
+  websocket finalization, which the HTTP bridge reuses), not in
+  `_handle_stream_error`: `invalid_request_error` is never penalized, so the
+  health handler never sees those frames. The helpers live in
+  `_service/observability.py`, the one module every transport domain may import.
+  Observation only: classification, account health and failover are unchanged,
+  and the counter is a no-op without `prometheus_client`.
 - No overflow behaviour is wired; the change is valuable stand-alone.
 
 ## Capabilities

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
@@ -1,0 +1,59 @@
+# Request an immediate coalesced usage refresh on streamed usage-limit failures
+
+## Why
+
+When an upstream stream fails with `usage_limit_reached`, `_handle_stream_error`
+marks the account `rate_limited` (status, `blocked_at`, `reset_at`) but writes no
+usage evidence. The pool-exhaustion predicate requires both a blocked status and a
+usage row at or above 100 %, so a pool whose last account just hit its limit keeps
+reporting `no_accounts` (or a local wait) instead of the structured
+`usage_limit_reached` failure with its `resets_at` until the background scheduler
+next refreshes the account -- up to one `usage_refresh_interval_seconds` plus the
+freshness gate, which only bypasses `rate_limited` rows after their `reset_at`
+elapses. That lag is the gap issue #2123 (WP-F) closes before any Model Source
+overflow decision depends on the predicate.
+
+The only immediate-refresh API today, `UsageUpdater.force_refresh`, is unsuitable
+from a streaming request: it waits for an in-flight refresh and then starts
+another (no coalescing under a 429 storm) and it mutates the caller's `Account`
+ORM instance, which belongs to the request session.
+
+## What Changes
+
+- `UsageUpdater.request_refresh(account_id)` returns a background refresh
+  coroutine (or `None` when suppressed) that loads the account from a fresh
+  background row, bypasses the freshness gate, joins any in-flight owned-session
+  refresh of the same account (`join_existing=True`; never queues a successor
+  fetch), and never touches a caller's `Account`. Repeats within a fixed 15 s
+  debounce window, disabled usage refresh, and accounts in auth cooldown return
+  `None`.
+- `_handle_stream_error` requests that refresh after `mark_rate_limit` when the
+  stream error code is exactly `usage_limit_reached`, scheduling it through
+  `ProxyService._schedule_cancel_safe_cleanup` (tracked task
+  `proxy-request_usage_refresh-<request_id>`). Plain `rate_limit_exceeded`
+  throttling and quota codes are excluded: throttling is transient, and quota
+  codes already pin `used_percent=100` in runtime state.
+- No overflow behaviour is wired; the change is valuable stand-alone.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: streamed usage-limit failures request an immediate,
+  coalesced, debounced, fresh-row, tracked usage refresh.
+
+## Impact
+
+- The pool reports `usage_limit_reached` with the correct `resets_at` on the next
+  selection after the >= 100 % row lands, seconds after the first upstream 429
+  instead of up to one scheduler interval later.
+- A 429 storm on one account produces at most one upstream `/wham/usage` fetch
+  per debounce window per process; concurrent requests join the in-flight fetch.
+- No new settings (PRINCIPLES.md P2): the debounce is a constant. No new SQL;
+  existing background repositories are reused (SQLite/PostgreSQL parity).
+- `CancelledError` propagates out of the tracked refresh; only `Exception` is
+  logged and swallowed inside it.

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
@@ -34,7 +34,11 @@ reasoning items are counted.
   joins a scheduler refresh already in flight and otherwise runs on the
   owned-session key with `join_existing=True` (never queues a successor fetch).
   Repeats within a fixed 15 s debounce window, disabled usage refresh, and
-  accounts in auth cooldown return `None`.
+  accounts in auth cooldown return `None`. A refresh that writes usage rows
+  invalidates the account selection cache (as the scheduler and the reset-credit
+  refresh already do): `mark_rate_limit` invalidated it before the row existed,
+  and a selection in between would otherwise pin usage-less inputs for the cache
+  TTL (5 s in production).
 - `_handle_stream_error` requests that refresh after `mark_rate_limit` when the
   stream error code is exactly `usage_limit_reached`, scheduling it through
   `ProxyService._schedule_cancel_safe_cleanup` (tracked task
@@ -64,7 +68,8 @@ None.
 
 - The pool reports `usage_limit_reached` with the correct `resets_at` on the next
   selection after the >= 100 % row lands, seconds after the first upstream 429
-  instead of up to one scheduler interval later.
+  instead of up to one scheduler interval later, and without waiting out the
+  selection cache TTL.
 - A 429 storm on one account produces at most one upstream `/wham/usage` fetch
   per debounce window per process; concurrent requests join the in-flight fetch,
   including a scheduler refresh of the same account that is already running. The

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
@@ -18,6 +18,11 @@ from a streaming request: it waits for an in-flight refresh and then starts
 another (no coalescing under a 429 storm) and it mutates the caller's `Account`
 ORM instance, which belongs to the request session.
 
+Separately, a forked thread that replays reasoning ciphertext minted for another
+account dies on ChatGPT's HTTP 400 and is undetectable from ids; the residual has
+to be sized before overflow ships, so upstream 400 rejections that reference
+reasoning items are counted.
+
 ## What Changes
 
 - `UsageUpdater.request_refresh(account_id)` returns a background refresh
@@ -33,6 +38,10 @@ ORM instance, which belongs to the request session.
   `proxy-request_usage_refresh-<request_id>`). Plain `rate_limit_exceeded`
   throttling and quota codes are excluded: throttling is transient, and quota
   codes already pin `used_percent=100` in runtime state.
+- `codex_lb_upstream_reasoning_replay_400_total` counts upstream HTTP 400
+  rejections (or code-less `invalid_request_error` frames) whose message
+  references reasoning. Observation only: classification, account health and
+  failover are unchanged, and the counter is a no-op without `prometheus_client`.
 - No overflow behaviour is wired; the change is valuable stand-alone.
 
 ## Capabilities
@@ -45,6 +54,8 @@ None.
 
 - `usage-refresh-policy`: streamed usage-limit failures request an immediate,
   coalesced, debounced, fresh-row, tracked usage refresh.
+- `proxy-runtime-observability`: upstream reasoning-replay rejections are
+  counted.
 
 ## Impact
 

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/proposal.md
@@ -27,11 +27,14 @@ reasoning items are counted.
 
 - `UsageUpdater.request_refresh(account_id)` returns a background refresh
   coroutine (or `None` when suppressed) that loads the account from a fresh
-  background row, bypasses the freshness gate, joins any in-flight owned-session
-  refresh of the same account (`join_existing=True`; never queues a successor
-  fetch), and never touches a caller's `Account`. Repeats within a fixed 15 s
-  debounce window, disabled usage refresh, and accounts in auth cooldown return
-  `None`.
+  background row, bypasses the freshness gate, and never touches a caller's
+  `Account`. Usage refreshes run on two per-account singleflight lanes -- the
+  scheduler and `force_refresh` on the bare account key, the rate-limit payload
+  and fleet paths on the owned-session key -- so the requested refresh first
+  joins a scheduler refresh already in flight and otherwise runs on the
+  owned-session key with `join_existing=True` (never queues a successor fetch).
+  Repeats within a fixed 15 s debounce window, disabled usage refresh, and
+  accounts in auth cooldown return `None`.
 - `_handle_stream_error` requests that refresh after `mark_rate_limit` when the
   stream error code is exactly `usage_limit_reached`, scheduling it through
   `ProxyService._schedule_cancel_safe_cleanup` (tracked task
@@ -63,7 +66,11 @@ None.
   selection after the >= 100 % row lands, seconds after the first upstream 429
   instead of up to one scheduler interval later.
 - A 429 storm on one account produces at most one upstream `/wham/usage` fetch
-  per debounce window per process; concurrent requests join the in-flight fetch.
+  per debounce window per process; concurrent requests join the in-flight fetch,
+  including a scheduler refresh of the same account that is already running. The
+  debounce and the singleflight lanes are process-local, so under a cross-replica
+  storm each replica fetches once per window (the scheduler lane does not join
+  request lanes; that pre-existing asymmetry is unchanged).
 - No new settings (PRINCIPLES.md P2): the debounce is a constant. No new SQL;
   existing background repositories are reused (SQLite/PostgreSQL parity).
 - `CancelledError` propagates out of the tracked refresh; only `Exception` is

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,29 @@
+# proxy-runtime-observability Delta
+
+## ADDED Requirements
+
+### Requirement: Upstream reasoning-replay rejections are counted
+
+When Prometheus support is available the proxy MUST expose a label-free counter
+named `codex_lb_upstream_reasoning_replay_400_total` and MUST increment it once
+per upstream stream failure that is an HTTP 400 rejection, or an
+`invalid_request_error` frame without an HTTP status, whose error message
+references reasoning. Counting MUST NOT alter failure classification, account
+health, or failover, MUST NOT log the rejection message body, and MUST degrade to
+a no-op when the Prometheus client is absent.
+
+#### Scenario: Reasoning replay rejection is counted
+
+- **WHEN** upstream rejects a stream with HTTP 400 and a message such as `Item with id 'rs_...' of type 'reasoning' was provided without its required following item.`
+- **THEN** `codex_lb_upstream_reasoning_replay_400_total` increments by one
+- **AND** the failure is classified and penalized exactly as before
+
+#### Scenario: Other rejections are not counted
+
+- **WHEN** upstream rejects a stream with HTTP 400 without referencing reasoning, or with a non-400 status whose message mentions reasoning
+- **THEN** the counter does not change
+
+#### Scenario: Missing Prometheus client
+
+- **WHEN** the Prometheus client is not installed
+- **THEN** counting is a no-op and stream error handling is unchanged

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/proxy-runtime-observability/spec.md
@@ -5,10 +5,15 @@
 ### Requirement: Upstream reasoning-replay rejections are counted
 
 When Prometheus support is available the proxy MUST expose a label-free counter
-named `codex_lb_upstream_reasoning_replay_400_total` and MUST increment it once
-per upstream stream failure that is an HTTP 400 rejection, or an
-`invalid_request_error` frame without an HTTP status, whose error message
-references reasoning. Counting MUST NOT alter failure classification, account
+named `codex_lb_upstream_reasoning_replay_400_total` and MUST increment it exactly
+once per upstream stream failure that is an HTTP 400 rejection, or a terminal
+`error` / `response.failed` frame carrying `invalid_request_error` without an HTTP
+status, whose error message references reasoning. Frames MUST be counted where
+the terminal frame is classified -- on the SSE streaming path, the websocket
+path, and the HTTP bridge (which finalizes through the websocket path) --
+independent of whether an account-health write follows, because
+`invalid_request_error` is never penalized and therefore never reaches the
+account-health handler. Counting MUST NOT alter failure classification, account
 health, or failover, MUST NOT log the rejection message body, and MUST degrade to
 a no-op when the Prometheus client is absent.
 
@@ -18,9 +23,15 @@ a no-op when the Prometheus client is absent.
 - **THEN** `codex_lb_upstream_reasoning_replay_400_total` increments by one
 - **AND** the failure is classified and penalized exactly as before
 
+#### Scenario: Terminal frames are counted without an account-health write
+
+- **WHEN** an upstream SSE stream, websocket session, or HTTP-bridge session ends with a terminal `error` or `response.failed` frame whose code is `invalid_request_error` and whose message references reasoning
+- **THEN** `codex_lb_upstream_reasoning_replay_400_total` increments by exactly one
+- **AND** the frame is neither penalized nor otherwise classified differently than before
+
 #### Scenario: Other rejections are not counted
 
-- **WHEN** upstream rejects a stream with HTTP 400 without referencing reasoning, or with a non-400 status whose message mentions reasoning
+- **WHEN** upstream rejects a stream with HTTP 400 without referencing reasoning, with a non-400 status whose message mentions reasoning, or with a terminal frame whose code is not `invalid_request_error`
 - **THEN** the counter does not change
 
 #### Scenario: Missing Prometheus client

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
@@ -9,10 +9,15 @@ MUST request an immediate usage refresh for the failing account in addition to
 marking it rate limited. The refresh MUST run as a tracked background task that
 never blocks or alters the response, MUST load the account from a fresh
 background-session row rather than the request's `Account` instance, and MUST
-bypass the usage freshness gate. Concurrent requests for the same account MUST
-join a single in-flight owned-session refresh (the scheduler's or another
-request's) and MUST NOT queue a successor fetch. Repeated requests for the same
-account within a fixed 15 second window MUST be dropped. The request MUST be
+bypass the usage freshness gate. Usage refreshes run on two per-account
+singleflight lanes: the background scheduler and forced refreshes use the bare
+account key with caller-bound sessions, while the rate-limit payload, fleet and
+request-triggered refreshes use the owned-session key. A requested refresh MUST
+join a refresh already in flight on either lane rather than starting a third
+concurrent upstream fetch, and concurrent requests for the same account MUST
+share a single in-flight owned-session refresh without queueing a successor
+fetch. Repeated requests for the same account within a fixed 15 second window
+MUST be dropped. The request MUST be
 skipped when usage refresh is disabled, when the account is in usage-refresh auth
 cooldown, or when the fresh row is missing, `paused`, `reauth_required`, or
 `deactivated`. Plain `rate_limit_exceeded` throttling and quota error codes MUST
@@ -27,9 +32,16 @@ NOT request a refresh.
 
 #### Scenario: A request joins the scheduler's in-flight refresh
 
-- **GIVEN** the background scheduler is refreshing an account on its owned-session singleflight key
+- **GIVEN** the background scheduler is refreshing an account on the bare account singleflight key
 - **WHEN** a stream on that account fails with `usage_limit_reached`
-- **THEN** the requested refresh joins the in-flight refresh
+- **THEN** the requested refresh waits on the scheduler's in-flight refresh and records its outcome
+- **AND** no additional upstream fetch starts
+
+#### Scenario: A request joins an in-flight owned-session refresh
+
+- **GIVEN** the rate-limit payload path or another request is refreshing an account on the owned-session singleflight key
+- **WHEN** a stream on that account fails with `usage_limit_reached`
+- **THEN** the requested refresh joins that in-flight refresh
 - **AND** no additional upstream fetch starts
 
 #### Scenario: Repeats inside the debounce window are dropped

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,61 @@
+# usage-refresh-policy Delta
+
+## ADDED Requirements
+
+### Requirement: Streaming usage-limit failures request an immediate coalesced usage refresh
+
+When an upstream stream fails with the error code `usage_limit_reached`, the proxy
+MUST request an immediate usage refresh for the failing account in addition to
+marking it rate limited. The refresh MUST run as a tracked background task that
+never blocks or alters the response, MUST load the account from a fresh
+background-session row rather than the request's `Account` instance, and MUST
+bypass the usage freshness gate. Concurrent requests for the same account MUST
+join a single in-flight owned-session refresh (the scheduler's or another
+request's) and MUST NOT queue a successor fetch. Repeated requests for the same
+account within a fixed 15 second window MUST be dropped. The request MUST be
+skipped when usage refresh is disabled, when the account is in usage-refresh auth
+cooldown, or when the fresh row is missing, `paused`, `reauth_required`, or
+`deactivated`. Plain `rate_limit_exceeded` throttling and quota error codes MUST
+NOT request a refresh.
+
+#### Scenario: A 429 storm produces a single upstream fetch
+
+- **GIVEN** twenty concurrent streams on one account fail upstream with `usage_limit_reached`
+- **WHEN** each failure requests a usage refresh
+- **THEN** at most one upstream usage fetch runs for that account
+- **AND** every failure's response is unaffected by the refresh
+
+#### Scenario: A request joins the scheduler's in-flight refresh
+
+- **GIVEN** the background scheduler is refreshing an account on its owned-session singleflight key
+- **WHEN** a stream on that account fails with `usage_limit_reached`
+- **THEN** the requested refresh joins the in-flight refresh
+- **AND** no additional upstream fetch starts
+
+#### Scenario: Repeats inside the debounce window are dropped
+
+- **GIVEN** a usage refresh was requested for an account less than 15 seconds ago
+- **WHEN** another stream on that account fails with `usage_limit_reached`
+- **THEN** no new refresh is requested
+- **AND** a failure after the window elapses requests a refresh again
+
+#### Scenario: The pool reports usage exhaustion on the next selection
+
+- **GIVEN** the last selectable account's stream fails upstream with `usage_limit_reached`
+- **AND** the requested refresh writes a usage row at or above 100 % with its reset time
+- **WHEN** the next request selects an account
+- **THEN** selection fails with the structured `usage_limit_reached` failure carrying that `resets_at`
+- **AND** it does not wait for the next scheduled refresh interval
+
+#### Scenario: The request never mutates the streaming request's account
+
+- **GIVEN** a stream fails with `usage_limit_reached` for an `Account` bound to the request session
+- **WHEN** the requested refresh runs
+- **THEN** it reads and updates only the fresh background-session row
+- **AND** the request's `Account` instance is neither read nor written by the refresh
+
+#### Scenario: Ineligible rows and disabled refresh are skipped
+
+- **GIVEN** usage refresh is disabled, or the account is in auth cooldown, or its fresh row is missing, `paused`, `reauth_required`, or `deactivated`
+- **WHEN** a stream on that account fails with `usage_limit_reached`
+- **THEN** no upstream usage fetch runs

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/specs/usage-refresh-policy/spec.md
@@ -20,8 +20,10 @@ fetch. Repeated requests for the same account within a fixed 15 second window
 MUST be dropped. The request MUST be
 skipped when usage refresh is disabled, when the account is in usage-refresh auth
 cooldown, or when the fresh row is missing, `paused`, `reauth_required`, or
-`deactivated`. Plain `rate_limit_exceeded` throttling and quota error codes MUST
-NOT request a refresh.
+`deactivated`. When the requested (or joined) refresh writes usage rows it MUST
+invalidate the account selection cache, so the next selection observes the new
+usage evidence without waiting out the cache TTL. Plain `rate_limit_exceeded`
+throttling and quota error codes MUST NOT request a refresh.
 
 #### Scenario: A 429 storm produces a single upstream fetch
 
@@ -54,10 +56,12 @@ NOT request a refresh.
 #### Scenario: The pool reports usage exhaustion on the next selection
 
 - **GIVEN** the last selectable account's stream fails upstream with `usage_limit_reached`
+- **AND** a selection between the rate-limit mark and the refresh's row write repopulated the selection cache without usage evidence
 - **AND** the requested refresh writes a usage row at or above 100 % with its reset time
 - **WHEN** the next request selects an account
-- **THEN** selection fails with the structured `usage_limit_reached` failure carrying that `resets_at`
-- **AND** it does not wait for the next scheduled refresh interval
+- **THEN** the written row has invalidated the selection cache
+- **AND** selection fails with the structured `usage_limit_reached` failure carrying that `resets_at`
+- **AND** it does not wait for the next scheduled refresh interval or the selection cache TTL
 
 #### Scenario: The request never mutates the streaming request's account
 

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
@@ -11,8 +11,13 @@
 - [x] 2.1 Request the refresh from `_handle_stream_error` after `mark_rate_limit` when the code is `usage_limit_reached`, scheduled via `_schedule_cancel_safe_cleanup(action="request_usage_refresh")`.
 - [x] 2.2 Keep `rate_limit_exceeded`, quota codes, account-neutral, model-scoped and transient failures free of refresh requests.
 
-## 3. Verification
+## 3. Reasoning-replay observability
 
-- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls.
+- [x] 3.1 Define `codex_lb_upstream_reasoning_replay_400_total` with the tri-state fallback and `__all__` entry.
+- [x] 3.2 Count upstream 400 (or code-less `invalid_request_error`) rejections whose message references reasoning without changing classification or account health.
+
+## 4. Verification
+
+- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths.
 - [x] 4.2 Integration coverage: a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick and the next selection reports `usage_limit_reached` with `resets_at`.
 - [x] 4.3 ruff format/check, ty, `scripts/check_proxy_architecture.py`, strict OpenSpec validation.

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
@@ -4,7 +4,7 @@
 
 - [x] 1.1 Add `UsageUpdater.request_refresh(account_id)` with a 15 s per-account debounce, `usage_refresh_enabled` and auth-cooldown short-circuits, and reset in `_clear_usage_refresh_state()`.
 - [x] 1.2 Join a scheduler refresh already in flight on the bare account key; otherwise run on the owned-session singleflight key with `join_existing=True`, loading a fresh background row and bypassing the freshness gate; never touch a caller's `Account`.
-- [x] 1.3 Record `_last_successful_refresh` and clear the auth cooldown on a successful fetch; log and swallow `Exception` only.
+- [x] 1.3 Record `_last_successful_refresh` and clear the auth cooldown on a successful fetch; invalidate the account selection cache when usage rows were written; log and swallow `Exception` only.
 
 ## 2. Streaming trigger
 
@@ -19,5 +19,5 @@
 ## 4. Verification
 
 - [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh on the bare account key and an owned-session refresh, ignores completed scheduler tasks, logs a joined scheduler failure, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths.
-- [x] 4.2 Integration coverage: a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick and the next selection reports `usage_limit_reached` with `resets_at`.
+- [x] 4.2 Integration coverage: with the production selection-cache TTL and a stale selection primed between the mark and the row write, a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick, invalidates the selection cache, and the next selection reports `usage_limit_reached` with `resets_at`.
 - [x] 4.3 ruff format/check, ty, `scripts/check_proxy_architecture.py`, strict OpenSpec validation.

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## 1. Coalesced request-triggered refresh
+
+- [x] 1.1 Add `UsageUpdater.request_refresh(account_id)` with a 15 s per-account debounce, `usage_refresh_enabled` and auth-cooldown short-circuits, and reset in `_clear_usage_refresh_state()`.
+- [x] 1.2 Run the refresh on the owned-session singleflight key with `join_existing=True`, loading a fresh background row and bypassing the freshness gate; never touch a caller's `Account`.
+- [x] 1.3 Record `_last_successful_refresh` and clear the auth cooldown on a successful fetch; log and swallow `Exception` only.
+
+## 2. Streaming trigger
+
+- [x] 2.1 Request the refresh from `_handle_stream_error` after `mark_rate_limit` when the code is `usage_limit_reached`, scheduled via `_schedule_cancel_safe_cleanup(action="request_usage_refresh")`.
+- [x] 2.2 Keep `rate_limit_exceeded`, quota codes, account-neutral, model-scoped and transient failures free of refresh requests.
+
+## 3. Verification
+
+- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls.
+- [x] 4.2 Integration coverage: a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick and the next selection reports `usage_limit_reached` with `resets_at`.
+- [x] 4.3 ruff format/check, ty, `scripts/check_proxy_architecture.py`, strict OpenSpec validation.

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
@@ -14,10 +14,10 @@
 ## 3. Reasoning-replay observability
 
 - [x] 3.1 Define `codex_lb_upstream_reasoning_replay_400_total` with the tri-state fallback and `__all__` entry.
-- [x] 3.2 Count upstream 400 (or code-less `invalid_request_error`) rejections whose message references reasoning without changing classification or account health.
+- [x] 3.2 Count upstream 400 rejections in `_handle_stream_error` and `invalid_request_error` terminal frames at the SSE frame-classification sites and websocket finalization (HTTP bridge included) via `_observe_terminal_stream_error_frame`, exactly once per failure and without changing classification or account health.
 
 ## 4. Verification
 
-- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh on the bare account key and an owned-session refresh, ignores completed scheduler tasks, logs a joined scheduler failure, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths.
-- [x] 4.2 Integration coverage: with the production selection-cache TTL and a stale selection primed between the mark and the row write, a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick, invalidates the selection cache, and the next selection reports `usage_limit_reached` with `resets_at`.
+- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh on the bare account key and an owned-session refresh, ignores completed scheduler tasks, logs a joined scheduler failure, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths, websocket/bridge terminal frames (raw, enveloped, `response.failed`), handler never double-counts frames.
+- [x] 4.2 Integration coverage: HTTP-400 status, raw and enveloped `error` frames and `response.failed` frames each increment the reasoning-replay counter exactly once (negatives stay at zero); with the production selection-cache TTL and a stale selection primed between the mark and the row write, a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick, invalidates the selection cache, and the next selection reports `usage_limit_reached` with `resets_at`.
 - [x] 4.3 ruff format/check, ty, `scripts/check_proxy_architecture.py`, strict OpenSpec validation.

--- a/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
+++ b/openspec/changes/request-usage-refresh-on-stream-usage-limit/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Coalesced request-triggered refresh
 
 - [x] 1.1 Add `UsageUpdater.request_refresh(account_id)` with a 15 s per-account debounce, `usage_refresh_enabled` and auth-cooldown short-circuits, and reset in `_clear_usage_refresh_state()`.
-- [x] 1.2 Run the refresh on the owned-session singleflight key with `join_existing=True`, loading a fresh background row and bypassing the freshness gate; never touch a caller's `Account`.
+- [x] 1.2 Join a scheduler refresh already in flight on the bare account key; otherwise run on the owned-session singleflight key with `join_existing=True`, loading a fresh background row and bypassing the freshness gate; never touch a caller's `Account`.
 - [x] 1.3 Record `_last_successful_refresh` and clear the auth cooldown on a successful fetch; log and swallow `Exception` only.
 
 ## 2. Streaming trigger
@@ -18,6 +18,6 @@
 
 ## 4. Verification
 
-- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths.
+- [x] 4.1 Unit coverage: storm -> single fetch, concurrent runs coalesce, joins the scheduler's in-flight refresh on the bare account key and an owned-session refresh, ignores completed scheduler tasks, logs a joined scheduler failure, debounce, fresh-row/ineligible rows, cancellation propagation, trigger and negative controls, counter predicate and no-op paths.
 - [x] 4.2 Integration coverage: a streamed `usage_limit_reached` writes the >= 100 % row without a scheduler tick and the next selection reports `usage_limit_reached` with `resets_at`.
 - [x] 4.3 ruff format/check, ty, `scripts/check_proxy_architecture.py`, strict OpenSpec validation.

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -10,20 +10,27 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+import time
 
 import aiohttp
 import pytest
 
+import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
+from app.core.config.settings import get_settings
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload
+from app.core.usage.models import RateLimitPayload, UsagePayload, UsageWindow
 from app.core.utils.request_id import get_request_id
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
+from app.modules.usage import updater as usage_updater_module
+from app.modules.usage.repository import UsageRepository
 
 pytestmark = pytest.mark.integration
 
@@ -1317,3 +1324,93 @@ async def test_compact_sticky_503_unknown_code_excludes_failing_account_on_failo
     assert response.status_code == 200
     assert response.json()["object"] == "response.compaction"
     assert seen_account_ids[:2] == ["acc_sticky_503_a", "acc_sticky_503_b"]
+
+
+# ===========================================================================
+# Streaming — usage_limit_reached requests an immediate usage refresh (#2123 WP-F)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exhaustion(async_client, monkeypatch):
+    """A streamed usage_limit_reached marks the account rate limited *and* writes the >= 100 %
+    usage row seconds later without a scheduler tick, so the next selection reports the
+    structured pool exhaustion with the row's reset time instead of waiting for the next
+    refresh interval."""
+    usage_updater_module._clear_usage_refresh_state()
+    raw_account_id = "acc_usage_limit_refresh"
+    account_id = await _import_account(async_client, raw_account_id, "usage-limit-refresh@example.com")
+    reset_at = int(time.time()) + 1800
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        raise ProxyResponseError(
+            429,
+            openai_error("usage_limit_reached", "usage limit reached"),
+            failure_phase="status",
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+    fetched: list[str | None] = []
+
+    async def fake_fetch_usage(*, access_token, account_id, route=None, allow_direct_egress=True):
+        fetched.append(account_id)
+        return UsagePayload(
+            plan_type="plus",
+            rate_limit=RateLimitPayload(
+                primary_window=UsageWindow(used_percent=100.0, reset_at=reset_at, limit_window_seconds=18000),
+                secondary_window=UsageWindow(
+                    used_percent=35.0,
+                    reset_at=reset_at + 6 * 86400,
+                    limit_window_seconds=604800,
+                ),
+            ),
+        )
+
+    # The suite disables background usage refresh globally; enable it for the updater only.
+    refresh_settings = get_settings().model_copy(update={"usage_refresh_enabled": True})
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 1)
+    monkeypatch.setattr(proxy_api_module, "_STREAM_STARTUP_ERROR_PROBE_SECONDS", 30.0)
+    monkeypatch.setattr(usage_updater_module, "fetch_usage", fake_fetch_usage)
+    monkeypatch.setattr(usage_updater_module, "get_settings", lambda: refresh_settings)
+
+    async def latest_primary_row():
+        async with SessionLocal() as session:
+            return await UsageRepository(session).latest_entry_for_account(account_id, window="primary")
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    try:
+        assert await latest_primary_row() is None
+        first = await async_client.post("/backend-api/codex/responses", json=payload)
+        assert first.status_code == 429
+        assert first.json()["error"]["code"] == "usage_limit_reached"
+
+        # The refresh is a tracked background task: poll briefly for its row instead of a
+        # scheduler tick (usage_refresh_interval_seconds).
+        latest = None
+        deadline = time.monotonic() + 5.0
+        while latest is None and time.monotonic() < deadline:
+            latest = await latest_primary_row()
+            if latest is None:
+                await asyncio.sleep(0.02)
+        assert latest is not None, "a streamed usage_limit_reached must request an immediate usage refresh"
+        assert latest.used_percent == 100.0
+        assert latest.reset_at == reset_at
+        assert fetched == [raw_account_id]
+
+        async with SessionLocal() as session:
+            account = await session.get(Account, account_id)
+            assert account is not None
+            assert account.status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
+
+        # With the >= 100 % row written, the pool is usage-proven exhausted on the very next
+        # selection and surfaces the structured failure with the row's reset time.
+        second = await async_client.post("/backend-api/codex/responses", json=payload)
+        assert second.status_code == 429
+        error = second.json()["error"]
+        assert error["code"] == "usage_limit_reached"
+        assert error["type"] == "usage_limit_reached"
+        assert error["resets_at"] == reset_at
+        assert fetched == [raw_account_id], "the second selection failure must not fetch upstream again"
+    finally:
+        usage_updater_module._clear_usage_refresh_state()

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -14,6 +14,7 @@ import asyncio
 import base64
 import json
 import time
+from unittest.mock import MagicMock
 
 import aiohttp
 import pytest
@@ -30,6 +31,7 @@ from app.core.usage.models import RateLimitPayload, UsagePayload, UsageWindow
 from app.core.utils.request_id import get_request_id
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
+from app.modules.proxy._service import observability as proxy_observability_module
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.repository import UsageRepository
@@ -1452,3 +1454,74 @@ async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exh
         release_fetch.set()
         usage_updater_module._clear_usage_refresh_state()
         selection_cache.invalidate()
+
+
+# ===========================================================================
+# Streaming — upstream reasoning-replay rejections are counted once per failure (#2123 CP-15)
+# ===========================================================================
+
+
+_REASONING_REPLAY_MESSAGE = (
+    "Item with id 'rs_0f3a' of type 'reasoning' was provided without its required following item."
+)
+
+
+@pytest.mark.parametrize(
+    ("upstream_shape", "message", "expected_increments"),
+    [
+        ("status_400", _REASONING_REPLAY_MESSAGE, 1),
+        ("error_frame", _REASONING_REPLAY_MESSAGE, 1),
+        ("error_frame_enveloped", _REASONING_REPLAY_MESSAGE, 1),
+        ("response_failed_frame", _REASONING_REPLAY_MESSAGE, 1),
+        ("error_frame", "Selected model is at capacity. Please try a different model.", 0),
+        ("response_failed_frame", "No tool output found for function call call_abc.", 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_reasoning_replay_rejection_counted_once_for_status_and_terminal_frames(
+    async_client, monkeypatch, upstream_shape: str, message: str, expected_increments: int
+):
+    """invalid_request_error is never penalized, so terminal ``error``/``response.failed`` frames
+    never reach ``_handle_stream_error``; the counter must fire at frame classification for them
+    and exactly once for the HTTP-400 status path."""
+    counter = MagicMock()
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
+    await _import_account(async_client, "acc_reasoning_replay", "reasoning-replay@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        if upstream_shape == "status_400":
+            raise ProxyResponseError(
+                400,
+                openai_error("invalid_request_error", message),
+                failure_phase="status",
+            )
+        if upstream_shape == "error_frame":
+            yield _sse_event({"type": "error", "code": "invalid_request_error", "message": message})
+        elif upstream_shape == "error_frame_enveloped":
+            yield _sse_event({"type": "error", "error": {"code": "invalid_request_error", "message": message}})
+        else:
+            yield _sse_event(
+                {
+                    "type": "response.failed",
+                    "response": {"error": {"code": "invalid_request_error", "message": message}},
+                }
+            )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 1)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    if upstream_shape == "status_400":
+        response = await async_client.post("/backend-api/codex/responses", json=payload)
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "invalid_request_error"
+    else:
+        async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+            assert resp.status_code == 200
+            lines = [line async for line in resp.aiter_lines() if line]
+        events = _extract_events(lines)
+        terminal = [event for event in events if event.get("type") in {"error", "response.failed"}]
+        assert len(terminal) == 1
+
+    assert counter.inc.call_count == expected_increments

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -18,6 +18,7 @@ import time
 import aiohttp
 import pytest
 
+import app.modules.proxy.account_cache as account_cache_module
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
@@ -29,6 +30,7 @@ from app.core.usage.models import RateLimitPayload, UsagePayload, UsageWindow
 from app.core.utils.request_id import get_request_id
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
+from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.repository import UsageRepository
 
@@ -1332,12 +1334,25 @@ async def test_compact_sticky_503_unknown_code_excludes_failing_account_on_failo
 
 
 @pytest.mark.asyncio
-async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exhaustion(async_client, monkeypatch):
+async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exhaustion(
+    async_client, app_instance, monkeypatch
+):
     """A streamed usage_limit_reached marks the account rate limited *and* writes the >= 100 %
     usage row seconds later without a scheduler tick, so the next selection reports the
     structured pool exhaustion with the row's reset time instead of waiting for the next
-    refresh interval."""
+    refresh interval.
+
+    Runs with the production selection-cache TTL (pytest defaults it to 0): ``mark_rate_limit``
+    invalidates the cache before the row exists, and a selection in between repopulates it
+    without usage evidence, so the refresh must invalidate again once the row is written.
+    The cross-replica invalidation poller is detached so its echo of the earlier
+    ``mark_rate_limit`` bump cannot stand in for the refresh's own invalidation.
+    """
     usage_updater_module._clear_usage_refresh_state()
+    monkeypatch.setattr(account_cache_module, "get_cache_invalidation_poller", lambda: None)
+    selection_cache = get_account_selection_cache()
+    monkeypatch.setattr(selection_cache, "_ttl_seconds", 5)
+    selection_cache.invalidate()
     raw_account_id = "acc_usage_limit_refresh"
     account_id = await _import_account(async_client, raw_account_id, "usage-limit-refresh@example.com")
     reset_at = int(time.time()) + 1800
@@ -1351,9 +1366,13 @@ async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exh
         yield  # pragma: no cover - makes this an async generator
 
     fetched: list[str | None] = []
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
 
     async def fake_fetch_usage(*, access_token, account_id, route=None, allow_direct_egress=True):
         fetched.append(account_id)
+        fetch_started.set()
+        await release_fetch.wait()
         return UsagePayload(
             plan_type="plus",
             rate_limit=RateLimitPayload(
@@ -1384,7 +1403,18 @@ async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exh
         first = await async_client.post("/backend-api/codex/responses", json=payload)
         assert first.status_code == 429
         assert first.json()["error"]["code"] == "usage_limit_reached"
+        await asyncio.wait_for(fetch_started.wait(), timeout=5)
+        assert fetched == [raw_account_id]
+        assert await latest_primary_row() is None
 
+        # Production race: a selection between ``mark_rate_limit`` and the refresh's row write
+        # repopulates the cache from a row set that carries no usage evidence yet.
+        load_balancer = app_instance.state.proxy_service._load_balancer
+        await load_balancer._load_selection_inputs(model=payload["model"])
+        assert selection_cache._cache, "the stale selection must be cached before the row lands"
+        stale_generation = selection_cache.generation
+
+        release_fetch.set()
         # The refresh is a tracked background task: poll briefly for its row instead of a
         # scheduler tick (usage_refresh_interval_seconds).
         latest = None
@@ -1396,15 +1426,21 @@ async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exh
         assert latest is not None, "a streamed usage_limit_reached must request an immediate usage refresh"
         assert latest.used_percent == 100.0
         assert latest.reset_at == reset_at
-        assert fetched == [raw_account_id]
+
+        deadline = time.monotonic() + 5.0
+        while selection_cache.generation == stale_generation and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+        assert selection_cache.generation > stale_generation, "the written row must invalidate the selection cache"
+        assert selection_cache._cache == {}
 
         async with SessionLocal() as session:
             account = await session.get(Account, account_id)
             assert account is not None
             assert account.status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
 
-        # With the >= 100 % row written, the pool is usage-proven exhausted on the very next
-        # selection and surfaces the structured failure with the row's reset time.
+        # With the >= 100 % row written and the stale selection dropped, the pool is
+        # usage-proven exhausted on the very next selection and surfaces the structured
+        # failure with the row's reset time -- without waiting out the cache TTL.
         second = await async_client.post("/backend-api/codex/responses", json=payload)
         assert second.status_code == 429
         error = second.json()["error"]
@@ -1413,4 +1449,6 @@ async def test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exh
         assert error["resets_at"] == reset_at
         assert fetched == [raw_account_id], "the second selection failure must not fetch upstream again"
     finally:
+        release_fetch.set()
         usage_updater_module._clear_usage_refresh_state()
+        selection_cache.invalidate()

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -140,6 +140,8 @@ def test_prometheus_metrics_defined_when_dependency_available(monkeypatch: pytes
     assert prometheus_module.continuity_owner_resolution_total.labelnames == ("surface", "source", "outcome")
     assert prometheus_module.continuity_fail_closed_total.name == "codex_lb_continuity_fail_closed_total"
     assert prometheus_module.continuity_fail_closed_total.labelnames == ("surface", "reason")
+    assert prometheus_module.upstream_reasoning_replay_400_total.name == "codex_lb_upstream_reasoning_replay_400_total"
+    assert prometheus_module.upstream_reasoning_replay_400_total.labelnames == ()
     assert prometheus_module.account_inflight_leases.name == "codex_lb_account_inflight_leases"
     assert prometheus_module.account_inflight_leases.labelnames == ("account_id", "kind")
     assert prometheus_module.image_requests_total.name == "codex_lb_image_requests_total"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -108,6 +108,7 @@ from app.modules.proxy.sticky_repository import StickySessionsRepository
 from app.modules.proxy.work_admission import AdmissionLease
 from app.modules.request_logs.repository import PreviousResponseOwnerRecord, RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+from app.modules.usage.updater import UsageUpdater
 from tests.unit._proxy_test_helpers import runtime_basic_auth_url
 from tests.unit.hypothesis_strategies import json_objects, json_values
 
@@ -502,6 +503,173 @@ async def test_rate_limit_still_marks_rate_limit() -> None:
 
     load_balancer.mark_rate_limit.assert_awaited_once()
     load_balancer.record_error.assert_not_awaited()
+
+
+def _stream_error_load_balancer() -> SimpleNamespace:
+    return SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+
+
+async def _sentinel_usage_refresh() -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_stream_error_requests_tracked_usage_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A streamed usage_limit_reached persists status via mark_rate_limit and also requests an
+    immediate usage refresh as a tracked background task, so the >= 100 % row that the pool
+    exhaustion predicate needs does not wait for the next scheduler tick."""
+    load_balancer = _stream_error_load_balancer()
+    schedule = MagicMock()
+    proxy = SimpleNamespace(_load_balancer=load_balancer, _schedule_cancel_safe_cleanup=schedule)
+    requested: list[str] = []
+    refresh = _sentinel_usage_refresh()
+
+    def fake_request_refresh(account_id: str):
+        requested.append(account_id)
+        return refresh
+
+    # ``raising=False`` keeps this a behavioural assertion on main, where the API does not exist.
+    monkeypatch.setattr(UsageUpdater, "request_refresh", staticmethod(fake_request_refresh), raising=False)
+    token = set_request_id("req_usage_limit_refresh")
+    try:
+        classified = await streaming_helpers_module._handle_stream_error(
+            proxy,
+            cast(Account, SimpleNamespace(id="acc-usage-limit")),
+            {"message": "usage limit reached"},
+            "usage_limit_reached",
+            429,
+        )
+    finally:
+        reset_request_id(token)
+        refresh.close()
+
+    assert classified["failure_class"] == "rate_limit"
+    load_balancer.mark_rate_limit.assert_awaited_once()
+    load_balancer.record_error.assert_not_awaited()
+    assert requested == ["acc-usage-limit"]
+    schedule.assert_called_once()
+    args, kwargs = schedule.call_args
+    assert args == (refresh,)
+    assert kwargs == {"action": "request_usage_refresh", "request_id": "req_usage_limit_refresh"}
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_stream_error_uses_unknown_request_id_outside_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schedule = MagicMock()
+    proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer(), _schedule_cancel_safe_cleanup=schedule)
+    refresh = _sentinel_usage_refresh()
+    monkeypatch.setattr(UsageUpdater, "request_refresh", staticmethod(lambda account_id: refresh))
+    assert get_request_id() is None
+
+    try:
+        await streaming_helpers_module._handle_stream_error(
+            proxy,
+            cast(Account, SimpleNamespace(id="acc-usage-limit")),
+            {"message": "usage limit reached"},
+            "usage_limit_reached",
+            429,
+        )
+    finally:
+        refresh.close()
+
+    assert schedule.call_args.kwargs["request_id"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_stream_error_skips_refresh_when_debounced(monkeypatch: pytest.MonkeyPatch) -> None:
+    load_balancer = _stream_error_load_balancer()
+    schedule = MagicMock()
+    proxy = SimpleNamespace(_load_balancer=load_balancer, _schedule_cancel_safe_cleanup=schedule)
+    monkeypatch.setattr(UsageUpdater, "request_refresh", staticmethod(lambda account_id: None))
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-usage-limit")),
+        {"message": "usage limit reached"},
+        "usage_limit_reached",
+        429,
+    )
+
+    load_balancer.mark_rate_limit.assert_awaited_once()
+    schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_stream_error_tolerates_proxy_without_cleanup_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test doubles without ``_schedule_cancel_safe_cleanup`` keep working; no coroutine is minted."""
+    load_balancer = _stream_error_load_balancer()
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "request_refresh",
+        staticmethod(lambda account_id: pytest.fail("no scheduler available: refresh must not be requested")),
+    )
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-usage-limit")),
+        {"message": "usage limit reached"},
+        "usage_limit_reached",
+        429,
+    )
+
+    assert classified["failure_class"] == "rate_limit"
+    load_balancer.mark_rate_limit.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("code", "http_status", "message"),
+    [
+        # Plain throttling is transient; only the pool-exhaustion signal triggers a fetch.
+        ("rate_limit_exceeded", 429, "Rate limit reached"),
+        # Quota codes already pin used_percent=100 in runtime state.
+        ("insufficient_quota", 429, "You exceeded your current quota"),
+        ("quota_exceeded", 429, "quota exceeded"),
+        # Account-neutral and model-scoped rejections never touch account health.
+        ("invalid_request_error", 400, "No tool output found for function call call_abc."),
+        (
+            "invalid_request_error",
+            400,
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        ),
+        # Transient and local failures.
+        ("upstream_error", 500, "Upstream request failed"),
+        ("stream_idle_timeout", None, "idle"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_usage_limit_stream_errors_do_not_request_usage_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    code: str,
+    http_status: int | None,
+    message: str,
+) -> None:
+    schedule = MagicMock()
+    proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer(), _schedule_cancel_safe_cleanup=schedule)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "request_refresh",
+        staticmethod(lambda account_id: pytest.fail(f"{code} must not request a usage refresh")),
+    )
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": message},
+        code,
+        http_status,
+    )
+
+    schedule.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -75,6 +75,7 @@ from app.modules.proxy import request_policy as proxy_request_policy
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import compact as proxy_compact_service
 from app.modules.proxy._service import file_ops as proxy_file_ops
+from app.modules.proxy._service import observability as proxy_observability_module
 from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service import warmup as proxy_warmup_service
 from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
@@ -705,8 +706,8 @@ async def test_reasoning_replay_400_increments_counter_without_changing_health(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     counter = MagicMock()
-    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", True)
-    monkeypatch.setattr(streaming_helpers_module, "upstream_reasoning_replay_400_total", counter)
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
     load_balancer = _stream_error_load_balancer()
     proxy = SimpleNamespace(_load_balancer=load_balancer, _schedule_cancel_safe_cleanup=MagicMock())
 
@@ -742,8 +743,8 @@ async def test_reasoning_replay_counter_ignores_non_matching_stream_errors(
     message: str,
 ) -> None:
     counter = MagicMock()
-    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", True)
-    monkeypatch.setattr(streaming_helpers_module, "upstream_reasoning_replay_400_total", counter)
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
     proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer())
 
     await streaming_helpers_module._handle_stream_error(
@@ -757,6 +758,53 @@ async def test_reasoning_replay_counter_ignores_non_matching_stream_errors(
     counter.inc.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_handle_stream_error_leaves_frame_counting_to_frame_sites(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Terminal frames (no HTTP status) are counted where they are classified, never twice via the handler."""
+    counter = MagicMock()
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
+    proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer())
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": _REASONING_REPLAY_400_MESSAGE},
+        "invalid_request_error",
+        None,
+    )
+
+    counter.inc.assert_not_called()
+    assert classified["failure_class"] == "non_retryable"
+
+
+@pytest.mark.parametrize(
+    ("code", "message", "expected_increments"),
+    [
+        ("invalid_request_error", _REASONING_REPLAY_400_MESSAGE, 1),
+        ("invalid_request_error", "Reasoning item rs_abc was not found in the conversation.", 1),
+        ("invalid_request_error", "No tool output found for function call call_abc.", 0),
+        ("upstream_error", _REASONING_REPLAY_400_MESSAGE, 0),
+        ("server_error", _REASONING_REPLAY_400_MESSAGE, 0),
+        ("invalid_request_error", None, 0),
+        (None, _REASONING_REPLAY_400_MESSAGE, 0),
+    ],
+)
+def test_observe_terminal_stream_error_frame_counts_reasoning_replay_only(
+    monkeypatch: pytest.MonkeyPatch,
+    code: str | None,
+    message: str | None,
+    expected_increments: int,
+) -> None:
+    counter = MagicMock()
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
+
+    proxy_observability_module._observe_terminal_stream_error_frame(code, message)
+
+    assert counter.inc.call_count == expected_increments
+
+
 @pytest.mark.parametrize("prometheus_available", [False, True])
 @pytest.mark.asyncio
 async def test_reasoning_replay_counter_is_noop_without_prometheus(
@@ -764,10 +812,10 @@ async def test_reasoning_replay_counter_is_noop_without_prometheus(
     prometheus_available: bool,
 ) -> None:
     counter = MagicMock()
-    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", prometheus_available)
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", prometheus_available)
     # Unavailable client: the counter object is absent; disabled flag: the object exists but is skipped.
     monkeypatch.setattr(
-        streaming_helpers_module,
+        proxy_observability_module,
         "upstream_reasoning_replay_400_total",
         None if prometheus_available else counter,
     )

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -672,6 +672,119 @@ async def test_non_usage_limit_stream_errors_do_not_request_usage_refresh(
     schedule.assert_not_called()
 
 
+_REASONING_REPLAY_400_MESSAGE = (
+    "Item with id 'rs_0123456789abcdef' of type 'reasoning' was provided without its required following item."
+)
+
+
+@pytest.mark.parametrize(
+    ("code", "http_status", "message", "expected"),
+    [
+        ("invalid_request_error", 400, _REASONING_REPLAY_400_MESSAGE, True),
+        # Case-insensitive; the live streaming path normalizes code-less 400s to upstream_error.
+        ("upstream_error", 400, "Reasoning item rs_abc was not found in the conversation.", True),
+        # Without an HTTP status (websocket error frames) only invalid_request_error qualifies.
+        ("invalid_request_error", None, _REASONING_REPLAY_400_MESSAGE, True),
+        ("upstream_error", None, _REASONING_REPLAY_400_MESSAGE, False),
+        ("invalid_request_error", 400, "No tool output found for function call call_abc.", False),
+        ("invalid_request_error", 400, None, False),
+        ("invalid_request_error", 400, "", False),
+        ("rate_limit_exceeded", 429, "reasoning quota exhausted", False),
+        ("server_error", 500, _REASONING_REPLAY_400_MESSAGE, False),
+    ],
+)
+def test_is_reasoning_replay_rejection(code: str, http_status: int | None, message: str | None, expected: bool) -> None:
+    assert (
+        streaming_helpers_module._is_reasoning_replay_rejection(code=code, http_status=http_status, message=message)
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_replay_400_increments_counter_without_changing_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counter = MagicMock()
+    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(streaming_helpers_module, "upstream_reasoning_replay_400_total", counter)
+    load_balancer = _stream_error_load_balancer()
+    proxy = SimpleNamespace(_load_balancer=load_balancer, _schedule_cancel_safe_cleanup=MagicMock())
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": _REASONING_REPLAY_400_MESSAGE},
+        "invalid_request_error",
+        400,
+    )
+
+    counter.inc.assert_called_once_with()
+    # Observation only: classification and account health handling are exactly today's.
+    assert classified["failure_class"] == "non_retryable"
+    load_balancer.record_error.assert_awaited_once()
+    load_balancer.mark_rate_limit.assert_not_awaited()
+    proxy._schedule_cancel_safe_cleanup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("code", "http_status", "message"),
+    [
+        ("invalid_request_error", 400, "No tool output found for function call call_abc."),
+        ("rate_limit_exceeded", 429, "reasoning quota exhausted"),
+        ("upstream_error", 500, _REASONING_REPLAY_400_MESSAGE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_reasoning_replay_counter_ignores_non_matching_stream_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    code: str,
+    http_status: int,
+    message: str,
+) -> None:
+    counter = MagicMock()
+    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(streaming_helpers_module, "upstream_reasoning_replay_400_total", counter)
+    proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer())
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": message},
+        code,
+        http_status,
+    )
+
+    counter.inc.assert_not_called()
+
+
+@pytest.mark.parametrize("prometheus_available", [False, True])
+@pytest.mark.asyncio
+async def test_reasoning_replay_counter_is_noop_without_prometheus(
+    monkeypatch: pytest.MonkeyPatch,
+    prometheus_available: bool,
+) -> None:
+    counter = MagicMock()
+    monkeypatch.setattr(streaming_helpers_module, "PROMETHEUS_AVAILABLE", prometheus_available)
+    # Unavailable client: the counter object is absent; disabled flag: the object exists but is skipped.
+    monkeypatch.setattr(
+        streaming_helpers_module,
+        "upstream_reasoning_replay_400_total",
+        None if prometheus_available else counter,
+    )
+    proxy = SimpleNamespace(_load_balancer=_stream_error_load_balancer())
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": _REASONING_REPLAY_400_MESSAGE},
+        "invalid_request_error",
+        400,
+    )
+
+    counter.inc.assert_not_called()
+    assert classified["failure_class"] == "non_retryable"
+
+
 @pytest.mark.asyncio
 async def test_stream_idle_timeout_does_not_penalize_account() -> None:
     load_balancer = SimpleNamespace(

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -5178,3 +5178,364 @@ async def test_refresh_accounts_does_not_repeat_post_reset_quota_probe(monkeypat
 
     updater = UsageUpdater(StubUsageRepository(), accounts_repo=None)
     await updater.refresh_accounts([acc], latest_usage={acc.id: latest})
+
+
+# ---------------------------------------------------------------------------
+# UsageUpdater.request_refresh: request-triggered coalesced background refresh
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _RequestRefreshSettings:
+    usage_refresh_enabled: bool = True
+    usage_refresh_interval_seconds: int = 60
+    usage_refresh_auth_failure_cooldown_seconds: int = 0
+
+
+def _install_owned_session_row(
+    monkeypatch: pytest.MonkeyPatch,
+    stored_account: Account | None,
+    *,
+    lookups: list[str],
+) -> None:
+    class AccountsRepo:
+        async def get_by_id(self, account_id: str):
+            lookups.append(account_id)
+            if stored_account is not None and account_id == stored_account.id:
+                return stored_account
+            return None
+
+        async def get_by_id_fresh(self, account_id: str):
+            return await self.get_by_id(account_id)
+
+    class AdditionalUsageRepo:
+        pass
+
+    monkeypatch.setattr(usage_updater_module, "get_settings", _RequestRefreshSettings)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAccountsRepository", AccountsRepo)
+    monkeypatch.setattr(usage_updater_module, "BackgroundUsageRepository", StubUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "BackgroundAdditionalUsageRepository", AdditionalUsageRepo)
+
+
+def test_request_refresh_returns_none_when_refresh_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        usage_updater_module, "get_settings", lambda: _RequestRefreshSettings(usage_refresh_enabled=False)
+    )
+
+    assert UsageUpdater.request_refresh("acc_request_disabled") is None
+    assert "acc_request_disabled" not in usage_updater_module._usage_request_refresh_deadlines
+
+
+def test_request_refresh_returns_none_during_auth_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usage_updater_module, "get_settings", _RequestRefreshSettings)
+    usage_updater_module._usage_refresh_auth_cooldowns["acc_request_cooldown"] = time.monotonic() + 60
+
+    assert UsageUpdater.request_refresh("acc_request_cooldown") is None
+    assert "acc_request_cooldown" not in usage_updater_module._usage_request_refresh_deadlines
+
+
+def test_request_refresh_debounces_repeats_until_window_elapses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usage_updater_module, "get_settings", _RequestRefreshSettings)
+    account_id = "acc_request_debounce"
+
+    first = UsageUpdater.request_refresh(account_id)
+    assert first is not None
+    first.close()
+    deadline = usage_updater_module._usage_request_refresh_deadlines[account_id]
+    assert deadline - time.monotonic() <= usage_updater_module._REQUEST_REFRESH_DEBOUNCE_SECONDS
+
+    assert UsageUpdater.request_refresh(account_id) is None
+    assert usage_updater_module._usage_request_refresh_deadlines[account_id] == deadline
+
+    # Elapsed window: the next request refreshes again and re-arms the debounce.
+    usage_updater_module._usage_request_refresh_deadlines[account_id] = time.monotonic() - 1
+    again = UsageUpdater.request_refresh(account_id)
+    assert again is not None
+    again.close()
+    assert usage_updater_module._usage_request_refresh_deadlines[account_id] > time.monotonic()
+
+    # Test isolation hook resets the debounce alongside the other refresh state.
+    usage_updater_module._clear_usage_refresh_state()
+    assert usage_updater_module._usage_request_refresh_deadlines == {}
+    reset = UsageUpdater.request_refresh(account_id)
+    assert reset is not None
+    reset.close()
+
+
+def test_request_refresh_debounce_is_per_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usage_updater_module, "get_settings", _RequestRefreshSettings)
+
+    first = UsageUpdater.request_refresh("acc_request_a")
+    other = UsageUpdater.request_refresh("acc_request_b")
+    assert first is not None and other is not None
+    first.close()
+    other.close()
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_storm_yields_single_upstream_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """20 concurrent usage_limit_reached failures on one account fetch upstream once."""
+    stored_account = _make_account("acc_request_storm", "workspace_request_storm")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    fetches = 0
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        nonlocal fetches
+        fetches += 1
+        await asyncio.sleep(0)
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+
+    requested = [UsageUpdater.request_refresh(stored_account.id) for _ in range(20)]
+    coroutines = [item for item in requested if item is not None]
+    assert len(coroutines) == 1
+
+    await asyncio.gather(*coroutines)
+
+    assert fetches == 1
+    assert lookups == [stored_account.id]
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_coalesces_concurrent_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent refresh runs for one account join a single in-flight fetch."""
+    stored_account = _make_account("acc_request_coalesce", "workspace_request_coalesce")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    fetches = 0
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        nonlocal fetches
+        fetches += 1
+        started.set()
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+
+    runs = [asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id)) for _ in range(20)]
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(*runs)
+
+    assert fetches == 1
+    assert lookups == [stored_account.id]
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_joins_inflight_scheduler_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A requested refresh joins the scheduler's owned-session refresh instead of fetching again."""
+    stored_account = _make_account("acc_request_join", "workspace_request_join")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "_refresh_account",
+        lambda *args, **kwargs: pytest.fail("joined refresh must not start its own fetch"),
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def scheduler_factory() -> usage_updater_module.AccountRefreshResult:
+        started.set()
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    scheduler_run = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(
+            usage_updater_module._usage_refresh_singleflight_key(stored_account.id, own_singleflight_session=True),
+            scheduler_factory,
+            join_existing=True,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    requested = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    await asyncio.sleep(0)
+    assert not requested.done()
+
+    release.set()
+    await asyncio.gather(scheduler_run, requested)
+
+    assert lookups == []
+    assert stored_account.id in usage_updater_module._last_successful_refresh
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_uses_fresh_row_and_bypasses_freshness(monkeypatch: pytest.MonkeyPatch) -> None:
+    caller_account = _make_account("acc_request_fresh", "workspace_request_fresh")
+    stored_account = _make_account("acc_request_fresh", "workspace_request_fresh_stored")
+    stored_account.status = AccountStatus.RATE_LIMITED
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    refreshed: list[tuple[Account, str | None]] = []
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        refreshed.append((account, usage_account_id))
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "_refresh_account_if_stale",
+        lambda *args, **kwargs: pytest.fail("requested refresh must bypass the freshness gate"),
+    )
+    usage_updater_module._usage_refresh_auth_cooldowns[stored_account.id] = time.monotonic() + 60
+
+    await usage_updater_module._run_requested_refresh(caller_account.id)
+
+    assert lookups == [caller_account.id]
+    assert len(refreshed) == 1
+    account, usage_account_id = refreshed[0]
+    assert account is stored_account
+    assert account is not caller_account
+    assert usage_account_id == "workspace_request_fresh_stored"
+    # The caller's row is never read or written; only the fresh background row is.
+    assert caller_account.status == AccountStatus.ACTIVE
+    assert stored_account.id in usage_updater_module._last_successful_refresh
+    assert stored_account.id not in usage_updater_module._usage_refresh_auth_cooldowns
+
+
+@pytest.mark.parametrize(
+    "stored_status",
+    [None, AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED],
+)
+@pytest.mark.asyncio
+async def test_requested_refresh_skips_missing_or_ineligible_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    stored_status: AccountStatus | None,
+) -> None:
+    stored_account = None
+    if stored_status is not None:
+        stored_account = _make_account("acc_request_ineligible", "workspace_request_ineligible")
+        stored_account.status = stored_status
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "_refresh_account",
+        lambda *args, **kwargs: pytest.fail("ineligible rows must not be fetched"),
+    )
+
+    await usage_updater_module._run_requested_refresh("acc_request_ineligible")
+
+    assert lookups == ["acc_request_ineligible"]
+    assert "acc_request_ineligible" not in usage_updater_module._last_successful_refresh
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_failed_fetch_does_not_record_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    stored_account = _make_account("acc_request_failed_fetch", "workspace_request_failed_fetch")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        return usage_updater_module.AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+    usage_updater_module._usage_refresh_auth_cooldowns[stored_account.id] = time.monotonic() + 60
+
+    await usage_updater_module._run_requested_refresh(stored_account.id)
+
+    assert stored_account.id not in usage_updater_module._last_successful_refresh
+    assert stored_account.id in usage_updater_module._usage_refresh_auth_cooldowns
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_logs_refresh_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stored_account = _make_account("acc_request_error", "workspace_request_error")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+
+    async def failing_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        raise RuntimeError("usage endpoint exploded")
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", failing_refresh_account)
+
+    with caplog.at_level(logging.WARNING, logger=usage_updater_module.logger.name):
+        await usage_updater_module._run_requested_refresh(stored_account.id)
+
+    assert any("Requested usage refresh failed" in record.getMessage() for record in caplog.records)
+    assert stored_account.id not in usage_updater_module._last_successful_refresh
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_cancellation_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancelling the tracked task raises CancelledError out of the refresh; it is never swallowed."""
+    stored_account = _make_account("acc_request_cancel", "workspace_request_cancel")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    factory_cancelled = asyncio.Event()
+
+    async def blocking_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            factory_cancelled.set()
+            raise
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", blocking_refresh_account)
+
+    task = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The waiter is cancelled; the owned singleflight fetch keeps running to completion.
+    key = usage_updater_module._usage_refresh_singleflight_key(stored_account.id, own_singleflight_session=True)
+    inflight = usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight[key]
+    assert not inflight.done()
+    assert not factory_cancelled.is_set()
+    release.set()
+    await inflight
+    assert stored_account.id not in usage_updater_module._last_successful_refresh

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -5342,7 +5342,12 @@ async def test_requested_refresh_coalesces_concurrent_runs(monkeypatch: pytest.M
 
 @pytest.mark.asyncio
 async def test_requested_refresh_joins_inflight_scheduler_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A requested refresh joins the scheduler's owned-session refresh instead of fetching again."""
+    """A requested refresh joins the scheduler's in-flight refresh instead of fetching again.
+
+    ``UsageRefreshScheduler`` calls ``refresh_accounts([account], ...)`` with the default
+    ``own_singleflight_sessions=False``, so its singleflight key is the bare account id --
+    not the owned-session key the request lane runs on.
+    """
     stored_account = _make_account("acc_request_join", "workspace_request_join")
     lookups: list[str] = []
     _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
@@ -5359,10 +5364,49 @@ async def test_requested_refresh_joins_inflight_scheduler_refresh(monkeypatch: p
         await release.wait()
         return usage_updater_module.AccountRefreshResult(usage_written=True)
 
+    scheduler_key = usage_updater_module._usage_refresh_singleflight_key(stored_account.id)
+    assert scheduler_key == stored_account.id
     scheduler_run = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(scheduler_key, scheduler_factory, join_existing=True)
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    requested = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    await asyncio.sleep(0)
+    assert not requested.done()
+    assert list(usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight) == [scheduler_key]
+
+    release.set()
+    await asyncio.gather(scheduler_run, requested)
+
+    assert lookups == []
+    assert stored_account.id in usage_updater_module._last_successful_refresh
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_joins_inflight_owned_session_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rate-limit payload and fleet lanes refresh on the owned-session key; a request joins them too."""
+    stored_account = _make_account("acc_request_join_owned", "workspace_request_join_owned")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "_refresh_account",
+        lambda *args, **kwargs: pytest.fail("joined refresh must not start its own fetch"),
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def owned_session_factory() -> usage_updater_module.AccountRefreshResult:
+        started.set()
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    owned_run = asyncio.create_task(
         usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(
             usage_updater_module._usage_refresh_singleflight_key(stored_account.id, own_singleflight_session=True),
-            scheduler_factory,
+            owned_session_factory,
             join_existing=True,
         )
     )
@@ -5373,10 +5417,85 @@ async def test_requested_refresh_joins_inflight_scheduler_refresh(monkeypatch: p
     assert not requested.done()
 
     release.set()
-    await asyncio.gather(scheduler_run, requested)
+    await asyncio.gather(owned_run, requested)
 
     assert lookups == []
     assert stored_account.id in usage_updater_module._last_successful_refresh
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_ignores_completed_scheduler_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A finished scheduler task lingering in the singleflight map is not joined; the request fetches."""
+    stored_account = _make_account("acc_request_join_done", "workspace_request_join_done")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    fetches = 0
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        nonlocal fetches
+        fetches += 1
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+
+    async def finished_factory() -> usage_updater_module.AccountRefreshResult:
+        return usage_updater_module.AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+
+    done_task = asyncio.create_task(finished_factory())
+    await done_task
+    usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight[stored_account.id] = done_task
+
+    await usage_updater_module._run_requested_refresh(stored_account.id)
+
+    assert fetches == 1
+    assert lookups == [stored_account.id]
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_logs_joined_scheduler_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failing scheduler refresh that the request joined is logged and swallowed, not re-fetched."""
+    stored_account = _make_account("acc_request_join_fail", "workspace_request_join_fail")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    monkeypatch.setattr(
+        UsageUpdater,
+        "_refresh_account",
+        lambda *args, **kwargs: pytest.fail("joined refresh must not start its own fetch"),
+    )
+    release = asyncio.Event()
+
+    async def failing_scheduler_factory() -> usage_updater_module.AccountRefreshResult:
+        await release.wait()
+        raise RuntimeError("upstream usage fetch exploded")
+
+    scheduler_run = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(
+            usage_updater_module._usage_refresh_singleflight_key(stored_account.id),
+            failing_scheduler_factory,
+            join_existing=True,
+        )
+    )
+    await asyncio.sleep(0)
+    requested = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    await asyncio.sleep(0)
+    release.set()
+
+    with caplog.at_level(logging.WARNING, logger=usage_updater_module.logger.name):
+        await requested
+    with pytest.raises(RuntimeError):
+        await scheduler_run
+
+    assert lookups == []
+    assert stored_account.id not in usage_updater_module._last_successful_refresh
+    assert any("Requested usage refresh failed" in record.getMessage() for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -5743,3 +5743,49 @@ async def test_requested_refresh_cancellation_propagates(monkeypatch: pytest.Mon
     release.set()
     await inflight
     assert stored_account.id not in usage_updater_module._last_successful_refresh
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_registers_owned_lane_before_first_suspension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bare-lane check and the owned-lane registration are one synchronous step.
+
+    ``_UsageRefreshSingleflight.run`` never awaits while holding its lock, so the
+    uncontended ``asyncio.Lock`` fast path registers the factory task before the
+    request's first suspension. Nothing can run between ``inflight(bare key)``
+    returning ``None`` and the owned-session task appearing in the map, so a
+    scheduler refresh cannot slip into that window and leave the request on a
+    third lane.
+    """
+    stored_account = _make_account("acc_request_atomic", "workspace_request_atomic")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    release = asyncio.Event()
+
+    async def held_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", held_refresh_account)
+    owned_key = usage_updater_module._usage_refresh_singleflight_key(stored_account.id, own_singleflight_session=True)
+
+    requested = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.inflight(owned_key) is None
+
+    # Exactly one loop iteration: the request's first step runs to its first suspension.
+    await asyncio.sleep(0)
+    assert not requested.done()
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.inflight(owned_key) is not None
+    assert list(usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight) == [owned_key]
+
+    release.set()
+    await requested
+    assert lookups == [stored_account.id]
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -5498,6 +5498,91 @@ async def test_requested_refresh_logs_joined_scheduler_failure(
     assert any("Requested usage refresh failed" in record.getMessage() for record in caplog.records)
 
 
+@pytest.mark.parametrize(
+    ("usage_written", "fetch_succeeded", "expected_invalidations"),
+    [
+        (True, True, 1),
+        (False, True, 0),
+        (False, False, 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_requested_refresh_invalidates_selection_cache_only_when_usage_written(
+    monkeypatch: pytest.MonkeyPatch,
+    usage_written: bool,
+    fetch_succeeded: bool,
+    expected_invalidations: int,
+) -> None:
+    """The written >= 100 % row must be visible to the next selection without waiting out the cache TTL."""
+    stored_account = _make_account("acc_request_cache", "workspace_request_cache")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    invalidations: list[bool] = []
+
+    class SelectionCache:
+        def invalidate(self, *, propagate: bool = True) -> None:
+            invalidations.append(propagate)
+
+    monkeypatch.setattr(usage_updater_module, "get_account_selection_cache", SelectionCache)
+
+    async def fake_refresh_account(
+        self: UsageUpdater,
+        account: Account,
+        *,
+        usage_account_id: str | None,
+        access_token_override: str | None = None,
+    ) -> usage_updater_module.AccountRefreshResult:
+        return usage_updater_module.AccountRefreshResult(
+            usage_written=usage_written,
+            fetch_succeeded=fetch_succeeded,
+        )
+
+    monkeypatch.setattr(UsageUpdater, "_refresh_account", fake_refresh_account)
+
+    await usage_updater_module._run_requested_refresh(stored_account.id)
+
+    assert invalidations == [True] * expected_invalidations
+
+
+@pytest.mark.asyncio
+async def test_requested_refresh_invalidates_selection_cache_after_joined_scheduler_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler only invalidates at cycle end; a joined per-account write is surfaced immediately."""
+    stored_account = _make_account("acc_request_cache_join", "workspace_request_cache_join")
+    lookups: list[str] = []
+    _install_owned_session_row(monkeypatch, stored_account, lookups=lookups)
+    invalidations = 0
+
+    class SelectionCache:
+        def invalidate(self, *, propagate: bool = True) -> None:
+            nonlocal invalidations
+            invalidations += 1
+
+    monkeypatch.setattr(usage_updater_module, "get_account_selection_cache", SelectionCache)
+    release = asyncio.Event()
+
+    async def scheduler_factory() -> usage_updater_module.AccountRefreshResult:
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    scheduler_run = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(
+            usage_updater_module._usage_refresh_singleflight_key(stored_account.id),
+            scheduler_factory,
+            join_existing=True,
+        )
+    )
+    await asyncio.sleep(0)
+    requested = asyncio.create_task(usage_updater_module._run_requested_refresh(stored_account.id))
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(scheduler_run, requested)
+
+    assert lookups == []
+    assert invalidations == 1
+
+
 @pytest.mark.asyncio
 async def test_requested_refresh_uses_fresh_row_and_bypasses_freshness(monkeypatch: pytest.MonkeyPatch) -> None:
     caller_account = _make_account("acc_request_fresh", "workspace_request_fresh")

--- a/tests/unit/test_websocket_upstream_transport_observability.py
+++ b/tests/unit/test_websocket_upstream_transport_observability.py
@@ -7,12 +7,15 @@ from collections import deque
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import anyio
 import pytest
 
 from app.core.crypto import TokenEncryptor
+from app.core.openai.parsing import parse_sse_event_payload
 from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy._service import observability as proxy_observability_module
 from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_HTTP,
     _REQUEST_TRANSPORT_WEBSOCKET,
@@ -455,3 +458,79 @@ async def test_fail_pending_websocket_requests_attributes_request_state_api_key(
 
     assert len(service.request_log_calls) == 1
     assert service.request_log_calls[0]["api_key"] is request_key
+
+
+_REASONING_REPLAY_MESSAGE = (
+    "Item with id 'rs_0f3a' of type 'reasoning' was provided without its required following item."
+)
+
+
+def _reasoning_replay_frame(event_type: str, *, code: str, message: str, enveloped: bool) -> dict[str, Any]:
+    if event_type == "response.failed":
+        return {
+            "type": "response.failed",
+            "response": {"id": "resp_replay", "error": {"code": code, "message": message}},
+        }
+    if enveloped:
+        return {"type": "error", "error": {"code": code, "message": message}}
+    # The ChatGPT-backed websocket emits error details directly on the frame.
+    return {"type": "error", "code": code, "message": message}
+
+
+@pytest.mark.parametrize(
+    ("event_type", "code", "message", "enveloped", "expected_increments"),
+    [
+        ("error", "invalid_request_error", _REASONING_REPLAY_MESSAGE, False, 1),
+        ("error", "invalid_request_error", _REASONING_REPLAY_MESSAGE, True, 1),
+        ("response.failed", "invalid_request_error", _REASONING_REPLAY_MESSAGE, True, 1),
+        ("error", "invalid_request_error", "No tool output found for function call call_abc.", False, 0),
+        ("response.failed", "server_error", _REASONING_REPLAY_MESSAGE, True, 0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_websocket_terminal_frame_counts_reasoning_replay_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+    event_type: str,
+    code: str,
+    message: str,
+    enveloped: bool,
+    expected_increments: int,
+) -> None:
+    """Websocket (and HTTP-bridge) terminal frames never carry an HTTP status and are never
+    penalized for invalid_request_error, so the reasoning-replay counter must fire at frame
+    finalization rather than inside the account-health handler."""
+    counter = MagicMock()
+    monkeypatch.setattr(proxy_observability_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_observability_module, "upstream_reasoning_replay_400_total", counter)
+    service = _DummyWebSocketService()
+    payload = _reasoning_replay_frame(event_type, code=code, message=message, enveloped=enveloped)
+    event = parse_sse_event_payload(payload)
+    request_state = _WebSocketRequestState(
+        request_id="ws_replay",
+        request_log_id="resp_replay_log",
+        response_id="resp_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport=_REQUEST_TRANSPORT_WEBSOCKET,
+        upstream_transport=_REQUEST_TRANSPORT_WEBSOCKET,
+    )
+
+    await service._finalize_websocket_request_state(
+        request_state,
+        account=cast(Any, SimpleNamespace(id="acc_replay")),
+        account_id_value="acc_replay",
+        event=event,
+        event_type=event_type,
+        payload=payload,
+        api_key=None,
+        upstream_control=_WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert counter.inc.call_count == expected_increments
+    assert len(service.request_log_calls) == 1
+    assert service.request_log_calls[0]["status"] == "error"
+    assert service.request_log_calls[0]["error_code"] == code


### PR DESCRIPTION
## Summary

When an upstream stream fails with `usage_limit_reached`, `_handle_stream_error` marked the account `rate_limited` but wrote no usage evidence, so the pool-exhaustion predicate (blocked status **and** a usage row at or above 100 %) could not fire and the pool kept answering `no_accounts` (or a local capacity wait) instead of the structured `429 usage_limit_reached` with `resets_at` until the background scheduler next refreshed that account — up to one `usage_refresh_interval_seconds` plus the freshness gate. This PR adds `UsageUpdater.request_refresh(account_id)`, a coalesced, debounced, fresh-row, tracked background refresh, triggers it from `_handle_stream_error` on the exact `usage_limit_reached` code, and adds the `codex_lb_upstream_reasoning_replay_400_total` counter that sizes the forked-thread reasoning-replay residual.

**Motivation.** Pre-existing gaps independent of any overflow behaviour: the only immediate-refresh API, `force_refresh`, waits for an in-flight refresh and then starts another (no coalescing under a 429 storm) and mutates the caller's `Account` ORM instance, so it cannot be used from a streaming request (DESIGN.md §0.1 C6). The lag between the first `usage_limit_reached` and the >= 100 % row is what makes the strict exhaustion predicate slow to become true (§4.3, §15 Q3 "WP-F shrinks the lag"). The reasoning-replay 400 residual (CP-15, §7.2) is currently unmeasurable. Design reference: **#2123 WP-F** — DESIGN.md §5 ("Companion refresh" row), §11, §16 WP-F. No overflow routing is introduced; the response to the client is never blocked or altered.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability (immediate refresh after a streamed usage-limit error; new Prometheus counter)
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Part of #2123 (WP-F)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path — no: it observes terminal frames and refreshes usage in the background; the wire format is untouched.

Change directory: `openspec/changes/request-usage-refresh-on-stream-usage-limit/` — ADDED requirements in `usage-refresh-policy` (request-triggered refresh: fresh row, freshness bypass, 15 s debounce, both singleflight lanes, selection-cache invalidation, process-local scope) and `proxy-runtime-observability` (the counter). `openspec validate request-usage-refresh-on-stream-usage-limit --strict` passes.

## Changes

**Usage refresh** (`app/modules/usage/updater.py`, +122/-16)
- `UsageUpdater.request_refresh(account_id) -> Coroutine | None` (sync): returns a background refresh coroutine for the caller to schedule as a tracked task, or `None` when suppressed (usage refresh disabled, auth cooldown, or the same account was requested within `_REQUEST_REFRESH_DEBOUNCE_SECONDS = 15.0` — a constant, not a setting).
- `_run_requested_refresh`: joins a scheduler refresh already in flight on the bare `account_id` singleflight key (new `_UsageRefreshSingleflight.inflight(key)` lookup), otherwise runs on `("owned-session", account_id)` with `join_existing=True` (rate-limit-payload and fleet lanes); loads the account from a fresh background-session row (never reads or writes a caller's `Account`); skips missing / `PAUSED` / `REAUTH_REQUIRED` / `DEACTIVATED` rows; calls `_refresh_account` unconditionally (freshness gate bypassed); on `usage_written` invalidates the account selection cache (matching the scheduler and reset-credit paths); records `_last_successful_refresh` and clears the auth cooldown on success; catches `Exception` only — `CancelledError` propagates.
- Row-loading half of `_refresh_account_if_stale_with_owned_session` extracted into the shared `_load_owned_session_updater`; the existing method keeps its name and signature.

**Trigger** (`app/modules/proxy/_service/streaming/helpers.py`)
- `_handle_stream_error` requests the refresh after `mark_rate_limit` for the exact `usage_limit_reached` code only, scheduled through `_schedule_cancel_safe_cleanup` as `proxy-request_usage_refresh-<request_id>`. `rate_limit_exceeded` is transient throttling and quota codes already pin `used_percent = 100`, so neither triggers. Error path only; no hot-path cost.

**Reasoning-replay counter** (`app/core/metrics/prometheus.py`, `app/modules/proxy/_service/observability.py`, `streaming/helpers.py`, `streaming/mixin.py` net zero, `websocket/mixin.py` +2)
- `codex_lb_upstream_reasoning_replay_400_total`: label-free Counter, tri-state fallback (no-op without `prometheus_client`), exported in `__all__`.
- `_is_reasoning_replay_rejection` + `_observe_terminal_stream_error_frame` live in `_service/observability.py` (the one module the streaming, websocket and http_bridge domains may all import). Hook sites: the SSE first-event and mid-stream terminal-frame classification (via `_classify_terminal_stream_error_frame`), the raw error-frame branch, websocket finalization (reused by the HTTP bridge), and HTTP-status rejections in `_handle_stream_error`. Each upstream failure is counted exactly once; classification, account health and failover are unchanged.

**Tests** (+1183): `tests/unit/test_usage_updater.py` (17 new: debounce per account, storm -> single upstream fetch, coalescing, joining the scheduler lane on the real bare key, joining the owned-session lane, completed task not joined, joined failure logged, selection-cache invalidation only when `usage_written`, fresh row + freshness bypass, ineligible rows, failed fetch, exception logging, cancellation propagation), `tests/unit/test_proxy_utils.py` (trigger + counter: tracked task, unknown request id, debounced skip, proxy without cleanup scheduler, negatives for other codes, predicate, health unchanged, no-op without prometheus, frame counting left to frame sites), `tests/unit/test_websocket_upstream_transport_observability.py` (raw, enveloped and `response.failed` frames), `tests/unit/test_metrics.py`, `tests/integration/test_proxy_transient_retry.py` (`test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exhaustion` with the production 5 s selection-cache TTL, a stale selection primed between the mark and the row write and the cross-replica poller detached so its echo cannot mask the gap; `test_stream_reasoning_replay_rejection_counted_once_for_status_and_terminal_frames`).

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** — works with zero config; gated by the existing `usage_refresh_enabled`.
- [x] No new required setup step
- New setting(s) and why each can't be a default: none (the 15 s debounce is a module constant).
- [x] README sections / `.env.example` / dashboard nav within budget — none added.

## Test plan

Branch based on `origin/main` @ `63ac81f34` (after #2103/#2104), head `07ef39858`.

```
.venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_usage_updater.py tests/unit/test_metrics.py \
  tests/unit/test_websocket_upstream_transport_observability.py tests/integration/test_proxy_transient_retry.py
# 207 passed in 53.66s
.venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_proxy_utils.py
# 1279 passed in 43.30s
python scripts/check_proxy_architecture.py      # passed (streaming/mixin.py net zero at its ceiling)
python scripts/check_proxy_timing_seams.py      # passed
python scripts/check_cancellation_safety.py     # passed
ruff check / ruff format --check / ty (3 production files)   # clean
openspec validate request-usage-refresh-on-stream-usage-limit --strict   # valid
codex review --base origin/main                 # 3 P2 findings, all fixed in the last three commits (see below)
```

**Fail-on-main evidence** (new tests copied onto the base worktree):

```
FAILED tests/unit/test_proxy_utils.py::test_usage_limit_stream_error_requests_tracked_usage_refresh
E  assert [] == ['acc-usage-limit']
FAILED tests/integration/test_proxy_transient_retry.py::test_stream_usage_limit_requests_immediate_refresh_so_pool_reports_exhaustion
E  AssertionError: a streamed usage_limit_reached must request an immediate usage refresh
```

Fixes that fail without their own commit: selection-cache invalidation (`assert 5 > 5`, "the written row must invalidate the selection cache"), scheduler-lane join (two concurrent fetches on `['acc-1', ('owned-session', 'acc-1')]` before the fix), and the SSE/WS frame counter hooks (frame cases increment 0 before the fix).

**Storm behaviour** (adversarial harness with the real `_schedule_cancel_safe_cleanup` and `request_refresh`, repos/fetch stubbed): 1000 concurrent `usage_limit_reached` errors on one account -> 1 upstream fetch, tracked tasks peak 1, no "coroutine never awaited" warnings; 3 storms x 300 within 15 s -> 1 fetch; 1000 distinct accounts -> 1000 fetches; `rate_limit_exceeded` / `insufficient_quota` / `server_error` -> 0 tasks. Per-error overhead ~41 us including mocks.

## Screenshots / output

Proxy behaviour: after an upstream `error` / `response.failed` frame with `usage_limit_reached`, the log shows `proxy-request_usage_refresh-<request_id>` scheduled and the >= 100 % usage row landing within the request's background task; the next selection for that pool answers `429 usage_limit_reached` with the row's `resets_at` instead of `no_accounts`. `codex_lb_upstream_reasoning_replay_400_total` appears in `/metrics` when `prometheus_client` is installed.

## Known limitations

Residual P3s from the adversarial verification (the three P2s it raised — scheduler-lane coalescing, selection-cache invalidation, frame-path counting — are fixed in the last three commits):

- If the in-flight owned-session task is the rate-limit-payload lane's stale-gated refresh and it resolves "fresh", `_run_requested_refresh` joins it, performs no fetch, yet records `_last_successful_refresh` and leaves the 15 s debounce armed; the >= 100 % row then waits for another 429 after 15 s or the scheduler. The window is milliseconds wide (that lane only enters singleflight for accounts its snapshot deemed stale).
- OpenSpec coherence: the existing `usage-refresh-policy` requirement "Blocked accounts refresh once their reset deadline elapses" says the freshness bypass "MUST NOT apply before the persisted reset deadline elapses" for the background sweep; the ADDED requirement introduces a pre-deadline bypass through a different trigger without a MODIFIED delta cross-referencing it. `--strict` passes; a follow-up wording delta would remove the apparent contradiction.
- `_is_reasoning_replay_rejection` matches any HTTP 400 whose message contains "reasoning" (faithful to the design's "400s mentioning reasoning"), so parameter-validation 400s such as `Unsupported parameter: 'reasoning.effort'` inflate the counter; a tighter match (`of type 'reasoning'`, `reasoning item`, `rs_` ids) would make the residual estimate more honest.
- `_usage_request_refresh_deadlines` is pruned only by the test hook `_clear_usage_refresh_state`; growth is bounded by distinct account ids that ever hit `usage_limit_reached` in the process (one float each).
- The debounce and singleflight lanes are process-local: under a cross-replica 429 storm each replica fetches once per 15 s per account (documented in the proposal). The scheduler lane does not join request lanes (pre-existing asymmetry).
- Production diff is +126 net vs the design's +41 estimate because the row-loading half of `_refresh_account_if_stale_with_owned_session` was extracted into `_load_owned_session_updater` instead of duplicated.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant subset locally (ruff, ty, targeted pytest, `check_proxy_architecture.py`, `check_proxy_timing_seams.py`, `check_cancellation_safety.py`).
- [x] If touching specs: `openspec validate --strict` passes for the change.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

Part of #2123

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Usage information now refreshes immediately after a streamed `usage_limit_reached` error, updating availability and reset times without waiting for the next scheduled refresh.
  - Repeated refresh requests are consolidated to reduce unnecessary work.

- **Observability**
  - Added Prometheus tracking for upstream HTTP 400 errors caused by replayed reasoning items across streaming and WebSocket responses.
  - Matching terminal errors are logged with their request identifiers for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->