### PR TITLE
chore: release v1.25.0-beta.4

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.3"  # x-release-please-version
+__version__ = "1.25.0-beta.4"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.3
-appVersion: 1.25.0-beta.3
+version: 1.25.0-beta.4
+appVersion: 1.25.0-beta.4
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.3",
+  "version": "1.25.0-beta.4",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.3"
+version = "1.25.0-beta.4"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0-beta.3"
+version = "1.25.0-beta.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.4 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.4 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.3
- fix(proxy): retry accepted output-free capacity failures with a single response lifecycle (#2127) (
dafc1a)
- feat(proxy): allow plaintext proxy credentials and surface a dashboard warning (#2144) (
a8339c)

## Release-candidate validation
Validated candidate: 5e0684c20f58d323d074e5955af2a21aca8945f6

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run [34137677461](https://github.com/Soju06/codex-lb/actions/runs/34137677461) green on the candidate SHA: pytest unit / integration-core-1..3 / integration-bridge / e2e / PostgreSQL, alembic migration checks (sqlite + PostgreSQL), ruff, ty, Rust workspace; the fixes in this train (#2139, #2141, #2144) each ran the full local unit suite as well (8067–8107 passed, only pre-existing `main` environment failures deselected)
- [x] Frontend tests/build — same CI run green: vite build, vitest + coverage, tsc, eslint, Playwright dashboard smoke; #2144 additionally ran `bun run lint` / `typecheck` / `vitest run` (152 files, 1232 tests) locally
- [x] Wheel/package validation — CI `Package (build)` green; additionally `uv build` from this exact SHA produced `codex_lb-1.25.0b4-py3-none-any.whl`, installed into a clean CPython 3.14 venv: `app.__version__ == "1.25.0-beta.4"`, `codex-lb==1.25.0b4`, `anyio==4.15.1`
- [x] Docker/container smoke — CI `Docker build` + `Helm smoke install (kind)` green; additionally built the image locally from this exact SHA and booted it (sqlite, `docker run`): `/health/ready` 200 after ~24s, `/health` `{"status":"ok"}`, `/health/startup` 200, unauthenticated `/v1/models`, `/api/accounts`, `/api/settings/upstream-proxy` all 401, migration head `20260830_000000_add_quota_warmup_claim_expiry` current, `app.__version__ == 1.25.0-beta.4`, anyio 4.15.1 inside the image, #2144 resolver change and `plaintextCredentials` frontend references present in `/app`, zero ERROR/CRITICAL/Traceback lines and zero loop-lag warnings after 20s idle
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this train's changes are backend-internal resilience fixes (#2139 bounded detached-retire sweep, #2141 architecture gate), the routing backoff (#2143 / 7b0f71750), and the proxy plaintext-credential policy relaxation with a dashboard warning (#2144, which is exactly what un-blocks the production egress that beta.2 failed on); live validation happens at the soju07 zdt deploy with its 180s observation window and auto-rollback, where the previously failing routed traffic is the first thing observed

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b4" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.4
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.4 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

