### PR TITLE
fix(deps): require anyio>=4.14 to close Lock cancelled-waiter deadlock

### DIFF
--- a/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/.openspec.yaml
+++ b/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/proposal.md
+++ b/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Production (soju07, 2026-09-07) ran for four days with five HTTP-bridge `pending_lock` instances in an unrecoverable state: no owner task, yet a non-empty waiter queue whose futures were never resolved. One of them sat under the per-request fail-safe handoff sweep (`_release_http_bridge_unanchored_handoffs_for_request` → `_retire_http_bridge_after_drain_if_ready`), so roughly 100 live request tasks were queued behind a detached session's lock with no way out. The other four pinned bridge cleanup tasks, which in turn kept cancelled request chains alive (see `fix-probe-task-cancel-cascade-spin`).
+
+The root cause is a lost wake-up in anyio 4.13's asyncio `Lock`/`Semaphore`: `release()` skips waiters whose futures are already cancelled and sets the owner to `None`, but those cancelled entries stay queued until their tasks run their `except` branch. An acquirer arriving in that window sees "no owner, non-empty queue", takes the slow path, and is never handed ownership once the cancelled entries remove themselves. anyio 4.14.0 fixes exactly this ("Fixed asyncio Lock and Semaphore deadlocks caused by cancelled waiters left queued during release"). The repository pins anyio only transitively (4.13.0 in `uv.lock`).
+
+## What Changes
+
+- Declare `anyio>=4.14.0` as a direct dependency and lock anyio 4.15.1 so the deadlock-free release path ships in the next release.
+- Add a deterministic unit regression that drives the exact release/cancel/acquire interleaving against `anyio.Lock`, `anyio.Semaphore`, and the stdlib `asyncio.Lock` reference, so a future dependency downgrade or a re-implementation of the primitive cannot silently reintroduce the deadlock.
+- No public API, configuration, persistence schema, or wire-format changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-architecture`: Require the asyncio synchronization primitives used by the proxy to remain acquirable after a release that coincides with a cancelled waiter.
+
+## Impact
+
+Affected code is limited to `pyproject.toml`, `uv.lock`, one unit test module, and the `proxy-architecture` spec. Runtime behaviour changes only in the fixed dependency: `anyio.Lock`/`anyio.Semaphore` no longer wedge when a cancelled waiter is left queued during release. Every `anyio.Lock()` in the application (23 instances, including the HTTP bridge `pending_lock`, the bridge registry lock, and the websocket mixin locks) benefits without code changes.

--- a/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/specs/proxy-architecture/spec.md
+++ b/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/specs/proxy-architecture/spec.md
@@ -1,18 +1,35 @@
 ## ADDED Requirements
 
-### Requirement: Async synchronization primitives survive cancelled-waiter releases
+### Requirement: AnyIO synchronization primitives survive cancelled-waiter releases
 
-The asyncio `Lock` and `Semaphore` primitives used by the proxy (including every HTTP-bridge session `pending_lock`, the bridge registry lock, and websocket mixin locks) MUST remain acquirable after a release that happens while a queued waiter has already been cancelled but has not yet removed itself from the waiter queue. A release in that window MUST NOT leave the primitive with no owner and a non-empty waiter queue that nobody will ever wake. The repository MUST pin a dependency floor whose primitive implementation satisfies this property and MUST keep a deterministic regression that drives the release/cancel/acquire interleaving.
+The proxy uses two families of asyncio synchronization primitives: the AnyIO asyncio-backend `anyio.Lock` and `anyio.Semaphore` (every HTTP-bridge session `pending_lock`, the bridge registry lock, websocket mixin locks, and cache locks) and the stdlib `asyncio.Lock` and `asyncio.Semaphore`. When a release happens while a queued waiter has already been cancelled but has not yet removed itself from the waiter queue, each primitive MUST satisfy the following:
 
-#### Scenario: Newcomer acquires after a release coinciding with a cancelled waiter
+- **Lock**: the release MUST either hand ownership to a live (non-cancelled) queued waiter or leave the lock unowned such that the next `acquire()` call succeeds. A release MUST NOT leave the lock with no owner and a queued waiter that is never woken.
+- **Semaphore**: the released permit MUST become available to a live queued waiter or to the next acquirer. A release MUST NOT strand the permit behind a cancelled waiter entry so that waiter progress stops while the permit count is positive.
 
-- **GIVEN** task O holds the lock and task W1 is queued behind it
-- **WHEN** W1 is cancelled, O releases, and a newcomer A calls acquire before W1 has run its cancellation handler
+The stdlib primitives already satisfy this (they skip cancelled waiters on acquire) and serve as the reference behaviour. The repository MUST declare an AnyIO dependency floor whose asyncio-backend implementation satisfies this (anyio 4.14.0 or later) and MUST keep a deterministic regression that drives the release/cancel/acquire interleaving against `anyio.Lock`, `anyio.Semaphore`, and the stdlib reference.
+
+#### Scenario: AnyIO Lock newcomer acquires after a release coinciding with a cancelled waiter
+
+- **GIVEN** task O holds an `anyio.Lock` and task W1 is queued behind it
+- **WHEN** W1 is cancelled, O releases, and a newcomer A calls `acquire()` before W1 has run its cancellation handler
 - **THEN** A acquires the lock within the same bounded wait
 - **AND** the lock reports no owner and no waiting tasks after A releases
+
+#### Scenario: AnyIO Semaphore newcomer acquires a permit after a release coinciding with a cancelled waiter
+
+- **GIVEN** task O holds the only permit of an `anyio.Semaphore(1)` and task W1 is queued behind it
+- **WHEN** W1 is cancelled, O releases, and a newcomer A calls `acquire()` before W1 has run its cancellation handler
+- **THEN** A acquires the permit within the same bounded wait
+- **AND** the semaphore reports its full permit count and no waiting tasks after A releases
+
+#### Scenario: Stdlib reference behaviour is preserved
+
+- **GIVEN** the same interleaving is driven against the stdlib `asyncio.Lock`
+- **THEN** the newcomer acquires within the same bounded wait
 
 #### Scenario: Dependency floor pins the fixed primitive
 
 - **WHEN** the project dependencies are resolved
 - **THEN** the resolved anyio version is at least 4.14.0
-- **AND** the regression covering the cancelled-waiter release interleaving passes
+- **AND** the regression covering the cancelled-waiter release interleaving passes for both AnyIO primitives and the stdlib reference

--- a/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/specs/proxy-architecture/spec.md
+++ b/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/specs/proxy-architecture/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Async synchronization primitives survive cancelled-waiter releases
+
+The asyncio `Lock` and `Semaphore` primitives used by the proxy (including every HTTP-bridge session `pending_lock`, the bridge registry lock, and websocket mixin locks) MUST remain acquirable after a release that happens while a queued waiter has already been cancelled but has not yet removed itself from the waiter queue. A release in that window MUST NOT leave the primitive with no owner and a non-empty waiter queue that nobody will ever wake. The repository MUST pin a dependency floor whose primitive implementation satisfies this property and MUST keep a deterministic regression that drives the release/cancel/acquire interleaving.
+
+#### Scenario: Newcomer acquires after a release coinciding with a cancelled waiter
+
+- **GIVEN** task O holds the lock and task W1 is queued behind it
+- **WHEN** W1 is cancelled, O releases, and a newcomer A calls acquire before W1 has run its cancellation handler
+- **THEN** A acquires the lock within the same bounded wait
+- **AND** the lock reports no owner and no waiting tasks after A releases
+
+#### Scenario: Dependency floor pins the fixed primitive
+
+- **WHEN** the project dependencies are resolved
+- **THEN** the resolved anyio version is at least 4.14.0
+- **AND** the regression covering the cancelled-waiter release interleaving passes

--- a/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/tasks.md
+++ b/openspec/changes/fix-anyio-lock-cancelled-waiter-deadlock/tasks.md
@@ -1,0 +1,13 @@
+## 1. Dependency Floor
+
+- [x] 1.1 Declare `anyio>=4.14.0` in `pyproject.toml` and refresh `uv.lock` (anyio 4.15.1).
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add a deterministic unit test that reproduces the release-with-cancelled-waiter interleaving for `anyio.Lock`, `anyio.Semaphore`, and the stdlib `asyncio.Lock` reference and asserts the newcomer acquires.
+- [x] 2.2 Confirm the test fails against anyio 4.13.0 and passes against the locked version.
+
+## 3. Validation
+
+- [x] 3.1 Run the focused unit test, lint, type, and architecture checks.
+- [x] 3.2 Run strict change-local OpenSpec validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 requires-python = ">=3.13"
 dependencies = [
     "aiohttp>=3.13.4",
+    "anyio>=4.14.0",
     "aiohttp-retry>=2.9.1",
     "alembic>=1.16.5",
     "aiosqlite>=0.22.1",

--- a/tests/unit/test_anyio_lock_cancelled_waiter_release.py
+++ b/tests/unit/test_anyio_lock_cancelled_waiter_release.py
@@ -1,0 +1,93 @@
+"""Regression test for the anyio 4.13 ``Lock`` lost-wakeup deadlock.
+
+Production autopsy (2026-09-07, soju07): five HTTP-bridge ``pending_lock``
+instances sat with ``_owner_task is None`` while their waiter deques held
+pending, never-resolved futures. One of them queued ~100 live request tasks
+behind the per-request fail-safe sweep for days.
+
+Mechanism in anyio <= 4.13 (``anyio/_backends/_asyncio.py::Lock``):
+
+1. owner O holds the lock, waiter W1 is queued;
+2. W1 is cancelled -> its future is cancelled but W1's ``except`` branch
+   (which removes W1 from the deque) has not run yet;
+3. O releases in the same loop iteration: every queued future is cancelled,
+   so ``release()`` sets ``_owner_task = None`` and returns;
+4. newcomer A calls ``acquire()``: ``_owner_task is None`` **but** the deque
+   is non-empty, so A takes the slow path and waits for a hand-off;
+5. W1 finally runs and removes itself -> the deque is ``[A]`` with no owner
+   and nobody left to hand ownership over. Every later acquirer queues
+   behind A forever.
+
+anyio 4.14.0 fixed this ("Fixed asyncio Lock and Semaphore deadlocks caused
+by cancelled waiters left queued during release"). This test pins the
+behaviour so the dependency floor cannot silently regress.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+async def _drive_release_race(primitive_factory, acquire_cm):
+    lock = primitive_factory()
+    hold = asyncio.Event()
+    outcome: dict[str, str] = {}
+
+    async def owner() -> None:
+        async with acquire_cm(lock):
+            await hold.wait()
+
+    async def cancelled_waiter() -> None:
+        async with acquire_cm(lock):
+            outcome["cancelled_waiter"] = "acquired"
+
+    async def newcomer() -> None:
+        try:
+            async with asyncio.timeout(1):
+                async with acquire_cm(lock):
+                    outcome["newcomer"] = "acquired"
+        except TimeoutError:
+            outcome["newcomer"] = "deadlocked"
+
+    owner_task = asyncio.create_task(owner())
+    await asyncio.sleep(0)
+    waiter_task = asyncio.create_task(cancelled_waiter())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    # Ready-queue order for the next iteration:
+    #   owner wakes (release) -> newcomer starts (acquire) -> cancelled waiter
+    #   wakes (removes its cancelled entry).
+    hold.set()
+    newcomer_task = asyncio.create_task(newcomer())
+    waiter_task.cancel()
+
+    await asyncio.gather(owner_task, waiter_task, newcomer_task, return_exceptions=True)
+    return outcome, lock
+
+
+async def test_anyio_lock_release_with_cancelled_waiter_does_not_strand_newcomer():
+    outcome, lock = await _drive_release_race(anyio.Lock, lambda lock: lock)
+    assert outcome.get("newcomer") == "acquired", outcome
+    assert not lock.locked()
+    assert lock.statistics().tasks_waiting == 0
+
+
+async def test_anyio_semaphore_release_with_cancelled_waiter_does_not_strand_newcomer():
+    outcome, semaphore = await _drive_release_race(lambda: anyio.Semaphore(1), lambda semaphore: semaphore)
+    assert outcome.get("newcomer") == "acquired", outcome
+    assert semaphore.value == 1
+    assert semaphore.statistics().tasks_waiting == 0
+
+
+async def test_stdlib_lock_release_with_cancelled_waiter_does_not_strand_newcomer():
+    """Reference behaviour: the stdlib lock jumps stale cancelled waiters."""
+
+    outcome, lock = await _drive_release_race(asyncio.Lock, lambda lock: lock)
+    assert outcome.get("newcomer") == "acquired", outcome
+    assert not lock.locked()

--- a/uv.lock
+++ b/uv.lock
@@ -176,14 +176,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
 ]
 
 [[package]]
@@ -494,6 +495,7 @@ dependencies = [
     { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "brotli" },
@@ -557,6 +559,7 @@ requires-dist = [
     { name = "aiohttp-socks", specifier = ">=0.10.1" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.16.5" },
+    { name = "anyio", specifier = ">=4.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "bcrypt", specifier = ">=4.3.0" },
     { name = "brotli", specifier = ">=1.2.0" },
@@ -2647,11 +2650,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Production (soju07, 2026-09-07) ran for four days with five HTTP-bridge `pending_lock` instances in an unrecoverable state: `_owner_task is None` while the waiter deque held pending, never-resolved futures. One of them sat under the per-request fail-safe sweep (`_release_http_bridge_unanchored_handoffs_for_request` → `_retire_http_bridge_after_drain_if_ready`), so ~100 live request tasks were queued behind a single detached session's lock. The other four pinned bridge cleanup tasks, which kept 15 client-cancelled request chains alive and spinning (see the companion PR for that spin).

Root cause is a lost wake-up in anyio 4.13's asyncio `Lock`/`Semaphore` (`anyio/_backends/_asyncio.py`):

1. owner O holds the lock, waiter W1 is queued;
2. W1 is cancelled → its future is cancelled, but W1's `except` branch (which removes it from the deque) has not run yet;
3. O releases in the same loop iteration: every queued future is cancelled, so `release()` sets `_owner_task = None`;
4. newcomer A calls `acquire()`: no owner **but** a non-empty deque → slow path, waits for a hand-off;
5. W1 removes itself → deque is `[A]`, no owner, nobody left to hand over. Every later acquirer queues behind A forever.

anyio 4.14.0 fixes exactly this: *"Fixed asyncio Lock and Semaphore deadlocks caused by cancelled waiters left queued during release"*. The repository only pinned anyio transitively (4.13.0 in `uv.lock`). The stdlib `asyncio.Lock` is immune (it jumps the queue when every queued waiter is cancelled).

## What

- Declare `anyio>=4.14.0` as a direct dependency; `uv.lock` resolves anyio 4.15.1 (typing-extensions 4.16.0 came along).
- `tests/unit/test_anyio_lock_cancelled_waiter_release.py`: deterministic reproduction of the release/cancel/acquire interleaving against `anyio.Lock`, `anyio.Semaphore`, and the stdlib `asyncio.Lock` reference. Fails on anyio 4.13.0 (`{'newcomer': 'deadlocked'}` for both anyio primitives), passes on 4.15.1.
- OpenSpec change `fix-anyio-lock-cancelled-waiter-deadlock` (`proxy-architecture` delta).

All 23 `anyio.Lock()` instances in the app (bridge `pending_lock`, bridge registry lock, websocket mixin locks, caches) benefit without code changes.

## Evidence from production

Loop probe (`sys.remote_exec` into the running process) on soju07 before restart:

```
lock e051dab55010  waiters_deque=100 owner=None  blocked_tasks=53
    x52  helpers.py:_release_http_bridge_unanchored_handoffs_for_request:2729 > request_submit.py:_retire_http_bridge_after_drain_if_ready:2991 > Lock.acquire
    lock ref: attr=session.pending_lock session_key=codex-lb-affinity-v1:thread_header:process_thread:9223ac…  session_closed=False
lock e051aa4eb650  waiters_deque=19  owner=None  blocked_tasks=19
    x18  request_submit.py:_cleanup_http_bridge_submit_interruption:2518 > Lock.acquire
```

Restarting the container cleared all wedged locks (`tasks_blocked_in_Lock.acquire=0`) and dropped app CPU from ~105% to ~55%.

## Validation

- `pytest tests/unit` (8063 passed; the only failure, `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses`, fails identically on `main` — `no such table: file_account_pins`)
- `ruff check` / `ruff format --check` / `ty check` / `scripts/check_cancellation_safety.py`
- `openspec validate fix-anyio-lock-cancelled-waiter-deadlock --strict`
- local `codex review --base origin/main`: no actionable defects

Related to #2029
Related to #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential deadlocks in asynchronous lock and semaphore handling when a waiting task is cancelled.
  * Improved reliability for HTTP bridge and WebSocket operations relying on these synchronization mechanisms.

* **Tests**
  * Added regression coverage for cancelled-waiter scenarios across supported AnyIO and standard-library lock and semaphore implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->