### PR TITLE
feat(proxy): allow plaintext proxy credentials and surface a dashboard warning

### DIFF
--- a/app/core/upstream_proxy/__init__.py
+++ b/app/core/upstream_proxy/__init__.py
@@ -1,11 +1,12 @@
 """Strict upstream proxy route resolution for Codex/OpenAI egress."""
 
 from app.core.upstream_proxy.resolver import UpstreamProxyRouteError, resolve_proxy_endpoint, resolve_upstream_route
-from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute, sends_plaintext_credentials
 
 __all__ = [
     "ResolvedProxyEndpoint",
     "ResolvedUpstreamRoute",
+    "sends_plaintext_credentials",
     "UpstreamProxyRouteError",
     "resolve_proxy_endpoint",
     "resolve_upstream_route",

--- a/app/core/upstream_proxy/resolver.py
+++ b/app/core/upstream_proxy/resolver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
@@ -7,12 +9,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.crypto import TokenEncryptor
-from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute, sends_plaintext_credentials
 from app.db.models import AccountProxyBinding, DashboardSettings, ProxyEndpoint, ProxyPool, ProxyPoolMember
 
 _ACCOUNT_BOUND_MODE = "account_bound"
 _DEFAULT_POOL_MODE = "default_pool"
 _SUPPORTED_SCHEMES = frozenset({"http", "https", "socks5", "socks5h"})
+
+logger = logging.getLogger(__name__)
+
+# Endpoint ids already warned about in this process; the resolver runs on every
+# routed request, so the plaintext-credential warning is emitted once per
+# endpoint rather than per request.
+_PLAINTEXT_CREDENTIAL_WARNINGS_EMITTED: set[str] = set()
 
 
 class UpstreamProxyRouteError(RuntimeError):
@@ -133,14 +142,28 @@ async def _resolve_pool(
     return ResolvedUpstreamRoute(mode=mode, pool_id=pool_id, endpoint=endpoints[0], fallbacks=tuple(endpoints[1:]))
 
 
+def _warn_plaintext_credentials_once(endpoint: ProxyEndpoint, scheme: str) -> None:
+    if endpoint.id in _PLAINTEXT_CREDENTIAL_WARNINGS_EMITTED:
+        return
+    _PLAINTEXT_CREDENTIAL_WARNINGS_EMITTED.add(endpoint.id)
+    logger.warning(
+        "Upstream proxy endpoint %s (%s://%s:%s) sends its credentials to the proxy in plaintext; "
+        "prefer an https:// proxy or an IP allowlist without credentials",
+        endpoint.id,
+        scheme,
+        endpoint.host,
+        endpoint.port,
+    )
+
+
 def _resolve_endpoint(endpoint: ProxyEndpoint, *, encryptor: TokenEncryptor | None) -> ResolvedProxyEndpoint:
     scheme = endpoint.scheme.lower().strip()
     if scheme not in _SUPPORTED_SCHEMES:
         raise UpstreamProxyRouteError("unsupported_proxy_scheme")
-    if scheme in {"http", "socks5", "socks5h"} and (
-        endpoint.username is not None or endpoint.password_encrypted is not None
+    if sends_plaintext_credentials(
+        scheme, has_credentials=endpoint.username is not None or endpoint.password_encrypted is not None
     ):
-        raise UpstreamProxyRouteError("plaintext_proxy_credentials_forbidden")
+        _warn_plaintext_credentials_once(endpoint, scheme)
     if endpoint.username is not None and ":" in endpoint.username:
         # RFC 7617 Basic credentials cannot encode a colon in the user-id.
         raise UpstreamProxyRouteError("invalid_proxy_username")

--- a/app/core/upstream_proxy/types.py
+++ b/app/core/upstream_proxy/types.py
@@ -8,6 +8,19 @@ from urllib.parse import quote
 _PLAINTEXT_SCHEMES = frozenset({"http", "socks5", "socks5h"})
 
 
+def sends_plaintext_credentials(scheme: str, *, has_credentials: bool) -> bool:
+    """Whether proxy credentials cross the LB-to-proxy hop unencrypted.
+
+    ``http`` (CONNECT ``Proxy-Authorization``) and ``socks5``/``socks5h``
+    (username/password sub-negotiation) both send the credential in the clear
+    to the proxy server; only an ``https`` proxy encrypts that hop. Such
+    endpoints are allowed, but the dashboard surfaces a warning and the
+    resolver logs one so operators can move to ``https`` or an IP allowlist.
+    """
+
+    return has_credentials and scheme.lower().strip() in _PLAINTEXT_SCHEMES
+
+
 def _encode_basic_proxy_auth(username: str, password: str) -> str:
     # RFC 7617 Basic token encoded with latin1, byte-identical to the header
     # value aiohttp derives from URL userinfo (``BasicAuth`` default encoding);
@@ -28,13 +41,14 @@ class ResolvedProxyEndpoint:
     username: str | None = None
     password: str | None = None
 
-    def _reject_plaintext_credentials(self) -> None:
-        if self.scheme.lower() in _PLAINTEXT_SCHEMES and (self.username is not None or self.password is not None):
-            raise ValueError("credential-bearing plaintext proxy URLs are forbidden")
+    @property
+    def plaintext_credentials(self) -> bool:
+        return sends_plaintext_credentials(
+            self.scheme, has_credentials=self.username is not None or self.password is not None
+        )
 
     @property
     def proxy_url(self) -> str:
-        self._reject_plaintext_credentials()
         scheme = "socks5h" if self.scheme == "socks5" else self.scheme
         auth = ""
         if self.username:
@@ -59,7 +73,6 @@ class ResolvedProxyEndpoint:
         only on the CONNECT tunnel request, i.e. for TLS (``https``/``wss``)
         targets; callers must not use these kwargs for plaintext targets.
         """
-        self._reject_plaintext_credentials()
         kwargs: dict[str, Any] = {"proxy": self.proxy_url_without_credentials}
         if self.username:
             kwargs["proxy_headers"] = {

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -24,7 +24,7 @@ from app.core.config.settings import get_settings as get_app_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardBadRequestError, DashboardSettingsConflictError
-from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_proxy_endpoint
+from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_proxy_endpoint, sends_plaintext_credentials
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.db.models import Account, AccountProxyBinding, AccountStatus, ProxyEndpoint, ProxyPool, ProxyPoolMember
 from app.dependencies import SettingsContext, get_proxy_service_for_app, get_settings_context
@@ -269,13 +269,6 @@ async def create_upstream_proxy_endpoint(
     _write_access=Depends(require_dashboard_write_access),
     context: SettingsContext = Depends(get_settings_context),
 ) -> UpstreamProxyEndpointResponse:
-    if payload.scheme in {"http", "socks5", "socks5h"} and (
-        payload.username is not None or payload.password is not None
-    ):
-        raise DashboardBadRequestError(
-            "Plaintext proxies cannot carry credentials",
-            code="plaintext_proxy_credentials_forbidden",
-        )
     if payload.username is not None and ":" in payload.username:
         # Mirrors the resolver: a Basic user-id cannot encode a colon.
         raise DashboardBadRequestError('Proxy usernames cannot contain ":"', code="invalid_proxy_username")
@@ -552,6 +545,9 @@ def _proxy_endpoint_response(row: ProxyEndpoint) -> UpstreamProxyEndpointRespons
         port=row.port,
         username=row.username,
         is_active=row.is_active,
+        plaintext_credentials=sends_plaintext_credentials(
+            row.scheme, has_credentials=row.username is not None or row.password_encrypted is not None
+        ),
     )
 
 

--- a/app/modules/settings/schemas.py
+++ b/app/modules/settings/schemas.py
@@ -218,6 +218,9 @@ class UpstreamProxyEndpointResponse(DashboardModel):
     port: int
     username: str | None
     is_active: bool
+    # Credentials cross the LB-to-proxy hop unencrypted (http/socks5/socks5h
+    # with a username or password); the dashboard renders a warning.
+    plaintext_credentials: bool = False
 
 
 class UpstreamProxyEndpointTestResponse(DashboardModel):

--- a/frontend/src/features/accounts/components/account-proxy-binding.test.tsx
+++ b/frontend/src/features/accounts/components/account-proxy-binding.test.tsx
@@ -131,6 +131,7 @@ describe("AccountProxyBinding", () => {
           port: 8080,
           username: "operator",
           isActive: true,
+          plaintextCredentials: true,
         },
         {
           id: "ep_secondary",
@@ -140,6 +141,7 @@ describe("AccountProxyBinding", () => {
           port: 8081,
           username: null,
           isActive: true,
+          plaintextCredentials: false,
         },
       ],
       pools: [

--- a/frontend/src/features/settings/components/upstream-proxy-settings.test.tsx
+++ b/frontend/src/features/settings/components/upstream-proxy-settings.test.tsx
@@ -46,6 +46,23 @@ describe("UpstreamProxySettings", () => {
     expect(screen.getByText(/1 endpoint\(s\)/)).toBeInTheDocument();
   });
 
+  it("warns when an endpoint sends credentials over a plaintext scheme", () => {
+    const admin = createUpstreamProxyAdmin();
+    renderSettings({
+      admin: { ...admin, endpoints: admin.endpoints.map((endpoint) => ({ ...endpoint, plaintextCredentials: true })) },
+    });
+
+    const warning = screen.getByTestId("proxy-endpoint-plaintext-warning-ep_primary");
+    expect(warning).toHaveTextContent(/unencrypted over http/);
+    expect(warning).toHaveTextContent(/https:\/\/ proxy or an IP allowlist/);
+  });
+
+  it("does not warn for endpoints whose credentials are encrypted in transit", () => {
+    renderSettings();
+
+    expect(screen.queryByTestId("proxy-endpoint-plaintext-warning-ep_primary")).not.toBeInTheDocument();
+  });
+
   it("shows explicit empty states when nothing is configured", () => {
     renderSettings({ admin: createUpstreamProxyAdmin({ endpoints: [], pools: [] }) });
 

--- a/frontend/src/features/settings/components/upstream-proxy-settings.tsx
+++ b/frontend/src/features/settings/components/upstream-proxy-settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Boxes, CheckCircle2, Loader2, Network, Plus, Server, XCircle } from "lucide-react";
+import { Boxes, CheckCircle2, Loader2, Network, Plus, Server, TriangleAlert, XCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -187,6 +187,16 @@ export function UpstreamProxySettings({
 	                          {t("upstreamProxy.actions.test")}
                         </Button>
                       </div>
+                      {endpoint.plaintextCredentials ? (
+                        <div
+                          role="note"
+                          className="flex items-start gap-1 text-amber-600 dark:text-amber-500"
+                          data-testid={`proxy-endpoint-plaintext-warning-${endpoint.id}`}
+                        >
+                          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+                          <span>{t("upstreamProxy.endpoints.plaintextCredentials", { scheme: endpoint.scheme })}</span>
+                        </div>
+                      ) : null}
                       {result ? (
                         <div
                           className={

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -307,6 +307,9 @@ export const UpstreamProxyEndpointSchema = z.object({
   port: z.number().int(),
   username: z.string().nullable().optional(),
   isActive: z.boolean(),
+  // Credentials cross the LB-to-proxy hop unencrypted (http/socks5 with a
+  // username or password); the endpoint list renders a warning.
+  plaintextCredentials: z.boolean().optional().default(false),
 });
 
 export const UpstreamProxyEndpointCreateRequestSchema = z.object({

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1453,6 +1453,7 @@
   "upstreamProxy.endpoints.connectionFailed": "Connection failed",
   "upstreamProxy.endpoints.connectionOk": "Connection ok",
   "upstreamProxy.endpoints.empty": "No proxy endpoints configured.",
+  "upstreamProxy.endpoints.plaintextCredentials": "Credentials are sent to this proxy unencrypted over {{scheme}}. Use an https:// proxy or an IP allowlist without credentials to protect them.",
   "upstreamProxy.endpoints.title": "Endpoints",
   "upstreamProxy.memberDialog.alreadyPresent": "Endpoint is already in {{pool}}.",
   "upstreamProxy.memberDialog.description": "Attach an existing endpoint to a proxy pool.",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1453,6 +1453,7 @@
   "upstreamProxy.endpoints.connectionFailed": "연결 실패",
   "upstreamProxy.endpoints.connectionOk": "연결 정상",
   "upstreamProxy.endpoints.empty": "항목 없음",
+  "upstreamProxy.endpoints.plaintextCredentials": "이 프록시로 자격증명이 {{scheme}}를 통해 암호화 없이 전송됩니다. https:// 프록시나 자격증명 없는 IP 허용목록 사용을 권장합니다.",
   "upstreamProxy.endpoints.title": "Endpoints",
   "upstreamProxy.memberDialog.alreadyPresent": "Endpoint가 이미 {{pool}}에 있습니다.",
   "upstreamProxy.memberDialog.description": "proxy pool에 endpoint를 추가합니다.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1453,6 +1453,7 @@
   "upstreamProxy.endpoints.connectionFailed": "连接失败",
   "upstreamProxy.endpoints.connectionOk": "连接正常",
   "upstreamProxy.endpoints.empty": "无项目",
+  "upstreamProxy.endpoints.plaintextCredentials": "凭据通过 {{scheme}} 以未加密方式发送到此代理。建议改用 https:// 代理或不带凭据的 IP 白名单。",
   "upstreamProxy.endpoints.title": "Endpoint",
   "upstreamProxy.memberDialog.alreadyPresent": "Endpoint 已在 {{pool}} 中。",
   "upstreamProxy.memberDialog.description": "将 endpoint 添加到 proxy pool。",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1270,6 +1270,9 @@ export const handlers = [
       port: payload.port,
       username: payload.username ?? null,
       isActive: payload.isActive ?? true,
+      // Mirrors the server: credentials on http/socks5 cross the proxy hop unencrypted.
+      plaintextCredentials:
+        payload.scheme !== "https" && (payload.username != null || payload.password != null),
     };
     state.upstreamProxyAdmin = {
       ...state.upstreamProxyAdmin,

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/.openspec.yaml
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/proposal.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+#1995 made route resolution reject any `http://`, `socks5://`, or `socks5h://` proxy endpoint that carries a username or password (`plaintext_proxy_credentials_forbidden`), and the dashboard refused to create such endpoints. The rule came from a CodeRabbit security finding (CWE-319, rated internal reachability and moderate/difficult exploitability) that was resolved by hard rejection instead of a risk decision. In practice most commercial egress proxies authenticate with Basic or SOCKS5 credentials over a plaintext hop and do not offer a TLS proxy port; the production deployment of 1.25.0-beta.2 on 2026-09-07 failed every routed request for ten minutes because both configured endpoints match that shape and had to be rolled back.
+
+The exposure is the proxy account credential on the LB-to-proxy hop only; upstream traffic itself is always TLS to the target. The maintainer decision is to allow these endpoints and make the trade-off visible instead of blocking them.
+
+## What Changes
+
+- Route resolution accepts credential-bearing `http://`, `socks5://`, and `socks5h://` endpoints. It logs one credential-free warning per endpoint per process naming the endpoint id, scheme, host, and port.
+- The upstream proxy admin API exposes `plaintextCredentials` on every endpoint (true when the scheme is not `https` and the endpoint has a username or password); endpoint creation no longer rejects such payloads.
+- The settings dashboard renders a warning under each flagged endpoint telling the operator the credentials are sent unencrypted over that scheme and recommending an `https://` proxy or a credential-free IP allowlist.
+- `ResolvedProxyEndpoint` keeps delivering credentials to aiohttp through `Proxy-Authorization` on the CONNECT tunnel (TLS targets) and to the SOCKS connector through its username/password parameters; the target-side guard (`_reject_credentialed_plaintext_target`, credentialed proxies require an https/wss upstream target) is unchanged.
+- No configuration, persistence schema, or wire-format changes; `plaintextCredentials` is an additive response field.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `outbound-http-clients`: Credential-bearing plaintext proxy endpoints are permitted; the requirement to reject them is replaced by the requirement to flag them.
+- `upstream-proxy-routing`: Route resolution warns once per plaintext-credential endpoint and the admin API exposes the flag.
+- `frontend-architecture`: The upstream proxy settings section shows the plaintext-credential warning per endpoint.
+
+## Impact
+
+Affected code: `app/core/upstream_proxy/{types,resolver}.py`, `app/modules/settings/{api,schemas}.py`, the settings frontend (schema, endpoint list, i18n en/ko/zh-CN, MSW mock), and the corresponding unit/integration/component tests. Operators with existing plaintext-credential endpoints regain routed egress on upgrade and see the warning in the dashboard.

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/proposal.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/proposal.md
@@ -10,7 +10,7 @@ The exposure is the proxy account credential on the LB-to-proxy hop only; upstre
 - The upstream proxy admin API exposes `plaintextCredentials` on every endpoint (true when the scheme is not `https` and the endpoint has a username or password); endpoint creation no longer rejects such payloads.
 - The settings dashboard renders a warning under each flagged endpoint telling the operator the credentials are sent unencrypted over that scheme and recommending an `https://` proxy or a credential-free IP allowlist.
 - `ResolvedProxyEndpoint` keeps delivering credentials to aiohttp through `Proxy-Authorization` on the CONNECT tunnel (TLS targets) and to the SOCKS connector through its username/password parameters; the target-side guard (`_reject_credentialed_plaintext_target`, credentialed proxies require an https/wss upstream target) is unchanged.
-- No configuration, persistence schema, or wire-format changes; `plaintextCredentials` is an additive response field.
+- Additive wire-format change: the upstream proxy admin API's endpoint objects (creation response and `GET /api/settings/upstream-proxy` listing) gain a boolean `plaintextCredentials` field. Existing fields, request payloads, configuration, and the persistence schema are unchanged; the dashboard schema reads the field with a `false` default so older servers still render.
 
 ## Capabilities
 

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/frontend-architecture/spec.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/frontend-architecture/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard settings must expose upstream proxy routing controls
+The settings dashboard MUST allow operators to inspect upstream proxy routing state, enable or disable routing, choose the default proxy pool, create proxy endpoints, create proxy pools, and add endpoints to pools. For every endpoint the admin API reports as `plaintextCredentials: true`, the endpoint list MUST render a warning stating that its credentials are sent unencrypted over that scheme and recommending an `https://` proxy or a credential-free IP allowlist; endpoints reported as `false` MUST render no such warning.
+
+#### Scenario: Operator creates a pool from existing endpoints
+- **GIVEN** the upstream proxy admin API returns at least one endpoint
+- **WHEN** an operator creates a pool and selects endpoint members
+- **THEN** the dashboard MUST call the pool creation API with the selected endpoint ids
+- **AND** refresh the displayed upstream proxy admin state.
+
+#### Scenario: Plaintext-credential endpoint shows a warning
+
+- **GIVEN** the upstream proxy admin API returns an endpoint with `plaintextCredentials: true`
+- **WHEN** the upstream proxy settings section renders
+- **THEN** that endpoint's row shows the plaintext-credential warning naming its scheme
+
+#### Scenario: Encrypted or credential-free endpoint shows no warning
+
+- **GIVEN** the upstream proxy admin API returns an endpoint with `plaintextCredentials: false`
+- **WHEN** the upstream proxy settings section renders
+- **THEN** that endpoint's row shows no plaintext-credential warning

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/outbound-http-clients/spec.md
@@ -1,0 +1,118 @@
+## MODIFIED Requirements
+
+### Requirement: Packaged native egress is preferred only across a replay-safe boundary
+
+When the fixed packaged `codex-lb-native-egress` executable is available, direct and account-routed Codex model-discovery, JSON/raw/multipart HTTP, Responses HTTP/SSE, and Responses or Live WebSocket calls MUST prefer it over the corresponding Python data-plane client. Python MUST retain ownership of account selection, route resolution, ordered proxy endpoint fallback, route metadata, and health classification, while each native command MUST target exactly one concrete direct or proxy endpoint. The worker MUST reuse one persistent helper generation and compatible reqwest HTTP/2 client pools across HTTP requests, and MUST multiplex concurrent HTTP and WebSocket operations without cross-delivering events. Native calls MUST preserve standard direct HTTP/HTTPS/SOCKS proxy environment resolution and `NO_PROXY` bypass behavior, and routed calls MUST use the resolved endpoint without consulting environment proxy variables. Python fallback is permitted only when the executable is absent or cannot be spawned. Once a helper process launches, a malformed, timed-out, or incompatible hello/negotiation exchange MUST fail closed without dispatching the operation to Python. A non-idempotent request, WebSocket handshake, or WebSocket frame MUST NOT fall back to Python after its native command may have been dispatched. Helper failure MUST fail operations from that generation without replay and MAY be recovered only by starting a new generation for a later operation. A confirmed pre-dispatch routed connection failure MAY use the next endpoint under the existing route policy, while a TLS verification failure or ambiguous delivery MUST NOT gain new replay eligibility.
+
+Credential-bearing routed proxy endpoints MAY use `http://`, `socks5://`, or
+`socks5h://` transport; the credential then crosses the LB-to-proxy hop
+unencrypted. Route resolution MUST accept such endpoints, MUST mark the
+resolved endpoint as carrying plaintext credentials, and MUST log one
+credential-free warning per endpoint per process. Credentials MUST still reach
+aiohttp through the CONNECT `Proxy-Authorization` header (TLS targets) or the
+SOCKS connector's username/password parameters, never through a logged URL,
+and a credentialed proxy route MUST still require an `https`/`wss` upstream
+target.
+
+#### Scenario: Plaintext proxy credentials fail before connector selection
+
+- **GIVEN** a routed endpoint contains credentials
+- **AND** the upstream target is not an `https`/`wss` URL, so aiohttp could not carry the credential on a CONNECT tunnel
+- **WHEN** codex-lb resolves the route for that operation
+- **THEN** the operation fails closed before either native or Python egress is selected
+- **AND** neither connector receives the credential-bearing route
+
+#### Scenario: Plaintext proxy credentials are accepted and flagged
+
+- **GIVEN** a routed endpoint contains credentials and uses `http://`, `socks5://`, or `socks5h://`
+- **WHEN** codex-lb resolves the route for an HTTP or WebSocket operation
+- **THEN** route resolution succeeds with the endpoint marked as carrying plaintext credentials
+- **AND** one warning naming the endpoint id, scheme, host, and port (never the credential) is logged the first time that endpoint resolves in the process
+
+#### Scenario: Packaged direct request prefers native transport
+
+- **GIVEN** the fixed native helper executable is available on the runtime path
+- **WHEN** a direct model-discovery or Responses HTTP/SSE request starts
+- **THEN** it is sent through the native helper
+- **AND** no aiohttp request is sent for that successful attempt
+
+#### Scenario: Compatible sequential requests reuse native pool
+
+- **GIVEN** the fixed native helper is available
+- **WHEN** compatible direct or routed requests complete sequentially in one worker
+- **THEN** they use the same helper generation and compatible reqwest client pool
+- **AND** the first response ending does not terminate the helper
+
+#### Scenario: Concurrent native requests remain isolated
+
+- **GIVEN** two direct or routed requests overlap in one helper generation
+- **WHEN** their head, chunk, frame, acknowledgement, and terminal events interleave
+- **THEN** each caller receives only events carrying its request identifier
+
+#### Scenario: Missing helper preserves zero-configuration behavior
+
+- **GIVEN** no native helper executable is available
+- **WHEN** codex-lb starts and sends a supported direct or routed request or opens a supported WebSocket
+- **THEN** startup succeeds
+- **AND** the existing Python transport handles the operation
+
+#### Scenario: Ambiguous native POST failure is not replayed
+
+- **GIVEN** a direct or routed Responses POST command may have reached the helper
+- **WHEN** the helper exits, its protocol fails, or its stream fails
+- **THEN** that attempt fails through the existing Responses error path
+- **AND** aiohttp and later route endpoints do not replay the POST
+
+#### Scenario: Later request restarts a dead helper
+
+- **GIVEN** a helper generation exited and its in-flight operations failed without replay
+- **WHEN** a later new direct or routed operation begins
+- **THEN** the worker may start a new helper generation for that new operation
+- **AND** no operation from the failed generation is resubmitted
+
+#### Scenario: Routed traffic retains existing transport
+
+- **WHEN** an HTTP or WebSocket request uses a resolved upstream proxy route
+- **THEN** Python selects one concrete endpoint and passes only that endpoint to the native helper
+- **AND** route fallback and account-health provenance remain owned by Python
+
+#### Scenario: Routed and WebSocket traffic retains existing transport
+
+- **WHEN** a request uses a resolved upstream proxy route and the native helper is unavailable before dispatch
+- **THEN** it retains the existing route-aware HTTP or WebSocket transport
+- **AND** an available helper enters the separately covered routed native cutover
+
+#### Scenario: Native direct request honors environment proxy routing
+
+- **GIVEN** a standard HTTPS or SOCKS proxy environment variable applies to the Codex upstream URL
+- **AND** `NO_PROXY` does not bypass that host and port
+- **WHEN** a native direct request starts
+- **THEN** the helper tunnels through the resolved environment proxy
+
+#### Scenario: Direct WebSocket uses native helper
+
+- **GIVEN** the fixed helper is available before connection dispatch
+- **WHEN** codex-lb opens a direct or account-routed Responses or Live upstream WebSocket
+- **THEN** the handshake and frames use the persistent native helper
+- **AND** the Python WebSocket connector is not opened
+
+#### Scenario: Native WebSocket failure is not replayed
+
+- **GIVEN** a native WebSocket handshake or frame command may have reached the helper
+- **WHEN** the helper reports a denial, transport failure, protocol failure, or exits
+- **THEN** that connection fails through the existing WebSocket error contract
+- **AND** codex-lb does not open a replacement Python connection or resend the frame
+
+#### Scenario: Confirmed routed connect failure uses next endpoint
+
+- **GIVEN** a routed native request has not reached upstream because connecting to its selected proxy endpoint failed
+- **WHEN** the route has another endpoint and existing policy permits fallback
+- **THEN** Python submits a new native command targeting the next endpoint
+- **AND** route metadata records that endpoint and fallback use
+
+#### Scenario: Routed TLS verification failure remains non-replayable
+
+- **GIVEN** a non-idempotent routed native request fails TLS certificate verification
+- **WHEN** another endpoint exists
+- **THEN** the request fails on the selected endpoint
+- **AND** neither the next endpoint nor aiohttp receives a replay

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/upstream-proxy-routing/spec.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/specs/upstream-proxy-routing/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Plaintext proxy credentials are surfaced, not blocked
+
+An upstream proxy endpoint whose scheme is `http`, `socks5`, or `socks5h` and which has a username or password MUST be accepted by endpoint creation and by route resolution. The upstream proxy admin API MUST report `plaintextCredentials: true` for such an endpoint and `false` for an `https` endpoint or a credential-free endpoint, and MUST NOT include the password in any response. Route resolution MUST emit exactly one warning per such endpoint per process, identifying the endpoint by id, scheme, host, and port without the credential.
+
+#### Scenario: Operator creates a credentialed http proxy endpoint
+
+- **WHEN** an operator creates an endpoint with scheme `http` and a username and password
+- **THEN** the request succeeds
+- **AND** the created endpoint and the admin listing report `plaintextCredentials: true`
+
+#### Scenario: Credentialed https endpoint is not flagged
+
+- **WHEN** an operator creates an endpoint with scheme `https` and a username and password
+- **THEN** the created endpoint reports `plaintextCredentials: false`
+
+#### Scenario: Resolver warns once per endpoint
+
+- **GIVEN** a credentialed `http` endpoint
+- **WHEN** it is resolved twice in the same process
+- **THEN** exactly one warning is logged for it
+- **AND** the warning contains neither the username nor the password

--- a/openspec/changes/allow-plaintext-proxy-credentials-with-warning/tasks.md
+++ b/openspec/changes/allow-plaintext-proxy-credentials-with-warning/tasks.md
@@ -1,0 +1,15 @@
+## 1. Backend
+
+- [x] 1.1 Replace the resolver rejection with a once-per-endpoint credential-free warning; expose `plaintext_credentials` on `ResolvedProxyEndpoint`.
+- [x] 1.2 Remove the endpoint-creation rejection and add `plaintextCredentials` to the admin endpoint response.
+- [x] 1.3 Update resolver, type, and settings API tests (allowed + flagged; https not flagged; warning emitted once, credential-free).
+
+## 2. Dashboard
+
+- [x] 2.1 Add `plaintextCredentials` to the endpoint schema and MSW mock.
+- [x] 2.2 Render the per-endpoint warning with en/ko/zh-CN strings; add component tests for flagged and unflagged endpoints.
+
+## 3. Validation
+
+- [x] 3.1 Backend lint, type, architecture checks, focused tests; frontend lint, typecheck, vitest.
+- [x] 3.2 Strict change-local OpenSpec validation; before/after screenshots in the PR body.

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -758,11 +758,11 @@ async def test_upstream_proxy_endpoint_test_rejects_proxy_auth_response(async_cl
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("scheme", ["http", "socks5", "socks5h"])
-async def test_upstream_proxy_endpoint_create_rejects_plaintext_credentials(async_client, scheme: str):
+async def test_upstream_proxy_endpoint_create_allows_plaintext_credentials_with_warning_flag(async_client, scheme: str):
     response = await async_client.post(
         "/api/settings/upstream-proxy/endpoints",
         json={
-            "name": "Unsafe proxy",
+            "name": "Plaintext proxy",
             "scheme": scheme,
             "host": "proxy.internal",
             "port": 8080,
@@ -771,8 +771,33 @@ async def test_upstream_proxy_endpoint_create_rejects_plaintext_credentials(asyn
         },
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"]["code"] == "plaintext_proxy_credentials_forbidden"
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["plaintextCredentials"] is True
+    assert "secret" not in str(payload)
+
+    listing = await async_client.get("/api/settings/upstream-proxy")
+    assert listing.status_code == 200
+    flags = {endpoint["id"]: endpoint["plaintextCredentials"] for endpoint in listing.json()["endpoints"]}
+    assert flags[payload["id"]] is True
+
+
+@pytest.mark.asyncio
+async def test_upstream_proxy_endpoint_https_credentials_are_not_flagged(async_client):
+    response = await async_client.post(
+        "/api/settings/upstream-proxy/endpoints",
+        json={
+            "name": "TLS proxy",
+            "scheme": "https",
+            "host": "proxy.internal",
+            "port": 8443,
+            "username": "user",
+            "password": "secret",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["plaintextCredentials"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upstream_proxy_resolver.py
+++ b/tests/unit/test_upstream_proxy_resolver.py
@@ -128,11 +128,19 @@ async def test_account_binding_uses_bound_pool_and_same_pool_fallbacks(
 
 
 @pytest.mark.parametrize("scheme", ["http", "socks5", "socks5h"])
-def test_resolver_rejects_credentials_on_plaintext_proxy(scheme: str) -> None:
+def test_resolver_allows_plaintext_proxy_credentials_and_warns_once(
+    scheme: str, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Credentials on http/socks5 proxies are allowed (the dashboard warns);
+    the resolver logs one credential-free warning per endpoint, not per request."""
+
+    from app.core.upstream_proxy import resolver as resolver_module
+
+    monkeypatch.setattr(resolver_module, "_PLAINTEXT_CREDENTIAL_WARNINGS_EMITTED", set())
     encryptor = _encryptor()
     endpoint = ProxyEndpoint(
-        id="unsafe",
-        name="unsafe",
+        id=f"plaintext-{scheme}",
+        name="plaintext",
         scheme=scheme,
         host="proxy.test",
         port=8080,
@@ -140,10 +148,32 @@ def test_resolver_rejects_credentials_on_plaintext_proxy(scheme: str) -> None:
         password_encrypted=encryptor.encrypt("secret"),
     )
 
-    with pytest.raises(UpstreamProxyRouteError) as exc_info:
+    with caplog.at_level("WARNING", logger="app.core.upstream_proxy.resolver"):
+        resolved = resolve_proxy_endpoint(endpoint, encryptor=encryptor)
         resolve_proxy_endpoint(endpoint, encryptor=encryptor)
 
-    assert exc_info.value.reason == "plaintext_proxy_credentials_forbidden"
+    assert resolved.username == "user"
+    assert resolved.password == "secret"
+    assert resolved.plaintext_credentials is True
+    warnings = [record for record in caplog.records if "plaintext" in record.getMessage()]
+    assert len(warnings) == 1
+    assert "secret" not in warnings[0].getMessage()
+    assert "user" not in warnings[0].getMessage().split("proxy in plaintext")[0].replace("plaintext-", "")
+
+
+def test_resolver_https_credentials_are_not_flagged_as_plaintext() -> None:
+    encryptor = _encryptor()
+    endpoint = ProxyEndpoint(
+        id="tls",
+        name="tls",
+        scheme="https",
+        host="proxy.test",
+        port=8443,
+        username="user",
+        password_encrypted=encryptor.encrypt("secret"),
+    )
+
+    assert resolve_proxy_endpoint(endpoint, encryptor=encryptor).plaintext_credentials is False
 
 
 def test_resolver_rejects_colon_in_proxy_username() -> None:

--- a/tests/unit/test_upstream_proxy_types.py
+++ b/tests/unit/test_upstream_proxy_types.py
@@ -48,11 +48,20 @@ def test_aiohttp_proxy_kwargs_move_credentials_into_proxy_authorization() -> Non
 
 
 @pytest.mark.parametrize("scheme", ["http", "socks5", "socks5h"])
-def test_aiohttp_proxy_kwargs_reject_plaintext_credentials(scheme: str) -> None:
+def test_plaintext_scheme_credentials_are_flagged_but_usable(scheme: str) -> None:
     endpoint = ResolvedProxyEndpoint("ep_1", scheme, "proxy.test", 8080, "u", "p")
 
-    with pytest.raises(ValueError, match="plaintext proxy URLs are forbidden"):
-        endpoint.aiohttp_proxy_kwargs()
+    assert endpoint.plaintext_credentials is True
+    assert endpoint.proxy_url.startswith(("http://u:p@", "socks5h://u:p@"))
+    assert endpoint.proxy_url_without_credentials in {"http://proxy.test:8080", "socks5h://proxy.test:8080"}
+    kwargs = endpoint.aiohttp_proxy_kwargs()
+    assert "@" not in kwargs["proxy"]
+    assert kwargs["proxy_headers"]["Proxy-Authorization"].startswith("Basic ")
+
+
+def test_https_credentials_are_not_flagged_as_plaintext() -> None:
+    assert _credentialed_endpoint().plaintext_credentials is False
+    assert ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080).plaintext_credentials is False
 
 
 def test_aiohttp_proxy_kwargs_reject_colon_in_username() -> None:


### PR DESCRIPTION
## Why

#1995 made route resolution reject any `http://`, `socks5://`, or `socks5h://` proxy endpoint that carries a username or password (`plaintext_proxy_credentials_forbidden`), and the dashboard refused to create one. Tracing the history: the rule was introduced to close two CodeRabbit **Security & Privacy · Major** findings (CWE-319, rated *Reachability: Internal, Exploitability: Moderate/Difficult*) by hard rejection, without a threat-model decision.

The exposure is the **proxy account credential on the LB→proxy hop only**; upstream traffic is always TLS to the target. Most commercial egress proxies authenticate with Basic/SOCKS5 credentials over exactly this hop and do not offer a TLS proxy port. Consequence on 2026-09-07: deploying 1.25.0-beta.2 to production failed **every routed request** for ten minutes (`upstream_proxy_unavailable`, reason `plaintext_proxy_credentials_forbidden`) because both configured smartproxy endpoints are `http` + credentials, and the deploy had to be rolled back.

Maintainer decision: allow these endpoints and make the trade-off visible instead of blocking them.

## What

- **Resolver** (`app/core/upstream_proxy/resolver.py`): accepts credential-bearing `http`/`socks5`/`socks5h` endpoints; logs **one credential-free warning per endpoint per process** (id, scheme, host, port). `ResolvedProxyEndpoint.plaintext_credentials` exposes the classification (`sends_plaintext_credentials()` shared helper).
- **Admin API** (`app/modules/settings`): endpoint creation no longer 400s; every endpoint response carries `plaintextCredentials` (true when scheme ≠ https and a username or password is set). Additive field.
- **Dashboard**: the Upstream proxy routing endpoint list renders an amber warning under each flagged endpoint (en/ko/zh-CN): *"Credentials are sent to this proxy unencrypted over http. Use an https:// proxy or an IP allowlist without credentials to protect them."* Unflagged endpoints are unchanged.
- **Unchanged guards**: credentials still travel via `Proxy-Authorization` on the CONNECT tunnel / SOCKS connector parameters (never in a logged URL), and `_reject_credentialed_plaintext_target` still requires an `https`/`wss` upstream target for credentialed routes.
- Tests: resolver (allowed + flagged, https not flagged, warning emitted exactly once without credentials), types, settings API (create + listing flag), frontend component (warning shown / not shown), MSW mock and account-binding fixtures updated.
- OpenSpec change `allow-plaintext-proxy-credentials-with-warning`: MODIFIED `outbound-http-clients` (the existing rejection scenario is kept but re-scoped to the target-side guard), ADDED `upstream-proxy-routing` requirement, MODIFIED `frontend-architecture` upstream proxy controls requirement.

## Screenshots (P5)

Before (main):

![before](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-proxy-plaintext-warning/pr-proxy-plaintext-warning/before.png)

After (this PR, `http` endpoint with credentials flagged, `https` endpoint not):

![after](https://raw.githubusercontent.com/Soju06/codex-lb/assets/pr-proxy-plaintext-warning/pr-proxy-plaintext-warning/after.png)

## Simplicity gates

No new setting, env var, or README surface; `plaintextCredentials` is a server-computed response field. Feature behaviour lives in OpenSpec.

## Validation

- Backend: `ruff check` / `ruff format --check` / `ty check` / all three architecture scripts; `tests/unit/test_upstream_proxy_{resolver,types}.py`, `tests/integration/test_settings_api.py -k upstream_proxy`; full `tests/unit` locally (only the three pre-existing `main` environment failures deselected).
- Frontend: `bun run lint`, `bun run typecheck`, `vitest run` (152 files / 1232 tests).
- `openspec validate allow-plaintext-proxy-credentials-with-warning --strict`.

Related to #1995
Related to #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentialed HTTP, SOCKS5, and SOCKS5h proxy endpoints are now accepted.
  * Proxy endpoint responses identify when credentials are transmitted without encryption.
  * The settings dashboard displays localized warnings recommending HTTPS proxies or credential-free allowlists.

* **Bug Fixes**
  * Preserved secure credential handling while allowing affected proxy endpoints.
  * Added one-time runtime warnings for affected endpoints.

* **Tests**
  * Expanded coverage for endpoint creation, reporting, resolution, warnings, and HTTPS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->