### PR TITLE
fix(routing): deprioritize accounts upstream keeps rejecting as overloaded for fresh selection

### DIFF
--- a/app/modules/proxy/_load_balancer/overload_backoff.py
+++ b/app/modules/proxy/_load_balancer/overload_backoff.py
@@ -30,10 +30,8 @@ import logging
 from collections.abc import Iterable, Mapping
 from typing import Any, Protocol
 
-from app.core.balancer import TrafficClass
 from app.core.balancer.logic import AccountState
 from app.db.models import Account
-from app.modules.proxy._load_balancer.sticky_selection import _pool_has_available_account_without_backoff
 from app.modules.proxy._load_balancer.types import RuntimeState
 
 logger = logging.getLogger(__name__)
@@ -53,9 +51,10 @@ OVERLOAD_BACKOFF_MAX_SECONDS = 600.0
 # The level decays back to the base once the account has gone this long
 # without tripping, so a recovered account is not punished for last hour.
 OVERLOAD_LEVEL_DECAY_SECONDS = 1800.0
-# Levels saturate once the interval is capped; the stored level and the
-# exponent are both bounded so sustained overload can never overflow.
-OVERLOAD_MAX_LEVEL = 8
+# Levels saturate at the first level whose interval hits the cap
+# (60, 120, 240, 480, then 600), so the stored level and the exponent are
+# both bounded and sustained overload can never overflow or inflate the log.
+OVERLOAD_MAX_LEVEL = 5
 
 
 class _OverloadBalancerLike(Protocol):
@@ -75,9 +74,9 @@ def overload_backoff_active(runtime: RuntimeState | None, now: float) -> bool:
     return runtime is not None and runtime.overload_backoff_until is not None and now < runtime.overload_backoff_until
 
 
-def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float | None:
-    """Record one overload rejection at ``now``; return the new backoff deadline
-    when this rejection trips the window, else ``None``.
+def record_overload_rejection_locked(runtime: RuntimeState, now: float, *, count: int = 1) -> float | None:
+    """Record ``count`` overload rejections observed at ``now``; return the new
+    backoff deadline when they trip the window, else ``None``.
 
     Caller holds the balancer's per-account lock.
     """
@@ -88,7 +87,7 @@ def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float
         runtime.overload_backoff_level = 0
     window_start = now - OVERLOAD_WINDOW_SECONDS
     recent = [at for at in (runtime.overload_rejections or ()) if at > window_start]
-    recent.append(now)
+    recent.extend([now] * max(1, count))
     if len(recent) < OVERLOAD_TRIP_COUNT:
         runtime.overload_rejections = recent
         return None
@@ -104,9 +103,17 @@ def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float
     return deadline
 
 
-async def record_upstream_overload(balancer: Any, account: Account, *, redact_account_id: bool = False) -> None:
-    """Record an upstream overload rejection for ``account`` on ``balancer``.
+async def record_upstream_overload(
+    balancer: Any,
+    account: Account,
+    *,
+    count: int = 1,
+    redact_account_id: bool = False,
+) -> None:
+    """Record ``count`` upstream overload rejections for ``account``.
 
+    ``count`` > 1 carries same-account retry aggregation: N rejections that
+    the retry loop absorbed before failing over are N admission refusals.
     No-op when ``balancer`` does not expose the runtime map (test doubles).
     """
     runtime_map = getattr(balancer, "_runtime", None)
