### PR TITLE
fix(http-bridge): keep accepted output-free replays on a hard sticky owner instead of excluding it

### DIFF
--- a/app/modules/proxy/_service/http_bridge/accepted_replay.py
+++ b/app/modules/proxy/_service/http_bridge/accepted_replay.py
@@ -26,6 +26,8 @@ from typing import Literal
 from app.core.types import JsonValue
 from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_WEBSOCKET,
+    _affinity_may_resolve_hard_owner,
+    _HTTPBridgeSession,
     _websocket_request_is_accepted_lifecycle_only,
     _WebSocketRequestState,
 )
@@ -139,6 +141,42 @@ def _http_bridge_accepted_capacity_retry_allowed(request_state: _WebSocketReques
     if not accepted or request_state.previous_response_id is None:
         return True
     return _http_bridge_accepted_anchored_replay_candidate(request_state)
+
+
+def _http_bridge_accepted_replay_may_exclude_account(
+    request_state: _WebSocketRequestState,
+    session: _HTTPBridgeSession,
+) -> bool:
+    """Return whether the bridge's fresh-request replay may exclude the account that accepted it.
+
+    ``_retry_http_bridge_precreated_request`` moves an account-neutral fresh
+    request off the failing account by excluding it from the reconnect
+    selection. The accepted-lifecycle replay of #2127 inherited that
+    exclusion on hard session keys (``session_header`` / ``thread_header`` /
+    ``turn_state_header``, every native Codex bridge session) -- yet the
+    reconnect selects with the session's affinity, and when that affinity
+    resolves a hard ``CODEX_SESSION`` owner (a turn-state row, or the raw
+    compatibility row an old replica persisted for the bare session header)
+    selection is narrowed to that owner. Excluding it makes every
+    re-selection fail with ``hard_affinity_saturated``, which the reconnect
+    loop treats as a transient owner outage and sleeps on until the bridge
+    request budget (7200s by default) is spent, long after the client gave up.
+
+    Mirror of ``_websocket_accepted_replay_may_exclude_account``: an accepted
+    replay (``replay_downstream_response_id`` captured) on a hard session key
+    whose affinity may resolve a hard owner reconnects without an exclusion,
+    so the same owner is re-selected and the request is re-sent to it within
+    the single lifecycle the client is reading. Everything else keeps the
+    established exclusion: the created-only replay (unchanged from before
+    accepted replays existed), soft session keys (never derived alongside a
+    hard-capable affinity -- turn-state, thread and bare session headers all
+    produce hard keys), and hard keys whose affinity cannot resolve an owner.
+    """
+    if request_state.replay_downstream_response_id is None:
+        return True
+    if session.key.strength != "hard":
+        return True
+    return not _affinity_may_resolve_hard_owner(session.affinity)
 
 
 def _positive_token_count(value: JsonValue | None) -> bool:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -2079,6 +2079,26 @@ def _preferred_http_bridge_reconnect_turn_state(session: "_HTTPBridgeSession") -
     return session.upstream_turn_state
 
 
+def _http_bridge_reconnect_turn_state(
+    session: "_HTTPBridgeSession",
+    account_id: str,
+    owner_rebind_affinity: _AffinityPolicy | None,
+) -> str | None:
+    """Return the turn state the replacement handshake for ``account_id`` may carry.
+
+    The turn state was learned from the retired socket and belongs to the
+    account that issued it. Only a reconnect to that same account offers it
+    again; a replacement account (or an owner rebind) opens its socket with no
+    turn state -- the same condition under which the reconnect clears the
+    session's turn state once the replacement socket is open, so the handshake
+    cannot leak what the session-side cleanup is about to drop
+    (``responses-api-compat``: "Cross-account bridge retries clear turn-state").
+    """
+    if owner_rebind_affinity is not None or account_id != session.account.id:
+        return None
+    return _preferred_http_bridge_reconnect_turn_state(session)
+
+
 def _http_bridge_turn_state_alias_key(turn_state: str, api_key_id: str | None) -> tuple[str, str | None]:
     return (turn_state, api_key_id)
 
@@ -3831,6 +3851,7 @@ for _helper_name in (
     "_http_bridge_session_retiring_with_visible_requests",
     "_http_bridge_payload_looks_like_full_resend",
     "_preferred_http_bridge_reconnect_turn_state",
+    "_http_bridge_reconnect_turn_state",
     "_http_bridge_turn_state_alias_key",
     "_http_bridge_previous_response_alias_key",
     "_http_bridge_session_allows_api_key",

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -98,6 +98,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_previous_response_owner_unavailable_error,
     _http_bridge_reconnect_connect_failure,
     _http_bridge_reconnect_selection_failure,
+    _http_bridge_reconnect_turn_state,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_needs_unanchored_handoff,
     _http_bridge_session_account_active,
@@ -117,7 +118,6 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _persist_http_bridge_replacement_account,
     _persistent_http_bridge_affinity,
     _plan_http_bridge_lru_capacity_closes,
-    _preferred_http_bridge_reconnect_turn_state,
     _raise_if_http_bridge_creation_superseded,
     _record_bridge_drain_recovery_allowed,
     _record_bridge_first_turn_timeout,
@@ -2267,8 +2267,7 @@ class _HTTPBridgeMixin(
                 if force_refresh and request_state.force_refresh_account_id == account.id:
                     request_state.force_refresh_account_id = None
                 connect_headers = _websocket_safe_headers_with_turn_state(
-                    session.headers,
-                    None if owner_rebind_affinity is not None else _preferred_http_bridge_reconnect_turn_state(session),
+                    session.headers, _http_bridge_reconnect_turn_state(session, account.id, owner_rebind_affinity)
                 )
                 upstream = await open_replacement_upstream(account, connect_headers)
                 _copy_websocket_route_metadata_to_session(session, request_state)
@@ -2286,12 +2285,7 @@ class _HTTPBridgeMixin(
                         timeout_seconds=self._remaining_budget_seconds(deadline),
                     )
                     connect_headers = _websocket_safe_headers_with_turn_state(
-                        session.headers,
-                        (
-                            None
-                            if owner_rebind_affinity is not None
-                            else _preferred_http_bridge_reconnect_turn_state(session)
-                        ),
+                        session.headers, _http_bridge_reconnect_turn_state(session, account.id, owner_rebind_affinity)
                     )
                     upstream = await open_replacement_upstream(account, connect_headers)
                     _copy_websocket_route_metadata_to_session(session, request_state)

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -78,6 +78,7 @@ from app.modules.proxy._service.compact import (
 )
 from app.modules.proxy._service.http_bridge.accepted_replay import (
     _claim_websocket_replay_create_gate,
+    _http_bridge_accepted_replay_may_exclude_account,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _HTTP_BRIDGE_COOLDOWN_SUPPRESSION_ATTR,
@@ -4125,7 +4126,15 @@ class _HTTPBridgeRequestSubmitMixin:
                         request_state.preferred_account_id = session.account.id
                     else:
                         request_state.preferred_account_id = None
-                        request_state.excluded_account_ids.add(session.account.id)
+                        # An accepted replay whose session affinity may resolve
+                        # a hard sticky owner reconnects unexcluded: the owner
+                        # is the only account selection can return, so the
+                        # exclusion would spin on ``hard_affinity_saturated``
+                        # until the bridge request budget ran out.
+                        if model_fallback_replay or _http_bridge_accepted_replay_may_exclude_account(
+                            request_state, session
+                        ):
+                            request_state.excluded_account_ids.add(session.account.id)
             if session.account.id in request_state.excluded_account_ids:
                 session.upstream_turn_state = None
                 session.downstream_turn_state = None

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -34,7 +34,7 @@ from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.core.utils.locks import fast_lock
 from app.core.utils.sse import sse_event_type_from_block
-from app.db.models import Account
+from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyRequestUsageBudget,
@@ -1760,6 +1760,28 @@ def _websocket_request_is_accepted_lifecycle_only(request_state: _WebSocketReque
     if request_state.deferred_reasoning_downstream_texts:
         return False
     return not (request_state.pending_function_call_ids or request_state.pending_tool_call_types)
+
+
+def _affinity_may_resolve_hard_owner(affinity_policy: _AffinityPolicy) -> bool:
+    """Return whether sticky selection may bind this affinity to one owner account.
+
+    A resolved hard ``CODEX_SESSION`` row narrows selection to its owner
+    (``hard_sticky`` in ``sticky_selection``): turn-state ownership, or the raw
+    compatibility row an old replica persisted for a bare session or thread
+    header, which every policy exposing ``legacy_selection_key`` consults and
+    which wins over the namespaced soft row. The owner is not a request-state
+    pin -- it is read from the database at selection time -- so neither the
+    direct websocket request nor the HTTP bridge session can tell whether its
+    affinity resolves to a hard owner. Any policy that may is treated as
+    owner-bound: excluding that owner would leave every re-selection at
+    ``hard_affinity_saturated`` until the connect budget runs out. Shared by
+    the direct websocket accepted-replay exclusion and the HTTP bridge one.
+    """
+    return (
+        affinity_policy.kind == StickySessionKind.CODEX_SESSION
+        or affinity_policy.legacy_selection_key is not None
+        or affinity_policy.legacy_continuity_source is not None
+    )
 
 
 def _record_websocket_route_metadata(

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -71,7 +71,6 @@ from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
     Account,
     AccountStatus,  # noqa: F401
-    StickySessionKind,
 )
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
@@ -291,6 +290,7 @@ from app.modules.proxy._service.support import (
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
+    _affinity_may_resolve_hard_owner,
     _clear_websocket_request_error_overrides,
     _DeferredKeyedStreamHealthPenalty,
     _event_type_from_payload,
@@ -625,22 +625,14 @@ def _websocket_accepted_replay_can_switch_account(request_state: "_WebSocketRequ
 def _websocket_affinity_may_resolve_hard_owner(affinity_policy: _AffinityPolicy) -> bool:
     """Return whether sticky selection may bind this request to one owner account.
 
-    A resolved hard ``CODEX_SESSION`` row narrows selection to its owner
-    (``hard_sticky`` in ``sticky_selection``): turn-state ownership, or the raw
-    compatibility row an old replica persisted for a bare session or thread
-    header, which every policy exposing ``legacy_selection_key`` consults and
-    which wins over the namespaced soft row. The owner is not a request-state
-    pin -- it is read from the database at selection time -- so the request
-    cannot tell whether its session resolves to a hard owner. Any policy that
-    may is treated as owner-bound: excluding that owner would leave every
-    re-selection at ``hard_affinity_saturated`` until the connect budget runs
-    out.
+    The predicate is shared with the HTTP bridge accepted replay
+    (``_affinity_may_resolve_hard_owner``): a resolved hard ``CODEX_SESSION``
+    row -- turn-state ownership or the raw compatibility row consulted through
+    ``legacy_selection_key`` -- narrows selection to an owner the request state
+    never carries, so excluding that owner would leave every re-selection at
+    ``hard_affinity_saturated`` until the connect budget runs out.
     """
-    return (
-        affinity_policy.kind == StickySessionKind.CODEX_SESSION
-        or affinity_policy.legacy_selection_key is not None
-        or affinity_policy.legacy_continuity_source is not None
-    )
+    return _affinity_may_resolve_hard_owner(affinity_policy)
 
 
 def _websocket_accepted_replay_may_exclude_account(request_state: "_WebSocketRequestState") -> bool:

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/.openspec.yaml
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/proposal.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/proposal.md
@@ -29,6 +29,17 @@ immediately; the direct WebSocket surface already refuses this exclusion
   as the created-only transport-close replay did before accepted replays
   existed on the direct WebSocket surface: the hard row resolves to the owner
   again and the request is re-sent to it within the single lifecycle.
+- The reconnect loop builds the replacement handshake before its
+  post-connect account-change cleanup. It now offers the retained turn state
+  only when selection returned the same account
+  (`_http_bridge_reconnect_turn_state` in `http_bridge/helpers.py`). The
+  unexcluded accepted replay skips the exclusion-driven turn-state cleanup of
+  the retry path, so when its soft namespaced row moved the replay to another
+  account (owner unselectable at reconnect time) the owner's turn state reached
+  the replacement handshake -- a regression against `main`, which cleared it
+  through the exclusion, and a violation of "Cross-account bridge retries clear
+  turn-state". No cross-account bridge reconnect carries a retired account's
+  turn state now, excluded or not; same-account reconnects are unchanged.
 - The "may resolve a hard owner" predicate is shared by both surfaces
   (`_affinity_may_resolve_hard_owner` in `_service/support.py`); the direct
   WebSocket helper delegates to it.
@@ -50,6 +61,9 @@ immediately; the direct WebSocket surface already refuses this exclusion
 
 - `responses-api-compat`: HTTP bridge accepted replays on hard session keys
   keep a hard-capable Codex session owner eligible instead of excluding it.
+- `responses-api-compat`: "Cross-account bridge retries clear turn-state"
+  covers every reconnect that lands on a different account, not only the
+  exclusion-driven replay.
 
 # Impact
 
@@ -59,3 +73,7 @@ close on the owner within the single lifecycle, instead of spinning on
 `hard_affinity_saturated` for up to the bridge request budget before a 502.
 Soft session keys, created-only replays and the direct WebSocket surface keep
 their existing behaviour.
+A bridge reconnect that lands on a different account -- through an exclusion
+or through a soft row moving an unexcluded replay -- opens the replacement
+socket without the retired account's turn state; same-account reconnects keep
+offering it.

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/proposal.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/proposal.md
@@ -1,0 +1,61 @@
+# Why
+
+`retry-accepted-output-free-capacity-failures` (#2127) replays an accepted,
+output-free native Codex turn once within the single response lifecycle the
+client is reading. On the HTTP bridge the replay reuses the fresh hard-request
+path of `_retry_http_bridge_precreated_request`, which moves an
+account-neutral request off the failing account by excluding it from the
+reconnect selection. Every native Codex bridge session carries a hard session
+key (`session_header` / `thread_header` / `turn_state_header`) and the
+reconnect selects with the session affinity; when that affinity resolves a
+hard `CODEX_SESSION` owner -- a turn-state row, or the raw legacy compatibility
+row an old replica persisted for the bare session header
+(`legacy_selection_key`) -- sticky selection is narrowed to that owner. With
+the owner excluded every re-selection reports `hard_affinity_saturated`, which
+the reconnect loop treats as a transient owner outage: it sleeps
+`_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS` per attempt until the bridge request
+budget (7200s by default) is spent and only then fails the turn (`503` ->
+`stream_incomplete`). `main` before #2127 failed the accepted shape closed
+immediately; the direct WebSocket surface already refuses this exclusion
+(`_websocket_affinity_may_resolve_hard_owner`, #2127 round 7).
+
+# What Changes
+
+- The HTTP bridge accepted-lifecycle replay (`replay_downstream_response_id`
+  captured) on a hard session key MUST NOT exclude the account that accepted
+  the turn when the session affinity may resolve a hard `CODEX_SESSION` owner
+  (`CODEX_SESSION` kind, or any affinity consulting a raw legacy compatibility
+  row). The replay reconnects through selection without an exclusion, exactly
+  as the created-only transport-close replay did before accepted replays
+  existed on the direct WebSocket surface: the hard row resolves to the owner
+  again and the request is re-sent to it within the single lifecycle.
+- The "may resolve a hard owner" predicate is shared by both surfaces
+  (`_affinity_may_resolve_hard_owner` in `_service/support.py`); the direct
+  WebSocket helper delegates to it.
+- Unchanged (main parity): the created-only (pre-created) bridge replay keeps
+  excluding the silent account; soft bridge session keys keep moving the
+  accepted replay to another account; model-fallback replays keep excluding
+  the rejecting account; hard keys whose affinity cannot resolve an owner keep
+  the exclusion.
+- Not changed: the reconnect loop's `hard_affinity_saturated` recovery wait is
+  not capped. The only cheap cap ("repeats with an unchanged exclusion set")
+  would also fail the legitimate wait for a briefly unavailable owner (the
+  reason the short recovery sleep exists), and the precise cap (the resolved
+  owner is in the exclusion set) needs the selector to report the owner and a
+  change to `http_bridge/mixin.py` at its line ceiling.
+
+# Capabilities
+
+## Modified Capabilities
+
+- `responses-api-compat`: HTTP bridge accepted replays on hard session keys
+  keep a hard-capable Codex session owner eligible instead of excluding it.
+
+# Impact
+
+Native Codex bridge sessions whose bare session header still resolves a raw
+legacy hard owner recover an accepted output-free capacity failure or abrupt
+close on the owner within the single lifecycle, instead of spinning on
+`hard_affinity_saturated` for up to the bridge request budget before a 502.
+Soft session keys, created-only replays and the direct WebSocket surface keep
+their existing behaviour.

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/specs/responses-api-compat/spec.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: HTTP bridge accepted replays keep a hard-capable Codex session owner eligible
+
+When the HTTP responses session bridge replays an accepted, output-free native Codex turn within its single response lifecycle (the `replay_downstream_response_id` capture of the accepted output-free capacity replay) on a hard bridge session key (`session_header`, `thread_header`, or `turn_state_header`), and the session affinity the reconnect selects with may resolve a hard `CODEX_SESSION` owner the request state does not carry -- a `CODEX_SESSION` affinity (bare session header or turn state) or any affinity that consults a raw legacy compatibility row (`legacy_selection_key`) -- the bridge MUST NOT exclude the account that accepted the turn from the replacement selection. The replay MUST reconnect through selection without that exclusion, so a resolved hard row resolves to the same owner again and the request is re-sent to it, and the reconnect MUST NOT wait on `hard_affinity_saturated` for the owner the replay itself excluded. The replacement reconnect MUST otherwise follow the established fresh hard-request path: the owner's account-scoped response-create lease is released and re-acquired for the selected account, no owner pin is installed, and the retry does not require a same-account reconnect, so a soft namespaced row may still move the replay through selection when the owner is unavailable.
+
+The created-only (pre-created) bridge replay MUST keep excluding the silent account exactly as before; a soft bridge session key MUST keep excluding the failing account so the accepted replay moves to another account; a model-fallback replay MUST keep excluding the rejecting account; and a hard session key whose affinity cannot resolve a hard owner MUST keep the exclusion. The predicate deciding whether an affinity may resolve a hard owner MUST be shared with the direct WebSocket surface.
+
+#### Scenario: Bridge bare-session accepted failure is re-sent to its hard sticky owner
+
+- **GIVEN** the HTTP responses session bridge is enabled, two accounts are selectable, and a native Codex request carries a `session_id` header, so the bridge session key is hard (`session_header`) and its affinity consults the raw legacy `CODEX_SESSION` row for that value
+- **AND** that raw row names the accepting account as the hard owner while the request carries no owner pin (unanchored, account-neutral turn)
+- **AND** upstream delivers `response.created` and `response.in_progress` on that owner and then an output-free capacity `error` (`server_is_overloaded` or `model_at_capacity`) or closes the transport abruptly (1011 or 1006) before any output
+- **WHEN** the bridge replays the turn
+- **THEN** the replacement selection is performed with no excluded account and resolves the raw row to the same owner
+- **AND** the request is re-sent once to that owner on a fresh socket and never to the other account
+- **AND** the client observes exactly one `response.created` and a `response.completed` carrying that id, never a `hard_affinity_saturated` selection failure or a synthetic `stream_incomplete`
+
+#### Scenario: Created-only and soft-key bridge replays keep excluding the failing account
+
+- **GIVEN** the same hard `session_header` bridge session whose affinity consults the raw legacy row
+- **WHEN** a pre-created request (no `response.created` observed) is replayed after a transport close
+- **THEN** the silent account is excluded from the replacement selection exactly as before this change
+- **WHEN** instead an accepted output-free request on a soft bridge session key (for example `request` or `prompt_cache`) is replayed
+- **THEN** the failing account is excluded and the replay moves to another account, unchanged

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/specs/responses-api-compat/spec.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/specs/responses-api-compat/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: HTTP bridge accepted replays keep a hard-capable Codex session owner eligible
 
-When the HTTP responses session bridge replays an accepted, output-free native Codex turn within its single response lifecycle (the `replay_downstream_response_id` capture of the accepted output-free capacity replay) on a hard bridge session key (`session_header`, `thread_header`, or `turn_state_header`), and the session affinity the reconnect selects with may resolve a hard `CODEX_SESSION` owner the request state does not carry -- a `CODEX_SESSION` affinity (bare session header or turn state) or any affinity that consults a raw legacy compatibility row (`legacy_selection_key`) -- the bridge MUST NOT exclude the account that accepted the turn from the replacement selection. The replay MUST reconnect through selection without that exclusion, so a resolved hard row resolves to the same owner again and the request is re-sent to it, and the reconnect MUST NOT wait on `hard_affinity_saturated` for the owner the replay itself excluded. The replacement reconnect MUST otherwise follow the established fresh hard-request path: the owner's account-scoped response-create lease is released and re-acquired for the selected account, no owner pin is installed, and the retry does not require a same-account reconnect, so a soft namespaced row may still move the replay through selection when the owner is unavailable.
+When the HTTP responses session bridge replays an accepted, output-free native Codex turn within its single response lifecycle (the `replay_downstream_response_id` capture of the accepted output-free capacity replay) on a hard bridge session key (`session_header`, `thread_header`, or `turn_state_header`), and the session affinity the reconnect selects with may resolve a hard `CODEX_SESSION` owner the request state does not carry -- a `CODEX_SESSION` affinity (bare session header or turn state) or any affinity that consults a raw legacy compatibility row (`legacy_selection_key`) -- the bridge MUST NOT exclude the account that accepted the turn from the replacement selection. The replay MUST reconnect through selection without that exclusion, so a resolved hard row resolves to the same owner again and the request is re-sent to it, and the reconnect MUST NOT wait on `hard_affinity_saturated` for the owner the replay itself excluded. The replacement reconnect MUST otherwise follow the established fresh hard-request path: the owner's account-scoped response-create lease is released and re-acquired for the selected account, no owner pin is installed, and the retry does not require a same-account reconnect, so a soft namespaced row may still move the replay through selection when the owner is unavailable. When that selection returns a different account, the replacement handshake MUST carry no turn state learned on the owner's socket (the modified requirement "Cross-account bridge retries clear turn-state" below applies to this unexcluded move as well).
 
 The created-only (pre-created) bridge replay MUST keep excluding the silent account exactly as before; a soft bridge session key MUST keep excluding the failing account so the accepted replay moves to another account; a model-fallback replay MUST keep excluding the rejecting account; and a hard session key whose affinity cannot resolve a hard owner MUST keep the exclusion. The predicate deciding whether an affinity may resolve a hard owner MUST be shared with the direct WebSocket surface.
 
@@ -25,3 +25,32 @@ The created-only (pre-created) bridge replay MUST keep excluding the silent acco
 - **THEN** the silent account is excluded from the replacement selection exactly as before this change
 - **WHEN** instead an accepted output-free request on a soft bridge session key (for example `request` or `prompt_cache`) is replayed
 - **THEN** the failing account is excluded and the replay moves to another account, unchanged
+
+## MODIFIED Requirements
+
+### Requirement: Cross-account bridge retries clear turn-state
+
+When an HTTP bridge request is replayed or reconnected on an account other than the one that served its retired socket -- whether that account was excluded before the reconnect (a pre-visible request proven safe to replay on another account) or the reconnect selected a different account without an exclusion (an accepted replay left unexcluded for a hard-capable Codex session owner whose soft namespaced row moved because the owner was unselectable) -- the proxy MUST NOT carry a turn state learned on the retired account into the replacement handshake. The replacement connection's `x-codex-turn-state` header, if any, MUST NOT be one learned from the retired account, and the proxy MUST clear the retired account's upstream and downstream turn-state from the session. The handshake decides this from the account selection actually returned, not from whether the retired account was excluded. A reconnect that returns to the same account keeps offering that account its own retained turn state.
+
+#### Scenario: safe bridge replay excludes the stalled account
+
+- **GIVEN** a pre-visible HTTP bridge request is proven safe to replay
+- **WHEN** the failed bridge account is excluded before reconnect
+- **THEN** the proxy clears the retired account's turn-state fields and header
+- **AND** the replacement account receives no turn-state from the retired socket
+
+#### Scenario: Unexcluded accepted replay moved by a soft row opens the replacement without the owner's turn state
+
+- **GIVEN** a native Codex bridge session on a hard `session_header` key whose accepted output-free replay left its owner unexcluded
+- **AND** the owner's socket issued an upstream turn state on its handshake
+- **AND** no raw legacy hard row exists for the bare session header, so the owner is only the soft-row preference and is unselectable at reconnect time
+- **WHEN** the reconnect selection returns the other account
+- **THEN** the replacement handshake carries no `x-codex-turn-state`
+- **AND** the session retains no turn state learned on the owner
+- **AND** the request is re-sent once to the replacement account within the single lifecycle the client is reading
+
+#### Scenario: Same-account reconnect keeps the retained turn state
+
+- **GIVEN** a bridge session that retained the upstream turn state issued on its current account's socket
+- **WHEN** the reconnect selection returns that same account
+- **THEN** the replacement handshake carries that retained turn state, unchanged from established reconnect behaviour

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/tasks.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/tasks.md
@@ -9,6 +9,11 @@
 - [x] 1.3 Consult it at the fresh-request exclusion site of
   `_retry_http_bridge_precreated_request` (model-fallback replays keep
   excluding).
+- [x] 1.4 Add `_http_bridge_reconnect_turn_state` in `http_bridge/helpers.py`
+  and build both replacement handshakes of `_reconnect_http_bridge_session`
+  through it: the retained turn state is offered only to the same account
+  (never to a replacement account or an owner rebind), keeping
+  `http_bridge/mixin.py` under its line ceiling.
 
 ## 2. Regression coverage
 
@@ -25,6 +30,16 @@
   to the owner within one lifecycle.
 - [x] 2.4 Mutant check: deleting the guard fails the accepted unit shapes and
   all four integration terminals.
+- [x] 2.5 Helper and reconnect-level unit coverage: same account keeps the
+  upstream turn state (and the codex-session anchor); a replacement account
+  or an owner rebind receives none, and the session retains none.
+- [x] 2.6 Relay-level bridge integration coverage: an unexcluded accepted
+  replay on a hard `session_header` key whose owner is unselectable at
+  reconnect time moves through the soft row to the other account, whose
+  handshake carries no `x-codex-turn-state` learned on the owner.
+- [x] 2.7 Mutant check: offering the turn state to any account fails the
+  replacement-account unit shapes and the integration test while the
+  same-account shapes still pass.
 
 ## 3. Validation
 

--- a/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/tasks.md
+++ b/openspec/changes/keep-accepted-bridge-replay-on-hard-owner/tasks.md
@@ -1,0 +1,35 @@
+## 1. Implementation
+
+- [x] 1.1 Move the "affinity may resolve a hard owner" predicate to
+  `_service/support.py` (`_affinity_may_resolve_hard_owner`) and make
+  `_websocket_affinity_may_resolve_hard_owner` delegate to it.
+- [x] 1.2 Add `_http_bridge_accepted_replay_may_exclude_account` in
+  `http_bridge/accepted_replay.py`: accepted replay + hard session key +
+  hard-capable session affinity -> no exclusion; everything else unchanged.
+- [x] 1.3 Consult it at the fresh-request exclusion site of
+  `_retry_http_bridge_precreated_request` (model-fallback replays keep
+  excluding).
+
+## 2. Regression coverage
+
+- [x] 2.1 Predicate unit coverage over created-only, bare session header,
+  turn state, thread header with legacy process lookup, hard key without an
+  owner lookup, and soft keys.
+- [x] 2.2 `_retry_http_bridge_precreated_request` unit coverage on a hard
+  `session_header` session whose affinity consults the raw legacy row:
+  transport-close and pre-staged capacity-terminal accepted shapes reconnect
+  with an empty exclusion set; the created-only shape still excludes.
+- [x] 2.3 Relay-level bridge integration coverage with a two-account fake
+  selection honoring `exclude_account_ids` and a raw legacy hard owner:
+  capacity error, `model_at_capacity`, abrupt close 1011 and 1006 are re-sent
+  to the owner within one lifecycle.
+- [x] 2.4 Mutant check: deleting the guard fails the accepted unit shapes and
+  all four integration terminals.
+
+## 3. Validation
+
+- [x] 3.1 ruff check/format, proxy architecture, cancellation safety and
+  timing seam gates.
+- [x] 3.2 HTTP bridge unit suite, proxy utils suite, HTTP responses bridge
+  integration suite, load balancer concurrency suite.
+- [x] 3.3 Strict OpenSpec validation for this change.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -16975,6 +16975,140 @@ async def test_backend_responses_http_bridge_re_sends_a_bare_session_accepted_fa
     assert failing_upstream.closed is True
 
 
+class _OwnerTurnStateAcceptedCapacityErrorUpstreamWebSocket(_AcceptedOutputFreeCapacityErrorUpstreamWebSocket):
+    """The owner's socket issues an upstream turn state on its handshake, then
+    accepts the turn and fails it output-free."""
+
+    def __init__(self, turn_state: str) -> None:
+        super().__init__()
+        self._turn_state = turn_state
+
+    def response_header(self, name: str) -> str | None:
+        if name.lower() == "x-codex-turn-state":
+            return self._turn_state
+        return None
+
+
+@pytest.mark.asyncio
+async def test_backend_responses_http_bridge_accepted_replay_moved_by_a_soft_row_clears_the_owner_turn_state(
+    async_client,
+    monkeypatch,
+):
+    """The accepted output-free replay on a hard ``session_header`` key leaves
+    its owner unexcluded so a raw legacy hard row can resolve to it again. On a
+    current replica the bare session header usually has NO raw row: the owner is
+    only the soft namespaced-row preference, and when it is unselectable at
+    reconnect time (error backoff, cap, status) the unexcluded reconnect moves
+    the replay to another account -- without ever passing the exclusion-driven
+    turn-state cleanup of ``_retry_http_bridge_precreated_request``. The
+    replacement handshake must still carry no ``x-codex-turn-state`` learned on
+    the owner's socket (``responses-api-compat`` "Cross-account bridge retries
+    clear turn-state"); ``main`` cleared it because the owner was excluded."""
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=_make_app_settings(enabled=True).model_copy(
+            update={"http_responses_session_bridge_request_budget_seconds": 15.0}
+        ),
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    monkeypatch.setattr(proxy_support, "_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS", 0.05)
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS", 0.01)
+    owner_id = await _import_account(
+        async_client,
+        "acc_http_bridge_turn_state_owner",
+        "http-bridge-turn-state-owner@example.com",
+    )
+    alternate_id = await _import_account(
+        async_client,
+        "acc_http_bridge_turn_state_alternate",
+        "http-bridge-turn-state-alternate@example.com",
+    )
+    owner = await _get_account(owner_id)
+    alternate = await _get_account(alternate_id)
+    failing_upstream = _OwnerTurnStateAcceptedCapacityErrorUpstreamWebSocket("owner_turn_state_token")
+    owner_recovered_upstream = _FakeBridgeUpstreamWebSocket("resp_turn_state_owner_recovered")
+    alternate_upstream = _FakeBridgeUpstreamWebSocket("resp_turn_state_alternate")
+    connects: list[tuple[str | None, dict[str, str]]] = []
+    reattach_selections: list[tuple[str | None, bool | None, frozenset[str]]] = []
+
+    async def fake_select_account_with_budget(self, deadline, *, request_id, kind, **kwargs):
+        del self, deadline, request_id, kind
+        excluded = frozenset(kwargs.get("exclude_account_ids") or ())
+        preferred_account_id = kwargs.get("preferred_account_id")
+        fallback = kwargs.get("fallback_on_preferred_account_unavailable")
+        if kwargs.get("request_stage") != "reattach":
+            return AccountSelection(account=owner, error_message=None, error_code=None)
+        reattach_selections.append((preferred_account_id, fallback, excluded))
+        # No raw legacy row exists for the bare session header, so the owner is
+        # only the soft-row preference; at reconnect time it is not selectable.
+        # The production selector reports the preferred miss when no fallback
+        # is allowed and otherwise returns the other account.
+        if preferred_account_id == owner.id and not fallback:
+            return AccountSelection(
+                account=None,
+                error_message="Preferred account is not available",
+                error_code="preferred_account_unavailable",
+            )
+        return AccountSelection(account=alternate, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del access_token, base_url, session
+        connects.append((account_id_header, {key.lower(): value for key, value in dict(headers).items()}))
+        if account_id_header == "acc_http_bridge_turn_state_owner":
+            return failing_upstream if not failing_upstream.sent_text else owner_recovered_upstream
+        return alternate_upstream
+
+    async def fail_legacy_stream(*args, **kwargs):
+        raise AssertionError("legacy core_stream_responses path must not be used when HTTP bridge is enabled")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fail_legacy_stream)
+
+    events = await _collect_sse_events(
+        async_client,
+        "/backend-api/codex/responses",
+        json_body={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "accepted-replay-soft-row-moves-without-owner-turn-state",
+            "stream": True,
+        },
+        headers={"session_id": "sid-http-bridge-turn-state-soft-row"},
+    )
+
+    _assert_single_response_lifecycle_completed(events)
+    # The unexcluded accepted replay preferred its owner, found it unselectable
+    # and moved through selection to the other account.
+    assert [account for account, _ in connects] == [
+        "acc_http_bridge_turn_state_owner",
+        "acc_http_bridge_turn_state_alternate",
+    ]
+    assert reattach_selections
+    assert all(excluded == frozenset() for _, _, excluded in reattach_selections), reattach_selections
+    assert reattach_selections[0][0] == owner.id
+    assert len(failing_upstream.sent_text) == 1
+    assert len(alternate_upstream.sent_text) == 1
+    assert owner_recovered_upstream.sent_text == []
+    assert json.loads(alternate_upstream.sent_text[0])["input"] == json.loads(failing_upstream.sent_text[0])["input"]
+    # The owner's socket did hand out a turn state, yet the replacement account's
+    # handshake carries none of it.
+    assert "x-codex-turn-state" not in connects[0][1]
+    assert "x-codex-turn-state" not in connects[1][1], connects[1][1]["x-codex-turn-state"]
+
+
 class _AcceptedOutputItemCapacityErrorUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     """Upstream accepts the turn, emits an output item, then fails with a
     capacity error. Once any model output exists the turn is not replay-safe."""

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -16562,8 +16562,9 @@ class _AcceptedOutputFreeCapacityErrorUpstreamWebSocket(_FakeBridgeUpstreamWebSo
 class _AcceptedOutputFreeAbruptCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     """Upstream ACCEPTS the request (created + in_progress) then the transport dies."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, close_code: int = 1011) -> None:
         super().__init__("resp_accepted_abrupt_closed")
+        self.close_code = close_code
 
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
@@ -16579,7 +16580,7 @@ class _AcceptedOutputFreeAbruptCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSock
             },
         ):
             await self._messages.put(_FakeUpstreamMessage("text", text=json.dumps(event, separators=(",", ":"))))
-        await self._messages.put(_FakeUpstreamMessage("close", close_code=1011))
+        await self._messages.put(_FakeUpstreamMessage("close", close_code=self.close_code))
 
 
 def _install_two_account_bridge_failover(
@@ -16802,6 +16803,176 @@ async def test_backend_responses_http_bridge_retries_accepted_output_free_abrupt
     assert len(failing_upstream.sent_text) == 1
     assert len(retry_upstream.sent_text) == 1
     assert json.loads(retry_upstream.sent_text[0])["input"] == json.loads(failing_upstream.sent_text[0])["input"]
+
+
+def _install_two_account_bridge_failover_with_hard_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    owner: Account,
+    alternate: Account,
+    legacy_session_key: str,
+    upstreams_by_account_header: dict[str, list[_FakeBridgeUpstreamWebSocket]],
+) -> tuple[list[str | None], list[frozenset[str]], list[str | None]]:
+    """Two selectable accounts whose fake selection honors what the real
+    sticky selection honors: ``exclude_account_ids``, and a raw legacy
+    ``CODEX_SESSION`` row for ``legacy_session_key`` naming ``owner`` as the hard
+    owner (``hard_sticky`` in ``sticky_selection``). A selection that consults
+    that row (``legacy_sticky_key``) can only return the owner; when the owner
+    is excluded it fails with ``hard_affinity_saturated`` exactly as the
+    production selector does. Upstream sockets are handed out per connected
+    account (``chatgpt-account-id`` header) in connect order.
+
+    Returns ``(connect_account_ids, selection_exclusions, selection_legacy_keys)``.
+    """
+
+    connect_account_ids: list[str | None] = []
+    selection_exclusions: list[frozenset[str]] = []
+    selection_legacy_keys: list[str | None] = []
+
+    async def fake_select_account_with_budget(self, deadline, *, request_id, kind, **kwargs):
+        del self, deadline, request_id, kind
+        excluded = frozenset(kwargs.get("exclude_account_ids") or ())
+        legacy_sticky_key = kwargs.get("legacy_sticky_key")
+        selection_exclusions.append(excluded)
+        selection_legacy_keys.append(legacy_sticky_key)
+        if legacy_sticky_key == legacy_session_key:
+            if owner.id in excluded:
+                return AccountSelection(
+                    account=None,
+                    error_message="Hard affinity owner account is unavailable",
+                    error_code="hard_affinity_saturated",
+                )
+            return AccountSelection(account=owner, error_message=None, error_code=None)
+        chosen = alternate if owner.id in excluded else owner
+        return AccountSelection(account=chosen, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, base_url, session
+        connect_account_ids.append(account_id_header)
+        upstreams = upstreams_by_account_header.get(account_id_header) or []
+        assert upstreams, f"unexpected upstream connect for account header {account_id_header!r}"
+        return upstreams.pop(0)
+
+    async def fail_legacy_stream(*args, **kwargs):
+        raise AssertionError("legacy core_stream_responses path must not be used when HTTP bridge is enabled")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fail_legacy_stream)
+    return connect_account_ids, selection_exclusions, selection_legacy_keys
+
+
+_BRIDGE_BARE_SESSION_ACCEPTED_TERMINALS = [
+    pytest.param(lambda: _AcceptedOutputFreeCapacityErrorUpstreamWebSocket(), id="capacity_error"),
+    pytest.param(
+        lambda: _AcceptedOutputFreeCapacityErrorUpstreamWebSocket(
+            error_code="model_at_capacity",
+            error_message="Selected model is at capacity. Please try a different model.",
+        ),
+        id="model_at_capacity",
+    ),
+    pytest.param(lambda: _AcceptedOutputFreeAbruptCloseUpstreamWebSocket(), id="abrupt_close_1011"),
+    pytest.param(lambda: _AcceptedOutputFreeAbruptCloseUpstreamWebSocket(close_code=1006), id="abrupt_close_1006"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("make_failing_upstream", _BRIDGE_BARE_SESSION_ACCEPTED_TERMINALS)
+async def test_backend_responses_http_bridge_re_sends_a_bare_session_accepted_failure_to_its_hard_sticky_owner(
+    async_client,
+    monkeypatch,
+    make_failing_upstream,
+):
+    """Bridge twin of the direct-websocket bare-session test (#2127 round 7):
+    a native Codex request carries ``session_id``, so the bridge session key is
+    hard (``session_header``) and its affinity consults the raw legacy
+    ``CODEX_SESSION`` row for that value, which an old replica may have persisted
+    naming the accepting account as the hard owner. The accepted output-free
+    replay used to exclude that owner like the created-only replay does, and
+    the raw row then failed every reconnect re-selection with
+    ``hard_affinity_saturated`` until the bridge request budget (7200s) ran out
+    (``main`` before #2127 failed this shape closed immediately). The replay
+    must leave the owner eligible and go back to it on a fresh socket within
+    the single lifecycle the client is reading."""
+    legacy_session_key = "sid-http-bridge-legacy-hard-owner"
+    # Bound the pre-fix failure mode (sleeping re-selection until the connect
+    # budget) so a regression fails in seconds instead of hanging for 7200s;
+    # the fixed path never waits.
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=_make_app_settings(enabled=True).model_copy(
+            update={"http_responses_session_bridge_request_budget_seconds": 15.0}
+        ),
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    monkeypatch.setattr(proxy_support, "_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS", 0.05)
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS", 0.01)
+    owner_id = await _import_account(
+        async_client,
+        "acc_http_bridge_bare_session_owner",
+        "http-bridge-bare-session-owner@example.com",
+    )
+    alternate_id = await _import_account(
+        async_client,
+        "acc_http_bridge_bare_session_alternate",
+        "http-bridge-bare-session-alternate@example.com",
+    )
+    owner = await _get_account(owner_id)
+    alternate = await _get_account(alternate_id)
+    failing_upstream = make_failing_upstream()
+    owner_recovered_upstream = _FakeBridgeUpstreamWebSocket("resp_bare_session_owner_recovered")
+    other_account_upstream = _FakeBridgeUpstreamWebSocket("resp_bare_session_other_account")
+    connect_account_ids, selection_exclusions, selection_legacy_keys = (
+        _install_two_account_bridge_failover_with_hard_owner(
+            monkeypatch,
+            owner=owner,
+            alternate=alternate,
+            legacy_session_key=legacy_session_key,
+            upstreams_by_account_header={
+                "acc_http_bridge_bare_session_owner": [failing_upstream, owner_recovered_upstream],
+                "acc_http_bridge_bare_session_alternate": [other_account_upstream],
+            },
+        )
+    )
+
+    events = await _collect_sse_events(
+        async_client,
+        "/backend-api/codex/responses",
+        json_body={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "retry-accepted-on-bare-session-hard-owner",
+            "stream": True,
+        },
+        headers={"session_id": legacy_session_key},
+    )
+
+    _assert_single_response_lifecycle_completed(events)
+    # Re-sent to the SAME owner: the replacement selection consulted the raw row
+    # (``legacy_sticky_key``) with nothing excluded, so the hard row resolved to
+    # the owner again instead of reporting ``hard_affinity_saturated``.
+    assert connect_account_ids == ["acc_http_bridge_bare_session_owner", "acc_http_bridge_bare_session_owner"]
+    assert selection_legacy_keys[-1] == legacy_session_key
+    assert selection_exclusions[-1] == frozenset()
+    assert len(failing_upstream.sent_text) == 1
+    assert len(owner_recovered_upstream.sent_text) == 1
+    assert other_account_upstream.sent_text == []
+    assert (
+        json.loads(owner_recovered_upstream.sent_text[0])["input"] == json.loads(failing_upstream.sent_text[0])["input"]
+    )
+    assert failing_upstream.closed is True
 
 
 class _AcceptedOutputItemCapacityErrorUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -12983,6 +12983,127 @@ async def test_reconnect_http_bridge_session_filters_http_headers_for_upstream_w
     assert "x-handshake-debug" not in forwarded
 
 
+@pytest.mark.parametrize(
+    ("codex_session_anchor", "selected_account_id", "owner_rebind", "expected"),
+    [
+        pytest.param(
+            False, "acc-bridge", False, "upstream-turn-state-owner", id="same_account_keeps_upstream_turn_state"
+        ),
+        pytest.param(False, "acc-replacement", False, None, id="replacement_account_receives_none"),
+        pytest.param(False, "acc-bridge", True, None, id="owner_rebind_receives_none"),
+        pytest.param(True, "acc-bridge", False, "bridge-test", id="same_account_keeps_codex_session_anchor"),
+        pytest.param(True, "acc-replacement", False, None, id="replacement_account_receives_no_codex_session_anchor"),
+    ],
+)
+def test_http_bridge_reconnect_turn_state_is_offered_only_to_the_account_that_issued_it(
+    codex_session_anchor: bool,
+    selected_account_id: str,
+    owner_rebind: bool,
+    expected: str | None,
+) -> None:
+    """The turn state a bridge session retains was learned on the retired
+    account's socket. The reconnect may offer it again only when selection
+    returns that same account; a replacement account -- or an owner rebind --
+    opens its socket without it (``responses-api-compat`` "Cross-account bridge
+    retries clear turn-state"), matching the session-side cleanup the
+    reconnect performs once the replacement socket is open."""
+    session = _make_bridge_session()
+    session.upstream_turn_state = "upstream-turn-state-owner"
+    if codex_session_anchor:
+        session.codex_session = True
+        session.downstream_turn_state = session.affinity.key
+    owner_rebind_affinity = (
+        proxy_service._AffinityPolicy(key="rebound-owner", kind=proxy_service.StickySessionKind.CODEX_SESSION)
+        if owner_rebind
+        else None
+    )
+
+    assert (
+        http_bridge_helpers_module._http_bridge_reconnect_turn_state(
+            session, selected_account_id, owner_rebind_affinity
+        )
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selected", ["same_account", "replacement_account"])
+async def test_reconnect_http_bridge_session_offers_the_retired_turn_state_only_to_the_same_account(
+    monkeypatch: pytest.MonkeyPatch,
+    selected: str,
+) -> None:
+    """A reconnect that is not pinned to the current account builds the
+    replacement handshake *before* the post-connect account-change cleanup. The
+    handshake must therefore decide on its own: the retained turn state goes to
+    the same account (established reconnect behaviour) but never to a
+    replacement account, whether the session moved through an exclusion or --
+    as the unexcluded accepted replay on a soft namespaced row does -- simply
+    because the preferred owner was unselectable at reconnect time."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.headers = {"x-codex-session-id": "bridge-test", "x-codex-turn-state": "stale-client-turn-state"}
+    session.upstream_turn_state = "upstream-turn-state-owner"
+    session.downstream_turn_state = "downstream-turn-state-owner"
+    replacement_account = cast(
+        Any, SimpleNamespace(id="acc-replacement", status=AccountStatus.ACTIVE, plan_type="plus")
+    )
+    selected_account = session.account if selected == "same_account" else replacement_account
+    captured_headers: list[dict[str, str]] = []
+
+    async def select_account(_deadline: float, **_: object) -> proxy_service.AccountSelection:
+        return proxy_service.AccountSelection(account=selected_account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    async def open_upstream(_account: object, headers: dict[str, str], **_: object) -> UpstreamWebSocket:
+        captured_headers.append(dict(headers))
+        return cast(UpstreamWebSocket, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-turn-state-account-boundary",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert len(captured_headers) == 1
+    forwarded = {key.lower(): value for key, value in captured_headers[0].items()}
+    assert session.account is selected_account
+    assert session.closed is False
+    if selected == "same_account":
+        assert forwarded["x-codex-turn-state"] == "upstream-turn-state-owner"
+        assert session.upstream_turn_state == "upstream-turn-state-owner"
+        assert session.downstream_turn_state == "downstream-turn-state-owner"
+    else:
+        # The replacement handshake carries no turn state learned on the
+        # retired account, and the session keeps none of it either.
+        assert "x-codex-turn-state" not in forwarded
+        assert session.upstream_turn_state is None
+        assert session.downstream_turn_state is None
+        assert not any(key.lower() == "x-codex-turn-state" for key in session.headers)
+
+
 @pytest.mark.asyncio
 async def test_reconnect_keeps_handoff_protected_during_lease_swap(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6336,6 +6336,211 @@ async def test_retry_http_bridge_precreated_request_refuses_accepted_replay_whil
     assert session.response_create_gate.locked() is False
 
 
+_BRIDGE_BARE_SESSION_HEADER_AFFINITY = proxy_service._AffinityPolicy(
+    key="bridge-legacy-process",
+    kind=proxy_service.StickySessionKind.CODEX_SESSION,
+    codex_session_source="session_header",
+)
+_BRIDGE_PROMPT_CACHE_AFFINITY = proxy_service._AffinityPolicy(
+    key="cache-key",
+    kind=proxy_service.StickySessionKind.PROMPT_CACHE,
+    max_age_seconds=300,
+)
+
+
+@pytest.mark.parametrize(
+    ("accepted", "key_kind", "session_affinity", "expected"),
+    [
+        pytest.param(
+            False, "session_header", _BRIDGE_BARE_SESSION_HEADER_AFFINITY, True, id="created_only_keeps_excluding"
+        ),
+        pytest.param(True, "session_header", _BRIDGE_BARE_SESSION_HEADER_AFFINITY, False, id="accepted_bare_session"),
+        pytest.param(
+            True,
+            "turn_state_header",
+            proxy_service._AffinityPolicy(
+                key="turn_0123456789abcdef0123456789abcdef",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+                codex_session_source="turn_state",
+            ),
+            False,
+            id="accepted_turn_state",
+        ),
+        pytest.param(
+            True,
+            "thread_header",
+            proxy_service._AffinityPolicy(
+                key="thread-selection-key",
+                kind=proxy_service.StickySessionKind.PROMPT_CACHE,
+                max_age_seconds=300,
+                codex_session_source="thread_header",
+                legacy_codex_session_key="bridge-legacy-process",
+                legacy_continuity_source="session_header",
+            ),
+            False,
+            id="accepted_thread_header_with_legacy_process_lookup",
+        ),
+        pytest.param(
+            True, "session_header", _BRIDGE_PROMPT_CACHE_AFFINITY, True, id="accepted_hard_key_without_owner_lookup"
+        ),
+        pytest.param(True, "prompt_cache", _BRIDGE_PROMPT_CACHE_AFFINITY, True, id="accepted_prompt_cache_key_moves"),
+        pytest.param(True, "request", proxy_service._AffinityPolicy(), True, id="accepted_request_key_moves"),
+        pytest.param(
+            True, "request", _BRIDGE_BARE_SESSION_HEADER_AFFINITY, True, id="accepted_soft_key_keeps_main_exclusion"
+        ),
+    ],
+)
+def test_http_bridge_accepted_replay_may_exclude_account_refuses_hard_capable_session_affinity(
+    accepted: bool,
+    key_kind: str,
+    session_affinity: proxy_service._AffinityPolicy,
+    expected: bool,
+) -> None:
+    """Bridge twin of ``_websocket_accepted_replay_may_exclude_account`` (#2127
+    round 7): the reconnect selects with the *session* affinity, and a resolved
+    hard ``CODEX_SESSION`` row -- turn state, or the raw compatibility row an
+    old replica persisted for the bare session header that
+    ``legacy_selection_key`` consults -- narrows selection to its owner. An
+    accepted replay on a hard session key must therefore leave that owner
+    eligible instead of excluding it into ``hard_affinity_saturated``. The
+    created-only replay and every soft session key are deliberately untouched
+    and keep excluding the failing account."""
+    request_state = _accepted_bridge_request_state(request_id="req-accepted-exclusion-predicate")
+    if accepted:
+        request_state.replay_downstream_response_id = request_state.response_id
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey(key_kind, "bridge-legacy-process", None),
+        key_value="bridge-legacy-process",
+    )
+    session.affinity = session_affinity
+    assert (session.key.strength == "hard") is (key_kind in proxy_service._HARD_HTTP_BRIDGE_AFFINITY_KINDS)
+
+    assert (
+        http_bridge_accepted_replay_module._http_bridge_accepted_replay_may_exclude_account(request_state, session)
+        is expected
+    )
+    # One predicate decides "may resolve a hard owner" on both surfaces so the
+    # bridge and the direct websocket cannot drift apart again.
+    assert (
+        http_bridge_accepted_replay_module._affinity_may_resolve_hard_owner
+        is proxy_support_module._affinity_may_resolve_hard_owner
+    )
+    assert websocket_helpers_module._websocket_affinity_may_resolve_hard_owner(
+        session_affinity
+    ) is proxy_support_module._affinity_may_resolve_hard_owner(session_affinity)
+
+
+def _hard_capable_bridge_session(
+    request_state: proxy_service._WebSocketRequestState,
+    *,
+    close_code: int | None,
+) -> proxy_service._HTTPBridgeSession:
+    """Native Codex bridge session (hard ``session_header`` key) whose affinity
+    consults the raw legacy ``CODEX_SESSION`` row for the bare session header."""
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-legacy-process", None),
+        key_value="bridge-legacy-process",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.affinity = _BRIDGE_BARE_SESSION_HEADER_AFFINITY
+    assert session.affinity.legacy_selection_key == "bridge-legacy-process"
+    session.account = cast(Any, SimpleNamespace(id="acc-legacy-hard-owner", status=AccountStatus.ACTIVE))
+    session.last_upstream_close_code = close_code
+    session.upstream_turn_state = "upstream-turn-state-owner"
+    session.upstream = cast(UpstreamWebSocket, SimpleNamespace(send_text=AsyncMock(), close=AsyncMock()))
+    return session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry", ["transport_close", "capacity_terminal_pre_staged", "created_only"])
+async def test_retry_http_bridge_precreated_request_keeps_accepted_replay_on_hard_capable_session_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    entry: str,
+) -> None:
+    """An accepted output-free request on a native Codex bridge session (hard
+    ``session_header`` key) is replayed as a fresh hard request: #2127 excluded
+    the accepting account like the created-only replay does. When the session
+    affinity resolves a raw legacy hard ``CODEX_SESSION`` row, that owner is the
+    only account selection can return, so the exclusion made every reconnect
+    re-selection fail with ``hard_affinity_saturated`` and sleep to the bridge
+    request budget (7200s) before a 502 -- ``main`` before #2127 failed this
+    shape closed immediately. The accepted replay now reconnects unexcluded
+    (direct-websocket parity) through the otherwise unchanged fresh-switch
+    path: the owner's pin stays clear, its create lease is released for
+    re-acquisition, and the reconnect is not same-account-required, so a soft
+    row could still move. The created-only shape keeps excluding the silent
+    account exactly as before."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    if entry == "created_only":
+        request_state = proxy_service._WebSocketRequestState(
+            request_id="req-created-only-legacy-owner",
+            model="gpt-5.6-sol",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=time.monotonic(),
+            awaiting_response_created=True,
+            request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+            transport="http",
+            account_response_create_lease=cast(Any, object()),
+        )
+    else:
+        request_state = _accepted_bridge_request_state(
+            request_id=f"req-accepted-legacy-owner-{entry}",
+            account_response_create_lease=cast(Any, object()),
+        )
+    session = _hard_capable_bridge_session(
+        request_state,
+        close_code=None if entry == "capacity_terminal_pre_staged" else 1006,
+    )
+    if entry == "capacity_terminal_pre_staged":
+        # The terminal-error branch stages the request (visible id captured,
+        # gate re-claimed) before it hands the pre-created shape to the retry.
+        assert await http_bridge_accepted_replay_module._stage_websocket_request_state_for_replay(
+            request_state,
+            create_gate=session.response_create_gate,
+            surface="http_bridge",
+            trigger="capacity_error",
+        )
+    old_lease = request_state.account_response_create_lease
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+    release_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    if entry == "created_only":
+        assert request_state.replay_downstream_response_id is None
+        assert request_state.excluded_account_ids == {"acc-legacy-hard-owner"}
+        # The owner's turn state cannot follow a request that left the account.
+        assert session.upstream_turn_state is None
+    else:
+        assert request_state.replay_downstream_response_id == "resp-accepted-visible"
+        assert request_state.suppress_next_created_downstream is True
+        assert request_state.suppress_next_in_progress_downstream is True
+        assert request_state.excluded_account_ids == set()
+        assert session.upstream_turn_state == "upstream-turn-state-owner"
+    assert request_state.preferred_account_id is None
+    assert request_state.replay_required_account_id is None
+    assert request_state.awaiting_response_created is True
+    assert request_state.response_id is None
+    assert request_state.replay_count == 1
+    assert request_state.response_create_gate_acquired is True
+    release_lease.assert_awaited_once_with(old_lease)
+    reconnect.assert_awaited_once()
+    reconnect_call = reconnect.await_args
+    assert reconnect_call is not None
+    assert reconnect_call.kwargs["request_state"] is request_state
+    assert "require_same_account" not in reconnect_call.kwargs
+    assert "require_preferred_account" not in reconnect_call.kwargs
+    cast(AsyncMock, session.upstream.send_text).assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_transport_close_with_a_visible_sibling_fails_both_requests_closed(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Follow-up to #2127 / relates #2126. On the HTTP bridge, an **accepted** output-free replay (upstream accepted the request, then closed or failed at capacity before any visible output) on a **hard** sticky session key (`session_header` / `thread_header`, i.e. every native Codex bridge session) excluded the account that accepted it. When that session's affinity resolves a raw legacy hard `CODEX_SESSION` owner, sticky selection then reports `hard_affinity_saturated` even though an alternate account is available, and `_reconnect_http_bridge_session` → `_select_account_with_budget` sleeps `_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS` (2s) per attempt until the bridge request budget (default `http_responses_session_bridge_request_budget_seconds` = 7200s) before surfacing 503 → 502 `stream_incomplete`. This PR keeps the accepting account eligible for that shape, mirroring the WebSocket-side guard, so the replay is re-sent to its hard owner immediately.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Follow-up to #2127 (introduced the accepted-shape regression), relates #2126.

## Defect

Introduced on `main` by #2127 (merged as dafc1a21d) for the **accepted** shape; confirmed by adversarial review at 7718911de and reproduced again against `origin/main` 15ccd901b (v1.25.0-beta.4) with this branch's fixtures.

- `app/modules/proxy/_service/http_bridge/request_submit.py`: the fresh-hard-request path in `_retry_http_bridge_precreated_request_admitted` (`fresh_hard_request_account_switch_allowed`) unconditionally did `excluded_account_ids.add(session.account.id)` with no accepted-lifecycle check.
- `sticky_selection.py` (`sticky_existing_is_legacy` / `hard_sticky`): when the session affinity hits `affinity_policy.legacy_selection_key` on a raw legacy hard `CODEX_SESSION` row owned by the now-excluded account, selection returns `hard_affinity_saturated` rather than spilling to the available alternate.
- `_reconnect_http_bridge_session` then loops on the 2s recovery sleep until the bridge budget is exhausted.
- Pre-#2127 `main` failed the accepted shape closed immediately. The **created-only** (pre-created, no `replay_downstream_response_id`) shape already had this loop on `main` and is intentionally left main-identical here (see Known limitations). 1011 closes on a hard key fail fast via `_require_http_bridge_bound_account_not_excluded` ("continuity account is excluded") — also unchanged.

## Reproduction

Selection level (`tests/unit/test_load_balancer_concurrency._make_cap_spillover_balancer`): raw sticky row `{"legacy-process": owner}` + `_AffinityPolicy(key=raw, kind=CODEX_SESSION, codex_session_source="session_header")`; owner excluded + alternate available → `hard_affinity_saturated`. Un-excluded → owner. `thread_header` policy with `legacy_codex_session_key` saturates the same way; a soft-only control (namespaced row, no raw row) spills to the alternate.

Relay level, this branch's new integration test run against `main` app code with the bridge budget bounded to 15s: `capacity_error` and `abrupt_close_1006` spin on `hard_affinity_saturated` — 1,174 "Waiting for an account to recover … Hard affinity owner account is unavailable" log lines, each test lasting the full 15s budget, then `stream_incomplete`. `abrupt_close_1011` fails fast with 502 "continuity account is excluded". A scratch variant with the **real** `LoadBalancer` and a real seeded raw `CODEX_SESSION` row (only `connect_responses_websocket` faked) showed 734 hard-affinity waits until `upstream_request_timeout` on `main`, versus re-send to the owner in 0.63s on this branch.

The retry-level unit test on `main`: `transport_close` and `capacity_terminal_pre_staged` params fail with `{'acc-legacy-hard-owner'} == set()`; `created_only` passes (main-identical by design).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/keep-accepted-bridge-replay-on-hard-owner/` (`openspec validate keep-accepted-bridge-replay-on-hard-owner --strict` valid on local 1.8.0 and on the CI pin via `npx @fission-ai/openspec@1.11.0`; `openspec validate --specs` 58/58). The requirement is ADDED rather than MODIFIED because the #2127 requirement still lives in its unarchived change, not the base spec.

## Changes

Fix direction: the "do not exclude" mirror of the WS guard (`_websocket_affinity_may_resolve_hard_owner` / `_websocket_accepted_replay_can_switch_account`), not the SSE-style same-owner retry. The retry variant would need a flag inside the selection loop of `http_bridge/mixin.py` (at its line ceiling) and would alter the created-only shape; the guard is smaller and leaves created-only byte-identical to `main`.

- `app/modules/proxy/_service/support.py` (+22): new shared predicate `_affinity_may_resolve_hard_owner(affinity_policy)` — `kind == CODEX_SESSION`, or `legacy_selection_key` / `legacy_continuity_source` set. Body is the former WS predicate verbatim.
- `app/modules/proxy/_service/websocket/helpers.py`: `_websocket_affinity_may_resolve_hard_owner` now delegates to the shared predicate (name kept; WS consumers at `websocket/mixin.py` and all WS tests unchanged; the new unit test asserts object identity).
- `app/modules/proxy/_service/http_bridge/accepted_replay.py` (+38): `_http_bridge_accepted_replay_may_exclude_account(request_state, session)` → `True` (exclude, `main` behaviour) unless `replay_downstream_response_id` is set **and** `session.key.strength == "hard"` **and** the *session* affinity may resolve a hard owner. Keyed on session key strength, not affinity alone, because the request-key test helper attaches a `CODEX_SESSION` affinity to soft keys that must keep moving.
- `app/modules/proxy/_service/http_bridge/request_submit.py` (+10/-1): the single fresh-request exclusion site is now `if model_fallback_replay or _http_bridge_accepted_replay_may_exclude_account(request_state, session): excluded_account_ids.add(session.account.id)`. Everything else on the fresh hard path is unchanged: `preferred_account_id = None`, `fresh_hard_request_account_switch_allowed` stays `True` (account-scoped create lease released and re-acquired), and the reconnect is called without `require_same_account` / `require_preferred_account`. The reconnect then prefers the still-eligible accepting account; a raw legacy hard row resolves to it, a soft row may still move if the owner is unavailable; a 1011 close keeps the pre-existing hard-key same-account close policy.
- `app/modules/proxy/_service/http_bridge/helpers.py` (+21) and `http_bridge/mixin.py` (2433 → 2427 lines, ceiling 2436): second commit `d3b317f04` adds `_http_bridge_reconnect_turn_state`, so a replacement socket opened for a *different* account (`account.id != session.account.id`, or an owner rebind) does not carry the retired owner's `x-codex-turn-state` into the handshake. Previously it was offered and only cleared post-connect; the predicate is identical to the existing post-connect cleanup condition. This closes a turn-state cross-account leak that becomes reachable on the now-unexcluded soft-row move.

### Main-parity argument

- **Created-only shape (`replay_downstream_response_id is None`)**: the guard's first clause returns `True`, so that branch executes exactly `main`'s `excluded_account_ids.add(...)`. Proven by the `created_only` param (asserts exclusion + turn state cleared; also passes on pure `origin/main` app code) and the untouched `test_retry_http_bridge_fresh_hard_request_excludes_silent_account`.
- **Soft keys**: `key.strength != "hard"` → `True` → main-identical; pre-existing `test_backend_responses_http_bridge_retries_accepted_output_free_{capacity_error,abrupt_close}_on_another_account` (no `session_id` header) still pass.
- **Model-fallback replays**: `model_fallback_replay` short-circuits to exclusion.
- **No exclusion leak into sticky reallocation**: the guard only suppresses the `set.add`; it never touches `reallocate_sticky` / affinity (the bridge fresh-hard path never did on `main` either); other exclusion writers (auth replay, owner-switch handoff, `upstream_events.py`) are untouched. The real-selector repro confirms the raw row remains owner-bound after the replay.
- Owner health writes (`record_error` ×1 + `record_upstream_overload`) do not block owner re-selection: overload backoff filters only soft fallback candidates (`sticky_selection.py`), error backoff needs 3+ errors — so any residual wait is pre-existing hard-owner semantics.

### Loop cap — not implemented, and why

The optional "fail closed when `hard_affinity_saturated` repeats with an unchanged exclusion set" cap was **not** added. The cheap form would also defeat the legitimate 30–300s wait for a briefly unavailable hard owner (the same saturation reason is reported), and the precise form needs the selector to report *which* account is the owner plus changes inside `http_bridge/mixin.py`'s selection loop. Rationale is recorded in `openspec/changes/keep-accepted-bridge-replay-on-hard-owner/proposal.md`; left as a follow-up.

## Test plan

New tests:

- `tests/unit/test_proxy_http_bridge.py` (+326): predicate test (8 params incl. `accepted_bare_session`, `accepted_turn_state`, `accepted_thread_header_with_legacy_process_lookup`, soft-key/prompt-cache-key/request-key moves, `created_only`), `test_retry_http_bridge_precreated_request_keeps_accepted_replay_on_hard_capable_session_owner[transport_close|capacity_terminal_pre_staged|created_only]` on a hard `session_header` session whose affinity consults the raw legacy row, and `_http_bridge_reconnect_turn_state` helper/reconnect tests (`same_account_*` keep turn state, `replacement_account_*` receive none).
- `tests/integration/test_http_responses_bridge.py` (+309): `_AcceptedOutputFreeAbruptCloseUpstreamWebSocket(close_code=...)`, `_install_two_account_bridge_failover_with_hard_owner` (fake selection honors `exclude_account_ids` and a raw legacy hard owner, returning `hard_affinity_saturated` when the owner is excluded, like `sticky_selection`; kwarg names match the real `_select_account_with_budget` call), `test_backend_responses_http_bridge_re_sends_a_bare_session_accepted_failure_to_its_hard_sticky_owner[capacity_error|model_at_capacity|abrupt_close_1011|abrupt_close_1006]` driving `/backend-api/codex/responses` with a `session_id` header (asserts last exclusion set is empty, legacy key consulted, `connects == [owner, owner]`, alternate never sent, single lifecycle, no error/failed/incomplete), and `test_backend_responses_http_bridge_accepted_replay_moved_by_a_soft_row_clears_the_owner_turn_state`.

```
.venv/bin/python -m pytest -p no:cacheprovider tests/unit/test_proxy_http_bridge.py \
  --deselect tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses
# 1057 passed, 1 deselected (the deselected test also fails on the merge base; pre-existing)
.venv/bin/python -m pytest -p no:cacheprovider tests/integration/test_http_responses_bridge.py
# 168 passed
.venv/bin/python -m pytest -p no:cacheprovider tests/unit/test_proxy_utils.py tests/unit/test_load_balancer_concurrency.py
# 1500 passed
# Four suites total: 2725 passed, 0 failed. 96 WS/LB hard-owner tests pass unchanged.
```

Mutants:

1. Guard deleted in `request_submit.py` (unconditional `excluded_account_ids.add`) / predicate forced to `return True` → 9 failed: `accepted_bare_session`, `accepted_turn_state`, `accepted_thread_header_with_legacy_process_lookup`, `retry[transport_close]`, `retry[capacity_terminal_pre_staged]`, and all 4 integration terminals (each reproducing the pre-fix `hard_affinity_saturated` spin under the 15s budget override). `created_only` and the 3 soft-key params survive, as intended.
2. `_http_bridge_reconnect_turn_state` reverted to `main` behaviour (offer unless owner rebind) → 4 failed (`replacement_account_receives_none`, `replacement_account_receives_no_codex_session_anchor`, `reconnect[replacement_account]`, soft-row integration test with `owner_turn_state_token` leaked into the alternate's handshake); all 4 same-account shapes pass.

Gates at HEAD: `ruff check` + `ruff format --check` clean; `scripts/check_proxy_architecture.py` pass (`service.py` untouched at 2600/2600, `http_bridge/mixin.py` 2427/2436 — new code lives in `helpers.py` / `accepted_replay.py` / `support.py`); `scripts/check_cancellation_safety.py` pass; `scripts/check_proxy_timing_seams.py` pass; `openspec validate keep-accepted-bridge-replay-on-hard-owner --strict` valid. `codex review --base origin/main`: "No actionable regressions were found".

## Known limitations

Verifier P3 advisories (neither refutes the fix):

- **Residual pre-existing loop for shapes left at main parity.** The created-only (pre-created) bridge replay and the model-fallback replay on a hard key whose affinity resolves a raw legacy `CODEX_SESSION` owner still exclude that owner and spin on `hard_affinity_saturated` (2s/attempt) until the 7200s budget, exactly as on `main`. The loop cap was deliberately not added (see above); tracked as a follow-up.
- **Scope of the turn-state handshake change (`d3b317f04`).** `_http_bridge_reconnect_turn_state` applies to *every* cross-account bridge reconnect, not only the new unexcluded accepted replay: pre-existing unexcluded moves on `main` (soft-key `skip_same_account` closes, soft-row fallback) previously carried the retired account's `x-codex-turn-state` into the handshake and cleared it only post-connect; they now open without it. Same predicate as the existing post-connect cleanup and consistent with the `responses-api-compat` requirement, so main-parity-or-better, but it is a generalized change the owner should consciously accept.
- Predicate over-approximation, not a defect: `_AffinityPolicy(kind=CODEX_SESSION)` with `key=None` (owner-bound full-resend) is treated as hard-capable so the replay prefers the same owner instead of excluding it — identical to the WS-side decision; falls back through selection when the owner is unselectable.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local gates (ruff, proxy architecture / cancellation-safety / timing-seam checks, targeted pytest suites).
- [x] If touching specs: `openspec validate --specs` passes; the new change validates `--strict`.
- [x] Simplicity gates reviewed: no new setting, README section, dashboard item, or default change.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP bridge recovery for accepted, output-free requests using hard session affinity.
  - Replays can now reconnect to the same account owner instead of being unnecessarily excluded from selection.
  - Prevented stale connection state from being carried across reconnects to a different account.
  - Preserved existing exclusion behavior for soft affinity, created-only sessions, and model-fallback replays.
  - Improved consistency between HTTP bridge and WebSocket affinity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->