### PR TITLE
perf(quota-planner): reduce demand history per slot inside the database

### DIFF
--- a/app/modules/accounts/usage_time_rollup_read.py
+++ b/app/modules/accounts/usage_time_rollup_read.py
@@ -43,11 +43,14 @@ the epoch (or the state row is missing, via the raw branch's OUTER join).
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Any
 
 from sqlalchemy import BigInteger, ColumnElement, Integer, Select, and_, cast, func, literal, or_, select, union_all
 from sqlalchemy import cast as sa_cast
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import ColumnExpressionArgument
 from sqlalchemy.sql.selectable import CompoundSelect
 
 from app.db.models import (
@@ -69,6 +72,13 @@ from app.modules.accounts.usage_time_rollup import (
     _requested_at_epoch_bucket_expr,
     conversation_id_expr,
     epoch_seconds,
+)
+from app.modules.quota_planner.logic import (
+    DEMAND_CACHED_INPUT_TOKEN_WEIGHT,
+    DEMAND_OUTPUT_TOKEN_WEIGHT,
+    DEMAND_TOKENS_PER_UNIT,
+    DEMAND_UNITS_PER_COST_USD,
+    DEMAND_UNITS_PER_REQUEST,
 )
 
 _EPOCH = datetime(1970, 1, 1)
@@ -210,6 +220,114 @@ async def sum_demand_window(
     if folded_until_epoch is None:
         return 0, raw_windows
     return folded_total, raw_windows
+
+
+@dataclass(frozen=True, slots=True)
+class DemandSlotUnitsRow:
+    """Demand units already summed per ``(slot_epoch, request_kind)``."""
+
+    slot_epoch: int
+    request_kind: str
+    demand_units: float
+
+
+def demand_units_sql_expr(
+    *,
+    dialect: str,
+    input_tokens: ColumnExpressionArgument[Any],
+    cached_input_tokens: ColumnExpressionArgument[Any],
+    output_tokens: ColumnExpressionArgument[Any],
+    cost_usd: ColumnExpressionArgument[Any],
+    request_count: ColumnExpressionArgument[Any],
+) -> ColumnElement[Any]:
+    """``_bin_demand_units`` compiled to SQL for ONE legacy-grain row.
+
+    ``max(token_units, cost_units, request_units)`` per row, with the same
+    ``max(0, ·)`` clamps; callers SUM this over the rows of a slot. Postgres
+    spells the scalar maximum ``GREATEST``; SQLite's multi-argument ``MAX``
+    is the scalar form.
+    """
+    scalar_max = func.greatest if dialect == "postgresql" else func.max
+    zero = literal(0)
+    token_units = (
+        scalar_max(input_tokens, zero)
+        + DEMAND_CACHED_INPUT_TOKEN_WEIGHT * scalar_max(cached_input_tokens, zero)
+        + DEMAND_OUTPUT_TOKEN_WEIGHT * scalar_max(output_tokens, zero)
+    ) / DEMAND_TOKENS_PER_UNIT
+    cost_units = scalar_max(cost_usd, literal(0.0)) * DEMAND_UNITS_PER_COST_USD
+    request_units = scalar_max(request_count, zero) * DEMAND_UNITS_PER_REQUEST
+    return scalar_max(token_units, cost_units, request_units)
+
+
+async def read_demand_slot_units_window(
+    session: AsyncSession,
+    since: datetime,
+    until: datetime | None = None,
+    *,
+    filters: Sequence[ColumnElement[bool]] = (),
+) -> tuple[list[DemandSlotUnitsRow], list[RawWindow]]:
+    """Watermark-consistent per-slot demand units over the demand rollup.
+
+    Same partitioning rule as ``read_demand_window`` but reduced in SQL: the
+    per-row ``_bin_demand_units`` max is applied at the rollup's legacy grain
+    and summed per ``(slot_epoch, request_kind)`` before crossing the wire,
+    so a 28-day planning window returns a few thousand rows instead of one
+    row per (account, key, model, effort, kind, status) grain. Watermark and
+    folded rows come from ONE statement (state LEFT JOIN demand bounded by
+    the state row's own watermark epoch), exactly like ``sum_demand_window``.
+    """
+    lo_epoch = epoch_seconds(ceil_to_grid(since, QUARTER_SLOT_SECONDS))
+    dialect = session.get_bind().dialect.name
+    if dialect == "postgresql":
+        watermark_epoch = sa_cast(func.extract("epoch", AccountUsageRollupState.hourly_folded_through), BigInteger)
+    else:
+        watermark_epoch = sa_cast(func.strftime("%s", AccountUsageRollupState.hourly_folded_through), Integer)
+    join_conditions = [
+        *filters,
+        RequestDemandQuarterRollup.slot_epoch >= lo_epoch,
+        RequestDemandQuarterRollup.slot_epoch < watermark_epoch,
+    ]
+    if until is not None:
+        join_conditions.append(
+            RequestDemandQuarterRollup.slot_epoch < epoch_seconds(floor_to_grid(until, QUARTER_SLOT_SECONDS))
+        )
+    units_expr = demand_units_sql_expr(
+        dialect=dialect,
+        input_tokens=RequestDemandQuarterRollup.input_tokens,
+        cached_input_tokens=RequestDemandQuarterRollup.cached_input_tokens,
+        output_tokens=RequestDemandQuarterRollup.output_or_reasoning_tokens,
+        cost_usd=RequestDemandQuarterRollup.cost_usd,
+        request_count=RequestDemandQuarterRollup.request_count,
+    )
+    stmt = (
+        select(
+            AccountUsageRollupState.hourly_folded_through,
+            RequestDemandQuarterRollup.slot_epoch,
+            RequestDemandQuarterRollup.request_kind,
+            func.sum(units_expr),
+        )
+        .select_from(AccountUsageRollupState)
+        .outerjoin(RequestDemandQuarterRollup, and_(*join_conditions))
+        .where(AccountUsageRollupState.id == _STATE_ROW_ID)
+        .group_by(
+            AccountUsageRollupState.hourly_folded_through,
+            RequestDemandQuarterRollup.slot_epoch,
+            RequestDemandQuarterRollup.request_kind,
+        )
+        .order_by(RequestDemandQuarterRollup.slot_epoch)
+    )
+    rows = (await session.execute(stmt)).all()
+    if not rows:
+        return [], [(since, until)]
+    watermark = rows[0][0]
+    folded_until_epoch, raw_windows = _partition_raw_windows(since, until, watermark, QUARTER_SLOT_SECONDS)
+    if folded_until_epoch is None:
+        return [], raw_windows
+    return [
+        DemandSlotUnitsRow(slot_epoch=int(row[1]), request_kind=row[2], demand_units=float(row[3] or 0.0))
+        for row in rows
+        if row[1] is not None
+    ], raw_windows
 
 
 def raw_windows_clause(windows: Sequence[RawWindow]) -> ColumnElement[bool]:

--- a/app/modules/quota_planner/api.py
+++ b/app/modules/quota_planner/api.py
@@ -207,8 +207,8 @@ async def get_quota_planner_forecast(
     context: QuotaPlannerContext = Depends(get_quota_planner_context),
 ) -> QuotaPlannerForecastResponse:
     settings = await context.repository.get_settings()
-    demand_bins = await context.repository.aggregate_demand_bins()
-    forecast = build_demand_forecast(settings=settings, bins=demand_bins, horizon_hours=horizon_hours)
+    demand_slots = await context.repository.aggregate_demand_slot_units()
+    forecast = build_demand_forecast(settings=settings, slot_units=demand_slots, horizon_hours=horizon_hours)
     accounts = await AccountsRepository(context.session).list_accounts()
     usage_repo = UsageRepository(context.session)
     latest_primary = await usage_repo.latest_by_account()

--- a/app/modules/quota_planner/logic.py
+++ b/app/modules/quota_planner/logic.py
@@ -24,6 +24,16 @@ DEFAULT_ACCOUNT_WINDOW_CAPACITY = 100.0
 MIN_PEAK_EXCESS_UNITS = 1.0
 _FORECAST_DEMAND_REQUEST_KINDS = frozenset({"normal", "real"})
 
+# Demand-unit formula coefficients (``_bin_demand_units``). The planner
+# repository compiles the same formula into SQL so folded history can be
+# summed per slot inside the database; keep the two in sync through these
+# constants only.
+DEMAND_TOKENS_PER_UNIT = 1000.0
+DEMAND_CACHED_INPUT_TOKEN_WEIGHT = 0.25
+DEMAND_OUTPUT_TOKEN_WEIGHT = 4.0
+DEMAND_UNITS_PER_COST_USD = 100.0
+DEMAND_UNITS_PER_REQUEST = 5.0
+
 
 @dataclass(frozen=True, slots=True)
 class PlannerSettings:
@@ -78,6 +88,24 @@ class DemandBinLike(Protocol):
 
     @property
     def request_count(self) -> int: ...
+
+
+class DemandSlotUnitsLike(Protocol):
+    """Demand already reduced to units per ``(slot_epoch, request_kind)``.
+
+    Produced by the repository's SQL aggregation: ``_bin_demand_units`` is
+    applied per legacy-grain row inside the query and summed per slot, so
+    the forecast never materializes one Python object per grain row.
+    """
+
+    @property
+    def slot_epoch(self) -> int: ...
+
+    @property
+    def request_kind(self) -> str: ...
+
+    @property
+    def demand_units(self) -> float: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -273,10 +301,36 @@ def plan_shadow_actions(
     return actions[: max(0, settings.max_warmups_per_day or 0)]
 
 
+def demand_units_by_slot_epoch(
+    bins: Sequence[DemandBinLike] = (),
+    slot_units: Sequence[DemandSlotUnitsLike] = (),
+) -> dict[int, float]:
+    """Sum forecast demand units per slot from either input shape.
+
+    ``bins`` carry the legacy grain and get ``_bin_demand_units`` applied per
+    row; ``slot_units`` arrive already reduced (the SQL path). Both feed the
+    same map, so a caller can combine folded slot units with a raw-tail bin
+    list without double counting as long as the two cover disjoint windows.
+    """
+    units_by_slot_epoch: dict[int, float] = {}
+    for row in bins:
+        if not _is_forecast_demand_request(row.request_kind):
+            continue
+        slot_epoch = int(row.slot_epoch)
+        units_by_slot_epoch[slot_epoch] = units_by_slot_epoch.get(slot_epoch, 0.0) + _bin_demand_units(row)
+    for slot in slot_units:
+        if not _is_forecast_demand_request(slot.request_kind):
+            continue
+        slot_epoch = int(slot.slot_epoch)
+        units_by_slot_epoch[slot_epoch] = units_by_slot_epoch.get(slot_epoch, 0.0) + max(0.0, float(slot.demand_units))
+    return units_by_slot_epoch
+
+
 def build_demand_forecast(
     *,
     settings: PlannerSettings,
-    bins: Sequence[DemandBinLike],
+    bins: Sequence[DemandBinLike] = (),
+    slot_units: Sequence[DemandSlotUnitsLike] = (),
     now: datetime | None = None,
     horizon_hours: int = DEFAULT_PLANNING_HORIZON_HOURS,
     slot_seconds: int = DEFAULT_SLOT_SECONDS,
@@ -284,14 +338,9 @@ def build_demand_forecast(
     current = _floor_datetime(now or datetime.now(timezone.utc), slot_seconds)
     history_by_weekday_slot: dict[tuple[int, int], list[float]] = {}
     history_by_work_hour: dict[int, list[float]] = {}
-    units_by_slot_epoch: dict[int, float] = {}
+    units_by_slot_epoch = demand_units_by_slot_epoch(bins, slot_units)
     recent_units = 0.0
     recent_cutoff = current.timestamp() - 24 * 60 * 60
-    for row in bins:
-        if not _is_forecast_demand_request(row.request_kind):
-            continue
-        slot_epoch = int(row.slot_epoch)
-        units_by_slot_epoch[slot_epoch] = units_by_slot_epoch.get(slot_epoch, 0.0) + _bin_demand_units(row)
 
     for slot_epoch, units in units_by_slot_epoch.items():
         slot = datetime.fromtimestamp(slot_epoch, tz=timezone.utc)
@@ -609,10 +658,12 @@ def _parse_hhmm(raw: str, fallback: dt_time) -> dt_time:
 
 def _bin_demand_units(row: DemandBinLike) -> float:
     token_units = (
-        max(0, row.input_tokens) + 0.25 * max(0, row.cached_input_tokens) + 4.0 * max(0, row.output_tokens)
-    ) / 1000.0
-    cost_units = max(0.0, row.cost_usd) * 100.0
-    request_units = max(0, row.request_count) * 5.0
+        max(0, row.input_tokens)
+        + DEMAND_CACHED_INPUT_TOKEN_WEIGHT * max(0, row.cached_input_tokens)
+        + DEMAND_OUTPUT_TOKEN_WEIGHT * max(0, row.output_tokens)
+    ) / DEMAND_TOKENS_PER_UNIT
+    cost_units = max(0.0, row.cost_usd) * DEMAND_UNITS_PER_COST_USD
+    request_units = max(0, row.request_count) * DEMAND_UNITS_PER_REQUEST
     return max(token_units, cost_units, request_units)
 
 

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -33,7 +33,14 @@ from app.db.models import (
 )
 from app.db.session import sqlite_writer_section
 from app.modules.accounts.usage_time_rollup import QUARTER_SLOT_SECONDS, from_dimension
-from app.modules.accounts.usage_time_rollup_read import RawWindow, raw_windows_clause, read_demand_window
+from app.modules.accounts.usage_time_rollup_read import (
+    DemandSlotUnitsRow,
+    RawWindow,
+    demand_units_sql_expr,
+    raw_windows_clause,
+    read_demand_slot_units_window,
+    read_demand_window,
+)
 from app.modules.quota_planner.logic import PlannerSettings, encode_working_days, parse_working_days
 
 _SETTINGS_ID = 1
@@ -574,9 +581,88 @@ class QuotaPlannerRepository:
         bins.sort(key=lambda demand: demand.slot_epoch)
         return bins
 
-    async def _aggregate_demand_bins_raw(self, windows: list[RawWindow], bucket_seconds: int) -> list[DemandBin]:
+    async def aggregate_demand_slot_units(
+        self,
+        *,
+        since: datetime | None = None,
+    ) -> list[DemandSlotUnitsRow]:
+        """``aggregate_demand_bins`` reduced to units per ``(slot, request_kind)``.
+
+        Same folded/raw partition as the bin reader, but ``_bin_demand_units``
+        is applied per legacy-grain row inside SQL and summed per slot, so the
+        result is bounded by slots x request kinds (a few thousand rows for
+        the 28-day window) instead of one object per grain row. The planner
+        tick and the forecast endpoint only ever consume per-slot totals, so
+        this is exact — see the parity test against ``aggregate_demand_bins``.
+        """
+        since = to_utc_naive(since) if since is not None else (utcnow() - timedelta(days=28))
+        slots, raw_windows = await read_demand_slot_units_window(
+            self._session,
+            since,
+            filters=(RequestDemandQuarterRollup.is_deleted.is_(false()),),
+        )
+        slots = list(slots)
+        if raw_windows:
+            slots.extend(await self._aggregate_demand_slot_units_raw(raw_windows, QUARTER_SLOT_SECONDS))
+        slots.sort(key=lambda slot: slot.slot_epoch)
+        return slots
+
+    async def _aggregate_demand_slot_units_raw(
+        self, windows: list[RawWindow], bucket_seconds: int
+    ) -> list[DemandSlotUnitsRow]:
+        dialect = self._dialect_name()
+        grain = self._raw_demand_bins_stmt(windows, bucket_seconds, dialect).subquery("demand_grain")
+        units_expr = demand_units_sql_expr(
+            dialect=dialect,
+            input_tokens=grain.c.input_tokens,
+            cached_input_tokens=grain.c.cached_input_tokens,
+            output_tokens=grain.c.output_tokens,
+            cost_usd=grain.c.cost_usd,
+            request_count=grain.c.request_count,
+        )
+        stmt = (
+            select(grain.c.slot_epoch, grain.c.request_kind, func.sum(units_expr).label("demand_units"))
+            .group_by(grain.c.slot_epoch, grain.c.request_kind)
+            .order_by(grain.c.slot_epoch)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            DemandSlotUnitsRow(
+                slot_epoch=int(row.slot_epoch),
+                request_kind=row.request_kind,
+                demand_units=float(row.demand_units or 0.0),
+            )
+            for row in result.all()
+        ]
+
+    def _dialect_name(self) -> str:
         bind = self._session.get_bind()
-        dialect = bind.dialect.name if bind else "sqlite"
+        return bind.dialect.name if bind else "sqlite"
+
+    async def _aggregate_demand_bins_raw(self, windows: list[RawWindow], bucket_seconds: int) -> list[DemandBin]:
+        stmt = self._raw_demand_bins_stmt(windows, bucket_seconds, self._dialect_name())
+        result = await self._session.execute(stmt)
+        return [
+            DemandBin(
+                slot_epoch=int(row.slot_epoch),
+                account_id=row.account_id,
+                api_key_id=row.api_key_id,
+                model=row.model,
+                reasoning_effort=row.reasoning_effort,
+                request_kind=row.request_kind,
+                status=row.status,
+                input_tokens=int(row.input_tokens or 0),
+                cached_input_tokens=int(row.cached_input_tokens or 0),
+                output_tokens=int(row.output_tokens or 0),
+                cost_usd=float(row.cost_usd or 0.0),
+                request_count=int(row.request_count or 0),
+            )
+            for row in result.all()
+        ]
+
+    @staticmethod
+    def _raw_demand_bins_stmt(windows: list[RawWindow], bucket_seconds: int, dialect: str):
+        """Legacy-grain GROUP BY over the raw ``request_logs`` tail."""
         if dialect == "postgresql":
             bucket_expr = func.floor(func.extract("epoch", RequestLog.requested_at) / bucket_seconds) * bucket_seconds
         else:
@@ -614,24 +700,7 @@ class QuotaPlannerRepository:
             )
             .order_by(bucket_col)
         )
-        result = await self._session.execute(stmt)
-        return [
-            DemandBin(
-                slot_epoch=int(row.slot_epoch),
-                account_id=row.account_id,
-                api_key_id=row.api_key_id,
-                model=row.model,
-                reasoning_effort=row.reasoning_effort,
-                request_kind=row.request_kind,
-                status=row.status,
-                input_tokens=int(row.input_tokens or 0),
-                cached_input_tokens=int(row.cached_input_tokens or 0),
-                output_tokens=int(row.output_tokens or 0),
-                cost_usd=float(row.cost_usd or 0.0),
-                request_count=int(row.request_count or 0),
-            )
-            for row in result.all()
-        ]
+        return stmt
 
 
 def _settings_from_row(row: QuotaPlannerSettings) -> PlannerSettings:

--- a/app/modules/quota_planner/scheduler.py
+++ b/app/modules/quota_planner/scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import json
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Protocol, TypeVar, cast
@@ -74,14 +75,22 @@ class QuotaPlannerScheduler:
                 pass
 
     async def run_once(self) -> None:
-        await _get_leader_election().run_if_leader(self._run_once_as_leader)
+        started = time.monotonic()
+        ran = await _get_leader_election().run_if_leader(self._run_once_as_leader)
+        if ran is not None:
+            # Tick cost surfaced next to the event-loop lag monitor: the body
+            # runs on the serving loop, so a slow tick is a serving stall.
+            logger.info(
+                "Quota planner tick completed duration_ms=%d",
+                int((time.monotonic() - started) * 1000),
+            )
 
-    async def _run_once_as_leader(self) -> None:
+    async def _run_once_as_leader(self) -> bool:
         async with get_background_session() as session:
             planner_repo = QuotaPlannerRepository(session)
             settings = await planner_repo.get_settings()
             if settings.mode == "off":
-                return
+                return False
             warmup_service = QuotaWarmupService(session)
             await self._reconcile_expired_warmup_claims(planner_repo=planner_repo, warmup_service=warmup_service)
             accounts_repo = AccountsRepository(session)
@@ -98,8 +107,8 @@ class QuotaPlannerScheduler:
                 runtime={},
             )
             now = datetime.now(timezone.utc)
-            demand_bins = await planner_repo.aggregate_demand_bins()
-            forecast = build_demand_forecast(settings=settings, bins=demand_bins, now=now)
+            demand_slots = await planner_repo.aggregate_demand_slot_units()
+            forecast = build_demand_forecast(settings=settings, slot_units=demand_slots, now=now)
             base_simulation = simulate_pool(settings=settings, states=states, demand_forecast=forecast, now=now)
             actions = plan_shadow_actions(settings=settings, states=states, demand_forecast=forecast, now=now)
             if not actions:
@@ -127,7 +136,7 @@ class QuotaPlannerScheduler:
                         separators=(",", ":"),
                     ),
                 )
