### PR TITLE
fix(build): make local CI work in Nix shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_migrations.py::test_usage_history_bulk_covering_indexes_migration_upgrade_and_downgrade \
 	tests/integration/test_migrations.py::test_usage_history_covering_index_migration_repairs_invalid_leftover_postgresql \
 	tests/integration/test_migrations.py::test_usage_history_autovacuum_tuning_migration_sets_and_resets_reloptions_postgresql
-SHELL := /bin/bash
+SHELL := bash
 
 .PHONY: help
 help:

--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,7 @@
           default = pkgs.mkShell {
             packages = [
               virtualenv
+              pkgs.bun
               pkgs.git
               pkgs.uv
             ];


### PR DESCRIPTION
  ## Summary

  Make the documented local CI command work inside the project’s Nix development shell by including Bun and removing the hardcoded `/bin/bash` dependency.

  ## Type of change

  - [x] `fix:` — bug fix (no behavior change beyond the bug)
  - [ ] `feat:` — new user-facing feature or capability
  - [ ] `refactor:` — internal refactor (no behavior change, no API change)
  - [ ] `docs:` — documentation only
  - [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
  - [ ] `test:` — test-only change
  - [ ] **Breaking change**

  Linked issue: N/A

  ## OpenSpec

  - [ ] This PR includes / updates an OpenSpec change
  - [ ] Not applicable — bug fix that matches the existing spec
  - [x] Not applicable — docs / CI / chore only
  - [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

  ## Changes

  - Add `pkgs.bun` to the default Nix development shell because the Makefile’s frontend targets require Bun.
  - Change `SHELL := /bin/bash` to `SHELL := bash`, allowing GNU Make to resolve Bash through the Nix shell’s `PATH`.
  - Preserve existing build, test, and application behavior outside the development environment.

  ## Simplicity

  - [x] New feature defaults to **off** or works with **zero config**
  - [x] No new required setup step
  - New setting(s) and why each can't be a default: None
  - [x] README sections / `.env.example` / dashboard nav remain within budget

  ## Test plan

  - Entered the default development shell with `nix develop`.
  - Confirmed both `bash` and `bun` resolve from the Nix store.
  - Ran `make frontend-install` successfully inside `nix develop`.
  - Ran `git diff --check` successfully.
  - Full local CI was not run.

  ## Checklist

  - [x] Title is in Conventional Commits format.
  - [ ] Linked the related issue / discussion above.
  - [ ] Added or updated tests covering the change.
  - [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
  - [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
  - [x] Simplicity gates reviewed.
  - [x] CHANGELOG is not edited by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell portability by resolving the command shell through the system’s `PATH`.
  * Added Bun to the default development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->