### PR TITLE
refactor(egress): move compact Responses SSE framing into Rust

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -118,7 +118,7 @@ class _PreparedNativeRequest:
     url: str
     headers: dict[str, str]
     body: bytes | None
-    timeout_seconds: float
+    timeout_seconds: float | None
     connect_timeout_seconds: float | None
     response_head_timeout_seconds: float | None
 
@@ -646,11 +646,10 @@ def _prepare_native_request(
     else:
         return None
 
-    timeout_seconds, connect_timeout_seconds, response_head_timeout_seconds = _native_timeout_parts(
-        kwargs.get("timeout")
-    )
-    if timeout_seconds is None:
+    timeouts = _native_timeout_parts(kwargs.get("timeout"))
+    if timeouts is None:
         return None
+    timeout_seconds, connect_timeout_seconds, response_head_timeout_seconds = timeouts
     return _PreparedNativeRequest(
         url=url,
         headers=headers,
@@ -661,22 +660,22 @@ def _prepare_native_request(
     )
 
 
-def _native_timeout_parts(value: Any) -> tuple[float | None, float | None, float | None]:
+def _native_timeout_parts(value: Any) -> tuple[float | None, float | None, float | None] | None:
     if value is None:
         return 60.0, None, None
     if isinstance(value, aiohttp.ClientTimeout):
-        total = float(value.total) if value.total is not None else 60.0
+        total = float(value.total) if value.total is not None else None
         connect = float(value.sock_connect) if value.sock_connect is not None else None
         response_head = float(value.sock_read) if value.sock_read is not None else None
     else:
         try:
             total = float(value)
         except (TypeError, ValueError):
-            return None, None, None
+            return None
         connect = None
         response_head = None
-    if total <= 0 or (connect is not None and connect <= 0) or (response_head is not None and response_head <= 0):
-        return None, None, None
+    if any(part is not None and part <= 0 for part in (total, connect, response_head)):
+        return None
     return total, connect, response_head
 
 

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -29,6 +29,7 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
         "failure_provenance_v1",
         "http",
         "http2_profile_v1",
+        "http_compact_sse_v1",
         "http_sse_v1",
         "websocket",
         "websocket_send_ack",
@@ -80,6 +81,7 @@ class NativeEgressTransportError(NativeEgressError):
 class NativeSseOptions:
     idle_timeout_seconds: float
     max_event_bytes: int
+    content_type_aware: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,7 +90,7 @@ class NativeEgressRequest:
     url: str
     headers: Mapping[str, str]
     body: bytes | None = None
-    timeout_seconds: float = 60.0
+    timeout_seconds: float | None = 60.0
     connect_timeout_seconds: float | None = None
     response_head_timeout_seconds: float | None = None
     proxy_url: str | None = None
@@ -562,7 +564,7 @@ class SubprocessNativeEgressClient:
     async def request(self, request: NativeEgressRequest) -> NativeEgressResponse:
         if not self.available:
             raise NativeEgressUnavailable(f"native egress helper is unavailable: {self.executable}")
-        if request.timeout_seconds <= 0:
+        if request.timeout_seconds is not None and request.timeout_seconds <= 0:
             raise ValueError("native egress timeout_seconds must be positive")
         if request.connect_timeout_seconds is not None and request.connect_timeout_seconds <= 0:
             raise ValueError("native egress connect_timeout_seconds must be positive")
@@ -586,7 +588,9 @@ class SubprocessNativeEgressClient:
             "url": request.url,
             "headers": list(request.headers.items()),
             "body": base64.b64encode(request.body).decode("ascii") if request.body is not None else None,
-            "timeout_ms": max(1, round(request.timeout_seconds * 1000)),
+            "timeout_ms": (
+                max(1, round(request.timeout_seconds * 1000)) if request.timeout_seconds is not None else None
+            ),
             "connect_timeout_ms": (
                 max(1, round(request.connect_timeout_seconds * 1000))
                 if request.connect_timeout_seconds is not None
@@ -597,6 +601,7 @@ class SubprocessNativeEgressClient:
                 {
                     "idle_timeout_ms": max(1, round(request.sse.idle_timeout_seconds * 1000)),
                     "max_event_bytes": request.sse.max_event_bytes,
+                    "content_type_aware": request.sse.content_type_aware,
                 }
                 if request.sse is not None
                 else None
@@ -605,7 +610,9 @@ class SubprocessNativeEgressClient:
         try:
             await self._send_command(process, generation, request_event)
             head_timeout = request.response_head_timeout_seconds or request.timeout_seconds
-            item = await asyncio.wait_for(events.get(), timeout=min(head_timeout, request.timeout_seconds))
+            if request.timeout_seconds is not None and head_timeout is not None:
+                head_timeout = min(head_timeout, request.timeout_seconds)
+            item = await asyncio.wait_for(events.get(), timeout=head_timeout)
             if isinstance(item, BaseException):
                 self._finish_request(request_id, generation, events)
                 raise item
@@ -621,14 +628,32 @@ class SubprocessNativeEgressClient:
             if not isinstance(status, int) or not isinstance(http_version, str) or not isinstance(raw_headers, list):
                 raise NativeEgressProtocolError("native response head has an invalid shape")
             headers = tuple(_decode_header_pair(pair) for pair in raw_headers)
+            content_type = next((value for name, value in headers if name.lower() == "content-type"), "")
+            sse_framed = (
+                request.sse is not None
+                and status < 400
+                and (
+                    not request.sse.content_type_aware
+                    or not content_type
+                    or "text/event-stream" in content_type.lower()
+                )
+            )
         except TimeoutError as exc:
-            await self._cancel_request(request_id, generation, events)
+            cancellation = await _await_cleanup_deferring_cancellation(
+                self._cancel_request(request_id, generation, events)
+            )
+            if cancellation is not None:
+                raise cancellation
             raise NativeEgressTransportError(
                 "native upstream response head timed out",
                 failure_phase="timeout",
             ) from exc
         except BaseException:
-            await self._cancel_request(request_id, generation, events)
+            cancellation = await _await_cleanup_deferring_cancellation(
+                self._cancel_request(request_id, generation, events)
+            )
+            if cancellation is not None:
+                raise cancellation
             raise
 
         return NativeEgressResponse(
@@ -639,7 +664,7 @@ class SubprocessNativeEgressClient:
             request_id=request_id,
             generation=generation,
             events=events,
-            sse_framed=request.sse is not None and status < 400,
+            sse_framed=sse_framed,
         )
 
     async def websocket(self, request: NativeWebSocketRequest) -> NativeEgressWebSocket:

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -635,7 +635,7 @@ class SubprocessNativeEgressClient:
                 and (
                     not request.sse.content_type_aware
                     or not content_type
-                    or "text/event-stream" in content_type.lower()
+                    or content_type.partition(";")[0].strip().lower() == "text/event-stream"
                 )
             )
         except TimeoutError as exc:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -551,6 +551,9 @@ class _CodexSSEResponse:
         del content_type
         return cast(JsonValue, await _codex_response_json(self._response))
 
+    async def read(self) -> bytes:
+        return await _codex_response_body(self._response)
+
     async def text(self, *, encoding: str | None = None, errors: str = "strict") -> str:
         del encoding, errors
         return await _codex_response_text(self._response)
@@ -1518,40 +1521,41 @@ async def _compact_response_payload_from_sse(
     last_payload: dict[str, JsonValue] | None = None
     output_items: dict[int, dict[str, JsonValue]] = {}
     unindexed_output_items: list[dict[str, JsonValue]] = []
-    async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
-        payload = parse_sse_data_json(event_block)
-        if payload is None:
-            continue
-        last_payload = payload
-        event_type = payload.get("type")
-        if event_type in {"response.output_item.added", "response.output_item.done"}:
-            output_index = payload.get("output_index")
-            item = payload.get("item")
-            if not isinstance(item, dict):
+    async with contextlib.aclosing(_iter_sse_events(resp, idle_timeout_seconds, max_event_bytes)) as events:
+        async for event_block in events:
+            payload = parse_sse_data_json(event_block)
+            if payload is None:
                 continue
-            if isinstance(output_index, int):
-                output_items[output_index] = dict(item)
-            elif event_type == "response.output_item.done":
-                # Some compatible upstream responses omit output_index on the
-                # terminal item even though response.completed has no output.
-                unindexed_output_items.append(dict(item))
-        if event_type == "response.completed":
-            response = payload.get("response")
-            if isinstance(response, dict):
-                existing_output = response.get("output")
-                if (output_items or unindexed_output_items) and not (
-                    isinstance(existing_output, list) and existing_output
-                ):
-                    merged_response = dict(response)
-                    merged_response["output"] = [
-                        *[item for _, item in sorted(output_items.items())],
-                        *unindexed_output_items,
-                    ]
-                    return merged_response
-                return response
-            raise ValueError("response.completed event missing response object")
-        if event_type in {"response.failed", "response.incomplete", "error"}:
-            raise _proxy_response_error_from_compact_sse_terminal(payload, event_type)
+            last_payload = payload
+            event_type = payload.get("type")
+            if event_type in {"response.output_item.added", "response.output_item.done"}:
+                output_index = payload.get("output_index")
+                item = payload.get("item")
+                if not isinstance(item, dict):
+                    continue
+                if isinstance(output_index, int):
+                    output_items[output_index] = dict(item)
+                elif event_type == "response.output_item.done":
+                    # Some compatible upstream responses omit output_index on the
+                    # terminal item even though response.completed has no output.
+                    unindexed_output_items.append(dict(item))
+            if event_type == "response.completed":
+                response = payload.get("response")
+                if isinstance(response, dict):
+                    existing_output = response.get("output")
+                    if (output_items or unindexed_output_items) and not (
+                        isinstance(existing_output, list) and existing_output
+                    ):
+                        merged_response = dict(response)
+                        merged_response["output"] = [
+                            *[item for _, item in sorted(output_items.items())],
+                            *unindexed_output_items,
+                        ]
+                        return merged_response
+                    return response
+                raise ValueError("response.completed event missing response object")
+            if event_type in {"response.failed", "response.incomplete", "error"}:
+                raise _proxy_response_error_from_compact_sse_terminal(payload, event_type)
     if last_payload is not None:
         raise ValueError("upstream SSE ended before response.completed")
     raise ValueError("empty upstream SSE response")
@@ -4824,121 +4828,99 @@ class _CompactCommandTransport:
             url=url,
             headers=upstream_headers,
         )
-        try:
-            if self.route is not None:
-                owns_codex_client = self.codex_client is None
-                active_codex_client = self.codex_client or CodexClient(create_codex_session())
-                request_kwargs: dict[str, Any] = {"json": payload_dict, "headers": upstream_headers}
-                if compact_timeout_seconds is not None:
-                    request_kwargs["timeout"] = compact_timeout_seconds
+        sse_options = NativeSseOptions(
+            compact_timeout_seconds or settings.stream_idle_timeout_seconds,
+            settings.max_sse_event_bytes,
+            content_type_aware=True,
+        )
+
+        @asynccontextmanager
+        async def _direct_response_context() -> AsyncIterator[aiohttp.ClientResponse | NativeEgressResponse]:
+            native_client = discover_native_egress_client()
+            if native_client is not None:
                 try:
-                    request_with_metadata = getattr(active_codex_client, "request_with_route_metadata", None)
-                    if callable(request_with_metadata):
-                        result = await request_with_metadata("POST", url, route=self.route, **request_kwargs)
-                        resp = result.response
-                        if self.route_trace is not None:
-                            self.route_trace.record(route=result.route, fallback_used=result.fallback_used)
-                    else:
-                        resp = await active_codex_client.request("POST", url, route=self.route, **request_kwargs)
-                        if self.route_trace is not None:
-                            self.route_trace.record(route=self.route, fallback_used=False)
+                    native_response = await native_client.request(
+                        NativeEgressRequest(
+                            method="POST",
+                            url=url,
+                            headers=upstream_headers,
+                            body=json.dumps(payload_dict, ensure_ascii=True, separators=(",", ":")).encode("utf-8"),
+                            timeout_seconds=compact_timeout_seconds,
+                            connect_timeout_seconds=effective_connect_timeout,
+                            response_head_timeout_seconds=compact_timeout_seconds,
+                            proxy_url=resolve_http_proxy_from_env(url),
+                            sse=sse_options,
+                        )
+                    )
+                except NativeEgressUnavailable:
+                    pass
+                else:
+                    async with native_response:
+                        yield native_response
+                    return
+            async with self.session.post(
+                url, json=payload_dict, headers=upstream_headers, timeout=timeout
+            ) as python_response:
+                yield python_response
+
+        @asynccontextmanager
+        async def _response_context() -> AsyncIterator[
+            aiohttp.ClientResponse | NativeEgressResponse | _CodexSSEResponse
+        ]:
+            if self.route is None:
+                async with _service_circuit_breaker_context(
+                    cast(AsyncContextManager[aiohttp.ClientResponse], _direct_response_context()),
+                    settings=settings,
+                    account_id=self.account_id,
+                ) as response:
+                    yield response
+                return
+            owns_codex_client = self.codex_client is None
+            active_codex_client = self.codex_client or CodexClient(create_codex_session())
+            raw_response: Any = None
+            try:
+                request_kwargs: dict[str, Any] = {
+                    "json": payload_dict,
+                    "headers": upstream_headers,
+                    "timeout": timeout,
+                    "buffer_response": False,
+                    "native_sse": sse_options,
+                }
+                request_with_metadata = getattr(active_codex_client, "request_with_route_metadata", None)
+                if callable(request_with_metadata):
+                    result = await request_with_metadata("POST", url, route=self.route, **request_kwargs)
+                    raw_response = result.response
+                    if self.route_trace is not None:
+                        self.route_trace.record(route=result.route, fallback_used=result.fallback_used)
+                else:
+                    raw_response = await active_codex_client.request("POST", url, route=self.route, **request_kwargs)
+                    if self.route_trace is not None:
+                        self.route_trace.record(route=self.route, fallback_used=False)
+                yield (
+                    raw_response if isinstance(raw_response, NativeEgressResponse) else _CodexSSEResponse(raw_response)
+                )
+            finally:
+                try:
+                    if raw_response is not None:
+                        cancellation = await _await_cleanup_deferring_cancellation(release_codex_response(raw_response))
+                        if cancellation is not None:
+                            raise cancellation
                 finally:
                     if owns_codex_client:
-                        await active_codex_client.close()
-                status_code = _codex_response_status(resp)
-                if status_code >= 400:
-                    error_payload = await _codex_error_payload_from_response(resp)
-                    archive_json(
-                        direction="server_to_codex",
-                        kind="compact",
-                        transport="http",
-                        payload=error_payload,
-                        account_id=self.account_id,
-                        method="POST",
-                        url=url,
-                        status_code=status_code,
-                        headers=upstream_headers,
-                    )
-                    error_code, error_message = _error_details_from_envelope(error_payload)
-                    failure_phase = "status"
-                    failure_detail = error_message
-                    retryable_same_contract = False
-                    raise ProxyResponseError(
-                        status_code,
-                        error_payload,
-                        failure_phase=failure_phase,
-                        retryable_same_contract=retryable_same_contract,
-                        failure_detail=failure_detail,
-                        upstream_status_code=status_code,
-                    )
-                try:
-                    data = await _compact_response_payload_from_success_response(
-                        _CodexSSEResponse(resp),
-                        idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
-                        max_event_bytes=settings.max_sse_event_bytes,
-                    )
-                except (StreamIdleTimeoutError, StreamEventTooLargeError) as exc:
-                    raise _proxy_response_error_from_compact_sse_stream_exception(
-                        exc,
-                        upstream_status_code=status_code,
-                    ) from exc
-                except ProxyResponseError:
-                    raise
-                except Exception as exc:
-                    error_code = "upstream_error"
-                    error_message = "Invalid JSON from upstream"
-                    failure_phase = "parse"
-                    failure_detail = str(exc) or error_message
-                    failure_exception_type = type(exc).__name__
-                    raise ProxyResponseError(
-                        502,
-                        openai_error("upstream_error", "Invalid JSON from upstream"),
-                        failure_phase=failure_phase,
-                        failure_detail=failure_detail,
-                        failure_exception_type=failure_exception_type,
-                        upstream_status_code=status_code,
-                    ) from exc
-                raw_data = data
-                data = _normalize_compact_response_payload_shape(data)
-                parsed = parse_compact_response_payload(data)
-                archive_json(
-                    direction="server_to_codex",
-                    kind="compact",
-                    transport="http",
-                    payload=raw_data,
-                    account_id=self.account_id,
-                    method="POST",
-                    url=url,
-                    status_code=status_code,
-                    headers=upstream_headers,
-                )
-                if parsed:
-                    payload_object = parsed.object
-                    return parsed
-                error_code = "upstream_error"
-                error_message = "Unexpected upstream payload"
-                failure_phase = "parse"
-                failure_detail = f"payload_type={type(data).__name__}"
-                raise ProxyResponseError(
-                    502,
-                    openai_error("upstream_error", "Unexpected upstream payload"),
-                    failure_phase=failure_phase,
-                    failure_detail=failure_detail,
-                    upstream_status_code=status_code,
-                )
-            async with _service_circuit_breaker_context(
-                self.session.post(
-                    url,
-                    json=payload_dict,
-                    headers=upstream_headers,
-                    timeout=timeout,
-                ),
-                settings=settings,
-                account_id=self.account_id,
-            ) as resp:
+                        cancellation = await _await_cleanup_deferring_cancellation(active_codex_client.close())
+                        if cancellation is not None:
+                            raise cancellation
+
+        try:
+            async with _response_context() as resp:
                 status_code = resp.status
                 if resp.status >= 400:
-                    error_payload = await _error_payload_from_response(resp)
+                    if self.route is not None:
+                        error_payload = await _codex_error_payload_from_response(resp)
+                    elif isinstance(resp, NativeEgressResponse):
+                        error_payload = await _error_payload_from_raw_body(cast(ErrorResponse, resp), await resp.read())
+                    else:
+                        error_payload = await _error_payload_from_response(cast(ErrorResponse, resp))
                     archive_json(
                         direction="server_to_codex",
                         kind="compact",
@@ -4995,7 +4977,7 @@ class _CompactCommandTransport:
                         exc,
                         upstream_status_code=resp.status,
                     ) from exc
-                except ProxyResponseError:
+                except (ProxyResponseError, NativeEgressError):
                     raise
                 except Exception as exc:
                     error_code = "upstream_error"
@@ -5062,6 +5044,39 @@ class _CompactCommandTransport:
                 retryable_same_contract=retryable_same_contract,
                 failure_detail=failure_detail,
                 failure_exception_type=failure_exception_type,
+            ) from exc
+        except NativeEgressError as exc:
+            transport_error = exc if isinstance(exc, NativeEgressTransportError) else None
+            failure_phase = (
+                "body_read"
+                if status_code is not None
+                else (transport_error.failure_phase if transport_error is not None else "protocol")
+            )
+            retryable_same_contract = bool(
+                status_code is None
+                and transport_error is not None
+                and transport_error.retryable_same_contract
+                and not transport_error.is_tls_verification_failure
+            )
+            process_failure = transport_error is not None and transport_error.failure_phase in {
+                "helper_exit",
+                "helper_read",
+                "helper_write",
+                "shutdown",
+            }
+            error_code = PROCESS_NETWORK_UNAVAILABLE_CODE if process_failure else "upstream_unavailable"
+            error_message = "Native compact upstream request failed"
+            failure_detail = "native_transport_error"
+            failure_exception_type = type(exc).__name__
+            raise ProxyResponseError(
+                502,
+                openai_error(error_code, error_message),
+                failure_phase=failure_phase,
+                retryable_same_contract=retryable_same_contract,
+                failure_detail=failure_detail,
+                failure_exception_type=failure_exception_type,
+                upstream_status_code=status_code,
+                failed_session=None,
             ) from exc
         except CodexTransportError as exc:
             error_code = exc.error_code or "upstream_unavailable"

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -548,8 +548,7 @@ class _CodexSSEResponse:
         self.content = _CodexSSEContent(response)
 
     async def json(self, *, content_type: str | None = None) -> JsonValue:
-        del content_type
-        return cast(JsonValue, await _codex_response_json(self._response))
+        return cast(JsonValue, await _codex_response_json(self._response, content_type=content_type))
 
     async def read(self) -> bytes:
         return await _codex_response_body(self._response)
@@ -1570,11 +1569,11 @@ async def _compact_response_payload_from_success_response(
     headers = _codex_response_headers(resp)
     content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
     content = getattr(resp, "content", None)
-    if "text/event-stream" in content_type.lower() or (
+    if content_type.partition(";")[0].strip().lower() == "text/event-stream" or (
         not content_type and callable(getattr(content, "iter_chunked", None))
     ):
         return await _compact_response_payload_from_sse(cast(SSEResponse, resp), idle_timeout_seconds, max_event_bytes)
-    return await _codex_response_json(resp)
+    return await _codex_response_json(resp, content_type=None)
 
 
 def _normalize_compact_response_payload_shape(payload: JsonValue) -> JsonValue:
@@ -5184,7 +5183,9 @@ def _codex_response_status(response: Any) -> int:
     return int(value)
 
 
-async def _codex_response_json(response: Any) -> Any:
+async def _codex_response_json(response: Any, *, content_type: str | None = "application/json") -> Any:
+    if isinstance(response, (aiohttp.ClientResponse, _CodexSSEResponse)):
+        return await response.json(content_type=content_type)
     json_method = getattr(response, "json", None)
     if callable(json_method):
         result = json_method()

--- a/crates/codex-lb-egress-worker/tests/http_protocol.rs
+++ b/crates/codex-lb-egress-worker/tests/http_protocol.rs
@@ -107,13 +107,18 @@ fn sse_request(
     })
 }
 
-async fn stop_helper(mut helper: Child, stdin: ChildStdin) {
+async fn stop_helper(mut helper: Child, stdin: ChildStdin, mut lines: HelperLines) {
     drop(stdin);
     let exit = tokio::time::timeout(Duration::from_secs(2), helper.wait())
         .await
         .expect("helper exit timeout")
         .expect("wait for helper");
     assert!(exit.success(), "native helper must exit cleanly");
+    let extra = lines.next_line().await.expect("drain helper output");
+    assert!(
+        extra.is_none(),
+        "duplicate terminal after stdin EOF: {extra:?}"
+    );
 }
 
 fn header_values(request: &str, expected_name: &str) -> Vec<String> {
@@ -386,7 +391,7 @@ async fn successful_sse_response_emits_utf8_safe_fragments_and_end() {
     assert!(fragment_count > 1);
     assert_eq!(reconstructed.as_bytes(), expected_body);
     server.await.expect("origin task");
-    stop_helper(helper, stdin).await;
+    stop_helper(helper, stdin, lines).await;
 }
 
 #[tokio::test]
@@ -450,14 +455,7 @@ async fn oversized_sse_event_is_typed_terminal_after_valid_prefix() {
     ));
 
     server.await.expect("origin task");
-    stop_helper(helper, stdin).await;
-    assert!(
-        lines
-            .next_line()
-            .await
-            .expect("drain helper output")
-            .is_none()
-    );
+    stop_helper(helper, stdin, lines).await;
 }
 
 #[tokio::test]
@@ -497,15 +495,8 @@ async fn sse_body_idle_timeout_has_distinct_failure_phase() {
         } if request_id == "idle-sse" && failure_phase == "stream_idle_timeout"
     ));
 
