### PR TITLE
chore: release v1.25.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.2"  # x-release-please-version
+__version__ = "1.25.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.2
-appVersion: 1.25.0-beta.2
+version: 1.25.0-beta.3
+appVersion: 1.25.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.2",
+  "version": "1.25.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.2"
+version = "1.25.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0-beta.2"
+version = "1.25.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.3 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.3 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.2
- perf(quota-planner): reduce demand history per slot inside the database (#2138) (3d4d11a)
- fix(routing): deprioritize accounts upstream keeps rejecting as overloaded for fresh selection (#2137) (
7b0f71)
- fix(proxy): bound the detached-session retire sweep's pending_lock wait (#2139) (
58c6a2)

## Release-candidate validation
Validated candidate: 936e702dca85dab5e6e0c6f7fad63cf6a9b49c46

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run https://github.com/Soju06/codex-lb/actions/runs/34124478962 on 936e702dca85dab5e6e0c6f7fad63cf6a9b49c46: unit, integration-core-1/2/3, integration-bridge, PostgreSQL, e2e, migration checks, ruff, ty all green. Candidate = main 58c6a28f2 (#2138 planner slot-units, #2137 overload soft backoff, #2139 bounded retire-sweep lock wait) + version bump only; tree identical to the previously validated 581f57c96 (tree a6690e86f7d2d2439979857ad724940bd80d7a2b).
- [x] Frontend tests/build — same CI run: frontend lint / tsc / vitest+coverage / vite build jobs green (version bump touches frontend/package.json so they ran).
- [x] Wheel/package validation — same CI run `Package (build)` green; locally on 936e702dc: `uv build` → `codex_lb-1.25.0b3-py3-none-any.whl`, installed into a fresh Python 3.14 venv, `import app; app.__version__ == "1.25.0-beta.3"` (frontend assets are produced by the CI build, absent from the local wheel as expected).
- [x] Docker/container smoke — local `docker build` of 936e702dc, booted with the default SQLite database: schema current at startup, `/health/ready` 200 within ~30 s with bridge ring membership, `/health/live` 200, `GET /v1/models` without key → 401 contract, `app.__version__` 1.25.0-beta.3 inside the container, both routing/planner fixes importable (`overload_backoff.record_upstream_overload`, `QuotaPlannerRepository.aggregate_demand_slot_units`), zero error/traceback log lines.
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — production rollout uses `zdt-deploy.sh` blue/green with a 180 s observation window and automatic rollback; the standby color remains as the rollback vehicle. Note for deployers: this train carries #1995, which refuses `http`/socks5 proxy endpoints that carry credentials (`plaintext_proxy_credentials_forbidden`); deployments whose upstream proxy pool uses such endpoints must migrate them first (this is what rolled back the 1.25.0-beta.2 attempt on soju07 at 11:31–11:43 UTC).

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

