### PR TITLE
fix(proxy): bound the detached-session retire sweep's pending_lock wait

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -713,6 +713,13 @@ _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR = "http_bridge_prepared_continuity_anchor"
 # which is overload or host-network evidence and must not be replayed.
 _HTTP_BRIDGE_COOLDOWN_SUPPRESSION_ATTR = "http_bridge_cooldown_suppression"
 _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
+# Upper bound for the per-request fail-safe sweep's wait on a detached
+# session's ``pending_lock``. The sweep runs on every bridge request, so a
+# single detached generation whose lock never frees (2026-09-07: an anyio 4.13
+# Lock lost-wakeup left ~100 live request tasks queued behind one detached
+# session) must not park every request; a skipped pass is revisited by the
+# next request's sweep and by the session's own close/drain paths.
+_HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS = 5.0
 _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
 
 
@@ -2782,7 +2789,12 @@ async def _release_http_bridge_unanchored_handoffs_for_request(
         # cannot leave a fully drained predecessor owning a socket and cap slot.
         detached_sessions = tuple(service._http_bridge_detached_sessions.values())
     for session in detached_sessions:
-        await service._retire_http_bridge_after_drain_if_ready(session)
+        # Bounded: this sweep is on every request's path, so one detached
+        # session whose lock stays busy (or wedged) must not stall the fleet.
+        await service._retire_http_bridge_after_drain_if_ready(
+            session,
+            lock_wait_timeout_seconds=_HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS,
+        )
 
 
 def _track_alias_registration(session: _HTTPBridgeSession, alias: str, *, turn_state: bool) -> int:

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -73,7 +73,12 @@ class _HTTPBridgeServiceProtocol(Protocol):
         inflight_future: asyncio.Future[_HTTPBridgeSession] | None,
         exc: BaseException,
     ) -> bool: ...
