### PR TITLE
fix(proxy): stop level-cancel cascade from respinning deferred probe cleanup

### DIFF
--- a/app/core/utils/shared_future.py
+++ b/app/core/utils/shared_future.py
@@ -100,7 +100,14 @@ async def _await_task_deferring_cancellation(
     result: _TaskResultT | None = None
     # The anyio shield keeps a level-cancelled Starlette scope from re-raising
     # into every ``await``, which would otherwise busy-spin this loop until the
-    # owned task completes. ``wait_on_shared_future`` keeps the loop's waits
+    # owned task completes. The shield only covers the task anyio tracks: when
+    # this helper runs inside a plain ``asyncio.create_task`` task that an
+    # anyio-tracked task awaits directly (``await task``), each level re-cancel
+    # of the tracked task cascades down the ``_fut_waiter`` chain and re-enters
+    # this loop anyway. Callers that hand such a task across a task boundary
+    # must await it through ``wait_on_shared_future`` so the proxy future, not
+    # the owned task, absorbs the repeated cancels (2026-09-07 production
+    # busy spin). ``wait_on_shared_future`` keeps the loop's waits
     # off the task's done-callback list: Python 3.14's ``asyncio.shield``
     # leaks a callback per cancelled wait, so re-shielding a task wedged on a
     # lock grew 100k+ callbacks and O(n^2) remove scans in the 2026-08-30

--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from app.core.errors import ResponseFailedEvent
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_dict
-from app.core.utils.shared_future import wait_on_shared_future
+from app.core.utils.shared_future import _await_task_deferring_cancellation, wait_on_shared_future
 
 type JsonPayload = Mapping[str, JsonValue] | ResponseFailedEvent
 
@@ -99,7 +99,18 @@ async def inject_sse_keepalives(
             if pending is not None and not pending.done():
                 pending.cancel()
                 try:
-                    await pending
+                    # Not ``await pending``: a level-cancelled consumer scope
+                    # re-cancels this task on every loop iteration, and a
+                    # direct task await cascades each cancel into ``pending``
+                    # and any cancellation-deferring wait beneath it (the
+                    # startup-probe task), spinning the loop until that
+                    # cleanup completes. The canonical helper shields this
+                    # task and waits through a proxy future, so the chunk task
+                    # sees only the explicit cancel above; it still settles
+                    # before the outer finalizers close the iterator chain the
+                    # chunk task is driving, and its eventual exception is
+                    # retrieved here rather than logged as never retrieved.
+                    await _await_task_deferring_cancellation(pending)
                 except BaseException:
                     pass
     finally:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -169,6 +169,10 @@ from app.core.utils.shared_future import (
 from app.core.utils.shared_future import (
     _await_result_deferring_cancellation as _shared_await_result_deferring_cancellation,
 )
+from app.core.utils.shared_future import (
+    _await_task_deferring_cancellation as _shared_await_task_deferring_cancellation,
+)
+from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
@@ -7841,15 +7845,32 @@ async def _prepend_items(items: list[str], stream: AsyncIterator[str]) -> AsyncI
 
 async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
     try:
-        first = await first_task
+        # Not ``await first_task``: a level-cancelled Starlette scope re-cancels
+        # the consuming task on every loop iteration, and ``Task.cancel()``
+        # cascades down the ``_fut_waiter`` chain into the awaited task. The
+        # probe task defers cancellation while its bridge cleanup finishes, so
+        # a direct await turned every client disconnect into a busy spin that
+        # lasted as long as that cleanup (2026-09-07 production: ~1.4e9
+        # re-cancels across 15 wedged requests). The per-waiter proxy future
+        # absorbs the level cancellation here; the probe sees only the single
+        # explicit teardown ``cancel()`` below.
+        first = await wait_on_shared_future(first_task)
     except StopAsyncIteration:
         return
     finally:
         # If the wrapping stream is closed before the first item is consumed
         # (client disconnect, request teardown), cancel the still-running probe
-        # task so it does not hold the upstream connection open.
+        # task so it does not hold the upstream connection open, then wait for
+        # its deferred bridge cleanup to settle so the stream it drives is not
+        # closed underneath it. The canonical helper waits without cascading
+        # repeated level cancels into the probe; its exception, if any, is
+        # retrieved here (the probe's done-callback also settles it).
         if not first_task.done():
             first_task.cancel()
+            try:
+                await _shared_await_task_deferring_cancellation(first_task)
+            except BaseException:
+                pass
     yield first
     async for line in stream:
         yield line

--- a/openspec/changes/fix-probe-task-cancel-cascade-spin/.openspec.yaml
+++ b/openspec/changes/fix-probe-task-cancel-cascade-spin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/fix-probe-task-cancel-cascade-spin/design.md
+++ b/openspec/changes/fix-probe-task-cancel-cascade-spin/design.md
@@ -1,0 +1,22 @@
+## Context
+
+`app/core/utils/shared_future.py` already provides `wait_on_shared_future()` (one fan-out callback per shared future, one proxy future per waiter) and `_await_task_deferring_cancellation()` (finish owned cleanup, then surface the caller's cancellation). Both assume the cancellation they defend against arrives at the task that runs them. The 2026-09-07 incident showed a second delivery path: anyio level cancellation of a *different* task that awaits the deferring task directly, cascading through `Task.cancel()` on each loop iteration.
+
+## Decisions
+
+### D1. Break the cascade at the task boundary, not inside the deferring helper
+
+The deferring helper cannot stop a cascade because every await it performs is what the cascade cancels. The fix belongs where an anyio-tracked task awaits an `asyncio` task that may defer cancellation: `_prepend_first_task` (probe task) and the `inject_sse_keepalives` teardown (chunk task). Awaiting through `wait_on_shared_future` gives the tracked task its own proxy future to be cancelled; the awaited task is untouched apart from the explicit teardown `cancel()` the code already performs.
+
+### D2. Teardown still waits for the awaited task to settle
+
+Both sites drive an async-generator chain from the awaited task. Returning from teardown early would let outer finalizers (`_wrap_source_responses_public_stream` and the injector's own `finally`) call `aclose()` on generators the task is still running, which raises `RuntimeError: aclose(): asynchronous generator is already running`, and would leave the task's eventual exception unretrieved. Teardown therefore cancels the task once and then waits through `_await_task_deferring_cancellation`: its anyio shield stops the level re-cancel of the tracked consumer task, its proxy wait absorbs any remaining direct cancel, and it retrieves the task's result or exception. The wait lasts as long as the deferred cleanup, exactly as the old spinning await did, but idles instead of burning the loop.
+
+### D3. No new primitive, no detached tasks
+
+The change reuses `wait_on_shared_future` and `_await_task_deferring_cancellation`; no iterator hand-off flag or background close task is introduced.
+
+## Risks / Trade-offs
+
+- **Teardown still blocks on deferred cleanup**: intentional and unchanged from the old behaviour; when that cleanup is itself wedged (see `fix-anyio-lock-cancelled-waiter-deadlock`) the request tasks stay parked but no longer consume CPU.
+- **Other direct awaits of `asyncio` tasks**: the AST cancellation gate does not yet reject `await task` across a task boundary. This change fixes the two sites on the production path and documents the rule; a structural gate is a follow-up.

--- a/openspec/changes/fix-probe-task-cancel-cascade-spin/proposal.md
+++ b/openspec/changes/fix-probe-task-cancel-cascade-spin/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Production (soju07, 2026-09-07) carried 15 client-cancelled Responses requests for four days. Each kept three tasks alive -- Starlette's streaming body task, the SSE keepalive injector's chunk task, and the startup-probe first-item task -- with `Task.cancelling()` near 1.4 billion, and the profile attributed roughly a third of the saturated core to anyio cancellation delivery plus the cancellation-deferring wait re-entering itself.
+
+A level-cancelled anyio scope re-delivers `Task.cancel()` to its host task on every event-loop iteration until the task leaves the scope. `_prepend_first_task` awaited the probe task directly (`await first_task`) and `inject_sse_keepalives` awaited its pending chunk task directly during teardown (`await pending`). `Task.cancel()` cascades down the `_fut_waiter` chain, so each re-delivery reached the probe task's cancellation-deferring cleanup wait. That wait is shielded with `anyio.CancelScope(shield=True)`, but the shield protects only a task anyio tracks; the probe is a plain `asyncio.create_task`, so the cascaded cancel re-entered the loop once per iteration for as long as the cleanup took. When the cleanup was itself blocked (see `fix-anyio-lock-cancelled-waiter-deadlock`), the spin never ended and starved every other task on the loop.
+
+## What Changes
+
+- `_prepend_first_task` awaits the startup-probe task through `wait_on_shared_future`, so a level-cancelled body task cancels only its own proxy future and the probe receives exactly the single explicit teardown `cancel()`.
+- `inject_sse_keepalives` awaits its cancelled pending chunk task through the canonical cancellation-deferring helper during teardown, so the chunk task still settles before the outer finalizers close the iterator chain it drives (`aclose()` on a still-running async generator raises) and its eventual exception is retrieved, while a level-cancelled consumer no longer re-cancels it every iteration.
+- `_prepend_first_task` teardown cancels the probe task and then waits for its deferred bridge cleanup through the same helper, preserving the "cancel and await handed-off preflight work" contract without the cascade.
+- Document in the canonical defer-cancellation helper that its anyio shield only covers anyio-tracked tasks and that cross-task awaits must go through the proxy future.
+- Add regressions that run a level-cancelled Starlette-shaped consumer against a probe whose cleanup is blocked and assert the probe and chunk tasks are cancelled at most once, that teardown still waits for the deferred cleanup, and that the source is closed only after the chunk task settles.
+- No public API, configuration, persistence schema, or wire-format changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require that a cancelled streamed response does not re-cancel deferred startup-probe or keepalive-chunk work on every event-loop iteration, while still waiting for that work to settle before closing the iterator chain it drives.
+
+## Impact
+
+Affected code is `app/modules/proxy/api.py::_prepend_first_task`, `app/core/utils/sse.py::inject_sse_keepalives`, a comment in `app/core/utils/shared_future.py`, and one unit test module. Client-visible streaming behaviour is unchanged; teardown of a cancelled response still waits for the deferred bridge cleanup, but idles on a proxy future instead of spinning the event loop until that cleanup finishes.

--- a/openspec/changes/fix-probe-task-cancel-cascade-spin/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-probe-task-cancel-cascade-spin/specs/responses-api-compat/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Cancelled streamed responses do not re-cancel deferred startup work every loop iteration
+
+When a streamed Responses body is cancelled by its response scope (client disconnect or request teardown) while the startup-probe first-item task or the SSE keepalive chunk task is still running cancellation-deferring cleanup, the proxy MUST NOT re-deliver cancellation to that task on every event-loop iteration. The body MUST await such tasks through a per-waiter proxy future so the level cancellation is absorbed by the proxy and the awaited task receives at most one explicit teardown cancellation. Teardown MUST still wait for that task to settle before closing the iterator chain it drives, so no `aclose()` is attempted on a running async generator and the task's eventual exception is retrieved.
+
+#### Scenario: Probe task is cancelled once while its cleanup is blocked
+
+- **GIVEN** a streamed response whose startup-probe task is waiting on cancellation-deferring cleanup that has not completed
+- **WHEN** the response scope is cancelled and the event loop runs many iterations
+- **THEN** the probe task's cancellation count stays at the single explicit teardown cancel
+- **AND** the deferred cleanup task is not cancelled
+- **AND** the response body task finishes once the cleanup settles, without spinning the loop meanwhile
+
+#### Scenario: Keepalive teardown waits for the chunk task without respinning it
+
+- **GIVEN** the SSE keepalive injector's pending chunk task is still driving a cancellation-deferring source when the consumer is cancelled
+- **WHEN** the event loop runs many iterations before that source's cleanup settles
+- **THEN** the chunk task is cancelled at most once
+- **AND** the source iterator is not closed while the chunk task drives it
+- **AND** the source iterator is closed exactly once after the chunk task settles

--- a/openspec/changes/fix-probe-task-cancel-cascade-spin/tasks.md
+++ b/openspec/changes/fix-probe-task-cancel-cascade-spin/tasks.md
@@ -1,0 +1,15 @@
+## 1. Break the Cancellation Cascade
+
+- [x] 1.1 Await the startup-probe task in `_prepend_first_task` through `wait_on_shared_future`.
+- [x] 1.2 Await the cancelled pending chunk task in `inject_sse_keepalives` teardown, and the cancelled probe task in `_prepend_first_task` teardown, through the canonical cancellation-deferring helper so they settle before the iterator chain is closed.
+- [x] 1.3 Document the tracked-task limitation of the anyio shield in the canonical defer-cancellation helper.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add a level-cancelled Starlette-shaped consumer regression asserting the probe task is cancelled at most once while its cleanup is blocked, and settles after release.
+- [x] 2.2 Add the same regression for the keepalive chunk task, including that teardown waits for it and closes the source only after it settles.
+
+## 3. Validation
+
+- [x] 3.1 Run focused cancellation tests, lint, format, type, and architecture checks.
+- [x] 3.2 Run strict change-local OpenSpec validation.

--- a/tests/unit/test_probe_task_cancel_cascade.py
+++ b/tests/unit/test_probe_task_cancel_cascade.py
@@ -38,12 +38,6 @@ from app.modules.proxy.api import _prepend_first_task
 
 pytestmark = pytest.mark.unit
 
-# The old cascade re-cancelled the probe once per loop iteration: thousands
-# of cancels in 50ms. The fixed path performs exactly one explicit teardown
-# cancel; allow a little slack for scheduler noise.
-_MAX_CANCELS = 3
-
-
 async def _run_level_cancelled_consumer(stream: AsyncIterator[str]) -> asyncio.Task[None]:
     """Consume ``stream`` inside a task group whose scope is then cancelled.
 
@@ -99,7 +93,7 @@ async def test_level_cancelled_response_does_not_respin_startup_probe_task():
 
     assert cleanup_task is not None
     assert not first_task.done(), "deferred cleanup must keep the probe alive"
-    assert first_task.cancelling() <= _MAX_CANCELS, first_task.cancelling()
+    assert first_task.cancelling() == 1, first_task.cancelling()
     assert cleanup_task.cancelling() == 0
     # Teardown still waits for the probe's deferred cleanup (ordering: the
     # probe drives the inner stream, so the body must not close it first).
@@ -137,7 +131,7 @@ async def test_level_cancelled_keepalive_consumer_does_not_respin_pending_chunk_
         t for t in asyncio.all_tasks() if t is not asyncio.current_task() and "_next_chunk" in repr(t.get_coro())
     ]
     assert pending_tasks, "keepalive injector should still own its pending chunk task"
-    assert all(t.cancelling() <= _MAX_CANCELS for t in pending_tasks), [t.cancelling() for t in pending_tasks]
+    assert [t.cancelling() for t in pending_tasks] == [1] * len(pending_tasks)
     assert cleanup_task is not None
     assert cleanup_task.cancelling() == 0
     assert not response_task.done()

--- a/tests/unit/test_probe_task_cancel_cascade.py
+++ b/tests/unit/test_probe_task_cancel_cascade.py
@@ -110,9 +110,13 @@ async def test_level_cancelled_keepalive_consumer_does_not_respin_pending_chunk_
     release = asyncio.Event()
     source_closed = asyncio.Event()
     cleanup_task: asyncio.Task[None] | None = None
+    chunk_task: asyncio.Task[object] | None = None
 
     async def deferring_source() -> AsyncIterator[str]:
-        nonlocal cleanup_task
+        nonlocal chunk_task, cleanup_task
+        # ``__anext__`` runs inside the injector's ``_next_chunk`` task, so the
+        # current task here is exactly the chunk task under test.
+        chunk_task = asyncio.current_task()
 
         async def cleanup() -> None:
             await release.wait()
@@ -128,11 +132,10 @@ async def test_level_cancelled_keepalive_consumer_does_not_respin_pending_chunk_
     response_task = await _run_level_cancelled_consumer(stream)
     await asyncio.sleep(0.05)
 
-    pending_tasks = [
-        t for t in asyncio.all_tasks() if t is not asyncio.current_task() and "_next_chunk" in repr(t.get_coro())
-    ]
-    assert pending_tasks, "keepalive injector should still own its pending chunk task"
-    assert [t.cancelling() for t in pending_tasks] == [1] * len(pending_tasks)
+    assert chunk_task is not None, "the injector must have started its chunk task"
+    assert chunk_task is not asyncio.current_task()
+    assert not chunk_task.done(), "the deferring source must keep the chunk task alive"
+    assert chunk_task.cancelling() == 1, chunk_task.cancelling()
     assert cleanup_task is not None
     assert cleanup_task.cancelling() == 0
     assert not response_task.done()
@@ -140,7 +143,7 @@ async def test_level_cancelled_keepalive_consumer_does_not_respin_pending_chunk_
 
     release.set()
     await asyncio.wait_for(response_task, timeout=1)
-    assert all(t.done() for t in pending_tasks)
+    assert chunk_task.done()
     # The chunk task settled first, then the injector's finalizer closed the
     # source exactly once (aclose on a finished generator is a no-op).
     assert source_closed.is_set()

--- a/tests/unit/test_probe_task_cancel_cascade.py
+++ b/tests/unit/test_probe_task_cancel_cascade.py
@@ -1,0 +1,151 @@
+"""Regression tests for the 2026-09-07 cancellation-cascade busy spin.
+
+Production autopsy (soju07): 15 client-cancelled Responses requests kept three
+tasks each alive for four days -- Starlette's ``StreamingResponse`` body task,
+the SSE keepalive injector's ``_next_chunk`` task, and the startup-probe
+``_read_first_stream_item`` task -- with ``Task.cancelling()`` at ~1.4e9.
+
+Mechanism: a level-cancelled anyio scope re-delivers ``Task.cancel()`` to its
+host task on *every* event-loop iteration until the task leaves the scope.
+When that host task awaits an ``asyncio`` task directly (``await task``),
+``Task.cancel()`` cascades down the ``_fut_waiter`` chain into the awaited
+task, and from there into any deferring wait it is running. The deferring
+helper is shielded with ``anyio.CancelScope(shield=True)``, but that shield
+only protects a task anyio tracks; a plain ``asyncio.create_task`` probe is
+not tracked, so the cascaded cancel re-enters its wait on every iteration and
+the loop spins for as long as the deferred cleanup takes (forever, when the
+cleanup is itself wedged).
+
+The invariant under test: a level-cancelled consumer must not re-cancel the
+probe task on every loop iteration, while teardown still waits for the
+probe's deferred cleanup before closing the stream it drives. Awaiting the
+probe through the shared-future proxy (``wait_on_shared_future`` /
+``_await_task_deferring_cancellation``) breaks the cascade, so the probe sees
+at most the single explicit teardown ``cancel()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import anyio
+import pytest
+
+from app.core.utils.shared_future import _await_task_deferring_cancellation
+from app.core.utils.sse import inject_sse_keepalives
+from app.modules.proxy.api import _prepend_first_task
+
+pytestmark = pytest.mark.unit
+
+# The old cascade re-cancelled the probe once per loop iteration: thousands
+# of cancels in 50ms. The fixed path performs exactly one explicit teardown
+# cancel; allow a little slack for scheduler noise.
+_MAX_CANCELS = 3
+
+
+async def _run_level_cancelled_consumer(stream: AsyncIterator[str]) -> asyncio.Task[None]:
+    """Consume ``stream`` inside a task group whose scope is then cancelled.
+
+    Mirrors ``starlette.responses.StreamingResponse.__call__``: the body
+    iterator runs in an anyio task group, and a client disconnect cancels the
+    group's cancel scope while the body is still awaiting its first frame.
+    """
+
+    started = asyncio.Event()
+
+    async def consume() -> None:
+        started.set()
+        async for _frame in stream:
+            pass
+
+    async def starlette_like_response() -> None:
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(consume)
+            await started.wait()
+            await asyncio.sleep(0)
+            task_group.cancel_scope.cancel()
+
+    return asyncio.create_task(starlette_like_response())
+
+
+async def _empty_rest() -> AsyncIterator[str]:
+    if False:  # pragma: no cover - keeps this an async generator
+        yield ""
+
+
+async def test_level_cancelled_response_does_not_respin_startup_probe_task():
+    release = asyncio.Event()
+    cleanup_task: asyncio.Task[None] | None = None
+
+    async def probe() -> str:
+        nonlocal cleanup_task
+
+        async def cleanup() -> None:
+            await release.wait()
+
+        cleanup_task = asyncio.create_task(cleanup())
+        await _await_task_deferring_cancellation(cleanup_task)
+        return "data: first\n\n"
+
+    first_task = asyncio.create_task(probe())
+    await asyncio.sleep(0)
+    stream = inject_sse_keepalives(_prepend_first_task(first_task, _empty_rest()), interval_seconds=60)
+
+    response_task = await _run_level_cancelled_consumer(stream)
+    # Give the old cascade ample loop iterations to manifest (it produced
+    # thousands of cancels per 50ms of wall clock in the reproduction).
+    await asyncio.sleep(0.05)
+
+    assert cleanup_task is not None
+    assert not first_task.done(), "deferred cleanup must keep the probe alive"
+    assert first_task.cancelling() <= _MAX_CANCELS, first_task.cancelling()
+    assert cleanup_task.cancelling() == 0
+    # Teardown still waits for the probe's deferred cleanup (ordering: the
+    # probe drives the inner stream, so the body must not close it first).
+    assert not response_task.done()
+
+    release.set()
+    await asyncio.wait_for(response_task, timeout=1)
+    assert first_task.done()
+    assert cleanup_task.done()
+
+
+async def test_level_cancelled_keepalive_consumer_does_not_respin_pending_chunk_task():
+    release = asyncio.Event()
+    source_closed = asyncio.Event()
+    cleanup_task: asyncio.Task[None] | None = None
+
+    async def deferring_source() -> AsyncIterator[str]:
+        nonlocal cleanup_task
+
+        async def cleanup() -> None:
+            await release.wait()
+
+        cleanup_task = asyncio.create_task(cleanup())
+        try:
+            await _await_task_deferring_cancellation(cleanup_task)
+            yield "data: first\n\n"
+        finally:
+            source_closed.set()
+
+    stream = inject_sse_keepalives(deferring_source(), interval_seconds=60)
+    response_task = await _run_level_cancelled_consumer(stream)
+    await asyncio.sleep(0.05)
+
+    pending_tasks = [
+        t for t in asyncio.all_tasks() if t is not asyncio.current_task() and "_next_chunk" in repr(t.get_coro())
+    ]
+    assert pending_tasks, "keepalive injector should still own its pending chunk task"
+    assert all(t.cancelling() <= _MAX_CANCELS for t in pending_tasks), [t.cancelling() for t in pending_tasks]
+    assert cleanup_task is not None
+    assert cleanup_task.cancelling() == 0
+    assert not response_task.done()
+    assert not source_closed.is_set(), "the source must not be closed while the chunk task drives it"
+
+    release.set()
+    await asyncio.wait_for(response_task, timeout=1)
+    assert all(t.done() for t in pending_tasks)
+    # The chunk task settled first, then the injector's finalizer closed the
+    # source exactly once (aclose on a finished generator is a no-op).
+    assert source_closed.is_set()

--- a/tests/unit/test_probe_task_cancel_cascade.py
+++ b/tests/unit/test_probe_task_cancel_cascade.py
@@ -38,6 +38,7 @@ from app.modules.proxy.api import _prepend_first_task
 
 pytestmark = pytest.mark.unit
 
+
 async def _run_level_cancelled_consumer(stream: AsyncIterator[str]) -> asyncio.Task[None]:
     """Consume ``stream`` inside a task group whose scope is then cancelled.
 


### PR DESCRIPTION
## Why

Production (soju07, 2026-09-07) carried 15 client-cancelled Responses requests for four days. Each kept three tasks alive — Starlette's `StreamingResponse` body task, the SSE keepalive injector's `_next_chunk` task, and the startup-probe `_read_first_stream_item` task — with `Task.cancelling()` at ~1.4×10⁹ (≈4k re-cancels/s averaged over the container's uptime). py-spy attributed ~30% of the saturated core to anyio `_deliver_cancellation` plus `_await_task_deferring_cancellation` / `wait_on_shared_future` re-entering themselves.

Mechanism:

- A level-cancelled anyio scope (Starlette's response task group after a client disconnect) re-delivers `Task.cancel()` to its host task on **every** event-loop iteration until the task leaves the scope.
- `_prepend_first_task` did `await first_task`, and `inject_sse_keepalives` did `await pending` on teardown. `Task.cancel()` cascades down the `_fut_waiter` chain, so each re-delivery reached the probe task's cancellation-deferring cleanup wait.
- That wait is wrapped in `anyio.CancelScope(shield=True)`, but the shield only covers a task anyio tracks. The probe is a plain `asyncio.create_task`, so the cascaded cancel re-entered its loop once per iteration for as long as the cleanup took — forever, when the cleanup was itself wedged on a `pending_lock` (see #2129).

Deterministic reproduction (deployed shape, 1 s of blocked cleanup): 21k–30k re-cancels per second; with C-accelerated asyncio the other tasks' timers did not fire at all during the spin. The existing `test_level_cancelled_scope_does_not_grow_task_callbacks` did not catch this because it cancels the *same* task that runs the helper; the cascade needs a second, untracked task in between.

## What

- `_prepend_first_task` awaits the probe through `wait_on_shared_future`; on teardown it cancels the probe once and waits for its deferred cleanup through `_await_task_deferring_cancellation` (cancel *and* await handed-off preflight work, as the spec requires, without the cascade).
- `inject_sse_keepalives` teardown cancels the pending chunk task once and waits for it through the same helper. The chunk task therefore still settles before the outer finalizers `aclose()` the generator chain it drives (which otherwise raises `aclose(): asynchronous generator is already running`), and its eventual exception is retrieved instead of logged as never retrieved.
- Comment in `_await_task_deferring_cancellation` documenting the tracked-task limit of the anyio shield and the cross-task-await rule.
- `tests/unit/test_probe_task_cancel_cascade.py`: Starlette-shaped level-cancelled consumer against a probe / source whose cleanup is blocked. Before: `first_task.cancelling()` 1,533 and chunk tasks `[2737, 1199]` after 50 ms; after: ≤ 1, teardown still waits for the cleanup, source closed exactly once after the chunk task settles.
- OpenSpec change `fix-probe-task-cancel-cascade-spin` (`responses-api-compat` delta).

Follow-up (not in this PR): the AST cancellation gate does not yet reject `await <asyncio task>` across a task boundary; this PR fixes the two sites on the production path and documents the rule.

## Validation

- `pytest tests/unit` (full suite; the only failures are pre-existing on `main`: two `test_metrics` cases that require `prometheus_client` to be absent, and `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses` — `no such table: file_account_pins`)
- `ruff check` / `ruff format --check` / `ty check` / `scripts/check_cancellation_safety.py` / `scripts/check_proxy_architecture.py`
- `openspec validate fix-probe-task-cancel-cascade-spin --strict`
- local `codex review --base origin/main` (two rounds; first round's P2s — outer finalizers closing running generators, unretrieved chunk-task exceptions — drove the "wait via the canonical helper" design)

Related to #2029
Related to #881
Related to #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed-response teardown during cancellation, preventing repeated cancellation loops and busy spinning.
  - Ensured startup probes and SSE keepalive tasks complete cleanup before streams close.
  - Preserved task results and exceptions during cancellation handling.
  - Improved reliability for cancelled or interrupted streaming responses, reducing hangs and delayed cleanup.

- **Tests**
  - Added regression coverage for probe and keepalive cancellation scenarios, including cleanup timing and cancellation frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->