### PR TITLE
chore: release v1.25.0-beta.5

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.4"  # x-release-please-version
+__version__ = "1.25.0-beta.5"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.4
-appVersion: 1.25.0-beta.4
+version: 1.25.0-beta.5
+appVersion: 1.25.0-beta.5
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.4",
+  "version": "1.25.0-beta.5",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.4"
+version = "1.25.0-beta.5"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0b4"
+version = "1.25.0-beta.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.5 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.5 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.4
- fix(http-bridge): keep accepted output-free replays on a hard sticky owner instead of excluding it (#2150) (
ae330b)
- fix(balancer): isolate sustained-overload accounts and weight selection by error rate (#2166) (
3de4be)

## Release-candidate validation
Validated candidate: 28a171ceb420716ff819751264c710a53076fccc

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run https://github.com/Soju06/codex-lb/actions/runs/34194600584 on 28a171ceb420716ff819751264c710a53076fccc: unit, integration-core-1/2/3, integration-bridge, PostgreSQL, Rust workspace, ruff, ty, OpenSpec validation green. Candidate = main 3de4be2aa (#2150 hard-owner replay fix, #2166 overload isolation + error-rate weighting) + version bump only. The Playwright dashboard smoke failed once on a layout width assertion unrelated to this train (no frontend changes since beta.4 besides the version bump; the identical tree passed on main 3de4be2aa) and was re-run.
- [x] Frontend tests/build — same CI run: frontend lint / tsc / vitest+coverage / vite build green (version bump touches frontend/package.json so they ran).
- [x] Wheel/package validation — same CI run `Package (build)` green; locally on 28a171ceb: `uv build` → `codex_lb-1.25.0b5-py3-none-any.whl`, installed into a fresh Python 3.14 venv, `import app; app.__version__ == "1.25.0-beta.5"` (frontend assets are produced by the CI build, absent from the local wheel as expected).
- [x] Docker/container smoke — local `docker build` of 28a171ceb, booted with the default SQLite database: schema current at startup, `/health/ready` 200 within ~20 s with bridge ring membership, `/health/live` 200, `GET /v1/models` without key → 401 contract, `app.__version__` 1.25.0-beta.5 inside the container, both routing modules importable (`overload_backoff.sticky_owner_isolation_reroute_pool`, `error_rate.error_rate_weight_multiplier`), zero error/traceback log lines.
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — production rollout uses `zdt-deploy.sh` blue/green with a 180 s observation window and automatic rollback; the standby color remains as the rollback vehicle. Both new behaviors have env kill switches (`CODEX_LB_PROXY_OVERLOAD_ISOLATION_SECONDS=0`, `CODEX_LB_PROXY_ACCOUNT_ERROR_RATE_WEIGHTING_ENABLED=false`).

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b5" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.5
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.5 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