@@ -116,11 +123,11 @@ async def record_upstream_overload(balancer: Any, account: Account, *, redact_ac
     async with lock:
         now = float(balancer._clock.time())
         runtime = runtime_map.setdefault(account.id, RuntimeState())
-        deadline = record_overload_rejection_locked(runtime, now)
+        deadline = record_overload_rejection_locked(runtime, now, count=count)
     if deadline is not None:
         logger.warning(
             "Account overload backoff engaged account_id=%s level=%d backoff_seconds=%.0f "
-            "(fresh selection deprioritizes the account while other candidates remain)",
+            "(fresh selection deprioritizes the account while another candidate can be selected)",
             "<redacted>" if redact_account_id else account.id,
             runtime.overload_backoff_level,
             deadline - now,
@@ -131,22 +138,21 @@ def filter_overload_backoff_candidates(
     states: list[AccountState],
     runtime_by_account_id: Mapping[str, RuntimeState],
     *,
-    traffic_class: TrafficClass,
     now: float,
 ) -> list[AccountState]:
-    """Drop candidates in overload backoff while an *eligible* other remains.
+    """Return the candidates not in overload backoff, or ``states`` itself
+    when that would leave nothing (or change nothing).
 
-    Soft by construction: the backed-off accounts are removed only when the
-    remainder still passes routing eligibility (status, cooldown, generic
-    error backoff, opportunistic window) on its own -- the same check the
-    recovery-probe filter uses. Otherwise the pool is returned unchanged, so
-    this can never turn usable capacity into ``No available accounts`` or a
-    spurious account-cap error.
+    Callers select from the returned list first and, when the configured
+    strategy rejects every remaining candidate, select again from the
+    original ``states`` -- the identity check (``is``) tells them whether a
+    fallback is possible. Eligibility is therefore judged by the real
+    selector under the real strategy and budget gates, never approximated
+    here, so the backoff can only ever *reorder* preference: it cannot turn
+    usable capacity into ``No available accounts`` or an account-cap error.
     """
     kept = [state for state in states if not overload_backoff_active(runtime_by_account_id.get(state.account_id), now)]
-    if len(kept) == len(states):
-        return states
-    if not kept or not _pool_has_available_account_without_backoff(kept, traffic_class=traffic_class, now=now):
+    if not kept or len(kept) == len(states):
         return states
     return kept
 

--- a/app/modules/proxy/_load_balancer/overload_backoff.py
+++ b/app/modules/proxy/_load_balancer/overload_backoff.py
@@ -30,8 +30,10 @@ import logging
 from collections.abc import Iterable, Mapping
 from typing import Any, Protocol
 
+from app.core.balancer import TrafficClass
 from app.core.balancer.logic import AccountState
 from app.db.models import Account
+from app.modules.proxy._load_balancer.sticky_selection import _pool_has_available_account_without_backoff
 from app.modules.proxy._load_balancer.types import RuntimeState
 
 logger = logging.getLogger(__name__)
@@ -51,6 +53,9 @@ OVERLOAD_BACKOFF_MAX_SECONDS = 600.0
 # The level decays back to the base once the account has gone this long
 # without tripping, so a recovered account is not punished for last hour.
 OVERLOAD_LEVEL_DECAY_SECONDS = 1800.0
+# Levels saturate once the interval is capped; the stored level and the
+# exponent are both bounded so sustained overload can never overflow.
+OVERLOAD_MAX_LEVEL = 8
 
 
 class _OverloadBalancerLike(Protocol):
@@ -61,8 +66,8 @@ class _OverloadBalancerLike(Protocol):
 
 
 def overload_backoff_seconds(level: int) -> float:
-    """Deprioritization interval for a trip at ``level`` (1-based)."""
-    exponent = max(0, level - 1)
+    """Deprioritization interval for a trip at ``level`` (1-based, saturating)."""
+    exponent = min(max(0, level - 1), OVERLOAD_MAX_LEVEL - 1)
     return min(OVERLOAD_BACKOFF_MAX_SECONDS, OVERLOAD_BACKOFF_BASE_SECONDS * (2**exponent))
 
 
@@ -88,7 +93,7 @@ def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float
         runtime.overload_rejections = recent
         return None
     runtime.overload_rejections = []
-    runtime.overload_backoff_level += 1
+    runtime.overload_backoff_level = min(runtime.overload_backoff_level + 1, OVERLOAD_MAX_LEVEL)
     runtime.overload_last_trip_at = now
     deadline = now + overload_backoff_seconds(runtime.overload_backoff_level)
     # A trip while already deprioritized (rejections keep arriving from
@@ -126,16 +131,22 @@ def filter_overload_backoff_candidates(
     states: list[AccountState],
     runtime_by_account_id: Mapping[str, RuntimeState],
     *,
+    traffic_class: TrafficClass,
     now: float,
 ) -> list[AccountState]:
-    """Drop candidates in overload backoff while at least one other remains.
+    """Drop candidates in overload backoff while an *eligible* other remains.
 
-    Soft by construction: when every candidate is backed off the list is
-    returned unchanged, so this can never turn an available pool into
-    ``No available accounts``.
+    Soft by construction: the backed-off accounts are removed only when the
+    remainder still passes routing eligibility (status, cooldown, generic
+    error backoff, opportunistic window) on its own -- the same check the
+    recovery-probe filter uses. Otherwise the pool is returned unchanged, so
+    this can never turn usable capacity into ``No available accounts`` or a
+    spurious account-cap error.
     """
     kept = [state for state in states if not overload_backoff_active(runtime_by_account_id.get(state.account_id), now)]
-    if not kept or len(kept) == len(states):
+    if len(kept) == len(states):
+        return states
+    if not kept or not _pool_has_available_account_without_backoff(kept, traffic_class=traffic_class, now=now):
         return states
     return kept
 

--- a/app/modules/proxy/_load_balancer/overload_backoff.py
+++ b/app/modules/proxy/_load_balancer/overload_backoff.py
@@ -74,9 +74,9 @@ def overload_backoff_active(runtime: RuntimeState | None, now: float) -> bool:
     return runtime is not None and runtime.overload_backoff_until is not None and now < runtime.overload_backoff_until
 
 
-def record_overload_rejection_locked(runtime: RuntimeState, now: float, *, count: int = 1) -> float | None:
-    """Record ``count`` overload rejections observed at ``now``; return the new
-    backoff deadline when they trip the window, else ``None``.
+def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float | None:
+    """Record one overload rejection observed at ``now``; return the new
+    backoff deadline when it trips the window, else ``None``.
 
     Caller holds the balancer's per-account lock.
     """
@@ -87,7 +87,7 @@ def record_overload_rejection_locked(runtime: RuntimeState, now: float, *, count
         runtime.overload_backoff_level = 0
     window_start = now - OVERLOAD_WINDOW_SECONDS
     recent = [at for at in (runtime.overload_rejections or ()) if at > window_start]
-    recent.extend([now] * max(1, count))
+    recent.append(now)
     if len(recent) < OVERLOAD_TRIP_COUNT:
         runtime.overload_rejections = recent
         return None
@@ -103,17 +103,11 @@ def record_overload_rejection_locked(runtime: RuntimeState, now: float, *, count
     return deadline
 
 
-async def record_upstream_overload(
-    balancer: Any,
-    account: Account,
-    *,
-    count: int = 1,
-    redact_account_id: bool = False,
-) -> None:
-    """Record ``count`` upstream overload rejections for ``account``.
+async def record_upstream_overload(balancer: Any, account: Account, *, redact_account_id: bool = False) -> None:
+    """Record one upstream overload rejection for ``account`` at the balancer clock.
 
-    ``count`` > 1 carries same-account retry aggregation: N rejections that
-    the retry loop absorbed before failing over are N admission refusals.
+    Observations are taken where account health is written (the
+    ``_handle_stream_error`` funnel), so they inherit its settlement ordering.
     No-op when ``balancer`` does not expose the runtime map (test doubles).
     """
     runtime_map = getattr(balancer, "_runtime", None)
@@ -123,7 +117,7 @@ async def record_upstream_overload(
     async with lock:
         now = float(balancer._clock.time())
         runtime = runtime_map.setdefault(account.id, RuntimeState())
-        deadline = record_overload_rejection_locked(runtime, now, count=count)
+        deadline = record_overload_rejection_locked(runtime, now)
     if deadline is not None:
         logger.warning(
             "Account overload backoff engaged account_id=%s level=%d backoff_seconds=%.0f "

--- a/app/modules/proxy/_load_balancer/overload_backoff.py
+++ b/app/modules/proxy/_load_balancer/overload_backoff.py
@@ -1,0 +1,153 @@
+"""Soft backoff for accounts upstream keeps rejecting as overloaded.
+
+``server_is_overloaded`` is an admission rejection: upstream refuses to start
+a *new* response for the account while already-admitted streams on the same
+account keep flowing. Two properties follow that the generic transient error
+path cannot express:
+
+- It is account-scoped and bursty. One account can be rejected on most fresh
+  admissions for an hour while its siblings are clean, and the rejection can
+  take 30-90 s to arrive, so every fresh admission routed there costs the
+  client that wait before failover even starts.
+- It says nothing bad about the account's live sessions. Bridge reuse and
+  sticky continuity on the same account keep succeeding, and every success
+  zeroes ``RuntimeState.error_count`` -- so the generic error backoff and the
+  drain tier never latch, and fresh selection keeps feeding the rejected
+  account.
+
+This module keeps a replica-local sliding window of overload rejections per
+account. When it trips, fresh (unbound) selection *deprioritizes* the account
+for a bounded, exponentially growing interval: it is dropped from the candidate
+pool only while at least one other candidate remains, so it can never empty
+the pool, and sticky / continuity / hard-affinity selection is untouched. The
+window is not reset by successes -- an account that succeeds on warm sessions
+but rejects fresh admissions is exactly the case this exists for.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from typing import Any, Protocol
+
+from app.core.balancer.logic import AccountState
+from app.db.models import Account
+from app.modules.proxy._load_balancer.types import RuntimeState
+
+logger = logging.getLogger(__name__)
+
+# Upstream error codes that mean "admission refused: overloaded". Both spellings
+# reach ``_handle_stream_error`` normalized to ``retryable_transient``.
+UPSTREAM_OVERLOAD_CODES: frozenset[str] = frozenset({"server_is_overloaded", "overloaded_error"})
+
+# Trip when this many rejections land inside the window. Three keeps a lone
+# rejection (upstream hiccup) from deprioritizing an account, while a rejected
+# account under real traffic trips within a minute or two.
+OVERLOAD_TRIP_COUNT = 3
+OVERLOAD_WINDOW_SECONDS = 120.0
+# Bounded exponential deprioritization: 60 s, 120 s, 240 s, ... capped at 10 min.
+OVERLOAD_BACKOFF_BASE_SECONDS = 60.0
+OVERLOAD_BACKOFF_MAX_SECONDS = 600.0
+# The level decays back to the base once the account has gone this long
+# without tripping, so a recovered account is not punished for last hour.
+OVERLOAD_LEVEL_DECAY_SECONDS = 1800.0
+
+
+class _OverloadBalancerLike(Protocol):
+    _runtime: dict[str, RuntimeState]
+    _clock: Any
+
+    async def _get_account_lock(self, account_id: str) -> Any: ...
+
+
+def overload_backoff_seconds(level: int) -> float:
+    """Deprioritization interval for a trip at ``level`` (1-based)."""
+    exponent = max(0, level - 1)
+    return min(OVERLOAD_BACKOFF_MAX_SECONDS, OVERLOAD_BACKOFF_BASE_SECONDS * (2**exponent))
+
+
+def overload_backoff_active(runtime: RuntimeState | None, now: float) -> bool:
+    return runtime is not None and runtime.overload_backoff_until is not None and now < runtime.overload_backoff_until
+
+
+def record_overload_rejection_locked(runtime: RuntimeState, now: float) -> float | None:
+    """Record one overload rejection at ``now``; return the new backoff deadline
+    when this rejection trips the window, else ``None``.
+
+    Caller holds the balancer's per-account lock.
+    """
+    if (
+        runtime.overload_last_trip_at is not None
+        and now - runtime.overload_last_trip_at >= OVERLOAD_LEVEL_DECAY_SECONDS
+    ):
+        runtime.overload_backoff_level = 0
+    window_start = now - OVERLOAD_WINDOW_SECONDS
+    recent = [at for at in (runtime.overload_rejections or ()) if at > window_start]
+    recent.append(now)
+    if len(recent) < OVERLOAD_TRIP_COUNT:
+        runtime.overload_rejections = recent
+        return None
+    runtime.overload_rejections = []
+    runtime.overload_backoff_level += 1
+    runtime.overload_last_trip_at = now
+    deadline = now + overload_backoff_seconds(runtime.overload_backoff_level)
+    # A trip while already deprioritized (rejections keep arriving from
+    # in-flight admissions) extends, never shortens, the deadline.
+    if runtime.overload_backoff_until is not None and runtime.overload_backoff_until > deadline:
+        deadline = runtime.overload_backoff_until
+    runtime.overload_backoff_until = deadline
+    return deadline
+
+
+async def record_upstream_overload(balancer: Any, account: Account, *, redact_account_id: bool = False) -> None:
+    """Record an upstream overload rejection for ``account`` on ``balancer``.
+
+    No-op when ``balancer`` does not expose the runtime map (test doubles).
+    """
+    runtime_map = getattr(balancer, "_runtime", None)
+    if not isinstance(runtime_map, dict):
+        return
+    lock = await balancer._get_account_lock(account.id)
+    async with lock:
+        now = float(balancer._clock.time())
+        runtime = runtime_map.setdefault(account.id, RuntimeState())
+        deadline = record_overload_rejection_locked(runtime, now)
+    if deadline is not None:
+        logger.warning(
+            "Account overload backoff engaged account_id=%s level=%d backoff_seconds=%.0f "
+            "(fresh selection deprioritizes the account while other candidates remain)",
+            "<redacted>" if redact_account_id else account.id,
+            runtime.overload_backoff_level,
+            deadline - now,
+        )
+
+
+def filter_overload_backoff_candidates(
+    states: list[AccountState],
+    runtime_by_account_id: Mapping[str, RuntimeState],
+    *,
+    now: float,
+) -> list[AccountState]:
+    """Drop candidates in overload backoff while at least one other remains.
+
+    Soft by construction: when every candidate is backed off the list is
+    returned unchanged, so this can never turn an available pool into
+    ``No available accounts``.
+    """
+    kept = [state for state in states if not overload_backoff_active(runtime_by_account_id.get(state.account_id), now)]
+    if not kept or len(kept) == len(states):
+        return states
+    return kept
+
+
+def overload_backed_off_account_ids(
+    states: Iterable[AccountState],
+    runtime_by_account_id: Mapping[str, RuntimeState],
+    *,
+    now: float,
+) -> list[str]:
+    return [
+        state.account_id
+        for state in states
+        if overload_backoff_active(runtime_by_account_id.get(state.account_id), now)
+    ]

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Collection, Iterable
+from collections.abc import Awaitable, Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Generic, Literal, Protocol, TypeVar
@@ -27,12 +27,14 @@ from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, AdditionalUsageHistory, StickySessionKind, UsageHistory
 from app.db.snapshot import clone_row
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.proxy._load_balancer.overload_backoff import filter_overload_backoff_candidates
 from app.modules.proxy._load_balancer.types import (
     MAX_SELECTION_ATTEMPTS,
     AccountConcurrencyCaps,
     AccountLease,
     AccountLeaseKind,
     ProbeReservation,
+    RuntimeState,
 )
 from app.modules.proxy.affinity import _CodexSessionSource
 from app.modules.proxy.fair_share import (
@@ -1176,6 +1178,7 @@ async def _select_with_stickiness(
     allow_usage_exhaustion_error: bool = True,
     usage_exhaustion_states: Iterable[AccountState] | None = None,
     sticky_refresh_skip_deadline: datetime | None = None,
+    overload_backoff_runtime: Mapping[str, RuntimeState] | None = None,
     clock: Clock,
 ) -> _StickySelectionOutcome:
     if not sticky_key or not sticky_repo:
@@ -1442,22 +1445,37 @@ async def _select_with_stickiness(
             if not preserve_existing_mapping_on_fallback:
                 pending_mutation = _StickyMutation(account_id=None)
 
-    chosen = _select_account_preferring_budget_safe(
-        states,
-        prefer_earlier_reset=prefer_earlier_reset_accounts,
-        prefer_earlier_reset_window=prefer_earlier_reset_window,
-        routing_strategy=routing_strategy,
-        relative_availability_power=relative_availability_power,
-        relative_availability_top_k=relative_availability_top_k,
-        budget_threshold_pct=budget_threshold_pct,
-        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-        apply_secondary_budget_threshold=apply_sticky_secondary_budget_threshold,
-        traffic_class=traffic_class,
-        ignore_standard_quota=ignore_standard_quota,
-        routing_costs_by_account_id=routing_costs_by_account_id,
-        allow_usage_exhaustion_error=allow_usage_exhaustion_error,
-        usage_exhaustion_states=usage_exhaustion_states,
-    )
+    def _choose_from(candidates: list[AccountState]) -> SelectionResult:
+        return _select_account_preferring_budget_safe(
+            candidates,
+            prefer_earlier_reset=prefer_earlier_reset_accounts,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            relative_availability_power=relative_availability_power,
+            relative_availability_top_k=relative_availability_top_k,
+            budget_threshold_pct=budget_threshold_pct,
+            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+            apply_secondary_budget_threshold=apply_sticky_secondary_budget_threshold,
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs_by_account_id=routing_costs_by_account_id,
+            allow_usage_exhaustion_error=allow_usage_exhaustion_error,
+            usage_exhaustion_states=usage_exhaustion_states,
+        )
+
+    # Reaching here means a NEW account is being chosen for this key (no
+    # owner, an unusable owner, or a reallocation): a fresh upstream
+    # admission, not warm-session reuse. Prefer accounts upstream is not
+    # currently rejecting as overloaded; fall back to the full pool when the
+    # strategy rejects every overload-free candidate. The pinned-owner paths
+    # above never consult the overload window, so an established owner keeps
+    # serving its session even while backed off.
+    fallback_candidates = states
+    if overload_backoff_runtime is not None:
+        fallback_candidates = filter_overload_backoff_candidates(states, overload_backoff_runtime, now=clock.time())
+    chosen = _choose_from(fallback_candidates)
+    if chosen.account is None and fallback_candidates is not states:
+        chosen = _choose_from(states)
     if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
         return finish_selection(chosen, persist_account_id=chosen.account.account_id)
     if preserve_existing_mapping_on_fallback and chosen.account is not None and existing is not None:

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -266,6 +266,10 @@ class _StickyMutation:
 class _StickySelectionOutcome:
     selection: SelectionResult
     mutation: _StickyMutation | None = None
+    # The candidate pool the selection actually ran over when a NEW account
+    # was chosen for the key (overload-free first pass); ``None`` means the
+    # caller's full pool. Probe reservation must use the same pool.
+    effective_states: list[AccountState] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -733,8 +737,12 @@ async def run_sticky_selection_path(
                     or reallocate_sticky
                 )
             )
+            # A fresh binding may have been chosen from the overload-free
+            # subset; reserve the recovery probe from that same pool so an
+            # older due probe the pass skipped cannot invalidate the match.
+            probe_states = sticky_outcome.effective_states or selection_states
             probing_result_requires_reservation = _probing_result_requires_recovery_reservation(
-                selection_states,
+                probe_states,
                 result.account,
                 routing_strategy=routing_strategy,
                 traffic_class=traffic_class,
@@ -748,7 +756,7 @@ async def run_sticky_selection_path(
                 # can temporarily consume the only due probing slot and
                 # make concurrent unbound traffic miss recovery.
                 probe_reservation = owner._reserve_due_probe_locked(
-                    selection_states,
+                    probe_states,
                     prefer_earlier_reset=prefer_earlier_reset_accounts,
                     prefer_earlier_reset_window=prefer_earlier_reset_window,
                     routing_strategy=routing_strategy,
@@ -1208,6 +1216,7 @@ async def _select_with_stickiness(
         *,
         persist_account_id: str | None = None,
         refresh_skip_deadline: datetime | None = None,
+        effective_states: list[AccountState] | None = None,
     ) -> _StickySelectionOutcome:
         mutation = pending_mutation
         if persist_account_id is not None:
@@ -1215,7 +1224,7 @@ async def _select_with_stickiness(
                 account_id=persist_account_id,
                 refresh_skip_deadline=refresh_skip_deadline,
             )
-        return _StickySelectionOutcome(selection=selection, mutation=mutation)
+        return _StickySelectionOutcome(selection=selection, mutation=mutation, effective_states=effective_states)
 
     if sticky_existing_account_id is _STICKY_EXISTING_UNSET:
         existing = await sticky_repo.get_account_id(
@@ -1475,9 +1484,11 @@ async def _select_with_stickiness(
         fallback_candidates = filter_overload_backoff_candidates(states, overload_backoff_runtime, now=clock.time())
     chosen = _choose_from(fallback_candidates)
     if chosen.account is None and fallback_candidates is not states:
+        fallback_candidates = states
         chosen = _choose_from(states)
+    chosen_pool = fallback_candidates if fallback_candidates is not states else None
     if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
-        return finish_selection(chosen, persist_account_id=chosen.account.account_id)
+        return finish_selection(chosen, persist_account_id=chosen.account.account_id, effective_states=chosen_pool)
     if preserve_existing_mapping_on_fallback and chosen.account is not None and existing is not None:
         # Spillover is deliberately request-local. The alternate may create
         # its own hard response/file/bridge owner, but local cap pressure
@@ -1488,7 +1499,7 @@ async def _select_with_stickiness(
             chosen.account.account_id,
             sticky_kind.value,
         )
-    return finish_selection(chosen)
+    return finish_selection(chosen, effective_states=chosen_pool)
 
 
 def _sticky_refresh_write_skippable(

--- a/app/modules/proxy/_load_balancer/types.py
+++ b/app/modules/proxy/_load_balancer/types.py
@@ -26,6 +26,14 @@ class RuntimeState:
     leased_tokens: float = 0.0
     leases: dict[str, AccountLease] | None = None
     stream_key_inflight: dict[str, int] | None = None
+    # Upstream-overload soft backoff (see ``_load_balancer/overload_backoff.py``).
+    # Recent ``server_is_overloaded`` rejection times inside the trip window,
+    # the deprioritization deadline once tripped, the exponential level, and
+    # when the level last tripped (for decay). Replica-local, never persisted.
+    overload_rejections: list[float] | None = None
+    overload_backoff_until: float | None = None
+    overload_backoff_level: int = 0
+    overload_last_trip_at: float | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -184,6 +184,7 @@ async def run_unbound_selection_path(
             selection_states = filter_overload_backoff_candidates(
                 selection_states,
                 owner._runtime,
+                traffic_class=traffic_class,
                 now=selection_now,
             )
             if suppress_recovery_probe_candidates:

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -235,8 +235,10 @@ async def run_unbound_selection_path(
                     owner._runtime,
                     now=selection_now,
                 )
+                effective_states = overload_free_states
                 result = _select_from(overload_free_states)
                 if result.account is None and overload_free_states is not selection_states:
+                    effective_states = selection_states
                     result = _select_from(selection_states)
                 if (
                     result.account is None
@@ -255,8 +257,12 @@ async def run_unbound_selection_path(
                         _account_cap_error_message(lease_kind, caps),
                         error_code=selection_error_code,
                     )
+                # Probe reservation must see the pool the selection actually
+                # ran over: reserving from the wider pool could pick an older
+                # due probe the overload pass skipped and invalidate the
+                # selection on an identity mismatch.
                 probing_result_requires_reservation = _probing_result_requires_recovery_reservation(
-                    selection_states,
+                    effective_states,
                     result.account,
                     routing_strategy=routing_strategy,
                     traffic_class=traffic_class,
@@ -271,7 +277,7 @@ async def run_unbound_selection_path(
                     # both succeed; otherwise the failed request can
                     # consume minutes of recovery capacity.
                     probe_reservation = owner._reserve_due_probe_locked(
-                        selection_states,
+                        effective_states,
                         prefer_earlier_reset=prefer_earlier_reset_accounts,
                         prefer_earlier_reset_window=prefer_earlier_reset_window,
                         routing_strategy=routing_strategy,

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -15,6 +15,7 @@ from app.core.balancer import (
     TrafficClass,
 )
 from app.db.models import Account, AccountStatus
+from app.modules.proxy._load_balancer.overload_backoff import filter_overload_backoff_candidates
 from app.modules.proxy._load_balancer.sticky_selection import (
     SelectionInputsProtocol,
     StickySelectionOwner,
@@ -175,6 +176,15 @@ async def run_unbound_selection_path(
                 lease_kind=lease_kind,
                 caps=caps,
                 stream_reserve_slots=stream_reserve_slots,
+            )
+            # Fresh admissions avoid accounts upstream is currently rejecting
+            # as overloaded, as long as another candidate remains. Sticky and
+            # continuity selection never reach this path, so warm sessions on
+            # those accounts keep flowing.
+            selection_states = filter_overload_backoff_candidates(
+                selection_states,
+                owner._runtime,
+                now=selection_now,
             )
             if suppress_recovery_probe_candidates:
                 selection_states = _filter_recovery_probe_candidates(

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Generic, Protocol, TypeVar
 
 from app.core.balancer import (
+    AccountState,
     ResetPreferenceWindow,
     RoutingCostsByAccount,
     RoutingStrategy,
@@ -177,16 +178,6 @@ async def run_unbound_selection_path(
                 caps=caps,
                 stream_reserve_slots=stream_reserve_slots,
             )
-            # Fresh admissions avoid accounts upstream is currently rejecting
-            # as overloaded, as long as another candidate remains. Sticky and
-            # continuity selection never reach this path, so warm sessions on
-            # those accounts keep flowing.
-            selection_states = filter_overload_backoff_candidates(
-                selection_states,
-                owner._runtime,
-                traffic_class=traffic_class,
-                now=selection_now,
-            )
             if suppress_recovery_probe_candidates:
                 selection_states = _filter_recovery_probe_candidates(
                     selection_states,
@@ -214,21 +205,39 @@ async def run_unbound_selection_path(
             else:
                 selection_error_code = None
                 selection_resets_at = None
-                result = _select_account_preferring_budget_safe(
+
+                def _select_from(candidates: list[AccountState]) -> SelectionResult:
+                    return _select_account_preferring_budget_safe(
+                        candidates,
+                        prefer_earlier_reset=prefer_earlier_reset_accounts,
+                        prefer_earlier_reset_window=prefer_earlier_reset_window,
+                        routing_strategy=routing_strategy,
+                        relative_availability_power=relative_availability_power,
+                        relative_availability_top_k=relative_availability_top_k,
+                        budget_threshold_pct=budget_threshold_pct,
+                        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+                        traffic_class=traffic_class,
+                        ignore_standard_quota=False,
+                        routing_costs_by_account_id=effective_routing_costs,
+                        allow_usage_exhaustion_error=allow_usage_exhaustion_error,
+                        usage_exhaustion_states=states,
+                    )
+
+                # Fresh admissions prefer accounts upstream is not currently
+                # rejecting as overloaded. The cap-filtered pool stays intact
+                # for cap-error detection below, and when the configured
+                # strategy rejects every overload-free candidate the full pool
+                # is selected from exactly as before. Sticky and continuity
+                # selection never reach this path, so warm sessions on those
+                # accounts keep flowing.
+                overload_free_states = filter_overload_backoff_candidates(
                     selection_states,
-                    prefer_earlier_reset=prefer_earlier_reset_accounts,
-                    prefer_earlier_reset_window=prefer_earlier_reset_window,
-                    routing_strategy=routing_strategy,
-                    relative_availability_power=relative_availability_power,
-                    relative_availability_top_k=relative_availability_top_k,
-                    budget_threshold_pct=budget_threshold_pct,
-                    secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-                    traffic_class=traffic_class,
-                    ignore_standard_quota=False,
-                    routing_costs_by_account_id=effective_routing_costs,
-                    allow_usage_exhaustion_error=allow_usage_exhaustion_error,
-                    usage_exhaustion_states=states,
+                    owner._runtime,
+                    now=selection_now,
                 )
+                result = _select_from(overload_free_states)
+                if result.account is None and overload_free_states is not selection_states:
+                    result = _select_from(selection_states)
                 if (
                     result.account is None
                     and result.error_code is None

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -70,6 +70,7 @@ from app.db.models import (
     Account,
     AccountStatus,  # noqa: F401
 )
+from app.modules.proxy._load_balancer.overload_backoff import UPSTREAM_OVERLOAD_CODES, record_upstream_overload
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
 )
@@ -1128,6 +1129,15 @@ async def _handle_stream_error(
             get_request_id(),
             code,
         )
+        if code in UPSTREAM_OVERLOAD_CODES:
+            # Overload is an admission rejection that successes on the same
+            # account's warm sessions keep masking from ``error_count``; feed
+            # the dedicated sliding window so fresh selection can deprioritize.
+            await record_upstream_overload(
+                proxy._load_balancer,
+                account,
+                redact_account_id=privacy_policy.redacts_sensitive_details,
+            )
     return classified
 
 

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -41,7 +41,7 @@ from app.core.utils.shared_future import _await_task_deferring_cancellation
 from app.core.utils.sse import format_sse_event
 from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
-from app.modules.proxy._load_balancer.overload_backoff import UPSTREAM_OVERLOAD_CODES, record_upstream_overload
+from app.modules.proxy._load_balancer.overload_backoff import UPSTREAM_OVERLOAD_CODES
 from app.modules.proxy._service.observability import (
     _maybe_log_proxy_request_shape,
     _record_continuity_fail_closed,
@@ -301,13 +301,6 @@ def _transient_retry_error_code(tex: BaseException) -> str:
     return "server_error"
 
 
-async def _record_aggregated_overload_observations(proxy: Any, account: Account, code: str, extra: int) -> None:
-    """Same-account retries absorbed ``extra`` further rejections before
-    failing over; each was an admission refusal for the overload window."""
-    if extra > 0 and code in UPSTREAM_OVERLOAD_CODES:
-        await record_upstream_overload(proxy._load_balancer, account, count=extra)
-
-
 class _StreamingRetryMixin:
     async def _stream_with_retry(
         self,
@@ -558,7 +551,6 @@ class _StreamingRetryMixin:
                         )
                         if retry_count > 1:
                             await proxy._load_balancer.record_errors(account, retry_count - 1)
-                            await _record_aggregated_overload_observations(proxy, account, error_code, retry_count - 1)
                     except Exception:
                         logger.warning(
                             "Failed to flush deferred keyed stream health account_id=%s request_id=%s",
@@ -678,9 +670,6 @@ class _StreamingRetryMixin:
             )
             if transient_retry_count > 1:
                 await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
-                await _record_aggregated_overload_observations(
-                    proxy, failed_account, failed_code, transient_retry_count - 1
-                )
             return classified
 
         async def _drain_pending_post_refresh_penalty_on_terminal(

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -41,6 +41,7 @@ from app.core.utils.shared_future import _await_task_deferring_cancellation
 from app.core.utils.sse import format_sse_event
 from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
+from app.modules.proxy._load_balancer.overload_backoff import UPSTREAM_OVERLOAD_CODES, record_upstream_overload
 from app.modules.proxy._service.observability import (
     _maybe_log_proxy_request_shape,
     _record_continuity_fail_closed,
@@ -279,6 +280,32 @@ async def _iter_account_capacity_recovery_wait(
 
 def _payload_size_estimate_bytes(payload: ResponsesRequest) -> int:
     return len(json.dumps(payload.to_payload(), ensure_ascii=True, separators=(",", ":")).encode("utf-8"))
+
+
+def _transient_retry_error_code(tex: BaseException) -> str:
+    """Error code the same-account transient retry loop aggregates under.
+
+    Stream-framed failures keep their own code. HTTP-status failures used to
+    collapse to ``server_error``; an upstream 5xx whose body says the account
+    is overloaded keeps that code so the health write after retry exhaustion
+    still counts as an admission rejection (the overload backoff feeds on the
+    code, and ``server_is_overloaded`` classifies as the same transient class).
+    """
+    if isinstance(tex, _TransientStreamError):
+        return tex.code
+    payload = getattr(tex, "payload", None)
+    if isinstance(payload, Mapping):
+        parsed = _parse_openai_error(payload)
+        if parsed is not None and isinstance(parsed.code, str) and parsed.code in UPSTREAM_OVERLOAD_CODES:
+            return parsed.code
+    return "server_error"
+
+
+async def _record_aggregated_overload_observations(proxy: Any, account: Account, code: str, extra: int) -> None:
+    """Same-account retries absorbed ``extra`` further rejections before
+    failing over; each was an admission refusal for the overload window."""
+    if extra > 0 and code in UPSTREAM_OVERLOAD_CODES:
+        await record_upstream_overload(proxy._load_balancer, account, count=extra)
 
 
 class _StreamingRetryMixin:
@@ -531,6 +558,7 @@ class _StreamingRetryMixin:
                         )
                         if retry_count > 1:
                             await proxy._load_balancer.record_errors(account, retry_count - 1)
+                            await _record_aggregated_overload_observations(proxy, account, error_code, retry_count - 1)
                     except Exception:
                         logger.warning(
                             "Failed to flush deferred keyed stream health account_id=%s request_id=%s",
@@ -650,6 +678,9 @@ class _StreamingRetryMixin:
             )
             if transient_retry_count > 1:
                 await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
+                await _record_aggregated_overload_observations(
+                    proxy, failed_account, failed_code, transient_retry_count - 1
+                )
             return classified
 
         async def _drain_pending_post_refresh_penalty_on_terminal(
@@ -2462,12 +2493,12 @@ class _StreamingRetryMixin:
                                     http_status=tex.status_code,
                                 )
                                 raise
-                            error_code = tex.code if isinstance(tex, _TransientStreamError) else "server_error"
                             error_payload: UpstreamError = (
                                 tex.error
                                 if isinstance(tex, _TransientStreamError)
                                 else _upstream_error_from_openai(_parse_openai_error(tex.payload))
                             )
+                            error_code = _transient_retry_error_code(tex)
                             error_message = str(error_payload.get("message") or "")
                             recovery_decision = await _wait_for_process_network_recovery(
                                 account,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1715,6 +1715,7 @@ class LoadBalancer:
             allow_usage_exhaustion_error=allow_usage_exhaustion_error,
             usage_exhaustion_states=usage_exhaustion_states,
             sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
+            overload_backoff_runtime=self._runtime,
             clock=self._clock,
         )
 

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
@@ -30,8 +30,9 @@ feeding the rejected accounts at their normal capacity weight.
   (60 s, 120 s, …, capped at 600 s; the level decays after 30 quiet minutes).
   A trip while already deprioritized extends the deadline, never shortens it.
 - Deprioritization is soft: the account is dropped from the fresh-selection
-  candidate pool only while at least one other candidate remains, so it can
-  never produce `No available accounts`. Sticky, continuity-owner, and
+  candidate pool only while the remaining candidates still pass routing
+  eligibility on their own (the same check the recovery-probe filter uses), so
+  it can never produce `No available accounts` or a spurious account-cap error. Sticky, continuity-owner, and
   hard-affinity selection are untouched, so warm sessions on the account keep
   flowing and hard-pinned sessions are never denied because of this signal.
 - Engaging the backoff is logged with the level and duration.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
@@ -29,10 +29,18 @@ feeding the rejected accounts at their normal capacity weight.
   fresh (unbound) selection for a bounded, exponentially growing interval
   (60 s, 120 s, …, capped at 600 s; the level decays after 30 quiet minutes).
   A trip while already deprioritized extends the deadline, never shortens it.
-- Deprioritization is soft: the account is dropped from the fresh-selection
-  candidate pool only while the remaining candidates still pass routing
-  eligibility on their own (the same check the recovery-probe filter uses), so
-  it can never produce `No available accounts` or a spurious account-cap error. Sticky, continuity-owner, and
+- Deprioritization is soft and strategy-agnostic: selection first runs over
+  the overload-free candidates and, when the configured strategy/budget gates
+  select none of them, runs again over the full pool exactly as before — so it
+  can never produce `No available accounts` or a spurious account-cap error,
+  and cap detection still sees the untouched cap-filtered pool.
+- It applies wherever a NEW account is chosen: the unbound path and the sticky
+  path's fresh binding / reallocation / fallback pick (a previously unseen
+  session or prompt-cache key is a fresh upstream admission). An established
+  sticky owner, continuity owner, or hard-affinity owner is never touched.
+- HTTP-status failures whose body carries an overload code keep that code
+  through the same-account retry loop (they used to collapse to
+  `server_error`), and each absorbed retry counts toward the window. Sticky, continuity-owner, and
   hard-affinity selection are untouched, so warm sessions on the account keep
   flowing and hard-pinned sessions are never denied because of this signal.
 - Engaging the backoff is logged with the level and duration.
@@ -57,8 +65,13 @@ None.
   trip/decay math, the soft candidate filter.
 - `app/modules/proxy/_service/streaming/helpers.py`: the hook after the
   transient penalty in `_handle_stream_error`.
-- `app/modules/proxy/_load_balancer/unbound_selection.py`: the filter after
-  the account-cap filter on the fresh-selection path.
-- No change to `load_balancer.py`, `service.py`, settings, schema, or API.
+- `app/modules/proxy/_load_balancer/unbound_selection.py`: overload-free
+  first pass with full-pool fallback on the fresh-selection path.
+- `app/modules/proxy/_load_balancer/sticky_selection.py`: the same two-pass
+  pick where the sticky path chooses a new account; `load_balancer.py`
+  forwards the runtime map (one line).
+- `app/modules/proxy/_service/streaming/retry.py`: overload codes survive
+  HTTP-status retry aggregation; absorbed retries feed the window.
+- No change to `service.py`, settings, schema, or API.
   Thresholds are fixed constants, matching the existing drain/probe
   thresholds.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
@@ -40,7 +40,13 @@ feeding the rejected accounts at their normal capacity weight.
   sticky owner, continuity owner, or hard-affinity owner is never touched.
 - HTTP-status failures whose body carries an overload code keep that code
   through the same-account retry loop (they used to collapse to
-  `server_error`), and each absorbed retry counts toward the window. Sticky, continuity-owner, and
+  `server_error`), so the post-exhaustion health write counts as a rejection.
+  Observations are taken exactly where account health is written, so they
+  inherit the existing settlement-before-health ordering; a same-account
+  retry that then succeeds writes no health and is therefore not counted
+  (known limit, shared with `error_count`).
+- Recovery-probe reservation uses the same pool the selection ran over, so an
+  older due probe skipped by the overload pass cannot invalidate the match. Sticky, continuity-owner, and
   hard-affinity selection are untouched, so warm sessions on the account keep
   flowing and hard-pinned sessions are never denied because of this signal.
 - Engaging the backoff is logged with the level and duration.
@@ -71,7 +77,7 @@ None.
   pick where the sticky path chooses a new account; `load_balancer.py`
   forwards the runtime map (one line).
 - `app/modules/proxy/_service/streaming/retry.py`: overload codes survive
-  HTTP-status retry aggregation; absorbed retries feed the window.
+  HTTP-status retry aggregation.
 - No change to `service.py`, settings, schema, or API.
   Thresholds are fixed constants, matching the existing drain/probe
   thresholds.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+Upstream `server_is_overloaded` is an admission rejection scoped to the
+account: upstream refuses to start a new response for that account while the
+account's already-admitted streams keep flowing. On a production pool during an
+upstream capacity incident, 7 of 14 accounts were rejected on 20–70 % of their
+fresh admissions for hours while the other 7 saw none — and each rejection took
+30–90 s to arrive, so every fresh request routed to a rejected account paid
+that wait before failover could even begin. Client-visible first-token latency
+roughly doubled.
+
+The existing account-health machinery never latched. The rejected accounts
+kept succeeding on bridge reuse and sticky continuity (those sessions are
+already admitted), and every success zeroes `RuntimeState.error_count`, so the
+generic transient error backoff (three errors) and the drain tier (two errors
+in 60 s) reset between rejections. A live probe of the balancer runtime showed
+`error_count=0, health_tier=HEALTHY` for an account that had returned 123
+overload rejections in the previous two hours. Fresh selection therefore kept
+feeding the rejected accounts at their normal capacity weight.
+
+## What Changes
+
+- Each `server_is_overloaded` / `overloaded_error` rejection recorded through
+  `_handle_stream_error` (the single funnel every transport uses for
+  stream-error account health) also feeds a replica-local sliding window on the
+  account's runtime state. The window is independent of `error_count` and is
+  not reset by successes.
+- When three rejections land inside 120 s, the account is deprioritized for
+  fresh (unbound) selection for a bounded, exponentially growing interval
+  (60 s, 120 s, …, capped at 600 s; the level decays after 30 quiet minutes).
+  A trip while already deprioritized extends the deadline, never shortens it.
+- Deprioritization is soft: the account is dropped from the fresh-selection
+  candidate pool only while at least one other candidate remains, so it can
+  never produce `No available accounts`. Sticky, continuity-owner, and
+  hard-affinity selection are untouched, so warm sessions on the account keep
+  flowing and hard-pinned sessions are never denied because of this signal.
+- Engaging the backoff is logged with the level and duration.
+- Failure classification, the failover decision, the generic `record_error`
+  penalty, and the client-visible status and body are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `account-routing`: overload rejections deprioritize the account for fresh
+  selection through a replica-local window that successes do not reset.
+
+## Impact
+
+- `app/modules/proxy/_load_balancer/types.py`: four runtime fields.
+- `app/modules/proxy/_load_balancer/overload_backoff.py` (new): window,
+  trip/decay math, the soft candidate filter.
+- `app/modules/proxy/_service/streaming/helpers.py`: the hook after the
+  transient penalty in `_handle_stream_error`.
+- `app/modules/proxy/_load_balancer/unbound_selection.py`: the filter after
+  the account-cap filter on the fresh-selection path.
+- No change to `load_balancer.py`, `service.py`, settings, schema, or API.
+  Thresholds are fixed constants, matching the existing drain/probe
+  thresholds.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Overload rejections deprioritize the account for fresh selection
+
+When upstream rejects a fresh admission for an account as overloaded
+(`server_is_overloaded` or `overloaded_error`), the proxy MUST record the
+rejection in a replica-local per-account window that is independent of the
+transient error count and MUST NOT be reset by later successes on that
+account. When at least three rejections land inside a 120-second window, the
+proxy MUST deprioritize the account for fresh (unbound) selection for a
+bounded interval that grows exponentially with consecutive trips (60 seconds
+base, capped at 600 seconds, decaying to the base after 30 minutes without a
+trip); a trip while already deprioritized MUST NOT shorten the deadline.
+Deprioritization MUST be soft: the account is removed from the fresh-selection
+candidate pool only while at least one other candidate remains, and it MUST
+NOT be applied to sticky, continuity-owner, or hard-affinity selection. The
+proxy MUST log when the backoff engages. The failure classification, the
+failover decision, the existing transient error penalty, and the status and
+body returned to the client MUST remain unchanged.
+
+#### Scenario: Warm sessions keep masking the generic error counters
+
+- **GIVEN** account A is rejected as overloaded on fresh admissions while its
+  bridge-reuse and sticky sessions keep succeeding
+- **WHEN** three rejections arrive within 120 seconds
+- **THEN** account A enters overload backoff even though its transient error
+  count is zero
+- **AND** fresh selection skips account A while another candidate is available
+
+#### Scenario: Backoff never empties the pool
+
+- **GIVEN** every selectable account is in overload backoff
+- **WHEN** a fresh request selects an account
+- **THEN** selection proceeds over the full candidate pool as if no account
+  were backed off
+
+#### Scenario: Pinned sessions are not denied by overload backoff
+
+- **GIVEN** account A is in overload backoff
+- **WHEN** a request hard-pinned to account A (continuity owner, sticky
+  session, or file affinity) selects an account
+- **THEN** the pin is honored exactly as before
+
+#### Scenario: Consecutive trips back off longer, bounded
+
+- **GIVEN** account A trips the window repeatedly with each burst starting when
+  the previous backoff expires
+- **WHEN** the backoff deadline is computed for each trip
+- **THEN** the interval doubles from 60 seconds and never exceeds 600 seconds
+- **AND** after 30 minutes without a trip the next trip returns to 60 seconds
+
+#### Scenario: Non-overload transient errors do not feed the window
+
+- **GIVEN** account A returns a transient `server_error`
+- **WHEN** the proxy records account health
+- **THEN** the generic transient error is recorded as before
+- **AND** the overload window for account A is unchanged

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
@@ -4,9 +4,9 @@
 
 When upstream rejects a fresh admission for an account as overloaded
 (`server_is_overloaded` or `overloaded_error`), the proxy MUST record the
-rejection in a replica-local per-account window that is independent of the
-transient error count and MUST NOT be reset by later successes on that
-account. When at least three rejections land inside a 120-second window, the
+rejection, at the point where account health is written for it, in a
+replica-local per-account window that is independent of the transient error
+count and MUST NOT be reset by later successes on that account. When at least three rejections land inside a 120-second window, the
 proxy MUST deprioritize the account for fresh (unbound) selection for a
 bounded interval that grows exponentially with consecutive trips (60 seconds
 base, capped at 600 seconds, decaying to the base after 30 minutes without a
@@ -57,14 +57,24 @@ body returned to the client MUST remain unchanged.
 - **THEN** the new binding is made to account B
 - **AND** a request whose key already maps to account A keeps using account A
 
-#### Scenario: Same-account retries count as admission rejections
+#### Scenario: HTTP-status overload rejections keep their code
 
 - **GIVEN** upstream answers a fresh admission with an HTTP 5xx whose body
   carries `server_is_overloaded`
 - **WHEN** the same-account transient retries are exhausted and health is
   written after settlement
-- **THEN** the health write keeps the overload code and every absorbed retry
-  counts toward the account's overload window
+- **THEN** the health write carries `server_is_overloaded` rather than a
+  collapsed `server_error`, so the rejection counts toward the account's
+  overload window
+
+#### Scenario: Recovery-probe reservation follows the selected pool
+
+- **GIVEN** a fresh request whose selection ran over the overload-free
+  candidates
+- **WHEN** the selected account is a due recovery probe that needs a
+  reservation
+- **THEN** the reservation is taken from that same overload-free pool, so an
+  older due probe skipped by the overload pass cannot invalidate the selection
 
 #### Scenario: Pinned sessions are not denied by overload backoff
 

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
@@ -13,10 +13,13 @@ base, capped at 600 seconds, decaying to the base after 30 minutes without a
 trip); the level MUST saturate once the cap is reached so sustained overload
 cannot grow it without bound, and a trip while already deprioritized MUST NOT
 shorten the deadline.
-Deprioritization MUST be soft: the account is removed from the fresh-selection
-candidate pool only while at least one other candidate that passes routing
-eligibility on its own remains, and it MUST NOT be applied to sticky,
-continuity-owner, or hard-affinity selection. The
+Deprioritization MUST be soft: selection first runs over the candidates not in
+overload backoff and, when the configured strategy and budget gates select
+none of them, runs again over the full candidate pool exactly as before. It
+MUST apply wherever a NEW account is chosen for a request — unbound selection
+and the sticky path's fresh binding, reallocation, or fallback pick — and MUST
+NOT apply to an established sticky owner, a continuity owner, or a
+hard-affinity owner. The
 proxy MUST log when the backoff engages. The failure classification, the
 failover decision, the existing transient error penalty, and the status and
 body returned to the client MUST remain unchanged.
@@ -39,12 +42,29 @@ body returned to the client MUST remain unchanged.
 
 #### Scenario: Backoff yields to an ineligible remainder
 
-- **GIVEN** account A is in overload backoff and every other account is
-  ineligible on its own (rate-limited, cooling down, or in generic error
-  backoff)
+- **GIVEN** account A is in overload backoff and the configured strategy
+  selects none of the other accounts (rate-limited, cooling down, in generic
+  error backoff, or excluded by the strategy's budget gates)
 - **WHEN** a fresh request selects an account
 - **THEN** account A is selected rather than failing the request or reporting
   an account-cap error
+
+#### Scenario: A previously unseen sticky key binds away from the backed-off account
+
+- **GIVEN** account A is in overload backoff and account B is selectable
+- **WHEN** a request carrying a session or prompt-cache key with no established
+  owner selects an account
+- **THEN** the new binding is made to account B
+- **AND** a request whose key already maps to account A keeps using account A
+
+#### Scenario: Same-account retries count as admission rejections
+
+- **GIVEN** upstream answers a fresh admission with an HTTP 5xx whose body
+  carries `server_is_overloaded`
+- **WHEN** the same-account transient retries are exhausted and health is
+  written after settlement
+- **THEN** the health write keeps the overload code and every absorbed retry
+  counts toward the account's overload window
 
 #### Scenario: Pinned sessions are not denied by overload backoff
 

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/specs/account-routing/spec.md
@@ -10,10 +10,13 @@ account. When at least three rejections land inside a 120-second window, the
 proxy MUST deprioritize the account for fresh (unbound) selection for a
 bounded interval that grows exponentially with consecutive trips (60 seconds
 base, capped at 600 seconds, decaying to the base after 30 minutes without a
-trip); a trip while already deprioritized MUST NOT shorten the deadline.
+trip); the level MUST saturate once the cap is reached so sustained overload
+cannot grow it without bound, and a trip while already deprioritized MUST NOT
+shorten the deadline.
 Deprioritization MUST be soft: the account is removed from the fresh-selection
-candidate pool only while at least one other candidate remains, and it MUST
-NOT be applied to sticky, continuity-owner, or hard-affinity selection. The
+candidate pool only while at least one other candidate that passes routing
+eligibility on its own remains, and it MUST NOT be applied to sticky,
+continuity-owner, or hard-affinity selection. The
 proxy MUST log when the backoff engages. The failure classification, the
 failover decision, the existing transient error penalty, and the status and
 body returned to the client MUST remain unchanged.
@@ -33,6 +36,15 @@ body returned to the client MUST remain unchanged.
 - **WHEN** a fresh request selects an account
 - **THEN** selection proceeds over the full candidate pool as if no account
   were backed off
+
+#### Scenario: Backoff yields to an ineligible remainder
+
+- **GIVEN** account A is in overload backoff and every other account is
+  ineligible on its own (rate-limited, cooling down, or in generic error
+  backoff)
+- **WHEN** a fresh request selects an account
+- **THEN** account A is selected rather than failing the request or reporting
+  an account-cap error
 
 #### Scenario: Pinned sessions are not denied by overload backoff
 

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
@@ -1,0 +1,16 @@
+## 1. Track overload rejections independently of the generic error counters
+
+- [x] 1.1 Add `overload_rejections`, `overload_backoff_until`, `overload_backoff_level`, `overload_last_trip_at` to `RuntimeState` (replica-local, never persisted).
+- [x] 1.2 Add `app/modules/proxy/_load_balancer/overload_backoff.py` with the window (3 rejections in 120 s), bounded exponential deadline (60 s base, 600 s cap, never shortened by a later trip), level decay after 1800 s, and `record_upstream_overload` taking the balancer's per-account lock.
+- [x] 1.3 Feed the window from `_handle_stream_error` after the transient penalty for `server_is_overloaded` / `overloaded_error`; keep classification, failover, and the client response unchanged.
+
+## 2. Deprioritize on fresh selection only
+
+- [x] 2.1 Apply `filter_overload_backoff_candidates` on the unbound selection path after the account-cap filter; return the pool unchanged when every candidate is backed off.
+- [x] 2.2 Leave sticky, continuity-owner, and hard-affinity selection untouched.
+
+## 3. Verification
+
+- [x] 3.1 Unit: trip only on the third in-window rejection, stale rejections pruned, exponential growth with cap, deadline never shortened, level decay, soft filter semantics (drops only while others remain).
+- [x] 3.2 Unit: `record_upstream_overload` writes runtime state and logs the engagement; `_handle_stream_error` feeds the window for overload codes only and still records the generic transient error.
+- [x] 3.3 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `scripts/check_proxy_architecture.py`, and the unit suite.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
@@ -6,12 +6,13 @@
 
 ## 2. Deprioritize on fresh selection only
 
-- [x] 2.1 Apply `filter_overload_backoff_candidates` on the unbound selection path after the account-cap filter; return the pool unchanged unless the non-backed-off remainder passes routing eligibility on its own.
-- [x] 2.2 Leave sticky, continuity-owner, and hard-affinity selection untouched.
+- [x] 2.1 Unbound path: select from the overload-free candidates first, then from the untouched cap-filtered pool when the strategy selects none; keep cap detection on the cap-filtered pool.
+- [x] 2.2 Sticky path: apply the same two-pass pick where a NEW account is chosen for a key (fresh binding, reallocation, fallback); pinned-owner paths untouched. `load_balancer.py` forwards its runtime map.
+- [x] 2.3 Retry loop: HTTP-status failures keep an overload payload code instead of collapsing to `server_error`; absorbed same-account retries feed the window after settlement.
 
 ## 3. Verification
 
 - [x] 3.1 Unit: trip only on the third in-window rejection, stale rejections pruned, exponential growth with cap, deadline never shortened, level decay, soft filter semantics (drops only while others remain).
 - [x] 3.2 Unit: `record_upstream_overload` writes runtime state and logs the engagement; `_handle_stream_error` feeds the window for overload codes only and still records the generic transient error; the level saturates (no overflow at any level).
-- [x] 3.3 Routing surface: `LoadBalancer.select_account()` skips a backed-off account while a healthy sibling exists, and still selects it when every sibling is in generic error backoff.
+- [x] 3.3 Routing surface: `LoadBalancer.select_account()` skips a backed-off account while a healthy sibling exists, and still selects it when every sibling is in generic error backoff; `LoadBalancer._select_with_stickiness` binds a fresh key away from the backed-off account, keeps an established owner, and falls back when no alternative exists; retry code preservation and aggregated observations.
 - [x] 3.4 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `scripts/check_proxy_architecture.py`, and the unit suite.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
@@ -8,11 +8,12 @@
 
 - [x] 2.1 Unbound path: select from the overload-free candidates first, then from the untouched cap-filtered pool when the strategy selects none; keep cap detection on the cap-filtered pool.
 - [x] 2.2 Sticky path: apply the same two-pass pick where a NEW account is chosen for a key (fresh binding, reallocation, fallback); pinned-owner paths untouched. `load_balancer.py` forwards its runtime map.
-- [x] 2.3 Retry loop: HTTP-status failures keep an overload payload code instead of collapsing to `server_error`; absorbed same-account retries feed the window after settlement.
+- [x] 2.3 Retry loop: HTTP-status failures keep an overload payload code instead of collapsing to `server_error`.
+- [x] 2.4 Probe reservation (unbound and sticky fresh binding) runs over the same pool the selection used.
 
 ## 3. Verification
 
 - [x] 3.1 Unit: trip only on the third in-window rejection, stale rejections pruned, exponential growth with cap, deadline never shortened, level decay, soft filter semantics (drops only while others remain).
 - [x] 3.2 Unit: `record_upstream_overload` writes runtime state and logs the engagement; `_handle_stream_error` feeds the window for overload codes only and still records the generic transient error; the level saturates (no overflow at any level).
-- [x] 3.3 Routing surface: `LoadBalancer.select_account()` skips a backed-off account while a healthy sibling exists, and still selects it when every sibling is in generic error backoff; `LoadBalancer._select_with_stickiness` binds a fresh key away from the backed-off account, keeps an established owner, and falls back when no alternative exists; retry code preservation and aggregated observations.
+- [x] 3.3 Routing surface: `LoadBalancer.select_account()` skips a backed-off account while a healthy sibling exists, and still selects it when every sibling is in generic error backoff; `LoadBalancer._select_with_stickiness` binds a fresh key away from the backed-off account, keeps an established owner, and falls back when no alternative exists; retry code preservation; probe reservation follows the overload-free pool.
 - [x] 3.4 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `scripts/check_proxy_architecture.py`, and the unit suite.

--- a/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
+++ b/openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection/tasks.md
@@ -6,11 +6,12 @@
 
 ## 2. Deprioritize on fresh selection only
 
-- [x] 2.1 Apply `filter_overload_backoff_candidates` on the unbound selection path after the account-cap filter; return the pool unchanged when every candidate is backed off.
+- [x] 2.1 Apply `filter_overload_backoff_candidates` on the unbound selection path after the account-cap filter; return the pool unchanged unless the non-backed-off remainder passes routing eligibility on its own.
 - [x] 2.2 Leave sticky, continuity-owner, and hard-affinity selection untouched.
 
 ## 3. Verification
 
 - [x] 3.1 Unit: trip only on the third in-window rejection, stale rejections pruned, exponential growth with cap, deadline never shortened, level decay, soft filter semantics (drops only while others remain).
-- [x] 3.2 Unit: `record_upstream_overload` writes runtime state and logs the engagement; `_handle_stream_error` feeds the window for overload codes only and still records the generic transient error.
-- [x] 3.3 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `scripts/check_proxy_architecture.py`, and the unit suite.
+- [x] 3.2 Unit: `record_upstream_overload` writes runtime state and logs the engagement; `_handle_stream_error` feeds the window for overload codes only and still records the generic transient error; the level saturates (no overflow at any level).
+- [x] 3.3 Routing surface: `LoadBalancer.select_account()` skips a backed-off account while a healthy sibling exists, and still selects it when every sibling is in generic error backoff.
+- [x] 3.4 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `scripts/check_proxy_architecture.py`, and the unit suite.

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -28,10 +28,7 @@ from app.modules.proxy._load_balancer.overload_backoff import (
     record_upstream_overload,
 )
 from app.modules.proxy._load_balancer.types import RuntimeState
-from app.modules.proxy._service.streaming.retry import (
-    _record_aggregated_overload_observations,
-    _transient_retry_error_code,
-)
+from app.modules.proxy._service.streaming.retry import _transient_retry_error_code
 from app.modules.proxy._service.support import _TransientStreamError
 from app.modules.proxy.load_balancer import LoadBalancer
 from tests.simulation.virtual_time import VirtualClock
@@ -188,26 +185,6 @@ def test_transient_retry_error_code_keeps_overload_codes_from_http_status_failur
     assert _transient_retry_error_code(RuntimeError("no payload at all")) == "server_error"
     framed = _TransientStreamError("stream_incomplete", {"message": "cut"})
     assert _transient_retry_error_code(framed) == "stream_incomplete"
-
-
-@pytest.mark.asyncio
-async def test_aggregated_retry_observations_feed_the_window_for_overload_codes_only() -> None:
-    clock = VirtualClock(epoch_value=2_000_000_000.0)
-    balancer = LoadBalancer(cast(Any, None), clock=clock)
-    account = _make_account("acc-retried")
-    proxy = SimpleNamespace(_load_balancer=balancer)
-
-    await _record_aggregated_overload_observations(proxy, account, "server_error", 2)
-    assert account.id not in balancer._runtime
-
-    await _record_aggregated_overload_observations(proxy, account, "server_is_overloaded", 0)
-    assert account.id not in balancer._runtime
-
-    # Two absorbed same-account retries plus the final health write = the trip count.
-    await _record_aggregated_overload_observations(proxy, account, "server_is_overloaded", OVERLOAD_TRIP_COUNT - 1)
-    assert balancer._runtime[account.id].overload_rejections == [clock.time()] * (OVERLOAD_TRIP_COUNT - 1)
-    await record_upstream_overload(balancer, account)
-    assert overload_backoff_active(balancer._runtime[account.id], clock.time())
 
 
 @pytest.mark.asyncio
@@ -368,3 +345,41 @@ async def test_fresh_sticky_binding_avoids_backed_off_account_but_established_ow
     alone = await _select_sticky(balancer, [_state("hot")], _sticky_repo(None))
     assert alone.account is not None
     assert alone.account.account_id == "hot"
+
+
+@pytest.mark.asyncio
+async def test_fresh_sticky_binding_reports_the_pool_it_selected_from() -> None:
+    """Probe reservation in the sticky run path reuses ``effective_states``; it
+    must name the overload-free pool only when that pool produced the pick."""
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    balancer = LoadBalancer(_mock_repo_factory, clock=clock)
+    balancer._runtime["hot"] = RuntimeState(overload_backoff_until=clock.time() + OVERLOAD_BACKOFF_BASE_SECONDS)
+    hot, clean = _state("hot"), _state("clean")
+    account_map = {state.account_id: cast(Account, AsyncMock()) for state in (hot, clean)}
+
+    async def _outcome(states: list[AccountState], existing: str | None):
+        return await balancer._select_with_stickiness(
+            states=states,
+            account_map=account_map,
+            sticky_key="key",
+            sticky_kind=StickySessionKind.PROMPT_CACHE,
+            reallocate_sticky=False,
+            sticky_max_age_seconds=600,
+            prefer_earlier_reset_accounts=False,
+            prefer_earlier_reset_window="secondary",
+            routing_strategy="usage_weighted",
+            sticky_repo=_sticky_repo(existing),
+        )
+
+    filtered = await _outcome([hot, clean], None)
+    assert filtered.selection.account is not None and filtered.selection.account.account_id == "clean"
+    assert filtered.effective_states is not None
+    assert [state.account_id for state in filtered.effective_states] == ["clean"]
+
+    unfiltered = await _outcome([hot], None)
+    assert unfiltered.selection.account is not None and unfiltered.selection.account.account_id == "hot"
+    assert unfiltered.effective_states is None
+
+    owned = await _outcome([hot, clean], "hot")
+    assert owned.selection.account is not None and owned.selection.account.account_id == "hot"
+    assert owned.effective_states is None

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.modules.proxy._service.streaming.helpers as streaming_helpers_module
+from app.core.balancer.logic import AccountState
+from app.core.crypto import TokenEncryptor
+from app.db.models import Account, AccountStatus
+from app.modules.proxy._load_balancer.overload_backoff import (
+    OVERLOAD_BACKOFF_BASE_SECONDS,
+    OVERLOAD_BACKOFF_MAX_SECONDS,
+    OVERLOAD_LEVEL_DECAY_SECONDS,
+    OVERLOAD_TRIP_COUNT,
+    OVERLOAD_WINDOW_SECONDS,
+    filter_overload_backoff_candidates,
+    overload_backoff_active,
+    record_overload_rejection_locked,
+    record_upstream_overload,
+)
+from app.modules.proxy._load_balancer.types import RuntimeState
+from app.modules.proxy.load_balancer import LoadBalancer
+from tests.simulation.virtual_time import VirtualClock
+
+pytestmark = pytest.mark.unit
+
+
+def _make_account(account_id: str) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=datetime.now(tz=timezone.utc),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+def _state(account_id: str) -> AccountState:
+    return AccountState(account_id=account_id, status=AccountStatus.ACTIVE, used_percent=0.0)
+
+
+def test_window_trips_only_on_the_third_rejection_inside_the_window() -> None:
+    runtime = RuntimeState()
+    assert record_overload_rejection_locked(runtime, 1000.0) is None
+    assert record_overload_rejection_locked(runtime, 1010.0) is None
+    assert not overload_backoff_active(runtime, 1010.0)
+
+    deadline = record_overload_rejection_locked(runtime, 1020.0)
+
+    assert deadline == pytest.approx(1020.0 + OVERLOAD_BACKOFF_BASE_SECONDS)
+    assert runtime.overload_backoff_level == 1
+    assert runtime.overload_rejections == []
+    assert overload_backoff_active(runtime, 1020.0 + OVERLOAD_BACKOFF_BASE_SECONDS - 1)
+    assert not overload_backoff_active(runtime, 1020.0 + OVERLOAD_BACKOFF_BASE_SECONDS)
+
+
+def test_rejections_outside_the_window_do_not_count() -> None:
+    runtime = RuntimeState()
+    record_overload_rejection_locked(runtime, 0.0)
+    record_overload_rejection_locked(runtime, 1.0)
+    # Two stale rejections plus one fresh one: below the trip count.
+    assert record_overload_rejection_locked(runtime, OVERLOAD_WINDOW_SECONDS + 5.0) is None
+    assert runtime.overload_rejections == [OVERLOAD_WINDOW_SECONDS + 5.0]
+
+
+def test_repeated_trips_grow_exponentially_and_are_capped() -> None:
+    runtime = RuntimeState()
+    now = 0.0
+    deadlines: list[float] = []
+    for _ in range(6):
+        for _ in range(OVERLOAD_TRIP_COUNT - 1):
+            assert record_overload_rejection_locked(runtime, now) is None
+        deadline = record_overload_rejection_locked(runtime, now)
+        assert deadline is not None
+        deadlines.append(deadline - now)
+        now = deadline  # next burst starts right when the backoff expires
+
+    assert deadlines[:4] == pytest.approx(
+        [
+            OVERLOAD_BACKOFF_BASE_SECONDS,
+            OVERLOAD_BACKOFF_BASE_SECONDS * 2,
+            OVERLOAD_BACKOFF_BASE_SECONDS * 4,
+            OVERLOAD_BACKOFF_BASE_SECONDS * 8,
+        ]
+    )
+    assert deadlines[-1] == pytest.approx(OVERLOAD_BACKOFF_MAX_SECONDS)
+
+
+def test_trip_while_deprioritized_never_shortens_the_deadline() -> None:
+    runtime = RuntimeState(overload_backoff_until=5000.0, overload_backoff_level=5, overload_last_trip_at=4000.0)
+    for _ in range(OVERLOAD_TRIP_COUNT - 1):
+        record_overload_rejection_locked(runtime, 4500.0)
+    deadline = record_overload_rejection_locked(runtime, 4500.0)
+    # Level 6 => 60 * 2**5 = 1920 s, capped at 600 s => 5100 > 5000.
+    assert deadline == pytest.approx(4500.0 + OVERLOAD_BACKOFF_MAX_SECONDS)
+
+    runtime = RuntimeState(overload_backoff_until=9000.0, overload_backoff_level=1, overload_last_trip_at=4000.0)
+    for _ in range(OVERLOAD_TRIP_COUNT - 1):
+        record_overload_rejection_locked(runtime, 4500.0)
+    assert record_overload_rejection_locked(runtime, 4500.0) == 9000.0
+
+
+def test_level_decays_after_a_quiet_period() -> None:
+    runtime = RuntimeState(overload_backoff_level=4, overload_last_trip_at=0.0)
+    now = OVERLOAD_LEVEL_DECAY_SECONDS + 1.0
+    for _ in range(OVERLOAD_TRIP_COUNT - 1):
+        record_overload_rejection_locked(runtime, now)
+    deadline = record_overload_rejection_locked(runtime, now)
+    assert runtime.overload_backoff_level == 1
+    assert deadline == pytest.approx(now + OVERLOAD_BACKOFF_BASE_SECONDS)
+
+
+def test_filter_drops_backed_off_candidates_only_while_others_remain() -> None:
+    now = 1000.0
+    runtime = {
+        "hot": RuntimeState(overload_backoff_until=now + 30.0),
+        "expired": RuntimeState(overload_backoff_until=now - 1.0),
+        "clean": RuntimeState(),
+    }
+    states = [_state("hot"), _state("expired"), _state("clean"), _state("unknown")]
+
+    kept = filter_overload_backoff_candidates(states, runtime, now=now)
+    assert [state.account_id for state in kept] == ["expired", "clean", "unknown"]
+
+    only_hot = [_state("hot")]
+    assert filter_overload_backoff_candidates(only_hot, runtime, now=now) is only_hot
+
+    all_hot = [_state("hot"), _state("hot2")]
+    runtime["hot2"] = RuntimeState(overload_backoff_until=now + 5.0)
+    assert filter_overload_backoff_candidates(all_hot, runtime, now=now) is all_hot
+
+    untouched = [_state("clean"), _state("expired")]
+    assert filter_overload_backoff_candidates(untouched, runtime, now=now) is untouched
+
+
+@pytest.mark.asyncio
+async def test_record_upstream_overload_writes_runtime_under_the_account_lock(caplog: pytest.LogCaptureFixture) -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    balancer = LoadBalancer(cast(Any, None), clock=clock)
+    account = _make_account("acc-overloaded")
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy._load_balancer.overload_backoff"):
+        for _ in range(OVERLOAD_TRIP_COUNT - 1):
+            await record_upstream_overload(balancer, account)
+            clock.advance(1.0)
+        assert not overload_backoff_active(balancer._runtime[account.id], clock.time())
+        assert "overload backoff engaged" not in caplog.text
+
+        await record_upstream_overload(balancer, account, redact_account_id=True)
+
+    runtime = balancer._runtime[account.id]
+    assert runtime.overload_backoff_level == 1
+    assert runtime.overload_backoff_until == pytest.approx(clock.time() + OVERLOAD_BACKOFF_BASE_SECONDS)
+    assert "Account overload backoff engaged account_id=<redacted> level=1" in caplog.text
+    # The generic error counters are untouched: this window is independent of
+    # ``record_success`` resetting ``error_count``.
+    assert runtime.error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_upstream_overload_ignores_balancers_without_a_runtime_map() -> None:
+    balancer = SimpleNamespace(record_error=AsyncMock())
+    await record_upstream_overload(balancer, _make_account("acc-double"))
+
+
+@pytest.mark.asyncio
+async def test_handle_stream_error_feeds_the_overload_window_for_overload_codes_only() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    balancer = LoadBalancer(cast(Any, None), clock=clock)
+    account = _make_account("acc-stream")
+    proxy = SimpleNamespace(_load_balancer=balancer)
+    # Keep the generic path inert: this test pins the overload hook only.
+    balancer.record_error = AsyncMock()  # type: ignore[method-assign]
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        account,
+        {"message": "Our servers are currently overloaded. Please try again later."},
+        "server_is_overloaded",
+        None,
+    )
+    assert classified["failure_class"] == "retryable_transient"
+    assert balancer._runtime[account.id].overload_rejections == [clock.time()]
+    balancer.record_error.assert_awaited_once()
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        account,
+        {"message": "upstream hiccup"},
+        "server_error",
+        None,
+    )
+    assert balancer._runtime[account.id].overload_rejections == [clock.time()]
+    assert balancer.record_error.await_count == 2

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 import app.modules.proxy._service.streaming.helpers as streaming_helpers_module
+from app.core.balancer import ERROR_BACKOFF_THRESHOLD, TRAFFIC_CLASS_FOREGROUND
 from app.core.balancer.logic import AccountState
 from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus
@@ -16,16 +17,23 @@ from app.modules.proxy._load_balancer.overload_backoff import (
     OVERLOAD_BACKOFF_BASE_SECONDS,
     OVERLOAD_BACKOFF_MAX_SECONDS,
     OVERLOAD_LEVEL_DECAY_SECONDS,
+    OVERLOAD_MAX_LEVEL,
     OVERLOAD_TRIP_COUNT,
     OVERLOAD_WINDOW_SECONDS,
     filter_overload_backoff_candidates,
     overload_backoff_active,
+    overload_backoff_seconds,
     record_overload_rejection_locked,
     record_upstream_overload,
 )
 from app.modules.proxy._load_balancer.types import RuntimeState
 from app.modules.proxy.load_balancer import LoadBalancer
 from tests.simulation.virtual_time import VirtualClock
+from tests.unit.test_load_balancer_concurrency import (
+    _repo_factory,
+    _StubAccountsRepository,
+    _StubUsageRepository,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -97,6 +105,17 @@ def test_repeated_trips_grow_exponentially_and_are_capped() -> None:
     assert deadlines[-1] == pytest.approx(OVERLOAD_BACKOFF_MAX_SECONDS)
 
 
+def test_level_saturates_so_sustained_overload_cannot_overflow() -> None:
+    assert overload_backoff_seconds(10_000) == OVERLOAD_BACKOFF_MAX_SECONDS
+    runtime = RuntimeState(overload_backoff_level=OVERLOAD_MAX_LEVEL, overload_last_trip_at=0.0)
+    now = 10.0
+    for _ in range(OVERLOAD_TRIP_COUNT - 1):
+        record_overload_rejection_locked(runtime, now)
+    deadline = record_overload_rejection_locked(runtime, now)
+    assert runtime.overload_backoff_level == OVERLOAD_MAX_LEVEL
+    assert deadline == pytest.approx(now + OVERLOAD_BACKOFF_MAX_SECONDS)
+
+
 def test_trip_while_deprioritized_never_shortens_the_deadline() -> None:
     runtime = RuntimeState(overload_backoff_until=5000.0, overload_backoff_level=5, overload_last_trip_at=4000.0)
     for _ in range(OVERLOAD_TRIP_COUNT - 1):
@@ -121,7 +140,11 @@ def test_level_decays_after_a_quiet_period() -> None:
     assert deadline == pytest.approx(now + OVERLOAD_BACKOFF_BASE_SECONDS)
 
 
-def test_filter_drops_backed_off_candidates_only_while_others_remain() -> None:
+def _filter(states: list[AccountState], runtime: dict[str, RuntimeState], now: float) -> list[AccountState]:
+    return filter_overload_backoff_candidates(states, runtime, traffic_class=TRAFFIC_CLASS_FOREGROUND, now=now)
+
+
+def test_filter_drops_backed_off_candidates_only_while_eligible_others_remain() -> None:
     now = 1000.0
     runtime = {
         "hot": RuntimeState(overload_backoff_until=now + 30.0),
@@ -130,18 +153,47 @@ def test_filter_drops_backed_off_candidates_only_while_others_remain() -> None:
     }
     states = [_state("hot"), _state("expired"), _state("clean"), _state("unknown")]
 
-    kept = filter_overload_backoff_candidates(states, runtime, now=now)
+    kept = _filter(states, runtime, now)
     assert [state.account_id for state in kept] == ["expired", "clean", "unknown"]
 
     only_hot = [_state("hot")]
-    assert filter_overload_backoff_candidates(only_hot, runtime, now=now) is only_hot
+    assert _filter(only_hot, runtime, now) is only_hot
 
     all_hot = [_state("hot"), _state("hot2")]
     runtime["hot2"] = RuntimeState(overload_backoff_until=now + 5.0)
-    assert filter_overload_backoff_candidates(all_hot, runtime, now=now) is all_hot
+    assert _filter(all_hot, runtime, now) is all_hot
 
     untouched = [_state("clean"), _state("expired")]
-    assert filter_overload_backoff_candidates(untouched, runtime, now=now) is untouched
+    assert _filter(untouched, runtime, now) is untouched
+
+
+def test_filter_keeps_backed_off_account_when_the_remainder_is_ineligible() -> None:
+    now = 1000.0
+    runtime = {"hot": RuntimeState(overload_backoff_until=now + 30.0)}
+    hot = _state("hot")
+    rate_limited = AccountState(
+        account_id="limited",
+        status=AccountStatus.RATE_LIMITED,
+        used_percent=0.0,
+        reset_at=now + 300.0,
+    )
+    cooling = AccountState(
+        account_id="cooling", status=AccountStatus.ACTIVE, used_percent=0.0, cooldown_until=now + 60.0
+    )
+    erroring = AccountState(
+        account_id="erroring",
+        status=AccountStatus.ACTIVE,
+        used_percent=0.0,
+        error_count=ERROR_BACKOFF_THRESHOLD,
+        last_error_at=now - 1.0,
+    )
+
+    pool = [hot, rate_limited, cooling, erroring]
+    assert _filter(pool, runtime, now) is pool
+
+    # One eligible sibling is enough to drop the backed-off account again.
+    with_clean = [hot, rate_limited, _state("clean")]
+    assert [state.account_id for state in _filter(with_clean, runtime, now)] == ["limited", "clean"]
 
 
 @pytest.mark.asyncio
@@ -203,3 +255,48 @@ async def test_handle_stream_error_feeds_the_overload_window_for_overload_codes_
     )
     assert balancer._runtime[account.id].overload_rejections == [clock.time()]
     assert balancer.record_error.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_select_account_skips_backed_off_account_while_a_healthy_sibling_exists() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    hot = _make_account("acc-hot")
+    clean = _make_account("acc-clean")
+    balancer = LoadBalancer(
+        lambda: _repo_factory(_StubAccountsRepository([hot, clean]), _StubUsageRepository({}, {})),
+        clock=clock,
+    )
+    balancer._runtime[hot.id] = RuntimeState(overload_backoff_until=clock.time() + OVERLOAD_BACKOFF_BASE_SECONDS)
+
+    # Equal weights: 40 draws all landing on ``clean`` is 2**-40 by chance.
+    for _ in range(40):
+        result = await balancer.select_account()
+        assert result.account is not None
+        assert result.account.id == clean.id
+
+    clock.advance(OVERLOAD_BACKOFF_BASE_SECONDS + 1.0)
+    selected: set[str] = set()
+    for _ in range(40):
+        result = await balancer.select_account()
+        assert result.account is not None
+        selected.add(result.account.id)
+    assert hot.id in selected
+
+
+@pytest.mark.asyncio
+async def test_select_account_still_uses_backed_off_account_when_every_sibling_is_in_error_backoff() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    hot = _make_account("acc-hot-only")
+    erroring = _make_account("acc-erroring")
+    balancer = LoadBalancer(
+        lambda: _repo_factory(_StubAccountsRepository([hot, erroring]), _StubUsageRepository({}, {})),
+        clock=clock,
+    )
+    balancer._runtime[hot.id] = RuntimeState(overload_backoff_until=clock.time() + OVERLOAD_BACKOFF_BASE_SECONDS)
+    balancer._runtime[erroring.id] = RuntimeState(error_count=ERROR_BACKOFF_THRESHOLD, last_error_at=clock.time())
+
+    result = await balancer.select_account(lease_kind="stream")
+
+    assert result.error_code is None, result.error_message
+    assert result.account is not None
+    assert result.account.id == hot.id

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
@@ -9,10 +10,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 import app.modules.proxy._service.streaming.helpers as streaming_helpers_module
-from app.core.balancer import ERROR_BACKOFF_THRESHOLD, TRAFFIC_CLASS_FOREGROUND
+from app.core.balancer import ERROR_BACKOFF_THRESHOLD
 from app.core.balancer.logic import AccountState
 from app.core.crypto import TokenEncryptor
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, StickySessionKind
 from app.modules.proxy._load_balancer.overload_backoff import (
     OVERLOAD_BACKOFF_BASE_SECONDS,
     OVERLOAD_BACKOFF_MAX_SECONDS,
@@ -27,6 +28,11 @@ from app.modules.proxy._load_balancer.overload_backoff import (
     record_upstream_overload,
 )
 from app.modules.proxy._load_balancer.types import RuntimeState
+from app.modules.proxy._service.streaming.retry import (
+    _record_aggregated_overload_observations,
+    _transient_retry_error_code,
+)
+from app.modules.proxy._service.support import _TransientStreamError
 from app.modules.proxy.load_balancer import LoadBalancer
 from tests.simulation.virtual_time import VirtualClock
 from tests.unit.test_load_balancer_concurrency import (
@@ -141,10 +147,10 @@ def test_level_decays_after_a_quiet_period() -> None:
 
 
 def _filter(states: list[AccountState], runtime: dict[str, RuntimeState], now: float) -> list[AccountState]:
-    return filter_overload_backoff_candidates(states, runtime, traffic_class=TRAFFIC_CLASS_FOREGROUND, now=now)
+    return filter_overload_backoff_candidates(states, runtime, now=now)
 
 
-def test_filter_drops_backed_off_candidates_only_while_eligible_others_remain() -> None:
+def test_filter_returns_the_overload_free_remainder_or_the_pool_itself() -> None:
     now = 1000.0
     runtime = {
         "hot": RuntimeState(overload_backoff_until=now + 30.0),
@@ -167,33 +173,41 @@ def test_filter_drops_backed_off_candidates_only_while_eligible_others_remain() 
     assert _filter(untouched, runtime, now) is untouched
 
 
-def test_filter_keeps_backed_off_account_when_the_remainder_is_ineligible() -> None:
-    now = 1000.0
-    runtime = {"hot": RuntimeState(overload_backoff_until=now + 30.0)}
-    hot = _state("hot")
-    rate_limited = AccountState(
-        account_id="limited",
-        status=AccountStatus.RATE_LIMITED,
-        used_percent=0.0,
-        reset_at=now + 300.0,
-    )
-    cooling = AccountState(
-        account_id="cooling", status=AccountStatus.ACTIVE, used_percent=0.0, cooldown_until=now + 60.0
-    )
-    erroring = AccountState(
-        account_id="erroring",
-        status=AccountStatus.ACTIVE,
-        used_percent=0.0,
-        error_count=ERROR_BACKOFF_THRESHOLD,
-        last_error_at=now - 1.0,
-    )
+def test_transient_retry_error_code_keeps_overload_codes_from_http_status_failures() -> None:
+    def _http_failure(code: str | None) -> SimpleNamespace:
+        error: dict[str, object] = {"message": "Our servers are currently overloaded.", "type": "server_error"}
+        if code is not None:
+            error["code"] = code
+        return SimpleNamespace(payload={"error": error}, status_code=500)
 
-    pool = [hot, rate_limited, cooling, erroring]
-    assert _filter(pool, runtime, now) is pool
+    assert _transient_retry_error_code(cast(BaseException, _http_failure("server_is_overloaded"))) == (
+        "server_is_overloaded"
+    )
+    assert _transient_retry_error_code(cast(BaseException, _http_failure("unknown_thing"))) == "server_error"
+    assert _transient_retry_error_code(cast(BaseException, _http_failure(None))) == "server_error"
+    assert _transient_retry_error_code(RuntimeError("no payload at all")) == "server_error"
+    framed = _TransientStreamError("stream_incomplete", {"message": "cut"})
+    assert _transient_retry_error_code(framed) == "stream_incomplete"
 
-    # One eligible sibling is enough to drop the backed-off account again.
-    with_clean = [hot, rate_limited, _state("clean")]
-    assert [state.account_id for state in _filter(with_clean, runtime, now)] == ["limited", "clean"]
+
+@pytest.mark.asyncio
+async def test_aggregated_retry_observations_feed_the_window_for_overload_codes_only() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    balancer = LoadBalancer(cast(Any, None), clock=clock)
+    account = _make_account("acc-retried")
+    proxy = SimpleNamespace(_load_balancer=balancer)
+
+    await _record_aggregated_overload_observations(proxy, account, "server_error", 2)
+    assert account.id not in balancer._runtime
+
+    await _record_aggregated_overload_observations(proxy, account, "server_is_overloaded", 0)
+    assert account.id not in balancer._runtime
+
+    # Two absorbed same-account retries plus the final health write = the trip count.
+    await _record_aggregated_overload_observations(proxy, account, "server_is_overloaded", OVERLOAD_TRIP_COUNT - 1)
+    assert balancer._runtime[account.id].overload_rejections == [clock.time()] * (OVERLOAD_TRIP_COUNT - 1)
+    await record_upstream_overload(balancer, account)
+    assert overload_backoff_active(balancer._runtime[account.id], clock.time())
 
 
 @pytest.mark.asyncio
@@ -300,3 +314,57 @@ async def test_select_account_still_uses_backed_off_account_when_every_sibling_i
     assert result.error_code is None, result.error_message
     assert result.account is not None
     assert result.account.id == hot.id
+
+
+@asynccontextmanager
+async def _mock_repo_factory():
+    yield AsyncMock()
+
+
+def _sticky_repo(existing_account_id: str | None) -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_account_id = AsyncMock(return_value=existing_account_id)
+    repo.upsert = AsyncMock()
+    repo.delete = AsyncMock()
+    return repo
+
+
+async def _select_sticky(balancer: LoadBalancer, states: list[AccountState], repo: AsyncMock):
+    account_map = {state.account_id: cast(Account, AsyncMock()) for state in states}
+    outcome = await balancer._select_with_stickiness(
+        states=states,
+        account_map=account_map,
+        sticky_key="fresh-or-owned-key",
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=600,
+        prefer_earlier_reset_accounts=False,
+        prefer_earlier_reset_window="secondary",
+        routing_strategy="usage_weighted",
+        sticky_repo=repo,
+    )
+    return outcome.selection
+
+
+@pytest.mark.asyncio
+async def test_fresh_sticky_binding_avoids_backed_off_account_but_established_owner_is_kept() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    balancer = LoadBalancer(_mock_repo_factory, clock=clock)
+    balancer._runtime["hot"] = RuntimeState(overload_backoff_until=clock.time() + OVERLOAD_BACKOFF_BASE_SECONDS)
+    states = [_state("hot"), _state("clean")]
+
+    # A previously unseen key is a fresh upstream admission: bind away from the overloaded account.
+    for _ in range(40):
+        fresh = await _select_sticky(balancer, [_state("hot"), _state("clean")], _sticky_repo(None))
+        assert fresh.account is not None
+        assert fresh.account.account_id == "clean"
+
+    # An established owner is warm-session reuse: the overload window never touches it.
+    owned = await _select_sticky(balancer, states, _sticky_repo("hot"))
+    assert owned.account is not None
+    assert owned.account.account_id == "hot"
+
+    # With no overload-free alternative the fresh binding still lands on the backed-off account.
+    alone = await _select_sticky(balancer, [_state("hot")], _sticky_repo(None))
+    assert alone.account is not None
+    assert alone.account.account_id == "hot"


### PR DESCRIPTION
Fixes #2136

## Why

During the 2026-09-07 upstream capacity incident, 7 of 14 accounts were rejected with `server_is_overloaded` on 20–70 % of their fresh admissions for hours while the other 7 saw none; each rejection took 30–90 s to arrive, so every fresh request routed there paid that wait before failover. Fresh selection kept feeding the rejected accounts because their bridge-reuse / sticky sessions kept succeeding and every success zeroes `RuntimeState.error_count` — a live probe of the serving replica showed `error_count=0, health_tier=HEALTHY` for an account with 123 rejections in two hours. Details in #2136.

## What

- `RuntimeState` gains an overload window (`overload_rejections`, `overload_backoff_until`, `overload_backoff_level`, `overload_last_trip_at`) — replica-local, never persisted, **not reset by successes**.
- New `app/modules/proxy/_load_balancer/overload_backoff.py`: 3 rejections in 120 s trip a bounded exponential deprioritization (60 s → 600 s cap; the level saturates at the cap and decays after 30 quiet minutes; a trip while tripped never shortens the deadline). Engagement is logged.
- `_handle_stream_error` (the single funnel every transport uses for stream-error account health) feeds the window for `server_is_overloaded` / `overloaded_error` **in addition to** the existing `record_error`; classification, failover decision and the client response are unchanged.
- Wherever a **new** account is chosen for a request — the unbound path, and the sticky path's fresh binding / reallocation / fallback pick (a previously unseen session or prompt-cache key is a fresh upstream admission) — selection runs first over the overload-free candidates and, when the configured strategy/budget gates select none of them, again over the full pool exactly as before. Strategy-agnostic and soft by construction: it can never turn usable capacity into `No available accounts` or a spurious account-cap error (cap detection keeps the untouched cap-filtered pool). Established sticky owners, continuity owners and hard-affinity owners are never touched, so warm sessions on backed-off accounts keep flowing and pinned sessions are never denied by this signal (the failure mode `spare-account-health-from-model-rejections` documented for the hard error backoff).
- An HTTP 5xx whose body carries `server_is_overloaded` used to collapse to `server_error` in the same-account retry loop, so the post-exhaustion health write never fed the window; the overload code is now kept. Observations are taken exactly where account health is written (so they inherit the settlement-before-health ordering); a same-account retry that then succeeds writes no health and is not counted — a known limit shared with `error_count`, called out in the proposal.
- Recovery-probe reservation (unbound and sticky fresh binding) runs over the same pool the selection used, so an older due probe skipped by the overload pass cannot invalidate the match.

`load_balancer.py` changes by one line (forwards its runtime map to the sticky selector; 3017/3021), `service.py` untouched, no settings, schema or API changes — thresholds are fixed constants like the existing drain/probe thresholds (PRINCIPLES rule 2: no new knob; trip count / window follow the existing 3-in-300 s eventless-timeout ejection precedent in `upstream_events.py`).

## OpenSpec

`openspec/changes/deprioritize-overloaded-accounts-for-fresh-selection` — `account-routing` ADDED requirement "Overload rejections deprioritize the account for fresh selection". `openspec validate` passes.

## Verification

- `tests/unit/test_overload_backoff.py`: trip only on the third in-window rejection, stale pruning, exponential growth with cap and level saturation (no overflow at any level), deadline never shortened, level decay, soft filter semantics incl. an ineligible remainder (rate-limited / cooling / generic error backoff siblings), runtime write under the account lock + engagement log, `_handle_stream_error` feeds the window for overload codes only while still recording the generic transient error.
- Routing surface (`LoadBalancer.select_account()`): a backed-off account is skipped while a healthy sibling exists (40 draws) and re-enters after the deadline; when every sibling is in generic error backoff the backed-off account is still selected with `lease_kind="stream"` and no `account_stream_cap` error. `LoadBalancer._select_with_stickiness`: a previously unseen key binds away from the backed-off account (40 draws), an established owner keeps its (backed-off) account, a pool with no alternative still binds, and the outcome reports the overload-free pool only when that pool produced the pick (probe reservation reuses it). Retry: `_transient_retry_error_code` keeps `server_is_overloaded` from an HTTP-status body.
- `uv run pytest` over `test_overload_backoff.py test_proxy_utils.py test_load_balancer_concurrency.py test_select_with_stickiness.py test_failover_foundation.py test_load_balancer_contract.py test_health_probes.py test_streaming_retry_virtual_time.py tests/integration/test_proxy_transient_retry.py` — 1614 passed.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `scripts/check_proxy_architecture.py` — clean.
- Local `codex review --base origin/main`: round 1 found P1 (filter ignored eligibility of the remainder) + P2 (exponent overflow at level 1025); round 2 found P1 (single_account eligibility approximation vs. sequential/reset drain) + P2 (fresh sticky bindings bypassed the filter) + P2 (HTTP 5xx overload collapsed to `server_error`); round 3 found P2s in the retry-count aggregation I had added (final-code batching, settlement-time stamps, success-after-retry) and a probe-reservation pool mismatch — the aggregation was removed and the reservation pools aligned. CodeRabbit's level-saturation and cap-detection comments are addressed by the same changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backoff for accounts experiencing repeated upstream overloads, with increasing delays and fallback selection.
  * New account selections now prefer accounts not currently in overload backoff, while preserving established sticky assignments.
  * Overload responses are tracked consistently across streaming failures and retries.

* **Bug Fixes**
  * Preserved overload error codes during retry and health reporting.
  * Recovery probes now use the same candidate pool as account selection.

* **Tests**
  * Added coverage for backoff timing, fallback behavior, retries, and sticky-session selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->