-    async def _retire_http_bridge_after_drain_if_ready(self, session: _HTTPBridgeSession) -> bool: ...
+    async def _retire_http_bridge_after_drain_if_ready(
+        self,
+        session: _HTTPBridgeSession,
+        *,
+        lock_wait_timeout_seconds: float | None = None,
+    ) -> bool: ...
     async def _release_http_bridge_admission_preregistration(
         self,
         session: _HTTPBridgeSession,

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -3386,14 +3386,48 @@ class _HTTPBridgeRequestSubmitMixin:
         await self._maybe_release_idle_http_bridge_session_lease(session)
         return True
 
-    async def _retire_http_bridge_after_drain_if_ready(self: Any, session: "_HTTPBridgeSession") -> bool:
+    async def _retire_http_bridge_after_drain_if_ready(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        lock_wait_timeout_seconds: float | None = None,
+    ) -> bool:
+        """Retire a drained session flagged ``retire_after_drain``.
+
+        ``lock_wait_timeout_seconds`` bounds the ``pending_lock`` wait for
+        callers on a shared hot path (the per-request fail-safe sweep over
+        detached sessions). When the bound elapses the check is skipped for
+        this pass and ``False`` is returned; the session stays tracked and is
+        reconsidered by the next sweep or by its own drain/close paths.
+        ``None`` keeps the unbounded wait for owners of the session lifecycle.
+        """
         if not (session.upstream_control.reconnect_requested and session.upstream_control.retire_after_drain):
             return False
-        async with session.pending_lock:
-            should_reconnect = _http_bridge_session_unowned_locked(session)
-            if should_reconnect:
+
+        def decide_locked() -> bool:
+            unowned = _http_bridge_session_unowned_locked(session)
+            if unowned:
                 session.pending_requests.clear()
                 session.upstream_close_attempted = True
+            return unowned
+
+        if lock_wait_timeout_seconds is None:
+            async with session.pending_lock:
+                should_reconnect = decide_locked()
+        else:
+            try:
+                await scheduler_for(self).wait_for(session.pending_lock.acquire(), timeout=lock_wait_timeout_seconds)
+            except TimeoutError:
+                logger.warning(
+                    "Skipping detached HTTP bridge retire check: pending_lock busy for %.1fs session_key=%s",
+                    lock_wait_timeout_seconds,
+                    _hash_identifier(session.key.affinity_key),
+                )
+                return False
+            try:
+                should_reconnect = decide_locked()
+            finally:
+                session.pending_lock.release()
         if not should_reconnect:
             return False
 

--- a/openspec/changes/bound-detached-retire-sweep-lock-wait/.openspec.yaml
+++ b/openspec/changes/bound-detached-retire-sweep-lock-wait/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/bound-detached-retire-sweep-lock-wait/proposal.md
+++ b/openspec/changes/bound-detached-retire-sweep-lock-wait/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`_release_http_bridge_unanchored_handoffs_for_request` is a fail-safe sweep that runs on every HTTP-bridge request. For each detached session it calls `_retire_http_bridge_after_drain_if_ready`, which acquires that session's `pending_lock` with no bound. On 2026-09-07 one detached `thread_header` generation's lock was left permanently unowned by an anyio 4.13 lost-wakeup, and roughly 100 live request tasks queued behind it inside this sweep. The lock bug is fixed by the dependency floor (`fix-anyio-lock-cancelled-waiter-deadlock`), but a hot path shared by every request must not be able to park the fleet behind a single detached generation, whatever the reason its lock stays busy.
+
+## What Changes
+
+- `_retire_http_bridge_after_drain_if_ready` accepts an optional `lock_wait_timeout_seconds`. When set and the bound elapses, it logs a warning, leaves the session tracked, and returns `False` without touching session state; when `None` (lifecycle owners) the wait stays unbounded.
+- The per-request fail-safe sweep passes a fixed 5 second bound for detached sessions. A skipped session is reconsidered by the next request's sweep and by its own drain/close paths.
+- Regressions: a sweep against a detached session whose lock is held forever returns within the bound without breaking the lock or closing the session; a free lock still retires; lifecycle owners without the bound still wait for the lock.
+- No public API, configuration, persistence schema, or wire-format changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require the per-request detached-session retire sweep to bound its wait on a session's `pending_lock`.
+
+## Impact
+
+Affected code: `helpers.py::_release_http_bridge_unanchored_handoffs_for_request`, `request_submit.py::_retire_http_bridge_after_drain_if_ready`, the bridge protocol stub, and unit regressions. Retirement semantics are unchanged whenever the lock is obtained; only the failure mode of an unobtainable lock changes from "every request waits forever" to "this pass skips, with a warning".

--- a/openspec/changes/bound-detached-retire-sweep-lock-wait/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-detached-retire-sweep-lock-wait/specs/responses-api-compat/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Per-request detached-session retire sweep bounds its lock wait
+
+The fail-safe sweep that reconsiders detached HTTP-bridge generations on every bridge request MUST bound how long it waits for any single detached session's `pending_lock`. When the bound elapses the sweep MUST skip that session for the current pass, emit a warning, leave the session tracked and its lock state untouched, and continue. Session lifecycle owners (drain, close, cooldown-suppression retirement) MUST keep waiting for the lock without a bound so retirement decisions stay authoritative.
+
+#### Scenario: Busy detached lock does not park the request path
+
+- **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is held by another task for longer than the bound
+- **WHEN** a request runs the fail-safe sweep
+- **THEN** the sweep returns after the bound without closing the session
+- **AND** a warning names the skipped session
+- **AND** the lock remains owned by its holder with no stranded waiter
+
+#### Scenario: Free detached lock still retires
+
+- **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is free and which no turn owns
+- **WHEN** a request runs the fail-safe sweep
+- **THEN** the session is retired exactly as before
+
+#### Scenario: Lifecycle owners keep the unbounded wait
+
+- **GIVEN** a drain or close path calls the retire check without a bound while another task briefly holds the lock
+- **WHEN** the holder releases
+- **THEN** the retire check proceeds and retires the session

--- a/openspec/changes/bound-detached-retire-sweep-lock-wait/tasks.md
+++ b/openspec/changes/bound-detached-retire-sweep-lock-wait/tasks.md
@@ -1,0 +1,14 @@
+## 1. Bound the Sweep
+
+- [x] 1.1 Add `lock_wait_timeout_seconds` to `_retire_http_bridge_after_drain_if_ready` (bounded acquire, warning on timeout, unchanged locked body, unbounded when `None`).
+- [x] 1.2 Pass a fixed 5 second bound from the per-request detached-session sweep.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Sweep against a permanently held detached lock returns within the bound, closes nothing, and leaves the lock owned by its holder.
+- [x] 2.2 Sweep against a free lock still retires; a lifecycle owner without the bound still waits.
+
+## 3. Validation
+
+- [x] 3.1 Focused unit tests, lint, format, type, and architecture checks.
+- [x] 3.2 Strict change-local OpenSpec validation.

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections import deque
 from contextlib import nullcontext
 from types import SimpleNamespace
@@ -1224,6 +1225,7 @@ async def test_detached_retire_sweep_is_bounded_by_pending_lock_wait(
     await asyncio.sleep(0)
     assert session.pending_lock.locked()
 
+    started = time.perf_counter()
     with caplog.at_level("WARNING", logger="app.modules.proxy.service"):
         await asyncio.wait_for(
             http_bridge_helpers._release_http_bridge_unanchored_handoffs_for_request(
@@ -1231,6 +1233,10 @@ async def test_detached_retire_sweep_is_bounded_by_pending_lock_wait(
             ),
             timeout=1,
         )
+    elapsed = time.perf_counter() - started
+    # Returned at the configured bound (0.05s) plus scheduling margin, not
+    # merely "eventually": a regression to a longer or unbounded wait fails here.
+    assert 0.04 <= elapsed < 0.5, elapsed
 
     close_bounded.assert_not_awaited()
     assert not session.upstream_close_attempted

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -1177,3 +1177,118 @@ async def test_grouped_terminal_error_releases_abandoned_session_lease(
     assert session.upstream_control.reconnect_requested is True
     assert session.account_lease is None
     release_account_lease.assert_awaited_once_with(lease)
+
+
+def _make_sweep_service(session: proxy_service._HTTPBridgeSession, close_bounded: AsyncMock) -> SimpleNamespace:
+    mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
+    service = SimpleNamespace(
+        _http_bridge_lock=anyio.Lock(),
+        _http_bridge_sessions={},
+        _http_bridge_detached_sessions={id(session): session},
+        _close_http_bridge_session_bounded=close_bounded,
+    )
+
+    async def retire(target: proxy_service._HTTPBridgeSession, **kwargs: Any) -> bool:
+        return await mixin._retire_http_bridge_after_drain_if_ready(service, target, **kwargs)
+
+    service._retire_http_bridge_after_drain_if_ready = retire
+    return service
+
+
+@pytest.mark.asyncio
+async def test_detached_retire_sweep_is_bounded_by_pending_lock_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The per-request fail-safe sweep must not park behind one detached
+    session whose ``pending_lock`` never frees (2026-09-07: an anyio 4.13
+    lost-wakeup queued ~100 live request tasks behind a single detached
+    generation). It skips that session for this pass and returns."""
+
+    from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers
+
+    monkeypatch.setattr(http_bridge_helpers, "_HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS", 0.05)
+    session = _make_bridge_session()
+    session.upstream_control.reconnect_requested = True
+    session.upstream_control.retire_after_drain = True
+    close_bounded = AsyncMock()
+    service = _make_sweep_service(session, close_bounded)
+
+    release = asyncio.Event()
+
+    async def hold_lock_forever() -> None:
+        async with session.pending_lock:
+            await release.wait()
+
+    holder = asyncio.create_task(hold_lock_forever())
+    await asyncio.sleep(0)
+    assert session.pending_lock.locked()
+
+    with caplog.at_level("WARNING", logger="app.modules.proxy.service"):
+        await asyncio.wait_for(
+            http_bridge_helpers._release_http_bridge_unanchored_handoffs_for_request(
+                cast(Any, service), request_scope_id="req-sweep"
+            ),
+            timeout=1,
+        )
+
+    close_bounded.assert_not_awaited()
+    assert not session.upstream_close_attempted
+    assert any("Skipping detached HTTP bridge retire check" in record.getMessage() for record in caplog.records)
+    # The lock is still owned by the holder: the sweep neither stole nor broke it.
+    assert session.pending_lock.locked()
+    assert session.pending_lock.statistics().tasks_waiting == 0
+
+    release.set()
+    await holder
+
+
+@pytest.mark.asyncio
+async def test_detached_retire_sweep_retires_when_lock_is_free() -> None:
+    from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers
+
+    session = _make_bridge_session()
+    session.upstream_control.reconnect_requested = True
+    session.upstream_control.retire_after_drain = True
+    close_bounded = AsyncMock()
+    service = _make_sweep_service(session, close_bounded)
+
+    await asyncio.wait_for(
+        http_bridge_helpers._release_http_bridge_unanchored_handoffs_for_request(
+            cast(Any, service), request_scope_id="req-sweep"
+        ),
+        timeout=1,
+    )
+
+    close_bounded.assert_awaited_once()
+    assert session.upstream_close_attempted
+    assert not session.pending_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_retire_without_timeout_still_waits_for_pending_lock() -> None:
+    """Lifecycle owners keep the unbounded wait: the check runs once the lock frees."""
+
+    mixin = http_bridge_request_submit_module._HTTPBridgeRequestSubmitMixin
+    session = _make_bridge_session()
+    session.upstream_control.reconnect_requested = True
+    session.upstream_control.retire_after_drain = True
+    close_bounded = AsyncMock()
+    fake_self = SimpleNamespace(_close_http_bridge_session_bounded=close_bounded)
+
+    release = asyncio.Event()
+
+    async def hold_lock_briefly() -> None:
+        async with session.pending_lock:
+            await release.wait()
+
+    holder = asyncio.create_task(hold_lock_briefly())
+    await asyncio.sleep(0)
+    retire_task = asyncio.create_task(mixin._retire_http_bridge_after_drain_if_ready(fake_self, session))
+    await asyncio.sleep(0.05)
+    assert not retire_task.done()
+
+    release.set()
+    await holder
+    assert await asyncio.wait_for(retire_task, timeout=1) is True
+    close_bounded.assert_awaited_once()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2539,7 +2539,7 @@ async def test_release_handoffs_retires_ready_detached_generation(
     )
 
     assert session.unanchored_reservation_id is None
-    retire.assert_awaited_once_with(session)
+    retire.assert_awaited_once_with(session, lock_wait_timeout_seconds=5.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

`_release_http_bridge_unanchored_handoffs_for_request` is a fail-safe sweep on **every** HTTP-bridge request. For each detached generation it calls `_retire_http_bridge_after_drain_if_ready`, which acquires that session's `pending_lock` with no bound. On 2026-09-07 one detached `thread_header` generation's lock was left permanently unowned by the anyio 4.13 lost-wakeup (#2129), and the production loop probe showed ~100 live request tasks queued behind it inside this sweep:

```
lock e051dab55010  waiters_deque=100 owner=None  blocked_tasks=53
    x52  helpers.py:_release_http_bridge_unanchored_handoffs_for_request:2729 > request_submit.py:_retire_http_bridge_after_drain_if_ready:2991 > Lock.acquire
```

#2129 removes the lock bug itself. This PR is the defense in depth: a hot path shared by every request must not be able to park the fleet behind one detached generation, whatever keeps its lock busy.

## What

- `_retire_http_bridge_after_drain_if_ready(session, *, lock_wait_timeout_seconds=None)`: with a bound, the `pending_lock` acquire goes through `scheduler_for(self).wait_for(...)`; on timeout it logs a warning naming the (hashed) session key, leaves the session tracked and its state untouched, and returns `False`. `None` keeps the unbounded wait for lifecycle owners (drain, close, cooldown-suppression retirement), so retirement decisions stay authoritative there.
- The per-request sweep passes a fixed 5 s bound (`_HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS`, a hardcoded constant, no new setting). A skipped session is reconsidered by the next request's sweep and by its own drain/close paths.
- Regressions (`tests/unit/test_http_bridge_idle_leases.py`): sweep against a permanently held detached lock returns within the bound, closes nothing, and leaves the lock owned by its holder with no stranded waiter; a free lock still retires; a lifecycle owner without the bound still waits and then retires.
- OpenSpec change `bound-detached-retire-sweep-lock-wait` (`responses-api-compat` delta).

## Validation

- `pytest tests/unit` (full suite locally; only the three pre-existing `main` environment failures deselected — two `test_metrics` cases needing `prometheus_client` absent, and the `file_account_pins` sqlite case)
- `ruff check` / `ruff format --check` / `ty check` / `check_proxy_architecture.py` / `check_cancellation_safety.py` / `check_proxy_timing_seams.py`
- `openspec validate bound-detached-retire-sweep-lock-wait --strict`

Related to #2029
Related to #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented requests from stalling when a detached HTTP session’s lock remains held.
  - Retirement sweeps now wait up to five seconds, log a warning on timeout, and retry the session later.
  - Sessions with available locks continue to close normally.
  - Other cleanup paths retain their existing waiting behavior.
- **Tests**
  - Added coverage for locked and available sessions, including lifecycle cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->