-                return
+                return True
             scenario = simulate_pool(
                 settings=settings,
                 states=states,
@@ -178,6 +187,7 @@ class QuotaPlannerScheduler:
                     # An expired executing row is reclaimed inside warm_now;
                     # a still-live executing row is read back and left alone.
                     await warmup_service.warm_now(account_id=action.account_id, decision_id=decision.id)
+            return True
 
     async def _reconcile_expired_warmup_claims(
         self,

--- a/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/proposal.md
+++ b/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Every quota planner tick (fixed 300 s cadence) loads the whole 28-day demand
+history at the legacy grain — one row per `(slot, account, api_key, model,
+reasoning_effort, request_kind, status)` — through the ORM and reduces it to
+per-slot totals in Python. On a production deployment that is ~126,000 rollup
+rows per tick; materializing them creates on the order of a million Python
+objects on the serving event loop, and freeing them when the tick returns holds
+the GIL for seconds. The loop-lag monitor records a 2–3 s stall every ~305 s
+(300 s interval plus tick duration) that lines up to the second with the
+planner decision timestamps; in-process sampling shows nothing but the C-level
+teardown, plus a ~0.5 s gen-2 garbage collection the burst triggers. Every
+in-flight stream on that replica stalls for the duration.
+
+The forecast never reads the grain: `build_demand_forecast` applies
+`_bin_demand_units` (a per-row `max()` of token, cost and request units) and
+then sums per slot. The grain only exists so that per-row `max()` runs before
+the per-slot sum.
+
+## What Changes
+
+- `_bin_demand_units` is compiled to SQL (`GREATEST` on Postgres, scalar
+  multi-argument `MAX` on SQLite) and applied per legacy-grain row inside the
+  query; the result is summed per `(slot_epoch, request_kind)` before it leaves
+  the database. The rollup segment and the raw tail keep the existing
+  watermark-consistent partition; the raw tail groups to the legacy grain in a
+  subquery first so its per-row `max()` is preserved too.
+- The planner tick and the `/api/quota-planner/forecast` endpoint consume the
+  reduced shape. `build_demand_forecast` accepts pre-reduced slot units next to
+  the existing bin input; both feed one per-slot map, so the forecast is
+  unchanged.
+- The tick logs its duration next to the event-loop lag monitor so a slow tick
+  is attributable without profiling.
+- `aggregate_demand_bins` stays as the exact-grain reader for parity tests;
+  the parity harness gains the reduced reader as a second key, asserted equal
+  across every watermark position.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `quota-phase-planner`: the demand history a tick loads is bounded by slots ×
+  request kinds, not by the legacy grain, and the tick reports its duration.
+
+## Impact
+
+- `app/modules/quota_planner/logic.py`: demand-unit coefficients become named
+  constants shared with the SQL compilation; `build_demand_forecast` gains a
+  `slot_units` input.
+- `app/modules/accounts/usage_time_rollup_read.py`: `demand_units_sql_expr`
+  and `read_demand_slot_units_window`.
+- `app/modules/quota_planner/repository.py`: `aggregate_demand_slot_units`;
+  the raw-tail statement is shared with the exact-grain reader.
+- `app/modules/quota_planner/scheduler.py`, `api.py`: consume the reduced
+  reader; tick duration log.
+- No schema, config, or API surface changes.

--- a/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/specs/quota-phase-planner/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Planner demand history is reduced per slot inside the database
+
+The quota planner SHALL obtain its demand-forecast history as demand units
+already summed per `(slot_epoch, request_kind)` by the database, not as one
+row per legacy demand grain (`slot`, `account`, `api_key`, `model`,
+`reasoning_effort`, `request_kind`, `status`). The per-row demand-unit formula
+(the maximum of token, cost, and request units with non-negative clamps) MUST
+be applied per legacy-grain row before the per-slot sum, so the reduced result
+equals the Python reduction of the exact-grain rows for any watermark
+position. The folded rollup segment and the un-folded raw tail MUST keep the
+existing watermark-consistent partition. A planner tick MUST log its duration
+so a slow tick is attributable from logs alone.
+
+#### Scenario: A tick over a long history returns a bounded row set
+
+- **GIVEN** 28 days of demand history at the legacy grain across many
+  accounts, keys, models, and efforts
+- **WHEN** the planner tick loads demand history
+- **THEN** the number of rows materialized in the process is bounded by slots
+  times request kinds, independent of how many accounts, keys, models, or
+  efforts produced traffic
+
+#### Scenario: Reduced history equals the exact-grain reduction
+
+- **GIVEN** the same window read as exact-grain bins and as per-slot units
+- **WHEN** both are reduced to demand units per slot
+- **THEN** the per-slot totals agree within floating-point tolerance for the
+  epoch watermark, a mid-history watermark, the full target watermark, and the
+  raw-degraded state after the operator escape hatch
+
+#### Scenario: Tick duration is observable
+
+- **GIVEN** a replica that ran a planner tick as leader
+- **WHEN** the tick completes
+- **THEN** the replica logs the tick duration in milliseconds

--- a/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/tasks.md
+++ b/openspec/changes/reduce-planner-demand-history-per-slot-in-sql/tasks.md
@@ -1,0 +1,17 @@
+## 1. Reduce demand history inside the database
+
+- [x] 1.1 Name the `_bin_demand_units` coefficients in `app/modules/quota_planner/logic.py` and compile the same formula to SQL (`demand_units_sql_expr`, dialect-aware scalar maximum) in `app/modules/accounts/usage_time_rollup_read.py`.
+- [x] 1.2 Add `read_demand_slot_units_window`: one statement (state LEFT JOIN demand rollup bounded by the state row's watermark) that sums the per-row units per `(slot_epoch, request_kind)`, returning the same raw windows as the grain reader.
+- [x] 1.3 Add `QuotaPlannerRepository.aggregate_demand_slot_units`; the raw tail groups to the legacy grain in a subquery (shared statement with `aggregate_demand_bins`) and sums per slot on top.
+
+## 2. Consume the reduced shape
+
+- [x] 2.1 `build_demand_forecast` accepts `slot_units` alongside `bins`; both feed `demand_units_by_slot_epoch` so a forecast built from either input is identical.
+- [x] 2.2 The scheduler tick and the forecast endpoint call `aggregate_demand_slot_units`.
+- [x] 2.3 The scheduler logs `Quota planner tick completed duration_ms=` after each leader tick.
+
+## 3. Verification
+
+- [x] 3.1 Unit: `demand_units_by_slot_epoch` agrees between bins and slot units (per-row `max()` before the per-slot sum, excluded request kinds, clamping); `build_demand_forecast` is identical for both inputs; the SQLite repository returns the reduced row for a seeded request.
+- [x] 3.2 Parity harness: `demand_slot_units` snapshot key asserted equal across the epoch, mid-history, full-target, concurrent-fold, escape-hatch, and retention-pruned watermark states.
+- [x] 3.3 Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, the unit suite, and `tests/integration/test_request_usage_rollup_parity.py`.

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -41,6 +41,7 @@ from app.modules.accounts.usage_time_rollup import (
     run_hourly_fold_pass,
 )
 from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.quota_planner.logic import _bin_demand_units
 from app.modules.quota_planner.repository import QuotaPlannerRepository
 from app.modules.reports.repository import ReportsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -294,6 +295,11 @@ async def _snapshot(*, lead_since: datetime = SINCE_UNALIGNED) -> dict:
         planner = QuotaPlannerRepository(session)
         api_keys = ApiKeysRepository(session)
         reports = ReportsRepository(session)
+        demand_bins = await planner.aggregate_demand_bins(since=BASE + timedelta(hours=1))
+        demand_slot_units = await planner.aggregate_demand_slot_units(since=BASE + timedelta(hours=1))
+        # Independent cross-check of the SQL reduction against the exact-grain
+        # Python reduction: per-row ``max()`` before the per-slot sum.
+        _assert_slot_units_match_bins(demand_slot_units, demand_bins)
         return {
             "buckets_1h": await logs.aggregate_by_bucket(lead_since, 3600),
             "buckets_6h": await logs.aggregate_by_bucket(lead_since, 21600),
@@ -324,10 +330,8 @@ async def _snapshot(*, lead_since: datetime = SINCE_UNALIGNED) -> dict:
             "top_error_tie": await logs.top_error_between(BASE + timedelta(days=3), BASE + timedelta(days=3, hours=3)),
             "top_error_empty": await logs.top_error_between(*EMPTY_ERROR_WINDOW),
             "earliest": await logs.earliest_activity_at(),
-            "demand": _project_demand(await planner.aggregate_demand_bins(since=BASE + timedelta(hours=1))),
-            "demand_slot_units": _project_demand_slot_units(
-                await planner.aggregate_demand_slot_units(since=BASE + timedelta(hours=1))
-            ),
+            "demand": _project_demand(demand_bins),
+            "demand_slot_units": _project_demand_slot_units(demand_slot_units),
             "trends_key1": await api_keys.trends_by_key("key_1", lead_since, NOW, 3600),
             "trends_key2": await api_keys.trends_by_key("key_2", SINCE_ALIGNED, UNTIL_UNALIGNED, 7200),
             "trends_raw_degrade": await api_keys.trends_by_key("key_1", lead_since, NOW, 5400),
@@ -392,6 +396,17 @@ def _project_demand(bins) -> dict:
         entry[3] += bin_row.output_tokens
         entry[4] += bin_row.cost_usd
     return projected
+
+
+def _assert_slot_units_match_bins(slots, bins) -> None:
+    expected: dict[tuple, float] = {}
+    for bin_row in bins:
+        key = (bin_row.slot_epoch, bin_row.request_kind)
+        expected[key] = expected.get(key, 0.0) + _bin_demand_units(bin_row)
+    actual = _project_demand_slot_units(slots)
+    assert actual.keys() == expected.keys()
+    for key, expected_units in expected.items():
+        assert actual[key] == pytest.approx(expected_units, rel=1e-9, abs=1e-9), key
 
 
 def _project_demand_slot_units(slots) -> dict:

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -325,6 +325,9 @@ async def _snapshot(*, lead_since: datetime = SINCE_UNALIGNED) -> dict:
             "top_error_empty": await logs.top_error_between(*EMPTY_ERROR_WINDOW),
             "earliest": await logs.earliest_activity_at(),
             "demand": _project_demand(await planner.aggregate_demand_bins(since=BASE + timedelta(hours=1))),
+            "demand_slot_units": _project_demand_slot_units(
+                await planner.aggregate_demand_slot_units(since=BASE + timedelta(hours=1))
+            ),
             "trends_key1": await api_keys.trends_by_key("key_1", lead_since, NOW, 3600),
             "trends_key2": await api_keys.trends_by_key("key_2", SINCE_ALIGNED, UNTIL_UNALIGNED, 7200),
             "trends_raw_degrade": await api_keys.trends_by_key("key_1", lead_since, NOW, 5400),
@@ -391,6 +394,17 @@ def _project_demand(bins) -> dict:
     return projected
 
 
+def _project_demand_slot_units(slots) -> dict:
+    """Per-(slot, request_kind) units from the SQL-reduced reader. The planner
+    only ever consumes per-slot totals, so this is the grain the reduced path
+    must hold across watermark states."""
+    projected: dict[tuple, float] = {}
+    for slot in slots:
+        key = (slot.slot_epoch, slot.request_kind)
+        projected[key] = projected.get(key, 0.0) + slot.demand_units
+    return projected
+
+
 def _assert_snapshots_equal(actual: dict, expected: dict, *, skip_keys: tuple[str, ...] = ()) -> None:
     assert actual.keys() == expected.keys()
     for key, expected_value in expected.items():
@@ -408,6 +422,10 @@ def _assert_snapshots_equal(actual: dict, expected: dict, *, skip_keys: tuple[st
                 actual_entry = actual_value[demand_key]
                 assert actual_entry[:4] == expected_entry[:4], (key, demand_key)
                 assert actual_entry[4] == pytest.approx(expected_entry[4], rel=1e-9, abs=1e-12), (key, demand_key)
+        elif key == "demand_slot_units":
+            assert actual_value.keys() == expected_value.keys(), key
+            for slot_key, expected_units in expected_value.items():
+                assert actual_value[slot_key] == pytest.approx(expected_units, rel=1e-9, abs=1e-9), (key, slot_key)
         elif key.startswith("reports_summary"):
             assert replace(actual_value, total_cost_usd=0.0) == replace(expected_value, total_cost_usd=0.0), key
             assert actual_value.total_cost_usd == pytest.approx(expected_value.total_cost_usd, rel=1e-9, abs=1e-12), key

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -15,6 +16,7 @@ from app.modules.quota_planner.logic import (
     build_demand_forecast,
     build_routing_costs,
     candidate_start_times,
+    demand_units_by_slot_epoch,
     parse_working_days,
     plan_shadow_actions,
     simulate_pool,
@@ -369,6 +371,11 @@ async def test_quota_planner_repository_normalizes_aware_datetimes_at_session_bo
         assert len(bins) == 1
         assert bins[0].request_count == 1
         assert bins[0].cost_usd == pytest.approx(0.25)
+
+        slots = await repo.aggregate_demand_slot_units(since=aware_since)
+
+        assert [(slot.slot_epoch, slot.request_kind) for slot in slots] == [(bins[0].slot_epoch, "warmup")]
+        assert slots[0].demand_units == pytest.approx(25.0)
 
 
 def test_candidate_start_times_do_not_floor_now_into_the_past() -> None:
@@ -743,3 +750,71 @@ def test_build_demand_forecast_uses_current_proxy_history_rows() -> None:
     peak_slot = next(slot for slot in forecast.slots if slot.slot_start.hour == 10)
 
     assert peak_slot.demand_units == pytest.approx(60.6)
+
+
+def _demand_bin(slot_epoch: int, request_kind: str = "real", **measures) -> DemandBin:
+    values = {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "cost_usd": 0.0,
+        "request_count": 0,
+    }
+    values.update(measures)
+    return DemandBin(
+        slot_epoch=slot_epoch,
+        account_id="acc",
+        api_key_id="key",
+        model="gpt-5.4-mini",
+        reasoning_effort=None,
+        request_kind=request_kind,
+        status="success",
+        **values,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _SlotUnits:
+    slot_epoch: int
+    request_kind: str
+    demand_units: float
+
+
+def test_demand_units_by_slot_epoch_matches_between_bins_and_slot_units() -> None:
+    # Two grain rows share slot 900: one is token-dominated, one is
+    # cost-dominated. ``max()`` runs per row before the per-slot sum, so the
+    # pre-reduced shape must carry the same per-row maxima summed.
+    bins = [
+        _demand_bin(900, input_tokens=12_000, request_count=1),  # 12.0 token units > 5.0 request units
+        _demand_bin(900, cost_usd=0.5, request_count=1),  # 50.0 cost units
+        _demand_bin(1800, request_count=3),  # 15.0 request units
+        _demand_bin(1800, request_kind="warmup", cost_usd=9.0, request_count=1),  # excluded kind
+    ]
+    from_bins = demand_units_by_slot_epoch(bins)
+    assert from_bins == {900: pytest.approx(62.0), 1800: pytest.approx(15.0)}
+
+    slot_units = [
+        _SlotUnits(900, "real", 62.0),
+        _SlotUnits(1800, "real", 15.0),
+        _SlotUnits(1800, "warmup", 900.0),
+        _SlotUnits(2700, "REAL", -3.0),  # kind matching is case-insensitive, negative units clamp to zero
+    ]
+    from_slots = demand_units_by_slot_epoch(slot_units=slot_units)
+    assert from_slots == {900: pytest.approx(62.0), 1800: pytest.approx(15.0), 2700: 0.0}
+
+    combined = demand_units_by_slot_epoch(bins[:2], slot_units[1:2])
+    assert combined == {900: pytest.approx(62.0), 1800: pytest.approx(15.0)}
+
+
+def test_build_demand_forecast_accepts_pre_reduced_slot_units() -> None:
+    now = datetime(2026, 6, 18, 9, 0, tzinfo=timezone.utc)
+    settings = PlannerSettings(timezone="UTC")
+    slot_epochs = [int((now - timedelta(days=7, hours=h)).timestamp()) for h in range(0, 6)]
+    bins = [_demand_bin(epoch, input_tokens=40_000 * (i + 1), request_count=4) for i, epoch in enumerate(slot_epochs)]
+    slot_units = [_SlotUnits(epoch, "real", units) for epoch, units in demand_units_by_slot_epoch(bins).items()]
+
+    from_bins = build_demand_forecast(settings=settings, bins=bins, now=now, horizon_hours=6)
+    from_slots = build_demand_forecast(settings=settings, slot_units=slot_units, now=now, horizon_hours=6)
+
+    assert from_bins.total_demand_units > 0
+    assert from_slots == from_bins


### PR DESCRIPTION
Fixes #2135

## Why

On a production replica the loop-lag monitor reports a 2–3 s `event_loop_lag` every ~305 s. It lines up to the second with `quota_planner_decisions.created_at` (300 s interval + tick duration); an in-process frame sampler over the stall window catches the tick body and nothing else attributable.

`aggregate_demand_bins()` loads the 28-day demand history at the legacy grain — one row per `(slot, account, api_key, model, reasoning_effort, request_kind, status)` — through the ORM on every tick: ~126,000 rollup rows (130 MB table) on the observed pool, i.e. on the order of a million Python objects. The stall is the C-level teardown of that burst when the tick returns (invisible to a Python-level sampler) plus the gen-2 GC it triggers (0.5 s, measured with a `gc.callbacks` probe). Every in-flight stream on the replica stalls for the duration. Details in #2135.

## What

The forecast never reads the grain — the grain only exists so per-row `max()` runs before the per-slot sum (`DemandBin` docstring). So:

- `logic.py`: the `_bin_demand_units` coefficients become named constants; `demand_units_by_slot_epoch(bins, slot_units)` is extracted and `build_demand_forecast` accepts pre-reduced `slot_units` next to `bins` (both feed one per-slot map, so the forecast is unchanged).
- `usage_time_rollup_read.py`: `demand_units_sql_expr` compiles the same formula to SQL (`GREATEST` on Postgres, scalar multi-arg `MAX` on SQLite, same `max(0, ·)` clamps) and `read_demand_slot_units_window` sums it per `(slot_epoch, request_kind)` in **one** statement (state LEFT JOIN demand bounded by the state row's own watermark epoch — same shape as `sum_demand_window`), returning the same raw windows as the grain reader.
- `repository.py`: `aggregate_demand_slot_units()`; the raw tail groups to the legacy grain in a subquery (statement shared with `aggregate_demand_bins`, which stays as the exact-grain reader for parity) and sums per slot on top.
- `scheduler.py` / `api.py` consume the reduced reader; the tick logs `Quota planner tick completed duration_ms=` so a slow tick is attributable from logs alone.

Result: the tick handles slots × request kinds (a few thousand rows for 28 days) instead of the grain, independent of how many accounts/keys/models/efforts produced traffic.

## OpenSpec

`openspec/changes/reduce-planner-demand-history-per-slot-in-sql` — `quota-phase-planner` ADDED requirement "Planner demand history is reduced per slot inside the database". `openspec validate` passes.

## Verification

- Unit (`tests/unit/test_quota_planner.py`): `demand_units_by_slot_epoch` agrees between bins and slot units (per-row `max()` before the per-slot sum, excluded request kinds, case-insensitive kind match, clamping); `build_demand_forecast` is identical for both inputs; the SQLite repository returns the reduced row for a seeded request.
- Parity harness (`tests/integration/test_request_usage_rollup_parity.py`): new `demand_slot_units` snapshot key asserted equal across the epoch, mid-history, full-target, concurrent-fold, escape-hatch and retention-pruned watermark states.
- `uv run pytest` on the 7 unit files touching quota_planner / usage_time_rollup — 388 passed; parity file — 7 passed.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `scripts/check_proxy_architecture.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Demand history is now reduced per time slot in the database, improving planner efficiency and reducing event-loop stalls during long-history forecasts.
  * Forecasting processes summarized demand data while preserving the existing calculation behavior.

* **Reliability**
  * Forecast results remain consistent with previous demand calculations.
  * Planner tick duration is recorded when execution occurs, making slow runs easier to identify.

* **Testing**
  * Added coverage validating reduced demand totals and forecast equivalence across supported calculation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->