+    stop_helper(helper, stdin, lines).await;
     server.await.expect("origin task");
-    stop_helper(helper, stdin).await;
-    assert!(
-        lines
-            .next_line()
-            .await
-            .expect("drain helper output")
-            .is_none()
-    );
 }
 
 #[tokio::test]
@@ -559,5 +550,5 @@ async fn http_error_with_sse_options_preserves_raw_body_chunks() {
     assert_eq!(received, body);
 
     server.await.expect("origin task");
-    stop_helper(helper, stdin).await;
+    stop_helper(helper, stdin, lines).await;
 }

--- a/crates/codex-lb-egress-worker/tests/http_protocol.rs
+++ b/crates/codex-lb-egress-worker/tests/http_protocol.rs
@@ -96,12 +96,13 @@ fn sse_request(
         url,
         headers: vec![("accept".to_owned(), "text/event-stream".to_owned())],
         body: None,
-        timeout_ms: 2_000,
+        timeout_ms: Some(2_000),
         connect_timeout_ms: Some(2_000),
         proxy_url: None,
         sse: Some(NativeSseOptions {
             idle_timeout_ms,
             max_event_bytes,
+            content_type_aware: false,
         }),
     })
 }
@@ -164,7 +165,7 @@ async fn gzip_response_relay_crosses_native_helper_boundary() {
             url: format!("http://{address}/response"),
             headers: vec![("accept-encoding".to_owned(), "br, zstd, gzip".to_owned())],
             body: None,
-            timeout_ms: 2_000,
+            timeout_ms: Some(2_000),
             connect_timeout_ms: Some(2_000),
             proxy_url: None,
             sse: None,
@@ -272,7 +273,7 @@ async fn request_without_accept_encoding_reaches_origin_without_accept_encoding(
             url: format!("http://{address}/response"),
             headers: vec![("accept".to_owned(), "application/json".to_owned())],
             body: None,
-            timeout_ms: 2_000,
+            timeout_ms: Some(2_000),
             connect_timeout_ms: Some(2_000),
             proxy_url: None,
             sse: None,

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -74,10 +74,10 @@ pub(crate) async fn execute_request(
     let sse = request.sse;
     let method = reqwest::Method::from_bytes(request.method.as_bytes())?;
     let headers = forwarded_headers(request.headers)?;
-    let mut builder = client
-        .request(method, request.url)
-        .headers(headers)
-        .timeout(Duration::from_millis(request.timeout_ms));
+    let mut builder = client.request(method, request.url).headers(headers);
+    if let Some(timeout_ms) = request.timeout_ms {
+        builder = builder.timeout(Duration::from_millis(timeout_ms));
+    }
     if let Some(encoded_body) = request.body {
         builder = builder.body(base64::engine::general_purpose::STANDARD.decode(encoded_body)?);
     }
@@ -105,7 +105,19 @@ pub(crate) async fn execute_request(
     )
     .await?;
 
-    if let Some(options) = sse.filter(|_| status < 400) {
+    if let Some(options) = sse.filter(|options| {
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .map(|value| String::from_utf8_lossy(value.as_bytes()))
+            .unwrap_or_default();
+        status < 400
+            && (!options.content_type_aware
+                || content_type.is_empty()
+                || content_type
+                    .to_ascii_lowercase()
+                    .contains("text/event-stream"))
+    }) {
         if !execute_sse_body(&mut response, &request.request_id, options, output).await? {
             return Ok(());
         }

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -114,9 +114,9 @@ pub(crate) async fn execute_request(
         status < 400
             && (!options.content_type_aware
                 || content_type.is_empty()
-                || content_type
-                    .to_ascii_lowercase()
-                    .contains("text/event-stream"))
+                || content_type.split(';').next().is_some_and(|media_type| {
+                    media_type.trim().eq_ignore_ascii_case("text/event-stream")
+                }))
     }) {
         if let Some(error) =
             execute_sse_body(&mut response, &request.request_id, options, output).await?

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -70,7 +70,7 @@ pub(crate) async fn execute_request(
     request: NativeRequest,
     client: reqwest::Client,
     output: &Output,
-) -> Result<(), RequestError> {
+) -> Result<NativeEvent, RequestError> {
     let sse = request.sse;
     let method = reqwest::Method::from_bytes(request.method.as_bytes())?;
     let headers = forwarded_headers(request.headers)?;
@@ -118,8 +118,14 @@ pub(crate) async fn execute_request(
                     .to_ascii_lowercase()
                     .contains("text/event-stream"))
     }) {
-        if !execute_sse_body(&mut response, &request.request_id, options, output).await? {
-            return Ok(());
+        if let Some(error) =
+            execute_sse_body(&mut response, &request.request_id, options, output).await?
+        {
+            return Ok(NativeEvent::SseEventTooLarge {
+                request_id: request.request_id,
+                size_bytes: error.size_bytes,
+                limit_bytes: error.limit_bytes,
+            });
         }
     } else {
         while let Some(chunk) = response.chunk().await? {
@@ -133,14 +139,9 @@ pub(crate) async fn execute_request(
             .await?;
         }
     }
-    emit(
-        output,
-        &NativeEvent::End {
-            request_id: request.request_id,
-        },
-    )
-    .await?;
-    Ok(())
+    Ok(NativeEvent::End {
+        request_id: request.request_id,
+    })
 }
 
 async fn execute_sse_body(
@@ -148,7 +149,7 @@ async fn execute_sse_body(
     request_id: &str,
     options: NativeSseOptions,
     output: &Output,
-) -> Result<bool, RequestError> {
+) -> Result<Option<SseEventTooLarge>, RequestError> {
     let idle_timeout = Duration::from_millis(options.idle_timeout_ms);
     let mut framer = SseFramer::new(options.max_event_bytes);
     loop {
@@ -160,35 +161,29 @@ async fn execute_sse_body(
         };
         for read in chunk.chunks(SSE_READ_CHUNK_SIZE) {
             framer.push(read);
-            if !emit_available_sse_events(&mut framer, request_id, output).await? {
-                return Ok(false);
+            if let Some(error) = emit_available_sse_events(&mut framer, request_id, output).await? {
+                return Ok(Some(error));
             }
         }
     }
     match framer.finish() {
         Ok(Some(text)) => emit_sse(output, request_id, &text).await?,
         Ok(None) => {}
-        Err(error) => {
-            emit_sse_too_large(output, request_id, error).await?;
-            return Ok(false);
-        }
+        Err(error) => return Ok(Some(error)),
     }
-    Ok(true)
+    Ok(None)
 }
 
 async fn emit_available_sse_events(
     framer: &mut SseFramer,
     request_id: &str,
     output: &Output,
-) -> Result<bool, std::io::Error> {
+) -> Result<Option<SseEventTooLarge>, std::io::Error> {
     loop {
         match framer.next_event() {
             Ok(Some(text)) => emit_sse(output, request_id, &text).await?,
-            Ok(None) => return Ok(true),
-            Err(error) => {
-                emit_sse_too_large(output, request_id, error).await?;
-                return Ok(false);
-            }
+            Ok(None) => return Ok(None),
+            Err(error) => return Ok(Some(error)),
         }
     }
 }
@@ -206,22 +201,6 @@ async fn emit_sse(output: &Output, request_id: &str, text: &str) -> Result<(), s
         .await?;
     }
     Ok(())
-}
-
-async fn emit_sse_too_large(
-    output: &Output,
-    request_id: &str,
-    error: SseEventTooLarge,
-) -> Result<(), std::io::Error> {
-    emit(
-        output,
-        &NativeEvent::SseEventTooLarge {
-            request_id: request_id.to_owned(),
-            size_bytes: error.size_bytes,
-            limit_bytes: error.limit_bytes,
-        },
-    )
-    .await
 }
 
 fn forwarded_headers(request_headers: Vec<(String, String)>) -> Result<HeaderMap, RequestError> {

--- a/crates/codex-lb-egress/src/runtime.rs
+++ b/crates/codex-lb-egress/src/runtime.rs
@@ -134,21 +134,27 @@ pub async fn run_stdio() -> Result<(), RequestError> {
                         let task_active = active.clone();
                         tasks.spawn(async move {
                             tokio::select! {
-                                // An already completed HTTP exchange wins an EOF/cancel
-                                // race, so its terminal event is not followed by Cancelled.
+                                // Prefer a completed exchange, and emit its terminal outside
+                                // the cancellable future: stdout flush can yield after the
+                                // parent sees the terminal and closes stdin.
                                 biased;
                                 result = execute_request(request, client, &task_output) => {
-                                    if let Err(error) = result {
-                                        let (message, phase, retryable, tls_verification) =
-                                            classify_error(error.as_ref());
-                                        let _ = emit_error(
-                                            &task_output,
-                                            &request_id,
-                                            message,
-                                            phase,
-                                            retryable,
-                                            tls_verification,
-                                        ).await;
+                                    match result {
+                                        Ok(terminal) => {
+                                            let _ = emit(&task_output, &terminal).await;
+                                        }
+                                        Err(error) => {
+                                            let (message, phase, retryable, tls_verification) =
+                                                classify_error(error.as_ref());
+                                            let _ = emit_error(
+                                                &task_output,
+                                                &request_id,
+                                                message,
+                                                phase,
+                                                retryable,
+                                                tls_verification,
+                                            ).await;
+                                        }
                                     }
                                 }
                                 _ = cancel_rx => {

--- a/crates/codex-lb-egress/src/runtime.rs
+++ b/crates/codex-lb-egress/src/runtime.rs
@@ -85,7 +85,7 @@ pub async fn run_stdio() -> Result<(), RequestError> {
                             ).await?;
                             continue;
                         }
-                        if request.timeout_ms == 0
+                        if request.timeout_ms == Some(0)
                             || request.connect_timeout_ms == Some(0)
                             || request.sse.is_some_and(|options| {
                                 options.idle_timeout_ms == 0 || options.max_event_bytes == 0
@@ -134,6 +134,9 @@ pub async fn run_stdio() -> Result<(), RequestError> {
                         let task_active = active.clone();
                         tasks.spawn(async move {
                             tokio::select! {
+                                // An already completed HTTP exchange wins an EOF/cancel
+                                // race, so its terminal event is not followed by Cancelled.
+                                biased;
                                 result = execute_request(request, client, &task_output) => {
                                     if let Err(error) = result {
                                         let (message, phase, retryable, tls_verification) =

--- a/crates/codex-lb-protocol/src/lib.rs
+++ b/crates/codex-lb-protocol/src/lib.rs
@@ -10,6 +10,7 @@ pub const CAPABILITIES: &[&str] = &[
     "failure_provenance_v1",
     "http",
     "http2_profile_v1",
+    "http_compact_sse_v1",
     "http_sse_v1",
     "websocket",
     "websocket_send_ack",
@@ -52,7 +53,7 @@ pub struct NativeRequest {
     pub url: String,
     pub headers: Vec<(String, String)>,
     pub body: Option<String>,
-    pub timeout_ms: u64,
+    pub timeout_ms: Option<u64>,
     pub connect_timeout_ms: Option<u64>,
     pub proxy_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,6 +64,8 @@ pub struct NativeRequest {
 pub struct NativeSseOptions {
     pub idle_timeout_ms: u64,
     pub max_event_bytes: usize,
+    #[serde(default)]
+    pub content_type_aware: bool,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
+++ b/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
@@ -11,6 +11,7 @@
       "failure_provenance_v1",
       "http",
       "http2_profile_v1",
+      "http_compact_sse_v1",
       "http_sse_v1",
       "websocket",
       "websocket_send_ack"

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -33,13 +33,21 @@ keeps the egress implementation usable from a future in-process Rust server;
 the transport will not need to be extracted from a subprocess executable when
 that migration reaches the application shell.
 
-Direct and account-routed streaming Responses requests delegate SSE byte framing to egress.
+Direct and account-routed streaming and compact Responses requests delegate SSE byte framing to egress.
 The adapter requires `http_sse_v1` and supplies the existing idle timeout and
 event byte limit as per-request options. Rust owns the deadline between body
 reads, including partial events; Python consumes framed text and retains event
 normalization, terminal detection, archives, and public error mapping. HTTP
-error bodies and non-streaming requests keep the raw chunk contract. Compact
-responses retain Python framing until their own cutover.
+error bodies and non-streaming requests keep the raw chunk contract.
+
+Compact requests additionally require `http_compact_sse_v1`. Their
+`content_type_aware` framing option preserves raw JSON success bodies, while
+`text/event-stream` and absent/empty Content-Type use native framing. Python
+still collects output items and returns the existing compact payload as soon
+as `response.completed` arrives, closing the request without waiting for HTTP
+EOF. A null total timeout stays unset; explicit total, connection, and SSE idle
+deadlines retain their meaning. The adapter and bundled helper must be updated
+together because an older helper cannot honor this contract.
 
 Routed requests carry typed `native_sse` options through `CodexClient` with
 `buffer_response=False`. Python selects each concrete endpoint and records
@@ -48,7 +56,10 @@ consumption. A confirmed pre-dispatch connect failure may use the next endpoint;
 body errors and cancellation cannot replay a dispatched POST. If the helper is
 unavailable before dispatch, the resolved Python transport uses ordinary byte
 framing, and receives no native-only option. A locally created routed client
-finishes closing its session even in an already cancelled scope.
+finishes closing its session even in an already cancelled scope. Compact
+responses likewise retain their transport and owned routed session through
+consumption, and finish cleanup on completion, failure, or cancellation,
+including cancellation before the native response headers arrive.
 
 SSE text crosses IPC in fragments of at most 16 KiB of UTF-8, with an explicit
 continuation flag. This keeps individual JSON lines and the existing bounded

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -42,7 +42,10 @@ error bodies and non-streaming requests keep the raw chunk contract.
 
 Compact requests additionally require `http_compact_sse_v1`. Their
 `content_type_aware` framing option preserves raw JSON success bodies, while
-`text/event-stream` and absent/empty Content-Type use native framing. Python
+the exact `text/event-stream` media type (ignoring parameters and case) and
+absent/empty Content-Type use native framing. Both Python compact paths apply
+the same comparison, so non-SSE types or parameters mentioning event-stream
+retain JSON parsing. Python
 still collects output items and returns the existing compact payload as soon
 as `response.completed` arrives, closing the request without waiting for HTTP
 EOF. A null total timeout stays unset; explicit total, connection, and SSE idle

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
@@ -1,0 +1,28 @@
+# Design
+
+Compact keeps its Python request/response policy but shares the native SSE
+framer used by ordinary Responses. A per-request `content_type_aware` option
+selects framing for successful responses whose Content-Type contains
+`text/event-stream` case-insensitively, or is absent/empty, matching the existing
+compact parser. Other success bodies and all HTTP errors remain raw bytes.
+The adapter derives the same mode from the request options and response headers;
+real-worker tests cover this cross-language decision. Ordinary SSE options retain
+their unconditional-success framing semantics.
+
+`http_compact_sse_v1` covers that option and `timeout_ms: null`, which means no
+transport total deadline. Positive connection and SSE idle limits still apply.
+An old helper must reject negotiation before a POST can be sent. No new public
+setting is introduced. Explicit compact deadlines remain finite across both
+header and body consumption, including a stream with continuous partial bytes.
+
+Routed compact must request `buffer_response=False`, preserve a native response,
+and close it before closing an owned routed client. Direct compact uses native
+egress inside the existing account circuit-breaker context. Both use Python
+only when the helper is absent before dispatch. A transport/protocol/body failure
+after dispatch never triggers Python fallback or another endpoint attempt.
+
+For example, a response containing output_item.done and response.completed can
+return the normalized compact payload immediately while upstream keeps HTTP
+open. The owned request is cancelled/closed at that boundary; another request
+on the same native helper remains usable. JSON success still uses the existing
+compact normalizer and does not pass through an SSE byte/text decoder.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
@@ -26,3 +26,9 @@ return the normalized compact payload immediately while upstream keeps HTTP
 open. The owned request is cancelled/closed at that boundary; another request
 on the same native helper remains usable. JSON success still uses the existing
 compact normalizer and does not pass through an SSE byte/text decoder.
+
+HTTP execution returns its terminal event to the runtime. The runtime writes
+that event after leaving the cancellation select, because stdout flush can
+yield after the event is already visible to the parent process. Prioritizing
+the execution future alone does not prevent a cancellation from interrupting
+that flush and emitting a second terminal during stdin EOF shutdown.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
@@ -33,3 +33,9 @@ that event after leaving the cancellation select, because stdout flush can
 yield after the event is already visible to the parent process. Prioritizing
 the execution future alone does not prevent a cancellation from interrupting
 that flush and emitting a second terminal during stdin EOF shutdown.
+
+Compact retains its existing dedicated read budget: when an effective compact
+timeout is set, it also supplies the SSE idle timeout; otherwise the ordinary
+stream idle timeout applies. The transport still enforces the total deadline
+independently across the entire request. Imposing the ordinary stream idle
+limit on compact with an explicit budget would change the pre-migration behavior.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/design.md
@@ -2,9 +2,10 @@
 
 Compact keeps its Python request/response policy but shares the native SSE
 framer used by ordinary Responses. A per-request `content_type_aware` option
-selects framing for successful responses whose Content-Type contains
-`text/event-stream` case-insensitively, or is absent/empty, matching the existing
-compact parser. Other success bodies and all HTTP errors remain raw bytes.
+selects framing for successful responses whose Content-Type media type equals
+`text/event-stream` ignoring parameters and case, or is absent/empty. Both Python
+compact paths use the same comparison; substring matches in non-SSE media types
+or parameters no longer select framing. Other success bodies and all HTTP errors remain raw bytes.
 The adapter derives the same mode from the request options and response headers;
 real-worker tests cover this cross-language decision. Ordinary SSE options retain
 their unconditional-success framing semantics.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/proposal.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/proposal.md
@@ -1,0 +1,26 @@
+# Change: Migrate compact Responses SSE framing to Rust
+
+## Why
+
+Compact requests still scan SSE bytes in Python: routed responses are buffered
+before parsing, and direct requests use aiohttp. The existing native framer can
+own this work, but compact also accepts JSON success bodies and permits an
+unset total timeout. Those contracts must survive the transport cutover.
+
+## What Changes
+
+- Negotiate `http_compact_sse_v1` for content-type-aware SSE options and an
+  optional total request timeout. Preserve raw JSON success and HTTP error bodies.
+- Consume direct and routed compact Responses unbuffered through native egress,
+  retaining the native response until terminal parsing and cleanup finish.
+- Keep payload normalization, terminal interpretation, archives, account and
+  endpoint selection, replay eligibility, and usage settlement in Python.
+- Preserve the missing-helper Python fallback, connection/total/idle budgets,
+  cancellation isolation, and no replay after dispatch.
+
+## Impact
+
+- Specs: `outbound-http-clients`, `responses-api-compat`.
+- Code: protocol/egress crates, native adapter, CodexClient, compact transport.
+- No new dependency, setting, public schema, or deployment action. The adapter
+  and bundled helper must be updated together, as with the existing handshake.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
@@ -44,8 +44,9 @@ MUST reject a clean EOF that leaves an incomplete event.
 
 The native protocol MUST advertise and the adapter MUST require
 `http_compact_sse_v1` before dispatching content-type-aware SSE requests.
-Such requests MUST frame successful responses when Content-Type contains
-`text/event-stream` case-insensitively or is absent or empty. Other successful
+Such requests MUST frame successful responses when the Content-Type media type
+is exactly `text/event-stream`, ignoring parameters and case, or when the header
+is absent or empty. Other successful
 responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
 requests without the content-type-aware option MUST retain their existing
 framing behavior. A null native total timeout MUST mean no total deadline;
@@ -62,6 +63,12 @@ positive explicit total, connection, and SSE idle limits MUST be preserved.
 - **WHEN** a compact success has a text/event-stream or absent/empty Content-Type
 - **THEN** Rust owns byte framing, original-byte limits, and body-read idle deadlines
 - **AND** Python consumes framed text without rescanning bytes
+
+#### Scenario: Non-SSE media type mentions event-stream
+
+- **WHEN** compact succeeds with `text/event-stream+json` or a JSON Content-Type parameter containing `text/event-stream`
+- **THEN** native and missing-helper Python transports use raw-body JSON parsing
+- **AND** the SSE event byte limit does not apply to the JSON body
 
 #### Scenario: Optional total timeout
 

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
@@ -1,0 +1,76 @@
+## MODIFIED Requirements
+
+### Requirement: Native SSE framing is an explicitly negotiated transport mode
+
+The native protocol MUST advertise and the Python adapter MUST require
+`http_sse_v1` before dispatch. HTTP requests MAY include SSE framing options
+with positive idle timeout and event byte limit. Without these options, and
+for HTTP statuses at least 400, the worker MUST preserve raw chunk output.
+With these options and a successful HTTP response selected for framing, Rust
+MUST emit complete SSE text blocks and own byte framing and the deadline between body reads.
+Python MUST NOT reframe these blocks or replay a dispatched request.
+IPC text fragments MUST be bounded to at most 16 KiB of UTF-8, with an explicit
+continuation flag; the adapter MUST join them before exposing an event and
+MUST reject a clean EOF that leaves an incomplete event.
+
+#### Scenario: Old helper cannot silently ignore framing options
+
+- **WHEN** an installed helper omits `http_sse_v1`
+- **THEN** negotiation fails before HTTP dispatch
+- **AND** the adapter does not fall back to another transport
+
+#### Scenario: Partial bytes keep the upstream stream active
+
+- **WHEN** body bytes arrive within each configured idle interval without completing an SSE block
+- **THEN** the Rust body-read deadline resets on activity
+- **AND** no premature event-wait timeout is introduced in Python
+
+#### Scenario: HTTP error and ordinary body consumption
+
+- **WHEN** SSE options are absent or the HTTP response status is at least 400
+- **THEN** consumers receive the ordinary raw body chunk contract
+
+#### Scenario: One framed request fails or is cancelled
+
+- **WHEN** one framed stream exceeds its byte limit, times out, or is cancelled
+- **THEN** only that attempt terminates and its stream registration is released
+- **AND** unrelated requests sharing the helper remain usable
+- **AND** failure diagnostics do not contain upstream body content or credentials
+
+
+## ADDED Requirements
+
+### Requirement: Compact native framing supports response content negotiation
+
+The native protocol MUST advertise and the adapter MUST require
+`http_compact_sse_v1` before dispatching content-type-aware SSE requests.
+Such requests MUST frame successful responses when Content-Type contains
+`text/event-stream` case-insensitively or is absent or empty. Other successful
+responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
+requests without the content-type-aware option MUST retain their existing
+framing behavior. A null native total timeout MUST mean no total deadline;
+positive explicit total, connection, and SSE idle limits MUST be preserved.
+
+#### Scenario: Compact success returns JSON
+
+- **WHEN** a compact request receives a successful application/json response
+- **THEN** the worker and adapter expose raw bytes for the existing JSON parser
+- **AND** SSE event limits and decoding are not applied to that JSON body
+
+#### Scenario: Compact success returns SSE or omits Content-Type
+
+- **WHEN** a compact success has a text/event-stream or absent/empty Content-Type
+- **THEN** Rust owns byte framing, original-byte limits, and body-read idle deadlines
+- **AND** Python consumes framed text without rescanning bytes
+
+#### Scenario: Optional total timeout
+
+- **WHEN** compact has no total timeout
+- **THEN** native transport does not substitute a default total timeout
+- **AND** its configured connection and SSE idle limits remain active
+
+#### Scenario: Incompatible helper
+
+- **WHEN** an installed helper lacks http_compact_sse_v1
+- **THEN** the adapter fails before dispatch rather than silently ignoring compact options
+- **AND** it does not replay through Python

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/outbound-http-clients/spec.md
@@ -51,6 +51,8 @@ responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
 requests without the content-type-aware option MUST retain their existing
 framing behavior. A null native total timeout MUST mean no total deadline;
 positive explicit total, connection, and SSE idle limits MUST be preserved.
+The compact SSE idle limit MUST retain the existing Python policy: use the
+effective compact timeout when set, otherwise use `stream_idle_timeout_seconds`.
 
 #### Scenario: Compact success returns JSON
 
@@ -69,6 +71,12 @@ positive explicit total, connection, and SSE idle limits MUST be preserved.
 - **WHEN** compact succeeds with `text/event-stream+json` or a JSON Content-Type parameter containing `text/event-stream`
 - **THEN** native and missing-helper Python transports use raw-body JSON parsing
 - **AND** the SSE event byte limit does not apply to the JSON body
+
+#### Scenario: Explicit compact timeout preserves its idle budget
+
+- **WHEN** a compact request has an effective compact timeout longer than the ordinary stream idle timeout
+- **THEN** native and missing-helper Python transports permit a body-read gap within that compact timeout
+- **AND** the compact total deadline still bounds the complete request
 
 #### Scenario: Optional total timeout
 

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Native compact Responses preserve terminal and ownership contracts
+
+Direct and account-routed compact requests MUST use native SSE framing when
+the helper is available. Python MUST retain request shaping, output collection,
+compact normalization, terminal error mapping, archives, routing, and settlement.
+Responses MUST remain open until consumption finishes, and owned responses and
+routed sessions MUST close on completion, failure, and cancellation. Missing
+helpers MAY use Python transport only before dispatch. Native failures after
+dispatch MUST NOT replay the POST through Python or another proxy endpoint.
+
+#### Scenario: Compact completes before HTTP EOF
+
+- **WHEN** response.completed follows compact output items while upstream keeps the body open
+- **THEN** compact returns the existing normalized payload without waiting for EOF
+- **AND** the owned transport request closes while unrelated helper requests stay usable
+
+#### Scenario: Terminal and framing failures
+
+- **WHEN** compact receives a terminal SSE error or exceeds its event/idle/total limit
+- **THEN** existing compact public error codes, status mapping, and replay safety are preserved
+- **AND** the response and owned client are cleaned up
+
+#### Scenario: Routed fallback before dispatch
+
+- **WHEN** a confirmed pre-dispatch connection failure permits the next configured endpoint
+- **THEN** native SSE options follow that attempt and its exact route metadata is recorded
+- **AND** an accepted response or ambiguous body failure never triggers endpoint replay
+
+#### Scenario: Missing helper and cancelled caller
+
+- **WHEN** the helper is missing before dispatch
+- **THEN** the resolved Python transport receives no native-only option and retains compact parsing
+- **AND** cancellation finishes owned response/session cleanup even in an already cancelled scope
+
+#### Scenario: Cancellation while waiting for native response headers
+
+- **WHEN** an already cancelled caller scope interrupts native response-head waiting
+- **THEN** request cancellation completes and its stream registration is removed
+- **AND** a completed native exchange wins a simultaneous shutdown/cancel race without an additional terminal event

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
@@ -2,8 +2,10 @@
 
 ### Requirement: Native compact Responses preserve terminal and ownership contracts
 
-Direct and account-routed compact requests MUST use native SSE framing when
-the helper has negotiated `http_compact_sse_v1`. Python MUST retain request shaping, output collection,
+Direct and account-routed compact requests MUST use native transport when the
+helper has negotiated `http_compact_sse_v1`. Native SSE framing MUST apply only
+to successful responses selected by the outbound HTTP Content-Type rule; other
+responses MUST retain raw body handling. Python MUST retain request shaping, output collection,
 compact normalization, terminal error mapping, archives, routing, and settlement.
 Responses MUST remain open until consumption finishes, and owned responses and
 routed sessions MUST close on completion, failure, and cancellation. Missing

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/specs/responses-api-compat/spec.md
@@ -3,11 +3,12 @@
 ### Requirement: Native compact Responses preserve terminal and ownership contracts
 
 Direct and account-routed compact requests MUST use native SSE framing when
-the helper is available. Python MUST retain request shaping, output collection,
+the helper has negotiated `http_compact_sse_v1`. Python MUST retain request shaping, output collection,
 compact normalization, terminal error mapping, archives, routing, and settlement.
 Responses MUST remain open until consumption finishes, and owned responses and
 routed sessions MUST close on completion, failure, and cancellation. Missing
-helpers MAY use Python transport only before dispatch. Native failures after
+helpers MAY use Python transport only before dispatch. An installed helper lacking
+`http_compact_sse_v1` MUST fail negotiation before dispatch without Python fallback. Native failures after
 dispatch MUST NOT replay the POST through Python or another proxy endpoint.
 
 #### Scenario: Compact completes before HTTP EOF

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/tasks.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contracts
+
+- [x] 1.1 Specify compact content-type selection, optional total deadlines, ownership, and cleanup.
+- [x] 1.2 Add real-worker regressions proving compact skips Python framing and keeps JSON/error compatibility.
+
+## 2. Implementation
+
+- [x] 2.1 Extend the negotiated native transport for content-type-aware framing and optional total timeouts.
+- [x] 2.2 Move direct and routed compact SSE consumption to the native framer with owned response/session cleanup.
+- [x] 2.3 Preserve missing-helper fallback, route metadata, and failure/replay provenance.
+
+## 3. Verification
+
+- [x] 3.1 Verify terminal completion without EOF, partial activity, idle/total/size failures, and cancellation isolation.
+- [x] 3.2 Run focused Python/Rust tests, lint/types, architecture checks, and strict OpenSpec validation.
+- [x] 3.3 Update architecture docs, synchronize specifications, archive verified changes, and back up source changes to NAS.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
@@ -39,7 +39,7 @@ python -m pytest -q --timeout=30 \
   tests/unit/test_codex_upstream_paths.py tests/unit/test_native_egress_packaging.py \
   tests/unit/test_native_sse_fixtures.py tests/unit/test_sse.py \
   tests/integration/test_native_sse_egress.py tests/integration/test_native_routed_egress.py
-# 276 passed
+# 284 passed (including the 8 media-type regressions added during review)
 
 python -m pytest -q --timeout=30 tests/unit/test_proxy_utils.py \
   tests/integration/test_proxy_responses.py -k compact
@@ -73,3 +73,13 @@ python -m pytest -q --timeout=30 tests/integration/test_native_sse_egress.py \
 
 CI failure evidence for the superseded poll-order fix:
 [Rust workspace job](https://github.com/Soju06/codex-lb/actions/runs/34193031991/job/101954940010).
+
+Review also identified substring-based Content-Type detection. Eight added
+cases failed before the fix: `text/event-stream+json` and a JSON media-type
+parameter containing `text/event-stream`, across native/missing-helper and
+direct/routed transports. Exact media-type comparison and content-type-independent
+compact JSON decoding now preserve all eight payloads without SSE scanning or
+event byte limits. The final 284-test native/client suite, 111 compact tests,
+`make rust-check`, Ruff/Ty, architecture checks, and strict specs all passed.
+Both compact requirements now explicitly require negotiated capability support;
+missing helpers may fall back, while incompatible installed helpers fail closed.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
@@ -39,7 +39,7 @@ python -m pytest -q --timeout=30 \
   tests/unit/test_codex_upstream_paths.py tests/unit/test_native_egress_packaging.py \
   tests/unit/test_native_sse_fixtures.py tests/unit/test_sse.py \
   tests/integration/test_native_sse_egress.py tests/integration/test_native_routed_egress.py
-# 284 passed (including the 8 media-type regressions added during review)
+# 288 passed (including 8 media-type and 4 compact idle-budget regressions)
 
 python -m pytest -q --timeout=30 tests/unit/test_proxy_utils.py \
   tests/integration/test_proxy_responses.py -k compact
@@ -79,7 +79,15 @@ cases failed before the fix: `text/event-stream+json` and a JSON media-type
 parameter containing `text/event-stream`, across native/missing-helper and
 direct/routed transports. Exact media-type comparison and content-type-independent
 compact JSON decoding now preserve all eight payloads without SSE scanning or
-event byte limits. The final 284-test native/client suite, 111 compact tests,
+event byte limits. The final 288-test native/client suite, 111 compact tests,
 `make rust-check`, Ruff/Ty, architecture checks, and strict specs all passed.
 Both compact requirements now explicitly require negotiated capability support;
 missing helpers may fall back, while incompatible installed helpers fail closed.
+
+Four additional direct/routed, native/missing-helper cases verify the existing
+compact idle-budget policy: a configured 1-second compact timeout permits a
+150-ms upstream body gap even when the ordinary stream idle timeout is 50 ms.
+The pre-migration Python implementation uses the same compact-timeout-first
+rule. The compact native integration subset passed 46 tests, and the complete
+288-test native/client suite passed against main including #2166. No runtime
+timeout or upstream scheme policy changed in response to those review notes.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
@@ -1,0 +1,57 @@
+# Verification — 2026-09-08
+
+Base: `8c6467d979104f3294f823c80c526cf56fbbe29d` (main).
+Python: CPython 3.13, existing frozen PR-2164 verification environment.
+Native worker: built from this worktree with the committed Cargo.lock.
+
+## Contract evidence
+
+- Direct/routed real-worker compact tests reject Python byte scanning and
+  return normalized output before HTTP EOF. Both failed before implementation
+  (direct used aiohttp; routed waited for buffered EOF).
+- Wire cases cover mixed-case, missing, and empty SSE Content-Type, JSON bodies
+  exceeding the SSE limit, raw HTTP errors, terminal SSE errors, truncated/empty
+  terminal lifecycles, oversized events, active partial chunks, idle and total
+  deadlines, and optional total timeouts.
+- A refused first proxy advances to the selected endpoint and preserves exact
+  route metadata. An accepted POST with a body failure never reaches the next
+  endpoint or Python fallback. Missing helpers retain Python parsing and raw
+  error interpretation even when JSON errors use text/plain.
+- Cancellation inside an already cancelled AnyIO scope closes the native
+  request and owned routed session while a peer request completes. A separate
+  deterministic pre-head regression proves stream unregistration; this failed
+  before the adapter cleanup fix.
+- The existing Rust oversized-event terminal test exposed an EOF/cancel race.
+  Completed exchanges now win simultaneous cancellation; the regression passed
+  20 consecutive runs after the fix.
+
+## Checks
+
+With `CODEX_LB_NATIVE_EGRESS_TEST_BINARY` pointing to the release worker:
+
+```sh
+python -m pytest -q --timeout=30 \
+  tests/unit/test_native_egress.py tests/unit/test_codex_client.py \
+  tests/unit/test_codex_upstream_paths.py tests/unit/test_native_egress_packaging.py \
+  tests/unit/test_native_sse_fixtures.py tests/unit/test_sse.py \
+  tests/integration/test_native_sse_egress.py tests/integration/test_native_routed_egress.py
+# 276 passed
+
+python -m pytest -q --timeout=30 tests/unit/test_proxy_utils.py \
+  tests/integration/test_proxy_responses.py -k compact
+# 111 passed, 1340 deselected
+
+make rust-check
+# fmt, Clippy (-D warnings), 19 tests, locked release build passed
+
+make rust-audit
+# advisories, bans, licenses, sources passed; existing duplicate-version warnings
+
+openspec validate --specs --strict
+# 58 passed; change delta also passed strict validation
+```
+
+Ruff check/format, Ty on changed Python files, proxy architecture,
+cancellation safety, timing seams, and git diff checks passed.
+No dependency or lockfile changes. Full repository/cloud CI, deployment, and
+performance measurement are outside this local verification.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md
@@ -22,8 +22,12 @@ Native worker: built from this worktree with the committed Cargo.lock.
   deterministic pre-head regression proves stream unregistration; this failed
   before the adapter cleanup fix.
 - The existing Rust oversized-event terminal test exposed an EOF/cancel race.
-  Completed exchanges now win simultaneous cancellation; the regression passed
-  20 consecutive runs after the fix.
+  CI reproduced it after the initial poll-order fix passed 20 local runs.
+  With two Tokio worker threads, the initial fix failed on local iteration 10.
+  Terminal emission now happens outside the cancellable HTTP future, including
+  stdout flush. The final code passed 100 consecutive protocol suites (600
+  test executions) with two Tokio worker threads; the suite checks no extra
+  terminal after successful SSE, raw HTTP errors, oversize, and idle timeout.
 
 ## Checks
 
@@ -55,3 +59,17 @@ Ruff check/format, Ty on changed Python files, proxy architecture,
 cancellation safety, timing seams, and git diff checks passed.
 No dependency or lockfile changes. Full repository/cloud CI, deployment, and
 performance measurement are outside this local verification.
+
+## CI follow-up verification
+
+The native-terminal correction was checked with `make rust-check` and the
+following real-worker probes on the rebuilt debug worker:
+
+```sh
+python -m pytest -q --timeout=30 tests/integration/test_native_sse_egress.py \
+  tests/integration/test_native_routed_egress.py
+# 57 passed
+```
+
+CI failure evidence for the superseded poll-order fix:
+[Rust workspace job](https://github.com/Soju06/codex-lb/actions/runs/34193031991/job/101954940010).

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -713,6 +713,8 @@ responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
 requests without the content-type-aware option MUST retain their existing
 framing behavior. A null native total timeout MUST mean no total deadline;
 positive explicit total, connection, and SSE idle limits MUST be preserved.
+The compact SSE idle limit MUST retain the existing Python policy: use the
+effective compact timeout when set, otherwise use `stream_idle_timeout_seconds`.
 
 #### Scenario: Compact success returns JSON
 
@@ -731,6 +733,12 @@ positive explicit total, connection, and SSE idle limits MUST be preserved.
 - **WHEN** compact succeeds with `text/event-stream+json` or a JSON Content-Type parameter containing `text/event-stream`
 - **THEN** native and missing-helper Python transports use raw-body JSON parsing
 - **AND** the SSE event byte limit does not apply to the JSON body
+
+#### Scenario: Explicit compact timeout preserves its idle budget
+
+- **WHEN** a compact request has an effective compact timeout longer than the ordinary stream idle timeout
+- **THEN** native and missing-helper Python transports permit a body-read gap within that compact timeout
+- **AND** the compact total deadline still bounds the complete request
 
 #### Scenario: Optional total timeout
 

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -706,8 +706,9 @@ retain selected route metadata and native framed-response consumption.
 
 The native protocol MUST advertise and the adapter MUST require
 `http_compact_sse_v1` before dispatching content-type-aware SSE requests.
-Such requests MUST frame successful responses when Content-Type contains
-`text/event-stream` case-insensitively or is absent or empty. Other successful
+Such requests MUST frame successful responses when the Content-Type media type
+is exactly `text/event-stream`, ignoring parameters and case, or when the header
+is absent or empty. Other successful
 responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
 requests without the content-type-aware option MUST retain their existing
 framing behavior. A null native total timeout MUST mean no total deadline;
@@ -724,6 +725,12 @@ positive explicit total, connection, and SSE idle limits MUST be preserved.
 - **WHEN** a compact success has a text/event-stream or absent/empty Content-Type
 - **THEN** Rust owns byte framing, original-byte limits, and body-read idle deadlines
 - **AND** Python consumes framed text without rescanning bytes
+
+#### Scenario: Non-SSE media type mentions event-stream
+
+- **WHEN** compact succeeds with `text/event-stream+json` or a JSON Content-Type parameter containing `text/event-stream`
+- **THEN** native and missing-helper Python transports use raw-body JSON parsing
+- **AND** the SSE event byte limit does not apply to the JSON body
 
 #### Scenario: Optional total timeout
 

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -645,8 +645,8 @@ The native protocol MUST advertise and the Python adapter MUST require
 `http_sse_v1` before dispatch. HTTP requests MAY include SSE framing options
 with positive idle timeout and event byte limit. Without these options, and
 for HTTP statuses at least 400, the worker MUST preserve raw chunk output.
-With these options and a successful HTTP response, Rust MUST emit complete
-SSE text blocks and own byte framing and the deadline between body reads.
+With these options and a successful HTTP response selected for framing, Rust
+MUST emit complete SSE text blocks and own byte framing and the deadline between body reads.
 Python MUST NOT reframe these blocks or replay a dispatched request.
 IPC text fragments MUST be bounded to at most 16 KiB of UTF-8, with an explicit
 continuation flag; the adapter MUST join them before exposing an event and
@@ -701,3 +701,38 @@ retain selected route metadata and native framed-response consumption.
 
 - **WHEN** a caller supplies native SSE options with buffered response consumption
 - **THEN** the request fails before either native or Python dispatch
+
+### Requirement: Compact native framing supports response content negotiation
+
+The native protocol MUST advertise and the adapter MUST require
+`http_compact_sse_v1` before dispatching content-type-aware SSE requests.
+Such requests MUST frame successful responses when Content-Type contains
+`text/event-stream` case-insensitively or is absent or empty. Other successful
+responses and HTTP errors MUST retain raw body consumption. Ordinary SSE
+requests without the content-type-aware option MUST retain their existing
+framing behavior. A null native total timeout MUST mean no total deadline;
+positive explicit total, connection, and SSE idle limits MUST be preserved.
+
+#### Scenario: Compact success returns JSON
+
+- **WHEN** a compact request receives a successful application/json response
+- **THEN** the worker and adapter expose raw bytes for the existing JSON parser
+- **AND** SSE event limits and decoding are not applied to that JSON body
+
+#### Scenario: Compact success returns SSE or omits Content-Type
+
+- **WHEN** a compact success has a text/event-stream or absent/empty Content-Type
+- **THEN** Rust owns byte framing, original-byte limits, and body-read idle deadlines
+- **AND** Python consumes framed text without rescanning bytes
+
+#### Scenario: Optional total timeout
+
+- **WHEN** compact has no total timeout
+- **THEN** native transport does not substitute a default total timeout
+- **AND** its configured connection and SSE idle limits remain active
+
+#### Scenario: Incompatible helper
+
+- **WHEN** an installed helper lacks http_compact_sse_v1
+- **THEN** the adapter fails before dispatch rather than silently ignoring compact options
+- **AND** it does not replay through Python

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5773,3 +5773,43 @@ cancellation MUST NOT replay a dispatched POST or switch its proxy endpoint.
 
 - **WHEN** the routed response is an HTTP error or the request disables streaming
 - **THEN** the ordinary JSON/error body path and public response envelope are preserved
+
+### Requirement: Native compact Responses preserve terminal and ownership contracts
+
+Direct and account-routed compact requests MUST use native SSE framing when
+the helper is available. Python MUST retain request shaping, output collection,
+compact normalization, terminal error mapping, archives, routing, and settlement.
+Responses MUST remain open until consumption finishes, and owned responses and
+routed sessions MUST close on completion, failure, and cancellation. Missing
+helpers MAY use Python transport only before dispatch. Native failures after
+dispatch MUST NOT replay the POST through Python or another proxy endpoint.
+
+#### Scenario: Compact completes before HTTP EOF
+
+- **WHEN** response.completed follows compact output items while upstream keeps the body open
+- **THEN** compact returns the existing normalized payload without waiting for EOF
+- **AND** the owned transport request closes while unrelated helper requests stay usable
+
+#### Scenario: Terminal and framing failures
+
+- **WHEN** compact receives a terminal SSE error or exceeds its event/idle/total limit
+- **THEN** existing compact public error codes, status mapping, and replay safety are preserved
+- **AND** the response and owned client are cleaned up
+
+#### Scenario: Routed fallback before dispatch
+
+- **WHEN** a confirmed pre-dispatch connection failure permits the next configured endpoint
+- **THEN** native SSE options follow that attempt and its exact route metadata is recorded
+- **AND** an accepted response or ambiguous body failure never triggers endpoint replay
+
+#### Scenario: Missing helper and cancelled caller
+
+- **WHEN** the helper is missing before dispatch
+- **THEN** the resolved Python transport receives no native-only option and retains compact parsing
+- **AND** cancellation finishes owned response/session cleanup even in an already cancelled scope
+
+#### Scenario: Cancellation while waiting for native response headers
+
+- **WHEN** an already cancelled caller scope interrupts native response-head waiting
+- **THEN** request cancellation completes and its stream registration is removed
+- **AND** a completed native exchange wins a simultaneous shutdown/cancel race without an additional terminal event

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5776,8 +5776,10 @@ cancellation MUST NOT replay a dispatched POST or switch its proxy endpoint.
 
 ### Requirement: Native compact Responses preserve terminal and ownership contracts
 
-Direct and account-routed compact requests MUST use native SSE framing when
-the helper has negotiated `http_compact_sse_v1`. Python MUST retain request shaping, output collection,
+Direct and account-routed compact requests MUST use native transport when the
+helper has negotiated `http_compact_sse_v1`. Native SSE framing MUST apply only
+to successful responses selected by the outbound HTTP Content-Type rule; other
+responses MUST retain raw body handling. Python MUST retain request shaping, output collection,
 compact normalization, terminal error mapping, archives, routing, and settlement.
 Responses MUST remain open until consumption finishes, and owned responses and
 routed sessions MUST close on completion, failure, and cancellation. Missing

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5777,11 +5777,12 @@ cancellation MUST NOT replay a dispatched POST or switch its proxy endpoint.
 ### Requirement: Native compact Responses preserve terminal and ownership contracts
 
 Direct and account-routed compact requests MUST use native SSE framing when
-the helper is available. Python MUST retain request shaping, output collection,
+the helper has negotiated `http_compact_sse_v1`. Python MUST retain request shaping, output collection,
 compact normalization, terminal error mapping, archives, routing, and settlement.
 Responses MUST remain open until consumption finishes, and owned responses and
 routed sessions MUST close on completion, failure, and cancellation. Missing
-helpers MAY use Python transport only before dispatch. Native failures after
+helpers MAY use Python transport only before dispatch. An installed helper lacking
+`http_compact_sse_v1` MUST fail negotiation before dispatch without Python fallback. Native failures after
 dispatch MUST NOT replay the POST through Python or another proxy endpoint.
 
 #### Scenario: Compact completes before HTTP EOF

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -913,6 +913,33 @@ async def test_native_compact_preserves_idle_and_total_deadlines(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("missing_helper", [False, True])
+async def test_compact_explicit_timeout_preserves_dedicated_idle_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    tmp_path: Path,
+    routed: bool,
+    missing_helper: bool,
+) -> None:
+    worker = SubprocessNativeEgressClient(tmp_path / "missing-helper") if missing_helper else native_worker
+    monkeypatch.setattr(proxy_module.get_settings(), "upstream_compact_timeout_seconds", 1.0)
+    monkeypatch.setattr(proxy_module.get_settings(), "stream_idle_timeout_seconds", 0.05)
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await asyncio.sleep(0.15)
+        await _write_chunk(writer, _COMPACT_EVENTS)
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession(trust_env=False) as session:
+        response = await _compact(
+            base_url, worker, monkeypatch, routed=routed, session=session if missing_helper else None
+        )
+        assert response.id == "resp_compact"
+    assert not worker._streams
+
+
+@pytest.mark.asyncio
 async def test_native_compact_cancellation_closes_owned_resources_and_keeps_peer(
     monkeypatch: pytest.MonkeyPatch,
     native_worker: SubprocessNativeEgressClient,

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -773,6 +773,43 @@ async def test_native_compact_frames_and_returns_before_body_eof(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ['application/json; profile="text/event-stream"', "text/event-stream+json"])
+@pytest.mark.parametrize("missing_helper", [False, True])
+async def test_compact_non_sse_media_types_keep_raw_json(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    tmp_path: Path,
+    routed: bool,
+    content_type: str,
+    missing_helper: bool,
+) -> None:
+    worker = SubprocessNativeEgressClient(tmp_path / "missing-helper") if missing_helper else native_worker
+    payload = {"object": "response.compact", "id": "compact_json", "padding": "x" * 512}
+    monkeypatch.setattr(proxy_module.get_settings(), "max_sse_event_bytes", 128)
+    hits: list[bytes] = []
+
+    def forbidden_python_scan(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("non-SSE compact JSON must bypass SSE framing")
+
+    monkeypatch.setattr(proxy_module, "_find_sse_separator", forbidden_python_scan)
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, head: bytes, _body: bytes) -> None:
+        hits.append(head)
+        await _start_chunked_response(writer, content_type=content_type)
+        await _write_chunk(writer, json.dumps(payload).encode())
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession(trust_env=False) as session:
+        response = await _compact(
+            base_url, worker, monkeypatch, routed=routed, session=session if missing_helper else None
+        )
+        assert response.id == payload["id"]
+        assert response.model_extra is not None and response.model_extra["padding"] == payload["padding"]
+    assert len(hits) == 1
+    assert not worker._streams
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("outcome", ["json", "http_error", "terminal", "eof", "oversize", "disconnect"])
 async def test_native_compact_preserves_payloads_errors_and_no_replay(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -18,8 +18,9 @@ import pytest
 import app.core.clients.proxy as proxy_module
 from app.core.clients.codex import CodexClient
 from app.core.clients.native_egress import SubprocessNativeEgressClient
-from app.core.clients.proxy import ProxyResponseError, override_stream_timeouts, stream_responses
-from app.core.openai.requests import ResponsesRequest
+from app.core.clients.proxy import ProxyResponseError, compact_responses, override_stream_timeouts, stream_responses
+from app.core.openai.models import CompactResponsePayload
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 
 pytestmark = pytest.mark.integration
@@ -58,14 +59,15 @@ async def _start_chunked_response(
     writer: asyncio.StreamWriter,
     *,
     status: str = "200 OK",
-    content_type: str = "text/event-stream",
+    content_type: str | None = "text/event-stream",
 ) -> None:
+    content_type_header = f"Content-Type: {content_type}\r\n" if content_type is not None else ""
     writer.write(
-        f"HTTP/1.1 {status}\r\n"
-        f"Content-Type: {content_type}\r\n"
-        "Transfer-Encoding: chunked\r\n"
-        "Connection: keep-alive\r\n"
-        "\r\n".encode("ascii")
+        (
+            f"HTTP/1.1 {status}\r\n" + content_type_header + "Transfer-Encoding: chunked\r\n"
+            "Connection: keep-alive\r\n"
+            "\r\n"
+        ).encode("ascii")
     )
     await writer.drain()
 
@@ -682,3 +684,367 @@ async def test_routed_owned_client_finishes_closing_in_cancelled_scope(
             assert not native_worker._streams
         finally:
             await cast(AsyncGenerator[str, None], stream).aclose()
+
+
+async def _compact(
+    base_url: str,
+    native_worker: SubprocessNativeEgressClient,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    routed: bool,
+    marker: str = "compact-probe",
+    session: aiohttp.ClientSession | None = None,
+    own_codex_client: bool = False,
+    selected_route: ResolvedUpstreamRoute | None = None,
+    route_trace: proxy_module.UpstreamProxyRouteTrace | None = None,
+) -> CompactResponsePayload:
+    monkeypatch.setattr(
+        proxy_module.get_settings(), "upstream_base_url", "http://upstream.invalid" if routed else base_url
+    )
+    monkeypatch.setattr(proxy_module, "discover_native_egress_client", lambda: native_worker)
+    session = session if session is not None else cast(aiohttp.ClientSession, _UnexpectedPythonSession())
+    route = selected_route or (
+        ResolvedUpstreamRoute(
+            mode="account_bound",
+            pool_id="compact-probe",
+            endpoint=ResolvedProxyEndpoint("compact-proxy", "http", "127.0.0.1", urlsplit(base_url).port or 80),
+        )
+        if routed
+        else None
+    )
+    return await compact_responses(
+        ResponsesCompactRequest(model="gpt-5.4", instructions="Summarize.", input=marker),
+        {},
+        "test-access-token",
+        "test-account",
+        session=session,
+        route=route,
+        codex_client=CodexClient(session, native_egress_client=native_worker)
+        if routed and not own_codex_client
+        else None,
+        route_trace=route_trace,
+        allow_direct_egress=not routed,
+    )
+
+
+_COMPACT_EVENTS = (
+    b'data: {"type":"response.output_item.done","output_index":0,'
+    b'"item":{"type":"compaction","encrypted_content":"compact-secret"}}\r\n\r\n'
+    b'data: {"type":"response.completed","response":'
+    b'{"object":"response","id":"resp_compact","output":[]}}\n\n'
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ["text/event-stream", "Text/Event-Stream; charset=utf-8", None, ""])
+async def test_native_compact_frames_and_returns_before_body_eof(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    content_type: str | None,
+) -> None:
+    closed = asyncio.Event()
+    requests: list[dict[str, object]] = []
+
+    def forbidden_python_scan(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("compact native SSE must bypass the Python byte scanner")
+
+    monkeypatch.setattr(proxy_module, "_find_sse_separator", forbidden_python_scan)
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, body: bytes) -> None:
+        requests.append(json.loads(body))
+        await _start_chunked_response(writer, content_type=content_type)
+        for offset in range(0, len(_COMPACT_EVENTS), 17):
+            await _write_chunk(writer, _COMPACT_EVENTS[offset : offset + 17])
+        await reader.read()
+        closed.set()
+
+    async with _serve_http(handler) as base_url:
+        response = await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), timeout=2)
+        await asyncio.wait_for(closed.wait(), timeout=2)
+    assert response.object == "response.compaction"
+    assert response.id == "resp_compact"
+    assert response.model_extra is not None
+    assert response.model_extra["output"][0]["encrypted_content"] == "compact-secret"
+    assert len(requests) == 1
+    assert requests[0]["stream"] is True
+    assert requests[0]["store"] is False
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["json", "http_error", "terminal", "eof", "oversize", "disconnect"])
+async def test_native_compact_preserves_payloads_errors_and_no_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    outcome: str,
+) -> None:
+    hits: list[bytes] = []
+    error = {"error": {"code": "rate_limit_exceeded", "type": "rate_limit_error", "message": "try later"}}
+    json_body = {"object": "response.compact", "id": "compact_json", "padding": "x" * 512}
+    monkeypatch.setattr(proxy_module.get_settings(), "max_sse_event_bytes", 128)
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, head: bytes, _body: bytes) -> None:
+        hits.append(head)
+        await _start_chunked_response(
+            writer,
+            status="429 Too Many Requests" if outcome == "http_error" else "200 OK",
+            content_type="application/json" if outcome in {"json", "http_error"} else "text/event-stream",
+        )
+        if outcome == "disconnect":
+            return  # An incomplete chunked body, not a clean SSE EOF.
+        body = {
+            "json": json.dumps(json_body).encode(),
+            "http_error": json.dumps(error).encode(),
+            "terminal": b"data: " + json.dumps({"type": "error", **error}).encode() + b"\n\n",
+            "eof": b'data: {"type":"response.created"}\n\n',
+            "oversize": b"data: " + b"x" * 150,
+        }[outcome]
+        await _write_chunk(writer, body)
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url:
+        if outcome == "json":
+            response = await _compact(base_url, native_worker, monkeypatch, routed=routed)
+            assert response.id == "compact_json"
+            assert response.model_extra is not None and response.model_extra["padding"] == json_body["padding"]
+        else:
+            with pytest.raises(ProxyResponseError) as caught:
+                await _compact(base_url, native_worker, monkeypatch, routed=routed)
+            exc = caught.value
+            assert exc.status_code == (429 if outcome in {"http_error", "terminal"} else 502)
+            assert (
+                exc.payload["error"]["code"]
+                == {
+                    "http_error": "rate_limit_exceeded",
+                    "terminal": "rate_limit_exceeded",
+                    "eof": "upstream_error",
+                    "oversize": "stream_event_too_large",
+                    "disconnect": "upstream_unavailable",
+                }[outcome]
+            )
+            assert not exc.retryable_same_contract
+            if outcome in {"http_error", "terminal"}:
+                assert exc.payload["error"] == error["error"]
+            if outcome == "disconnect":
+                assert exc.failure_phase == "body_read"
+    assert len(hits) == 1
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["idle", "total", "active"])
+async def test_native_compact_preserves_idle_and_total_deadlines(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    mode: str,
+) -> None:
+    settings = proxy_module.get_settings()
+    monkeypatch.setattr(settings, "upstream_compact_timeout_seconds", 0.2 if mode == "total" else None)
+    monkeypatch.setattr(settings, "stream_idle_timeout_seconds", 0.15)
+    closed = asyncio.Event()
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        if mode == "idle":
+            await reader.read()
+            closed.set()
+            return
+        for offset in range(0, len(_COMPACT_EVENTS), 30):
+            await _write_chunk(writer, _COMPACT_EVENTS[offset : offset + 30])
+            await asyncio.sleep(0.04)
+        await reader.read()
+        closed.set()
+
+    async with _serve_http(handler) as base_url:
+        started = asyncio.get_running_loop().time()
+        if mode == "active":
+            response = await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), timeout=2)
+            assert response.id == "resp_compact"
+            assert asyncio.get_running_loop().time() - started > 0.2
+            await asyncio.wait_for(closed.wait(), timeout=2)
+        else:
+            with pytest.raises(ProxyResponseError) as caught:
+                await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), timeout=2)
+            assert caught.value.payload["error"]["code"] == (
+                "stream_idle_timeout" if mode == "idle" else "upstream_unavailable"
+            )
+            assert not caught.value.retryable_same_contract
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+async def test_native_compact_cancellation_closes_owned_resources_and_keeps_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+) -> None:
+    partial = asyncio.Event()
+    closed = asyncio.Event()
+    peer_ready = asyncio.Event()
+    release_peer = asyncio.Event()
+    owned_sessions: list[_UnexpectedPythonSession] = []
+
+    class DelayedCloseSession(_UnexpectedPythonSession):
+        async def close(self) -> None:
+            await asyncio.sleep(0)
+            await super().close()
+
+    def create_session() -> DelayedCloseSession:
+        session = DelayedCloseSession()
+        owned_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(proxy_module, "create_codex_session", create_session)
+    monkeypatch.setattr(
+        proxy_module, "CodexClient", lambda session: CodexClient(session, native_egress_client=native_worker)
+    )
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, body: bytes) -> None:
+        await _start_chunked_response(writer)
+        if b"cancel-compact" in body:
+            await _write_chunk(writer, b'data: {"type":"response.created"')
+            partial.set()
+            await reader.read()
+            closed.set()
+        else:
+            peer_ready.set()
+            await release_peer.wait()
+            await _write_chunk(writer, _COMPACT_EVENTS)
+            await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url:
+        scope_ready: asyncio.Future[anyio.CancelScope] = asyncio.get_running_loop().create_future()
+
+        async def cancelled_request() -> None:
+            with anyio.CancelScope() as scope:
+                scope_ready.set_result(scope)
+                await _compact(
+                    base_url, native_worker, monkeypatch, routed=routed, marker="cancel-compact", own_codex_client=True
+                )
+
+        cancelled_task = asyncio.create_task(cancelled_request())
+        peer_task = asyncio.create_task(
+            _compact(base_url, native_worker, monkeypatch, routed=routed, marker="peer-compact")
+        )
+        try:
+            scope = await scope_ready
+            await asyncio.wait_for(partial.wait(), timeout=2)
+            await asyncio.wait_for(peer_ready.wait(), timeout=2)
+            process = native_worker._process
+            scope.cancel()
+            await asyncio.wait_for(cancelled_task, timeout=2)
+            await asyncio.wait_for(closed.wait(), timeout=2)
+            assert all(session.closed for session in owned_sessions)
+            release_peer.set()
+            response = await asyncio.wait_for(peer_task, timeout=2)
+            assert response.id == "resp_compact"
+            assert native_worker._process is process
+            assert process is not None and process.returncode is None
+        finally:
+            release_peer.set()
+            for task in (cancelled_task, peer_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(cancelled_task, peer_task, return_exceptions=True)
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_error", [False, True])
+async def test_compact_missing_helper_preserves_python_transport(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, routed: bool, http_error: bool
+) -> None:
+    missing = SubprocessNativeEgressClient(tmp_path / "missing-compact-helper")
+    hits: list[bytes] = []
+    scans = 0
+    scan = proxy_module._find_sse_separator
+
+    def count_scan(buffer: bytes | bytearray, start: int = 0) -> tuple[int, int] | None:
+        nonlocal scans
+        scans += 1
+        return scan(buffer, start)
+
+    monkeypatch.setattr(proxy_module, "_find_sse_separator", count_scan)
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, head: bytes, _body: bytes) -> None:
+        hits.append(head)
+        await _start_chunked_response(
+            writer,
+            status="400 Bad Request" if http_error else "200 OK",
+            content_type="text/plain" if http_error else "text/event-stream",
+        )
+        await _write_chunk(
+            writer,
+            b'{"error":{"code":"invalid_request_error","message":"compact input invalid"}}'
+            if http_error
+            else _COMPACT_EVENTS,
+        )
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession(trust_env=False) as session:
+        if http_error:
+            with pytest.raises(ProxyResponseError) as caught:
+                await _compact(base_url, missing, monkeypatch, routed=routed, session=session)
+            assert caught.value.status_code == 400
+            assert caught.value.payload["error"]["code"] == "invalid_request_error"
+        else:
+            response = await _compact(base_url, missing, monkeypatch, routed=routed, session=session)
+            assert response.id == "resp_compact"
+        assert not session.closed  # caller owns this session
+    assert len(hits) == 1
+    assert hits[0].startswith(b"POST http://upstream.invalid/" if routed else b"POST /codex/responses ")
+    assert (scans > 0) is not http_error
+    assert missing._process is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["complete", "disconnect"])
+async def test_native_compact_routed_fallback_keeps_metadata_and_never_replays_accepted_post(
+    monkeypatch: pytest.MonkeyPatch, native_worker: SubprocessNativeEgressClient, outcome: str
+) -> None:
+    accepted: list[bytes] = []
+    replays: list[bytes] = []
+
+    async def selected(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, head: bytes, _body: bytes) -> None:
+        accepted.append(head)
+        await _start_chunked_response(writer)
+        if outcome == "complete":
+            await _write_chunk(writer, _COMPACT_EVENTS)
+            await _finish_chunks(writer)
+
+    async def replay(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, head: bytes, _body: bytes) -> None:
+        replays.append(head)
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, _COMPACT_EVENTS)
+        await _finish_chunks(writer)
+
+    async with _serve_http(selected) as selected_url, _serve_http(replay) as replay_url:
+        with socket.socket() as refused:
+            refused.bind(("127.0.0.1", 0))  # reserved port without a listener
+            route = ResolvedUpstreamRoute(
+                mode="account_bound",
+                pool_id="compact-fallback",
+                endpoint=ResolvedProxyEndpoint("refused", "http", "127.0.0.1", refused.getsockname()[1]),
+                fallbacks=(
+                    ResolvedProxyEndpoint("selected", "http", "127.0.0.1", urlsplit(selected_url).port or 80),
+                    ResolvedProxyEndpoint("replay", "http", "127.0.0.1", urlsplit(replay_url).port or 80),
+                ),
+            )
+            trace = proxy_module.UpstreamProxyRouteTrace()
+            request = _compact(
+                selected_url, native_worker, monkeypatch, routed=True, selected_route=route, route_trace=trace
+            )
+            if outcome == "complete":
+                assert (await request).id == "resp_compact"
+            else:
+                with pytest.raises(ProxyResponseError) as caught:
+                    await request
+                assert caught.value.failure_phase == "body_read"
+                assert not caught.value.retryable_same_contract
+    assert len(accepted) == 1
+    assert not replays
+    assert trace == proxy_module.UpstreamProxyRouteTrace("account_bound", "compact-fallback", "selected", True)
+    assert not native_worker._streams

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -202,8 +202,9 @@ async def test_request_passes_resolver_proxy_and_builtin_fingerprint(route: Reso
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("native_sse", [None, NativeSseOptions(3, 1024)])
+@pytest.mark.parametrize("total_timeout", [90, None])
 async def test_routed_request_prefers_native_single_endpoint_attempt(
-    route: ResolvedUpstreamRoute, native_sse: NativeSseOptions | None
+    route: ResolvedUpstreamRoute, native_sse: NativeSseOptions | None, total_timeout: int | None
 ) -> None:
     session = _Session()
     native = _NativeClient()
@@ -216,7 +217,7 @@ async def test_routed_request_prefers_native_single_endpoint_attempt(
         params={"client": "codex"},
         json={"input": "hello"},
         headers={"Authorization": "Bearer token"},
-        timeout=aiohttp.ClientTimeout(total=90, sock_connect=7, sock_read=30),
+        timeout=aiohttp.ClientTimeout(total=total_timeout, sock_connect=7, sock_read=30),
         buffer_response=native_sse is None,
         native_sse=native_sse,
     )
@@ -230,7 +231,7 @@ async def test_routed_request_prefers_native_single_endpoint_attempt(
     assert request.url == "https://upstream.test/responses?existing=1&client=codex"
     assert request.body == b'{"input":"hello"}'
     assert request.headers["Content-Type"] == "application/json"
-    assert request.timeout_seconds == 90
+    assert request.timeout_seconds == total_timeout
     assert request.connect_timeout_seconds == 7
     assert request.response_head_timeout_seconds == 30
     assert request.sse is native_sse

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -41,6 +41,7 @@ print(json.dumps({
         "failure_provenance_v1",
         "http",
         "http2_profile_v1",
+        "http_compact_sse_v1",
         "http_sse_v1",
         "websocket",
         "websocket_send_ack",
@@ -803,7 +804,7 @@ for line in sys.stdin:
     if command["type"] == "cancel":
         print(json.dumps({{"type": "cancelled", "request_id": request_id}}), flush=True)
         continue
-    assert command["sse"] == {{"idle_timeout_ms": 1000, "max_event_bytes": 1024}}
+    assert command["sse"] == {{"idle_timeout_ms": 1000, "max_event_bytes": 1024, "content_type_aware": False}}
     print(json.dumps({{"type": "head", "request_id": request_id, "status": 200,
                        "http_version": "HTTP/1.1", "headers": []}}), flush=True)
     for event in {events!r}:
@@ -868,15 +869,16 @@ async def test_native_sse_failure_releases_owned_stream(
 
 
 @pytest.mark.asyncio
-async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path) -> None:
+@pytest.mark.parametrize("capability", ["http_sse_v1", "http_compact_sse_v1"])
+async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path, capability: str) -> None:
     helper = tmp_path / "native-helper"
-    preamble = _HELPER_PROTOCOL_PREAMBLE.replace('        "http_sse_v1",\n', "")
+    preamble = _HELPER_PROTOCOL_PREAMBLE.replace(f'        "{capability}",\n', "")
     source = "#!/usr/bin/env python3\n" + preamble + "\nassert sys.stdin.readline() == ''\n"
     helper.write_text(source, encoding="utf-8")
     helper.chmod(helper.stat().st_mode | stat.S_IXUSR)
     client = SubprocessNativeEgressClient(helper)
     try:
-        with pytest.raises(NativeEgressProtocolError, match="http_sse_v1"):
+        with pytest.raises(NativeEgressProtocolError, match=capability):
             await client.request(NativeEgressRequest("GET", "https://example.test", {}, sse=NativeSseOptions(1, 1024)))
         assert client._process is None
         assert not client._streams
@@ -923,4 +925,50 @@ async def test_native_sse_close_finishes_in_cancelled_scope(tmp_path: Path) -> N
         assert not client._streams
         assert client._process is not None and client._process.returncode is None
     finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_native_request_cancelled_before_head_unregisters_stream_in_cancelled_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = tmp_path / "native-helper"
+    _write_helper(
+        helper,
+        """#!/usr/bin/env python3
+for line in sys.stdin:
+    command = json.loads(line)
+    if command["type"] == "cancel":
+        print(json.dumps({"type": "cancelled", "request_id": command["request_id"]}), flush=True)
+""",
+    )
+    client = SubprocessNativeEgressClient(helper)
+    sent = asyncio.Event()
+    original_send = client._send_command
+
+    async def send(process, generation, command):
+        await original_send(process, generation, command)
+        if command.get("type") == "request":
+            sent.set()
+
+    monkeypatch.setattr(client, "_send_command", send)
+    scope_ready: asyncio.Future[anyio.CancelScope] = asyncio.get_running_loop().create_future()
+
+    async def request() -> None:
+        with anyio.CancelScope() as scope:
+            scope_ready.set_result(scope)
+            await client.request(NativeEgressRequest("POST", "https://example.test", {}, timeout_seconds=None))
+
+    task = asyncio.create_task(request())
+    try:
+        scope = await scope_ready
+        await asyncio.wait_for(sent.wait(), timeout=2)
+        scope.cancel()
+        await asyncio.wait_for(task, timeout=2)
+        assert not client._streams
+        assert client._process is not None and client._process.returncode is None
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
         await client.aclose()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12580,6 +12580,7 @@ async def test_compact_responses_without_trigger_canonicalization_hits_upstream_
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        max_sse_event_bytes = 16 * 1024 * 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 


### PR DESCRIPTION
## Summary

Direct and account-routed compact requests now consume SSE through the Rust framer and return the normalized compact result at `response.completed` without waiting for HTTP EOF. Python retains request shaping, terminal interpretation, routing/replay policy, archives, and settlement.

## Type of change

- [x] `refactor:` — internal refactor

Related to #2164 (the preceding Responses SSE migration).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Verified and archived change: [`openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/`](openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/). Main outbound HTTP and Responses compatibility specs are synchronized.

## Changes

- Negotiate `http_compact_sse_v1` for content-type-aware framing and optional total deadlines. Compare the exact media type, ignoring parameters and case, across Rust and Python; non-SSE JSON remains parseable even if its Content-Type mentions event-stream. Preserve raw JSON success, raw HTTP errors, and Python fallback when the helper is absent before dispatch. The adapter and bundled helper must be updated together.
- Keep responses and owned routed sessions open through consumption, and close them on completion, failure, or cancellation. Finish pre-head cancellation inside cancelled AnyIO scopes; finish native terminal output outside the cancellable HTTP future so a yielding stdout flush cannot produce duplicate terminals.
- Cover framing, timeout, terminal, route metadata, replay, and cancellation contracts with real-worker regressions. Update architecture documentation and OpenSpec verification evidence.

## Test plan

- 288 native/client/SSE Python tests passed with the release worker; 111 compact unit/integration tests passed.
- `make rust-check`: formatting, Clippy with warnings denied, 19 Rust tests, and locked release build passed.
- `make rust-audit`: advisories, bans, licenses, and sources passed (existing duplicate-version warnings).
- Ruff check/format, Ty on changed Python files, proxy architecture/cancellation/timing checks, and `git diff --check` passed.
- `openspec validate --specs --strict`: 58 specs passed; the change delta also passed before archival.
- After reproducing the terminal/EOF race on CI, the corrected protocol suite passed 100 consecutive runs (600 test executions) with two Tokio worker threads; all 57 native integration probes passed again.

Exact test commands and scope: [`verification.md`](openspec/changes/archive/2026-09-08-migrate-compact-sse-framing/verification.md). Cloud validation is reported by the current GitHub checks. Integration CI is refreshed against main at `3de4be2aa9221db6a7137daca4c14c5d2a1ff639` (including #2166). Performance gains have not been measured.

## Example output

For a compact request such as `POST /v1/responses/compact` with `{"model":"gpt-5","input":"Summarize the conversation"}`, an upstream SSE terminal containing `{"type":"response.completed","response":{"id":"resp_compact","object":"response.compaction","output":[{"type":"compaction","encrypted_content":"opaque"}]}}` produces the same normalized compact JSON. A routed request can now finish at that terminal even while upstream keeps the HTTP body open.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related PR above; no issue is claimed as resolved.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] Strict OpenSpec validation and change verification passed.
- [x] Simplicity gates reviewed: no new settings, setup, README sections, or dashboard changes.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compact Responses streaming can use native SSE framing.
  - Content type determines whether SSE framing is applied, preserving raw JSON and error responses.
  - Requests may run without a total timeout when no deadline is specified.
  - Native capability negotiation supports compact streaming.

- **Bug Fixes**
  - Improved cancellation and cleanup for interrupted streams.
  - Prevented request replay after native transport failures.
  - Preserved completion handling while the HTTP body remains open.

- **Documentation**
  - Added guidance for compact streaming, fallback behavior, timeouts, and resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->