### PR TITLE
refactor(responses): collect compact SSE results in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "aws-lc-rs",
  "base64",
  "codex-lb-protocol",
+ "codex-lb-responses",
  "futures-util",
  "hyper",
  "hyper-rustls",
@@ -183,6 +184,14 @@ dependencies = [
 
 [[package]]
 name = "codex-lb-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "codex-lb-responses"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/codex-lb-egress",
     "crates/codex-lb-egress-worker",
     "crates/codex-lb-protocol",
+    "crates/codex-lb-responses",
 ]
 
 [workspace.package]
@@ -25,7 +26,7 @@ reqwest = { version = "=0.12.28", default-features = false, features = ["http2",
 rustls = { version = "=0.23.36", default-features = false, features = ["aws_lc_rs", "prefer-post-quantum", "std", "tls12"] }
 rustls-native-certs = "0.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = { version = "1.0.149", features = ["raw_value"] }
 tokio = { version = "=1.49.0", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws_lc_rs", "tls12"] }
 tokio-tungstenite = { version = "0.28.0", features = ["proxy", "rustls-tls-native-roots"] }

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -29,6 +29,7 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
         "failure_provenance_v1",
         "http",
         "http2_profile_v1",
+        "http_compact_collect_v1",
         "http_compact_sse_v1",
         "http_sse_v1",
         "websocket",
@@ -82,6 +83,7 @@ class NativeSseOptions:
     idle_timeout_seconds: float
     max_event_bytes: int
     content_type_aware: bool = False
+    collect_compact: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +141,7 @@ class NativeEgressResponse:
         generation: int,
         events: asyncio.Queue[dict[str, object] | BaseException],
         sse_framed: bool = False,
+        compact_collected: bool = False,
     ) -> None:
         self.status = status
         self.http_version = http_version
@@ -146,6 +149,7 @@ class NativeEgressResponse:
         self.headers: CIMultiDict[str] = CIMultiDict(headers)
         self.content = _NativeEgressContent(self)
         self.sse_framed = sse_framed
+        self.compact_collected = compact_collected
         self._client = client
         self._request_id = request_id
         self._generation = generation
@@ -168,15 +172,40 @@ class NativeEgressResponse:
                     raise NativeEgressProtocolError("native chunk contains invalid base64 data") from exc
 
     async def iter_sse_events(self) -> AsyncGenerator[str, None]:
-        if not self.sse_framed:
+        if not self.sse_framed or self.compact_collected:
             raise NativeEgressProtocolError("native response did not request SSE framing")
+        async with contextlib.aclosing(self._iter_text_results("sse")) as results:
+            async for text in results:
+                yield text
+
+    async def compact_result(self) -> object:
+        if not self.compact_collected:
+            raise NativeEgressProtocolError("native response did not request compact collection")
+        result: object = None
+        received = False
+        async with contextlib.aclosing(self._iter_text_results("compact")) as results:
+            async for text in results:
+                if received:
+                    raise NativeEgressProtocolError("native compact response contains multiple results")
+                try:
+                    result = json.loads(text)
+                except ValueError as exc:
+                    raise NativeEgressProtocolError("native compact result is invalid JSON") from exc
+                received = True
+        if not received:
+            raise NativeEgressProtocolError("native compact response ended without a result")
+        return result
+
+    async def _iter_text_results(self, event_type: str) -> AsyncGenerator[str, None]:
         fragments: list[str] = []
-        async with contextlib.aclosing(self._iter_body_events("sse")) as events:
+        async with contextlib.aclosing(self._iter_body_events(event_type)) as events:
             async for event in events:
                 text = event.get("text")
                 more = event.get("more")
                 if not isinstance(text, str) or type(more) is not bool:
-                    raise NativeEgressProtocolError("native SSE fragment has an invalid shape")
+                    raise NativeEgressProtocolError(f"native {event_type} fragment has an invalid shape")
+                if event_type == "compact" and len(text.encode("utf-8")) > 16 * 1024:
+                    raise NativeEgressProtocolError("native compact fragment exceeds the text limit")
                 if more:
                     fragments.append(text)
                 elif fragments:
@@ -187,7 +216,7 @@ class NativeEgressResponse:
                 else:
                     yield text
         if fragments:
-            raise NativeEgressProtocolError("native SSE response ended during an event")
+            raise NativeEgressProtocolError(f"native {event_type} response ended during an event")
 
     async def _iter_body_events(self, expected_type: str) -> AsyncGenerator[dict[str, object], None]:
         if self._iterated:
@@ -571,6 +600,8 @@ class SubprocessNativeEgressClient:
         if request.response_head_timeout_seconds is not None and request.response_head_timeout_seconds <= 0:
             raise ValueError("native egress response_head_timeout_seconds must be positive")
         if request.sse is not None:
+            if request.sse.collect_compact and not request.sse.content_type_aware:
+                raise ValueError("native compact collection requires content-type-aware framing")
             if not math.isfinite(request.sse.idle_timeout_seconds) or request.sse.idle_timeout_seconds <= 0:
                 raise ValueError("native SSE idle_timeout_seconds must be finite and positive")
             if type(request.sse.max_event_bytes) is not int or request.sse.max_event_bytes <= 0:
@@ -602,6 +633,7 @@ class SubprocessNativeEgressClient:
                     "idle_timeout_ms": max(1, round(request.sse.idle_timeout_seconds * 1000)),
                     "max_event_bytes": request.sse.max_event_bytes,
                     "content_type_aware": request.sse.content_type_aware,
+                    "collect_compact": request.sse.collect_compact,
                 }
                 if request.sse is not None
                 else None
@@ -665,6 +697,7 @@ class SubprocessNativeEgressClient:
             generation=generation,
             events=events,
             sse_framed=sse_framed,
+            compact_collected=sse_framed and request.sse is not None and request.sse.collect_compact,
         )
 
     async def websocket(self, request: NativeWebSocketRequest) -> NativeEgressWebSocket:
@@ -880,7 +913,7 @@ class SubprocessNativeEgressClient:
                 events = state[1]
                 try:
                     events.put_nowait(event)
-                    if event.get("type") in {"head", "websocket_open", "sse"}:
+                    if event.get("type") in {"head", "websocket_open", "sse", "compact"}:
                         # Hand the accepted response to its consumer before a
                         # helper with already-buffered output can fill the body
                         # queue in this reader task's scheduling turn.

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1566,6 +1566,20 @@ async def _compact_response_payload_from_success_response(
     idle_timeout_seconds: float,
     max_event_bytes: int,
 ) -> JsonValue:
+    if isinstance(resp, NativeEgressResponse) and resp.compact_collected:
+        result = await resp.compact_result()
+        if not is_json_mapping(result):
+            raise NativeEgressProtocolError("native compact result has an invalid envelope")
+        kind = result.get("kind")
+        if kind == "completed" and is_json_mapping(response := result.get("response")):
+            return response
+        if kind == "terminal_error" and is_json_mapping(event := result.get("event")):
+            event_type = event.get("type")
+            if isinstance(event_type, str) and event_type in {"response.failed", "response.incomplete", "error"}:
+                raise _proxy_response_error_from_compact_sse_terminal(event, event_type)
+        if kind == "invalid" and isinstance(message := result.get("message"), str):
+            raise ValueError(message)
+        raise NativeEgressProtocolError("native compact result has an invalid envelope")
     headers = _codex_response_headers(resp)
     content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
     content = getattr(resp, "content", None)
@@ -4831,6 +4845,7 @@ class _CompactCommandTransport:
             compact_timeout_seconds or settings.stream_idle_timeout_seconds,
             settings.max_sse_event_bytes,
             content_type_aware=True,
+            collect_compact=True,
         )
 
         @asynccontextmanager

--- a/crates/codex-lb-egress-worker/tests/http_protocol.rs
+++ b/crates/codex-lb-egress-worker/tests/http_protocol.rs
@@ -103,6 +103,7 @@ fn sse_request(
             idle_timeout_ms,
             max_event_bytes,
             content_type_aware: false,
+            collect_compact: false,
         }),
     })
 }

--- a/crates/codex-lb-egress/Cargo.toml
+++ b/crates/codex-lb-egress/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 aws-lc-rs.workspace = true
 base64.workspace = true
 codex-lb-protocol = { version = "0.1.0", path = "../codex-lb-protocol" }
+codex-lb-responses = { version = "0.1.0", path = "../codex-lb-responses" }
 futures-util.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use base64::Engine as _;
 use codex_lb_protocol::{NativeEvent, NativeRequest, NativeSseOptions};
+use codex_lb_responses::compact::{CompactCollector, CompactResult};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::runtime::{Output, RequestError, emit};
@@ -152,6 +153,7 @@ async fn execute_sse_body(
 ) -> Result<Option<SseEventTooLarge>, RequestError> {
     let idle_timeout = Duration::from_millis(options.idle_timeout_ms);
     let mut framer = SseFramer::new(options.max_event_bytes);
+    let mut collector = options.collect_compact.then(CompactCollector::default);
     loop {
         let chunk = tokio::time::timeout(idle_timeout, response.chunk())
             .await
@@ -161,31 +163,69 @@ async fn execute_sse_body(
         };
         for read in chunk.chunks(SSE_READ_CHUNK_SIZE) {
             framer.push(read);
-            if let Some(error) = emit_available_sse_events(&mut framer, request_id, output).await? {
-                return Ok(Some(error));
+            loop {
+                match framer.next_event() {
+                    Ok(Some(text)) => {
+                        if consume_sse(output, request_id, &text, &mut collector).await? {
+                            return Ok(None);
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(error) => return Ok(Some(error)),
+                }
             }
         }
     }
     match framer.finish() {
-        Ok(Some(text)) => emit_sse(output, request_id, &text).await?,
+        Ok(Some(text)) => {
+            if consume_sse(output, request_id, &text, &mut collector).await? {
+                return Ok(None);
+            }
+        }
         Ok(None) => {}
         Err(error) => return Ok(Some(error)),
+    }
+    if let Some(collector) = collector {
+        emit_compact(output, request_id, collector.finish()).await?;
     }
     Ok(None)
 }
 
-async fn emit_available_sse_events(
-    framer: &mut SseFramer,
-    request_id: &str,
+async fn consume_sse(
     output: &Output,
-) -> Result<Option<SseEventTooLarge>, std::io::Error> {
-    loop {
-        match framer.next_event() {
-            Ok(Some(text)) => emit_sse(output, request_id, &text).await?,
-            Ok(None) => return Ok(None),
-            Err(error) => return Ok(Some(error)),
+    request_id: &str,
+    text: &str,
+    collector: &mut Option<CompactCollector>,
+) -> Result<bool, std::io::Error> {
+    if let Some(collector) = collector {
+        if let Some(result) = collector.push(text) {
+            emit_compact(output, request_id, result).await?;
+            return Ok(true);
         }
+    } else {
+        emit_sse(output, request_id, text).await?;
     }
+    Ok(false)
+}
+
+async fn emit_compact(
+    output: &Output,
+    request_id: &str,
+    result: CompactResult,
+) -> Result<(), std::io::Error> {
+    let text = serde_json::to_string(&result)?;
+    for (fragment, more) in text_fragments(&text, SSE_IPC_TEXT_FRAGMENT_SIZE) {
+        emit(
+            output,
+            &NativeEvent::Compact {
+                request_id: request_id.to_owned(),
+                text: fragment.to_owned(),
+                more,
+            },
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 async fn emit_sse(output: &Output, request_id: &str, text: &str) -> Result<(), std::io::Error> {

--- a/crates/codex-lb-egress/src/runtime.rs
+++ b/crates/codex-lb-egress/src/runtime.rs
@@ -89,6 +89,7 @@ pub async fn run_stdio() -> Result<(), RequestError> {
                             || request.connect_timeout_ms == Some(0)
                             || request.sse.is_some_and(|options| {
                                 options.idle_timeout_ms == 0 || options.max_event_bytes == 0
+                                    || (options.collect_compact && !options.content_type_aware)
                             })
                         {
                             emit_error(

--- a/crates/codex-lb-protocol/src/lib.rs
+++ b/crates/codex-lb-protocol/src/lib.rs
@@ -10,6 +10,7 @@ pub const CAPABILITIES: &[&str] = &[
     "failure_provenance_v1",
     "http",
     "http2_profile_v1",
+    "http_compact_collect_v1",
     "http_compact_sse_v1",
     "http_sse_v1",
     "websocket",
@@ -66,6 +67,8 @@ pub struct NativeSseOptions {
     pub max_event_bytes: usize,
     #[serde(default)]
     pub content_type_aware: bool,
+    #[serde(default)]
+    pub collect_compact: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -106,6 +109,11 @@ pub enum NativeEvent {
         request_id: String,
         size_bytes: usize,
         limit_bytes: usize,
+    },
+    Compact {
+        request_id: String,
+        text: String,
+        more: bool,
     },
     End {
         request_id: String,

--- a/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
+++ b/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
@@ -11,6 +11,7 @@
       "failure_provenance_v1",
       "http",
       "http2_profile_v1",
+      "http_compact_collect_v1",
       "http_compact_sse_v1",
       "http_sse_v1",
       "websocket",

--- a/crates/codex-lb-responses/Cargo.toml
+++ b/crates/codex-lb-responses/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "codex-lb-responses"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/codex-lb-responses/src/compact.rs
+++ b/crates/codex-lb-responses/src/compact.rs
@@ -1,12 +1,40 @@
 //! Collect a compact response from already framed SSE events.
 
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize, de::Visitor};
 use serde_json::value::{RawValue, to_raw_value};
 
-type Object = BTreeMap<String, Box<RawValue>>;
+type Object = BTreeMap<FieldName, Box<RawValue>>;
+
+// Decode keys as bytes so opaque unknown keys can retain Python's escaped
+// surrogate handling. Only ASCII contract keys are inspected by the collector.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+struct FieldName(Vec<u8>);
+
+impl Borrow<[u8]> for FieldName {
+    fn borrow(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for FieldName {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct KeyVisitor;
+        impl Visitor<'_> for KeyVisitor {
+            type Value = FieldName;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a JSON object key")
+            }
+            fn visit_bytes<E: serde::de::Error>(self, value: &[u8]) -> Result<FieldName, E> {
+                Ok(FieldName(value.to_vec()))
+            }
+        }
+        deserializer.deserialize_bytes(KeyVisitor)
+    }
+}
 
 #[derive(Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -36,14 +64,15 @@ impl CompactCollector {
             .join("\n");
         let mut payload: Object = serde_json::from_str(&data).ok()?;
         self.saw_payload = true;
-        let event_type: String = serde_json::from_str(payload.get("type")?.get()).ok()?;
+        let event_type: String =
+            serde_json::from_str(payload.get(b"type".as_slice())?.get()).ok()?;
         match event_type.as_str() {
             "response.output_item.added" | "response.output_item.done" => {
                 let item = payload
-                    .remove("item")
+                    .remove(b"item".as_slice())
                     .filter(|item| item.get().starts_with('{'))?;
                 if let Some(index) = payload
-                    .get("output_index")
+                    .get(b"output_index".as_slice())
                     .and_then(|index| OutputIndex::parse(index.get()))
                 {
                     self.indexed.insert(index, item);
@@ -54,7 +83,7 @@ impl CompactCollector {
             }
             "response.completed" => {
                 let Some(response) = payload
-                    .remove("response")
+                    .remove(b"response".as_slice())
                     .filter(|response| response.get().starts_with('{'))
                 else {
                     return Some(CompactResult::Invalid {
@@ -62,25 +91,33 @@ impl CompactCollector {
                     });
                 };
                 // Only interpret the output array; all other JSON remains opaque.
-                let mut fields: Object =
-                    serde_json::from_str(response.get()).expect("validated JSON object");
-                let has_output = fields.get("output").is_some_and(|output| {
+                if self.indexed.is_empty() && self.unindexed.is_empty() {
+                    return Some(CompactResult::Completed { response });
+                }
+                let Ok(fields) = serde_json::from_str::<Object>(response.get()) else {
+                    return Some(CompactResult::Invalid {
+                        message: "response.completed contains an invalid response object",
+                    });
+                };
+                let has_output = fields.get(b"output".as_slice()).is_some_and(|output| {
                     serde_json::from_str::<Vec<Box<RawValue>>>(output.get())
                         .is_ok_and(|items| !items.is_empty())
                 });
-                if has_output || (self.indexed.is_empty() && self.unindexed.is_empty()) {
+                if has_output {
                     return Some(CompactResult::Completed { response });
                 }
                 let items: Vec<_> = std::mem::take(&mut self.indexed)
                     .into_values()
                     .chain(std::mem::take(&mut self.unindexed))
                     .collect();
-                fields.insert(
-                    "output".to_owned(),
-                    to_raw_value(&items).expect("serialize raw items"),
-                );
+                // JSON's last-key precedence matches Python. Append the assembled
+                // output while preserving every other byte, including opaque keys.
+                let prefix = &response.get()[..response.get().len() - 1];
+                let comma = if fields.is_empty() { "" } else { "," };
+                let output = to_raw_value(&items).expect("serialize raw items");
+                let assembled = format!("{prefix}{comma}\"output\":{}}}", output.get());
                 Some(CompactResult::Completed {
-                    response: to_raw_value(&fields).expect("serialize raw response"),
+                    response: RawValue::from_string(assembled).expect("assembled raw response"),
                 })
             }
             "response.failed" | "response.incomplete" | "error" => {

--- a/crates/codex-lb-responses/src/compact.rs
+++ b/crates/codex-lb-responses/src/compact.rs
@@ -1,0 +1,150 @@
+//! Collect a compact response from already framed SSE events.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::value::{RawValue, to_raw_value};
+
+type Object = BTreeMap<String, Box<RawValue>>;
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CompactResult {
+    Completed { response: Box<RawValue> },
+    TerminalError { event: Box<RawValue> },
+    Invalid { message: &'static str },
+}
+
+/// One collector belongs to exactly one response. Stop feeding it after a result.
+#[derive(Default)]
+pub struct CompactCollector {
+    indexed: BTreeMap<OutputIndex, Box<RawValue>>,
+    unindexed: Vec<Box<RawValue>>,
+    saw_payload: bool,
+}
+
+impl CompactCollector {
+    pub fn push(&mut self, block: &str) -> Option<CompactResult> {
+        let data = block
+            .split(['\r', '\n'])
+            .filter_map(|line| {
+                let (field, value) = line.split_once(':').unwrap_or((line, ""));
+                (field == "data").then(|| value.strip_prefix(' ').unwrap_or(value))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut payload: Object = serde_json::from_str(&data).ok()?;
+        self.saw_payload = true;
+        let event_type: String = serde_json::from_str(payload.get("type")?.get()).ok()?;
+        match event_type.as_str() {
+            "response.output_item.added" | "response.output_item.done" => {
+                let item = payload
+                    .remove("item")
+                    .filter(|item| item.get().starts_with('{'))?;
+                if let Some(index) = payload
+                    .get("output_index")
+                    .and_then(|index| OutputIndex::parse(index.get()))
+                {
+                    self.indexed.insert(index, item);
+                } else if event_type == "response.output_item.done" {
+                    self.unindexed.push(item);
+                }
+                None
+            }
+            "response.completed" => {
+                let Some(response) = payload
+                    .remove("response")
+                    .filter(|response| response.get().starts_with('{'))
+                else {
+                    return Some(CompactResult::Invalid {
+                        message: "response.completed event missing response object",
+                    });
+                };
+                // Only interpret the output array; all other JSON remains opaque.
+                let mut fields: Object =
+                    serde_json::from_str(response.get()).expect("validated JSON object");
+                let has_output = fields.get("output").is_some_and(|output| {
+                    serde_json::from_str::<Vec<Box<RawValue>>>(output.get())
+                        .is_ok_and(|items| !items.is_empty())
+                });
+                if has_output || (self.indexed.is_empty() && self.unindexed.is_empty()) {
+                    return Some(CompactResult::Completed { response });
+                }
+                let items: Vec<_> = std::mem::take(&mut self.indexed)
+                    .into_values()
+                    .chain(std::mem::take(&mut self.unindexed))
+                    .collect();
+                fields.insert(
+                    "output".to_owned(),
+                    to_raw_value(&items).expect("serialize raw items"),
+                );
+                Some(CompactResult::Completed {
+                    response: to_raw_value(&fields).expect("serialize raw response"),
+                })
+            }
+            "response.failed" | "response.incomplete" | "error" => {
+                Some(CompactResult::TerminalError {
+                    event: RawValue::from_string(data).expect("validated JSON payload"),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn finish(self) -> CompactResult {
+        CompactResult::Invalid {
+            message: if self.saw_payload {
+                "upstream SSE ended before response.completed"
+            } else {
+                "empty upstream SSE response"
+            },
+        }
+    }
+}
+
+/// Python integer ordering, including bool indices, without narrowing large ints.
+#[derive(Eq, PartialEq)]
+struct OutputIndex(String);
+
+impl OutputIndex {
+    fn parse(raw: &str) -> Option<Self> {
+        let raw = match raw {
+            "true" => "1",
+            "false" | "-0" => "0",
+            value => value,
+        };
+        let magnitude = raw.strip_prefix('-').unwrap_or(raw);
+        (!magnitude.is_empty() && magnitude.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| Self(raw.to_owned()))
+    }
+}
+
+impl Ord for OutputIndex {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let left_negative = self.0.starts_with('-');
+        let right_negative = other.0.starts_with('-');
+        match (left_negative, right_negative) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => {
+                let order = self
+                    .0
+                    .len()
+                    .cmp(&other.0.len())
+                    .then_with(|| self.0.cmp(&other.0));
+                if left_negative {
+                    order.reverse()
+                } else {
+                    order
+                }
+            }
+        }
+    }
+}
+
+impl PartialOrd for OutputIndex {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/codex-lb-responses/src/lib.rs
+++ b/crates/codex-lb-responses/src/lib.rs
@@ -1,0 +1,3 @@
+//! Responses semantics independent of transport, process lifecycle, and routing.
+
+pub mod compact;

--- a/crates/codex-lb-responses/tests/compact.rs
+++ b/crates/codex-lb-responses/tests/compact.rs
@@ -1,6 +1,22 @@
 use codex_lb_responses::compact::CompactCollector;
 
 #[test]
+fn escaped_surrogate_key_survives_assembly() {
+    let mut collector = CompactCollector::default();
+    assert!(
+        collector
+            .push("data: {\"type\":\"response.output_item.done\",\"item\":{}}\n\n")
+            .is_none()
+    );
+    let result = collector
+        .push(r#"data: {"type":"response.completed","response":{"\ud800":1}}"#)
+        .unwrap();
+    let text = serde_json::to_string(&result).unwrap();
+    assert!(text.contains(r#"\ud800"#));
+    assert!(text.contains(r#""output":[{}]"#));
+}
+
+#[test]
 fn shared_compact_fixtures() {
     let cases: serde_json::Value =
         serde_json::from_str(include_str!("fixtures/compact-v1.json")).unwrap();

--- a/crates/codex-lb-responses/tests/compact.rs
+++ b/crates/codex-lb-responses/tests/compact.rs
@@ -1,0 +1,22 @@
+use codex_lb_responses::compact::CompactCollector;
+
+#[test]
+fn shared_compact_fixtures() {
+    let cases: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/compact-v1.json")).unwrap();
+    for case in cases.as_array().unwrap() {
+        let mut collector = CompactCollector::default();
+        let result = case["blocks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find_map(|block| collector.push(block.as_str().unwrap()))
+            .unwrap_or_else(|| collector.finish());
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            case["expected"],
+            "{}",
+            case["name"]
+        );
+    }
+}

--- a/crates/codex-lb-responses/tests/fixtures/compact-v1.json
+++ b/crates/codex-lb-responses/tests/fixtures/compact-v1.json
@@ -1,0 +1,350 @@
+[
+  {
+    "name": "indexed_replace_and_sort",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"ten\"}, \"output_index\": 10}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"minus\"}, \"output_index\": -5}\n\n",
+      "data: {\"type\": \"response.output_item.added\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"old\"}, \"output_index\": 2}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"new\"}, \"output_index\": 2}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": [
+          {
+            "type": "compaction",
+            "encrypted_content": "minus"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "new"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "ten"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "unindexed_order",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.added\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"ignored\"}}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"first\"}}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"float\"}, \"output_index\": 1.5}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"string\"}, \"output_index\": \"1\"}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"zero\"}, \"output_index\": 0}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": [
+          {
+            "type": "compaction",
+            "encrypted_content": "zero"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "first"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "float"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "string"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "bool_and_large_integer_indices",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"old\"}, \"output_index\": true}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"one\"}, \"output_index\": 1}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"zero\"}, \"output_index\": false}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"big-negative\"}, \"output_index\": -100000000000000000000000000000000000000000000000000}\n\n",
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"big-positive\"}, \"output_index\": 100000000000000000000000000000000000000000000000000}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": [
+          {
+            "type": "compaction",
+            "encrypted_content": "big-negative"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "zero"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "one"
+          },
+          {
+            "type": "compaction",
+            "encrypted_content": "big-positive"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "terminal_output_wins",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"ignored\"}, \"output_index\": 0}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"output\": [{\"keep\": true}], \"unknown\": {\"integer\": 10000000000000000000000000000000000000000000000000000000000000000000000, \"text\": \"\\ud55c\\uae00 \\ud83d\\ude00\"}}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "output": [
+          {
+            "keep": true
+          }
+        ],
+        "unknown": {
+          "integer": 10000000000000000000000000000000000000000000000000000000000000000000000,
+          "text": "한글 😀"
+        }
+      }
+    }
+  },
+  {
+    "name": "unknown_fields_when_assembled",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.done\", \"item\": {\"type\": \"compaction\", \"encrypted_content\": \"item\"}, \"output_index\": 0}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"output\": null, \"unknown\": {\"integer\": 10000000000000000000000000000000000000000000000000000000000000000000000, \"text\": \"\\ud55c\\uae00 \\ud83d\\ude00\"}}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "output": [
+          {
+            "type": "compaction",
+            "encrypted_content": "item"
+          }
+        ],
+        "unknown": {
+          "integer": 10000000000000000000000000000000000000000000000000000000000000000000000,
+          "text": "한글 😀"
+        }
+      }
+    }
+  },
+  {
+    "name": "no_items_preserves_output_shape",
+    "blocks": [
+      "data: {\"type\": \"response.completed\", \"response\": {\"output\": \"opaque\", \"other\": 42}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "output": "opaque",
+        "other": 42
+      }
+    }
+  },
+  {
+    "name": "empty_output_stays_empty",
+    "blocks": [
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": []
+      }
+    }
+  },
+  {
+    "name": "ignore_non_object_items",
+    "blocks": [
+      "data: {\"type\": \"response.output_item.done\", \"output_index\": 0, \"item\": []}\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": []
+      }
+    }
+  },
+  {
+    "name": "stop_after_completion",
+    "blocks": [
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n",
+      "data: {\"type\": \"response.failed\", \"response\": {\"error\": {\"message\": \"late\"}}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": []
+      }
+    }
+  },
+  {
+    "name": "multiline_crlf",
+    "blocks": [
+      ": comment\r\nevent: ignored\r\ndata: {\"type\":\"response.completed\",\r\ndata: \"response\":{\"object\":\"response.compact\"}}\r\n\r\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact"
+      }
+    }
+  },
+  {
+    "name": "bare_cr",
+    "blocks": [
+      "data:{\"type\":\"response.completed\",\"response\":{}}\r\r"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {}
+    }
+  },
+  {
+    "name": "ignore_invalid_prefix",
+    "blocks": [
+      ": ping\n\n",
+      "data: [DONE]\n\n",
+      "data: invalid\n\n",
+      "data: []\n\n",
+      "data: {\"type\": \"response.completed\", \"response\": {\"object\": \"response.compact\", \"id\": \"shared\", \"output\": []}}\n\n"
+    ],
+    "expected": {
+      "kind": "completed",
+      "response": {
+        "object": "response.compact",
+        "id": "shared",
+        "output": []
+      }
+    }
+  },
+  {
+    "name": "empty",
+    "blocks": [],
+    "expected": {
+      "kind": "invalid",
+      "message": "empty upstream SSE response"
+    }
+  },
+  {
+    "name": "only_invalid",
+    "blocks": [
+      "data: nope\n\n"
+    ],
+    "expected": {
+      "kind": "invalid",
+      "message": "empty upstream SSE response"
+    }
+  },
+  {
+    "name": "missing_completion",
+    "blocks": [
+      "data: {\"type\": \"response.created\"}\n\n"
+    ],
+    "expected": {
+      "kind": "invalid",
+      "message": "upstream SSE ended before response.completed"
+    }
+  },
+  {
+    "name": "object_without_type",
+    "blocks": [
+      "data: {}\n\n"
+    ],
+    "expected": {
+      "kind": "invalid",
+      "message": "upstream SSE ended before response.completed"
+    }
+  },
+  {
+    "name": "bad_completed_response",
+    "blocks": [
+      "data: {\"type\": \"response.completed\", \"response\": []}\n\n"
+    ],
+    "expected": {
+      "kind": "invalid",
+      "message": "response.completed event missing response object"
+    }
+  },
+  {
+    "name": "response.failed",
+    "blocks": [
+      "data: {\"type\": \"response.failed\", \"response\": {\"error\": {\"code\": \"quota_exceeded\", \"message\": \"quota\", \"retry_after_seconds\": 9}}}\n\n"
+    ],
+    "expected": {
+      "kind": "terminal_error",
+      "event": {
+        "type": "response.failed",
+        "response": {
+          "error": {
+            "code": "quota_exceeded",
+            "message": "quota",
+            "retry_after_seconds": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "response.incomplete",
+    "blocks": [
+      "data: {\"type\": \"response.incomplete\", \"response\": {\"error\": {\"code\": \"quota_exceeded\", \"message\": \"quota\", \"retry_after_seconds\": 9}}}\n\n"
+    ],
+    "expected": {
+      "kind": "terminal_error",
+      "event": {
+        "type": "response.incomplete",
+        "response": {
+          "error": {
+            "code": "quota_exceeded",
+            "message": "quota",
+            "retry_after_seconds": 9
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "error",
+    "blocks": [
+      "data: {\"type\": \"error\", \"response\": {\"error\": {\"code\": \"quota_exceeded\", \"message\": \"quota\", \"retry_after_seconds\": 9}}}\n\n"
+    ],
+    "expected": {
+      "kind": "terminal_error",
+      "event": {
+        "type": "error",
+        "response": {
+          "error": {
+            "code": "quota_exceeded",
+            "message": "quota",
+            "retry_after_seconds": 9
+          }
+        }
+      }
+    }
+  }
+]

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -17,14 +17,15 @@ rust-toolchain.toml               pinned compiler, rustfmt, and clippy
 deny.toml                         advisory, license, and source policy
 crates/
   codex-lb-protocol/              versioned Python/Rust IPC data contract
+  codex-lb-responses/             synchronous Responses semantics and collection
   codex-lb-egress/                reusable HTTP, TLS, and WebSocket transport
   codex-lb-egress-worker/         stdio process lifecycle and binary target
 app/core/clients/native_egress.py Python adapter and replay-safe ownership
 ```
 
 The dependency direction is one way: the worker depends on egress, and egress
-depends on protocol. The protocol crate has no async runtime or networking
-dependencies. Application policy must not move into the worker merely because
+depends on protocol and Responses. The protocol and Responses crates have no
+async runtime or networking dependencies. Application policy must not move into the worker merely because
 the worker is Rust: Python currently retains account selection, endpoint
 ordering, retries, health classification, and persistence.
 
@@ -36,7 +37,7 @@ that migration reaches the application shell.
 Direct and account-routed streaming and compact Responses requests delegate SSE byte framing to egress.
 The adapter requires `http_sse_v1` and supplies the existing idle timeout and
 event byte limit as per-request options. Rust owns the deadline between body
-reads, including partial events; Python consumes framed text and retains event
+reads, including partial events; for ordinary streaming Python consumes framed text and retains event
 normalization, terminal detection, archives, and public error mapping. HTTP
 error bodies and non-streaming requests keep the raw chunk contract.
 
@@ -45,10 +46,14 @@ Compact requests additionally require `http_compact_sse_v1`. Their
 the exact `text/event-stream` media type (ignoring parameters and case) and
 absent/empty Content-Type use native framing. Both Python compact paths apply
 the same comparison, so non-SSE types or parameters mentioning event-stream
-retain JSON parsing. Python
-still collects output items and returns the existing compact payload as soon
-as `response.completed` arrives, closing the request without waiting for HTTP
-EOF. A null total timeout stays unset; explicit total, connection, and SSE idle
+retain JSON parsing. Compact SSE additionally requires `http_compact_collect_v1`:
+Rust collects output items and assembles the completed response in the reusable
+Responses library. Python receives one fragmented result, retains public shape
+normalization and error translation, and returns as soon as `response.completed`
+arrives without waiting for HTTP EOF. Unknown fields and large integers remain
+opaque JSON; indexed items use last-write precedence and numeric ordering,
+followed by unindexed done items. The Python collector serves only the
+missing-helper transport. A null total timeout stays unset; explicit total, connection, and SSE idle
 deadlines retain their meaning. The adapter and bundled helper must be updated
 together because an older helper cannot honor this contract.
 
@@ -68,6 +73,9 @@ SSE text crosses IPC in fragments of at most 16 KiB of UTF-8, with an explicit
 continuation flag. This keeps individual JSON lines and the existing bounded
 queue small even for large events or escaped control characters. The adapter
 joins text fragments without scanning or decoding the SSE bytes again.
+Compact result envelopes use the same text-fragment bound. Intermediate compact
+events remain inside Rust, including output-item updates; Python only decodes
+the resulting response, terminal error, or invalid-completion envelope.
 The framing contract and cancellation behavior are specified by
 [outbound HTTP clients](https://github.com/Soju06/codex-lb/blob/main/openspec/specs/outbound-http-clients/spec.md) and
 [Responses compatibility](https://github.com/Soju06/codex-lb/blob/main/openspec/specs/responses-api-compat/spec.md).

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/design.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/design.md
@@ -1,0 +1,39 @@
+## Context
+
+Compact SSE framing is native, but Python still parses each framed event and
+collects indexed and unindexed output before returning the terminal response.
+Python also owns public shape normalization, errors, routing, and archives.
+
+## Decisions
+
+- Introduce `codex-lb-responses`, a synchronous library without networking or IPC
+  dependencies. Egress composes its compact collector with the existing framer.
+- Add `collect_compact` to SSE options, requiring content-type-aware framing and
+  negotiated `http_compact_collect_v1`. Raw JSON success and HTTP errors retain
+  the raw-body path. No ordinary streaming or WebSocket behavior changes.
+- Send a `compact` result as UTF-8 text fragments with the same 16 KiB bound as
+  SSE fragments. The envelope distinguishes completed response, upstream terminal
+  error, and invalid/missing completion. Python parses this one envelope and
+  uses the existing public error translation and payload normalization.
+- Stop reading immediately on a terminal event, including when more bytes or an
+  oversized event follow in the same body read. Emit transport `end` outside the
+  cancellable HTTP execution future as with existing requests.
+- Preserve unknown response/item fields as raw JSON. This avoids lossy conversion
+  of large integers and unnecessary interpretation of application payloads.
+- Python collection remains only for the supported missing-helper transport.
+  Native requests never replay or invoke the Python collector after dispatch.
+
+## Risks / Trade-offs
+
+- Collector semantic drift: shared fixtures run through both the Rust collector
+  and the existing Python implementation, plus direct/routed real-helper probes.
+- Large collected outputs: retain the existing aggregate behavior; bound each
+  IPC line and keep cancellation/queue bounds. No new public aggregate limit.
+- Helper version skew: require the new capability before dispatch and ship the
+  adapter and helper together. Incompatible installed helpers fail closed.
+
+## Migration Plan
+
+Cut over only successful compact SSE collection. Verify exact output precedence,
+missing completion, terminal errors, timeouts, cancellation, and cleanup before
+archiving. Future Rust application code can directly reuse this library.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/proposal.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Compact Responses already delegates SSE framing to Rust but sends every event
+across IPC for Python to collect output items. Moving that collector beside the
+native framer removes per-event Python work and establishes a reusable Responses
+library for subsequent application migration.
+
+## What Changes
+
+- Add a pure Rust Responses library owning compact SSE event interpretation,
+  indexed/unindexed output collection, and terminal response assembly.
+- Negotiate compact collection separately and return a fragmented result through
+  IPC as soon as a terminal event arrives, without waiting for HTTP EOF.
+- Keep Python public payload normalization, error translation, routing, archives,
+  and settlement. Preserve missing-helper fallback and raw JSON/error handling.
+- Add shared collector fixtures and direct/routed real-worker regressions.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `outbound-http-clients`: negotiated compact collection and bounded IPC results.
+- `responses-api-compat`: native compact collection preserves output and terminal behavior.
+
+## Impact
+
+Cargo workspace, protocol, egress integration, Python adapter and compact client,
+contract fixtures, integration tests, and Rust architecture documentation.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/specs/outbound-http-clients/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Native compact collection is negotiated and bounded across IPC
+
+The adapter MUST require `http_compact_collect_v1` before requesting native
+compact collection. Collection MUST apply only to successful responses selected
+for SSE by the compact Content-Type contract. Other bodies MUST retain raw-body
+handling. Collected result IPC text fragments MUST NOT exceed 16 KiB of UTF-8.
+The adapter MUST reject malformed or truncated results without replaying the
+request. Missing-helper fallback MUST remain limited to the pre-dispatch boundary.
+
+#### Scenario: Large collected result
+
+- **WHEN** a compact result exceeds one IPC text fragment
+- **THEN** the adapter reconstructs one complete result with all unknown fields intact
+- **AND** ready consumers receive scheduling opportunities between fragments
+
+#### Scenario: Incompatible installed helper
+
+- **WHEN** a launched helper lacks the compact collection capability
+- **THEN** negotiation fails before dispatch and no Python replay occurs
+
+#### Scenario: Cancellation while collecting
+
+- **WHEN** a compact caller cancels before a terminal result
+- **THEN** its native request and owned response/session close
+- **AND** another request sharing the helper remains usable

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/specs/responses-api-compat/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Native compact collection preserves terminal output assembly
+
+For direct and account-routed compact SSE requests with negotiated native
+collection, Rust MUST collect output items and assemble the terminal response.
+The last item for each integer output index MUST win; indexed items MUST be
+ordered numerically, followed by unindexed done items in arrival order. A
+nonempty terminal output array MUST take precedence over collected items.
+Unknown JSON fields and integer values MUST be preserved. Python MUST retain
+public shape normalization, error translation, archives, routing, and settlement.
+
+#### Scenario: Completion without terminal output
+
+- **WHEN** output-item events precede a completed response with missing or empty output
+- **THEN** the result includes collected items in the documented order
+- **AND** returns on completion without waiting for HTTP EOF or interpreting later events
+
+#### Scenario: Existing terminal output
+
+- **WHEN** the completed response contains a nonempty output array
+- **THEN** that array is returned without merging earlier collected items
+
+#### Scenario: Terminal failure or missing completion
+
+- **WHEN** an SSE stream fails, is incomplete, has no valid completed response object, or ends before completion
+- **THEN** the existing compact error envelope and failure classification are preserved
+
+#### Scenario: Missing-helper compatibility
+
+- **WHEN** the native helper is unavailable before dispatch
+- **THEN** Python transport and collection preserve the same output assembly contract
+
+## MODIFIED Requirements
+
+### Requirement: Native compact Responses preserve terminal and ownership contracts
+
+Direct and account-routed compact requests MUST use native transport when the
+helper has negotiated `http_compact_sse_v1` and `http_compact_collect_v1`. Native SSE framing MUST apply only
+to successful responses selected by the outbound HTTP Content-Type rule; other
+responses MUST retain raw body handling. Python MUST retain request shaping,
+compact normalization, terminal error mapping, archives, routing, and settlement.
+Responses MUST remain open until consumption finishes, and owned responses and
+routed sessions MUST close on completion, failure, and cancellation. Missing
+helpers MAY use Python transport only before dispatch. An installed helper lacking
+either required compact capability MUST fail negotiation before dispatch without Python fallback. Native failures after
+dispatch MUST NOT replay the POST through Python or another proxy endpoint.
+
+#### Scenario: Compact completes before HTTP EOF
+
+- **WHEN** response.completed follows compact output items while upstream keeps the body open
+- **THEN** compact returns the existing normalized payload without waiting for EOF
+- **AND** the owned transport request closes while unrelated helper requests stay usable
+
+#### Scenario: Terminal and framing failures
+
+- **WHEN** compact receives a terminal SSE error or exceeds its event/idle/total limit
+- **THEN** existing compact public error codes, status mapping, and replay safety are preserved
+- **AND** the response and owned client are cleaned up
+
+#### Scenario: Routed fallback before dispatch
+
+- **WHEN** a confirmed pre-dispatch connection failure permits the next configured endpoint
+- **THEN** native SSE options follow that attempt and its exact route metadata is recorded
+- **AND** an accepted response or ambiguous body failure never triggers endpoint replay
+
+#### Scenario: Missing helper and cancelled caller
+
+- **WHEN** the helper is missing before dispatch
+- **THEN** the resolved Python transport receives no native-only option and retains compact parsing
+- **AND** cancellation finishes owned response/session cleanup even in an already cancelled scope
+
+#### Scenario: Cancellation while waiting for native response headers
+
+- **WHEN** an already cancelled caller scope interrupts native response-head waiting
+- **THEN** request cancellation completes and its stream registration is removed
+- **AND** a completed native exchange wins a simultaneous shutdown/cancel race without an additional terminal event

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/tasks.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/tasks.md
@@ -1,0 +1,10 @@
+## 1. Contract and collector
+- [x] 1.1 Add the synchronous Responses collector and shared Python/Rust fixtures.
+- [x] 1.2 Extend negotiated SSE options and fragmented compact result contract.
+## 2. Native cutover
+- [x] 2.1 Compose framing and collection, stopping on terminal events before EOF.
+- [x] 2.2 Consume native results in Python while retaining public translation and pre-dispatch fallback.
+## 3. Verification
+- [x] 3.1 Verify output parity, large results, terminal errors, cancellation, and no replay through direct/routed paths.
+- [x] 3.2 Run Rust checks, Python regressions, lint/types, architecture, and strict specs.
+- [x] 3.3 Record performance baseline and verification, sync specs, and archive.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
@@ -1,0 +1,49 @@
+# Verification
+
+## Completeness and correctness
+
+- The Responses library owns compact SSE collection; egress composes it with
+  framing, and Python retains public normalization/error translation.
+- 20 shared collector fixtures agree with the original Python collector. The
+  direct/routed public compact comparison runs every case through both native
+  and missing-helper paths, including terminal errors and missing completion.
+- A collected result exceeding 2 MiB arrives through more than 64 bounded
+  fragments without Python event collection. Its unknown fields and 71-digit
+  integer survive, and trailing oversized SSE does not invalidate completion.
+- Existing compact tests prove cancellation before/after headers, timeout
+  precedence, framing limits, resource ownership, and replay-safe endpoint use.
+- Malformed, truncated, duplicate, oversized, or wrong-kind IPC results fail
+  without replay. An installed helper lacking the new capability fails closed.
+
+## Local validation
+
+- Native adapter/client/packaging/shared fixtures and real-worker routed/SSE
+  integration group: 249 passed; the invalid-option group also passed all six cases after adding
+  the collection/content-type constraint.
+- Existing compact client regressions: 101 passed.
+- Rust workspace tests: 20 passed, including the 20-case collector fixture test.
+- Locked release build, formatting, Clippy with denied warnings, cargo-deny,
+  Ruff, changed-file ty, architecture/cancellation/timing checks passed.
+- Strict OpenSpec delta validation passed before archival.
+
+## Performance scope
+
+The reproducible benchmark is retained under
+`~/benchmarks/codex-lb-compact/2026-09-08/compare_collectors.py`, with results
+archived alongside migration evidence. It uses the same release helper and
+loopback HTTP body for both native framing/Python collection and native
+collection. 2,049 events, 270,260 upstream bytes, 30 measured sequential calls
+per mode after warmup: median 431.6 ms versus 9.8 ms; p95 554.6 ms versus 13.9 ms.
+Python process CPU averages 291.3 ms versus 4.8 ms per call; helper CPU is excluded.
+This synthetic measurement is not a production latency or whole-service CPU claim.
+At concurrency 8 (48 measured calls per mode), median latency was 3,441.1 ms
+versus 40.5 ms, and p95 was 3,599.7 ms versus 49.2 ms.
+RSS is recorded jointly for both modes and cannot establish a memory reduction.
+
+## Coherence
+
+The synchronous Responses crate has no networking or IPC dependencies. The
+collector preserves opaque JSON and numeric index ordering. Existing wire
+fields keep their meaning; the new optional behavior requires an additional
+capability. No public configuration or deployment steps were introduced.
+No outstanding implementation, scenario, or ownership gaps were found.

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
@@ -35,6 +35,9 @@
   and the scheduling opportunity after every accepted native event.
 - The large compact result regression fixes its queue capacity at 64 so it
   continues to exercise consumer progress after the default capacity increased.
+- Buffered Responses SSE/JSON/error and adapter burst regressions also fix the
+  queue capacity at 64; their consumers start reading immediately. This preserves
+  over-capacity coverage for 256- and 2,000-event bursts after the main update.
 - Combined adapter/client/shared fixture tests: 125 passed; compact route and
   packaging/framing fixture tests: 62 passed; real-worker integration: 119 passed.
 - Release workspace tests: 21 passed. Release build, Ruff, changed-file typing,

--- a/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-compact-response-collection/verification.md
@@ -14,6 +14,9 @@
   precedence, framing limits, resource ownership, and replay-safe endpoint use.
 - Malformed, truncated, duplicate, oversized, or wrong-kind IPC results fail
   without replay. An installed helper lacking the new capability fails closed.
+- Escaped surrogate keys remain opaque during assembly rather than panicking a
+  worker task. Rust and direct/routed integration regressions verify preservation.
+
 
 ## Local validation
 
@@ -21,7 +24,7 @@
   integration group: 249 passed; the invalid-option group also passed all six cases after adding
   the collection/content-type constraint.
 - Existing compact client regressions: 101 passed.
-- Rust workspace tests: 20 passed, including the 20-case collector fixture test.
+- Rust workspace tests: 21 passed, including the 20-case collector fixture test.
 - Locked release build, formatting, Clippy with denied warnings, cargo-deny,
   Ruff, changed-file ty, architecture/cancellation/timing checks passed.
 - Strict OpenSpec delta validation passed before archival.

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -751,3 +751,29 @@ effective compact timeout when set, otherwise use `stream_idle_timeout_seconds`.
 - **WHEN** an installed helper lacks http_compact_sse_v1
 - **THEN** the adapter fails before dispatch rather than silently ignoring compact options
 - **AND** it does not replay through Python
+
+### Requirement: Native compact collection is negotiated and bounded across IPC
+
+The adapter MUST require `http_compact_collect_v1` before requesting native
+compact collection. Collection MUST apply only to successful responses selected
+for SSE by the compact Content-Type contract. Other bodies MUST retain raw-body
+handling. Collected result IPC text fragments MUST NOT exceed 16 KiB of UTF-8.
+The adapter MUST reject malformed or truncated results without replaying the
+request. Missing-helper fallback MUST remain limited to the pre-dispatch boundary.
+
+#### Scenario: Large collected result
+
+- **WHEN** a compact result exceeds one IPC text fragment
+- **THEN** the adapter reconstructs one complete result with all unknown fields intact
+- **AND** ready consumers receive scheduling opportunities between fragments
+
+#### Scenario: Incompatible installed helper
+
+- **WHEN** a launched helper lacks the compact collection capability
+- **THEN** negotiation fails before dispatch and no Python replay occurs
+
+#### Scenario: Cancellation while collecting
+
+- **WHEN** a compact caller cancels before a terminal result
+- **THEN** its native request and owned response/session close
+- **AND** another request sharing the helper remains usable

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5777,14 +5777,14 @@ cancellation MUST NOT replay a dispatched POST or switch its proxy endpoint.
 ### Requirement: Native compact Responses preserve terminal and ownership contracts
 
 Direct and account-routed compact requests MUST use native transport when the
-helper has negotiated `http_compact_sse_v1`. Native SSE framing MUST apply only
+helper has negotiated `http_compact_sse_v1` and `http_compact_collect_v1`. Native SSE framing MUST apply only
 to successful responses selected by the outbound HTTP Content-Type rule; other
-responses MUST retain raw body handling. Python MUST retain request shaping, output collection,
+responses MUST retain raw body handling. Python MUST retain request shaping,
 compact normalization, terminal error mapping, archives, routing, and settlement.
 Responses MUST remain open until consumption finishes, and owned responses and
 routed sessions MUST close on completion, failure, and cancellation. Missing
 helpers MAY use Python transport only before dispatch. An installed helper lacking
-`http_compact_sse_v1` MUST fail negotiation before dispatch without Python fallback. Native failures after
+either required compact capability MUST fail negotiation before dispatch without Python fallback. Native failures after
 dispatch MUST NOT replay the POST through Python or another proxy endpoint.
 
 #### Scenario: Compact completes before HTTP EOF
@@ -5816,3 +5816,34 @@ dispatch MUST NOT replay the POST through Python or another proxy endpoint.
 - **WHEN** an already cancelled caller scope interrupts native response-head waiting
 - **THEN** request cancellation completes and its stream registration is removed
 - **AND** a completed native exchange wins a simultaneous shutdown/cancel race without an additional terminal event
+
+### Requirement: Native compact collection preserves terminal output assembly
+
+For direct and account-routed compact SSE requests with negotiated native
+collection, Rust MUST collect output items and assemble the terminal response.
+The last item for each integer output index MUST win; indexed items MUST be
+ordered numerically, followed by unindexed done items in arrival order. A
+nonempty terminal output array MUST take precedence over collected items.
+Unknown JSON fields and integer values MUST be preserved. Python MUST retain
+public shape normalization, error translation, archives, routing, and settlement.
+
+#### Scenario: Completion without terminal output
+
+- **WHEN** output-item events precede a completed response with missing or empty output
+- **THEN** the result includes collected items in the documented order
+- **AND** returns on completion without waiting for HTTP EOF or interpreting later events
+
+#### Scenario: Existing terminal output
+
+- **WHEN** the completed response contains a nonempty output array
+- **THEN** that array is returned without merging earlier collected items
+
+#### Scenario: Terminal failure or missing completion
+
+- **WHEN** an SSE stream fails, is incomplete, has no valid completed response object, or ends before completion
+- **THEN** the existing compact error envelope and failure classification are preserved
+
+#### Scenario: Missing-helper compatibility
+
+- **WHEN** the native helper is unavailable before dispatch
+- **THEN** Python transport and collection preserve the same output assembly contract

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -836,8 +836,9 @@ async def test_native_compact_escaped_surrogate_key_preserves_python_validation(
         await _finish_chunks(writer)
 
     async with _serve_http(handler) as base_url, aiohttp.ClientSession() as session:
+        missing = SubprocessNativeEgressClient(Path("/tmp/missing-compact-surrogate-helper"))
         with pytest.raises(ProxyResponseError) as expected:
-            await asyncio.wait_for(_compact(base_url, None, monkeypatch, routed=routed, session=session), 2)
+            await asyncio.wait_for(_compact(base_url, missing, monkeypatch, routed=routed, session=session), 2)
         with pytest.raises(ProxyResponseError) as actual:
             await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), 2)
         assert actual.value.status_code == expected.value.status_code == 502

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -8,13 +8,14 @@ import socket
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from urllib.parse import urlsplit
 
 import aiohttp
 import anyio
 import pytest
 
+import app.core.clients.native_egress as native_module
 import app.core.clients.proxy as proxy_module
 from app.core.clients.codex import CodexClient
 from app.core.clients.native_egress import SubprocessNativeEgressClient
@@ -734,6 +735,89 @@ _COMPACT_EVENTS = (
     b'{"object":"response","id":"resp_compact","output":[]}}\n\n'
 )
 
+_COMPACT_CASES = json.loads(
+    (Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/compact-v1.json").read_text()
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _COMPACT_CASES, ids=[case["name"] for case in _COMPACT_CASES])
+async def test_native_compact_collection_matches_python_public_result(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    tmp_path: Path,
+    routed: bool,
+    case: dict[str, Any],
+) -> None:
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        body = "".join(case["blocks"]).encode()
+        if body:
+            await _write_chunk(writer, body)
+        await _finish_chunks(writer)
+
+    async def outcome(
+        base_url: str, worker: SubprocessNativeEgressClient, session: aiohttp.ClientSession | None
+    ) -> object:
+        try:
+            result = await _compact(base_url, worker, monkeypatch, routed=routed, session=session)
+            return result.model_dump()
+        except ProxyResponseError as exc:
+            return exc.status_code, exc.payload, exc.failure_phase
+
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession() as session:
+        missing = SubprocessNativeEgressClient(tmp_path / "missing-helper")
+        expected = await outcome(base_url, missing, session)
+
+        def forbidden_collection(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("native compact must not enter the Python collector")
+
+        monkeypatch.setattr(proxy_module, "_compact_response_payload_from_sse", forbidden_collection)
+        assert await outcome(base_url, native_worker, None) == expected
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+async def test_native_compact_large_result_is_fragmented_and_stops_before_late_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+) -> None:
+    items = [{"index": i, "padding": "한글" * 4096, "integer": 10**70} for i in range(96)]
+    blocks = [
+        json.dumps({"type": "response.output_item.done", "output_index": i, "item": item}, ensure_ascii=False)
+        for i, item in enumerate(items)
+    ]
+    blocks.append(json.dumps({"type": "response.completed", "response": {"object": "response.compact", "id": "large"}}))
+    body = "".join("data: " + block + "\n\n" for block in blocks).encode() + b"data: " + b"x" * 100_000 + b"\n\n"
+    monkeypatch.setattr(proxy_module.get_settings(), "max_sse_event_bytes", 64 * 1024)
+    original_read = native_module._read_event
+    fragments: list[int] = []
+
+    async def read_event(stdout: asyncio.StreamReader) -> dict[str, object]:
+        event = await original_read(stdout)
+        if event.get("type") == "compact":
+            fragments.append(len(str(event["text"]).encode()))
+        assert event.get("type") != "sse", "compact intermediate events must stay in Rust"
+        return event
+
+    monkeypatch.setattr(native_module, "_read_event", read_event)
+    closed = asyncio.Event()
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, body)
+        await reader.read()
+        closed.set()
+
+    async with _serve_http(handler) as base_url:
+        result = await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), timeout=5)
+        await asyncio.wait_for(closed.wait(), timeout=2)
+    assert result.model_extra is not None
+    assert result.model_extra["output"] == items
+    assert len(fragments) > 64
+    assert max(fragments) <= 16 * 1024
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("content_type", ["text/event-stream", "Text/Event-Stream; charset=utf-8", None, ""])
@@ -750,6 +834,7 @@ async def test_native_compact_frames_and_returns_before_body_eof(
         raise AssertionError("compact native SSE must bypass the Python byte scanner")
 
     monkeypatch.setattr(proxy_module, "_find_sse_separator", forbidden_python_scan)
+    monkeypatch.setattr(proxy_module, "_compact_response_payload_from_sse", forbidden_python_scan)
 
     async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, body: bytes) -> None:
         requests.append(json.loads(body))

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -820,6 +820,30 @@ async def test_native_compact_large_result_is_fragmented_and_stops_before_late_f
 
 
 @pytest.mark.asyncio
+async def test_native_compact_escaped_surrogate_key_preserves_python_result(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+) -> None:
+    body = (
+        b'data: {"type":"response.output_item.done","item":{}}\n\n'
+        b'data: {"type":"response.completed","response":{"object":"response.compact","\\ud800":1}}\n\n'
+    )
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, body)
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url:
+        result = await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), 2)
+        assert result.model_extra is not None
+        assert result.model_extra["\ud800"] == 1
+        assert result.model_extra["output"] == [{}]
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("content_type", ["text/event-stream", "Text/Event-Stream; charset=utf-8", None, ""])
 async def test_native_compact_frames_and_returns_before_body_eof(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -824,6 +824,7 @@ async def test_native_compact_escaped_surrogate_key_preserves_python_validation(
     monkeypatch: pytest.MonkeyPatch,
     native_worker: SubprocessNativeEgressClient,
     routed: bool,
+    tmp_path: Path,
 ) -> None:
     body = (
         b'data: {"type":"response.output_item.done","item":{}}\n\n'
@@ -836,7 +837,7 @@ async def test_native_compact_escaped_surrogate_key_preserves_python_validation(
         await _finish_chunks(writer)
 
     async with _serve_http(handler) as base_url, aiohttp.ClientSession() as session:
-        missing = SubprocessNativeEgressClient(Path("/tmp/missing-compact-surrogate-helper"))
+        missing = SubprocessNativeEgressClient(tmp_path / "missing-helper")
         with pytest.raises(ProxyResponseError) as expected:
             await asyncio.wait_for(_compact(base_url, missing, monkeypatch, routed=routed, session=session), 2)
         with pytest.raises(ProxyResponseError) as actual:

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -205,8 +205,9 @@ def _stream(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("response_kind", ["sse", "json", "error"])
 async def test_buffered_native_burst_preserves_responses_result(
-    tmp_path: Path, routed: bool, response_kind: str
+    tmp_path: Path, routed: bool, response_kind: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(native_module, "_NATIVE_STREAM_QUEUE_LIMIT", 64)
     handshake = json.loads(
         (Path(__file__).resolve().parents[2] / "crates/codex-lb-protocol/tests/fixtures/handshake-v1.json").read_text()
     )

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -820,7 +820,7 @@ async def test_native_compact_large_result_is_fragmented_and_stops_before_late_f
 
 
 @pytest.mark.asyncio
-async def test_native_compact_escaped_surrogate_key_preserves_python_result(
+async def test_native_compact_escaped_surrogate_key_preserves_python_validation(
     monkeypatch: pytest.MonkeyPatch,
     native_worker: SubprocessNativeEgressClient,
     routed: bool,
@@ -835,11 +835,14 @@ async def test_native_compact_escaped_surrogate_key_preserves_python_result(
         await _write_chunk(writer, body)
         await _finish_chunks(writer)
 
-    async with _serve_http(handler) as base_url:
-        result = await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), 2)
-        assert result.model_extra is not None
-        assert result.model_extra["\ud800"] == 1
-        assert result.model_extra["output"] == [{}]
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession() as session:
+        with pytest.raises(ProxyResponseError) as expected:
+            await asyncio.wait_for(_compact(base_url, None, monkeypatch, routed=routed, session=session), 2)
+        with pytest.raises(ProxyResponseError) as actual:
+            await asyncio.wait_for(_compact(base_url, native_worker, monkeypatch, routed=routed), 2)
+        assert actual.value.status_code == expected.value.status_code == 502
+        assert actual.value.payload == expected.value.payload
+        assert actual.value.failure_phase == expected.value.failure_phase == "parse"
     assert not native_worker._streams
 
 

--- a/tests/unit/test_native_compact_fixtures.py
+++ b/tests/unit/test_native_compact_fixtures.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from app.core.clients.proxy import ProxyResponseError, SSEResponse, _compact_response_payload_from_sse
+
+FIXTURES = Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/compact-v1.json"
+CASES = json.loads(FIXTURES.read_text())
+
+
+class _FramedResponse:
+    def __init__(self, blocks: list[str]) -> None:
+        self.blocks = blocks
+        self.content = self
+
+    async def iter_chunked(self, size: int) -> AsyncIterator[bytes]:
+        for block in self.blocks:
+            yield block.encode()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+async def test_compact_fixture_matches_python_collector(case: dict[str, Any]) -> None:
+    expected = case["expected"]
+    response = cast(SSEResponse, _FramedResponse(case["blocks"]))
+    if expected["kind"] == "invalid":
+        with pytest.raises(ValueError, match=expected["message"]):
+            await _compact_response_payload_from_sse(response, 1, 1024 * 1024)
+    elif expected["kind"] == "terminal_error":
+        with pytest.raises(ProxyResponseError):
+            await _compact_response_payload_from_sse(response, 1, 1024 * 1024)
+    else:
+        assert await _compact_response_payload_from_sse(response, 1, 1024 * 1024) == expected["response"]

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -41,6 +41,7 @@ print(json.dumps({
         "failure_provenance_v1",
         "http",
         "http2_profile_v1",
+        "http_compact_collect_v1",
         "http_compact_sse_v1",
         "http_sse_v1",
         "websocket",
@@ -804,7 +805,8 @@ for line in sys.stdin:
     if command["type"] == "cancel":
         print(json.dumps({{"type": "cancelled", "request_id": request_id}}), flush=True)
         continue
-    assert command["sse"] == {{"idle_timeout_ms": 1000, "max_event_bytes": 1024, "content_type_aware": False}}
+    assert command["sse"] == {{"idle_timeout_ms": 1000, "max_event_bytes": 1024,
+                              "content_type_aware": False, "collect_compact": False}}
     print(json.dumps({{"type": "head", "request_id": request_id, "status": 200,
                        "http_version": "HTTP/1.1", "headers": []}}), flush=True)
     for event in {events!r}:
@@ -869,7 +871,7 @@ async def test_native_sse_failure_releases_owned_stream(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("capability", ["http_sse_v1", "http_compact_sse_v1"])
+@pytest.mark.parametrize("capability", ["http_sse_v1", "http_compact_sse_v1", "http_compact_collect_v1"])
 async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path, capability: str) -> None:
     helper = tmp_path / "native-helper"
     preamble = _HELPER_PROTOCOL_PREAMBLE.replace(f'        "{capability}",\n', "")
@@ -888,6 +890,47 @@ async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path,
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "events",
+    [
+        [{"type": "end"}],
+        [{"type": "compact", "text": "{", "more": True}, {"type": "end"}],
+        [{"type": "compact", "text": "not-json", "more": False}, {"type": "end"}],
+        [{"type": "compact", "text": "{}", "more": "false"}],
+        [{"type": "compact", "text": "x" * (16 * 1024 + 1), "more": False}],
+        [{"type": "compact", "text": "{}", "more": False}] * 2 + [{"type": "end"}],
+        [{"type": "sse", "text": "data: {}\n\n", "more": False}],
+    ],
+)
+async def test_native_compact_rejects_broken_result_without_replay(
+    tmp_path: Path,
+    events: list[dict[str, object]],
+) -> None:
+    helper = tmp_path / "compact-helper"
+    source = _sse_helper_source(events).replace(
+        '"content_type_aware": False, "collect_compact": False',
+        '"content_type_aware": True, "collect_compact": True',
+    )
+    _write_helper(helper, source)
+    client = SubprocessNativeEgressClient(helper)
+    try:
+        response = await client.request(
+            NativeEgressRequest(
+                "POST",
+                "https://example.test",
+                {},
+                sse=NativeSseOptions(1, 1024, True, True),
+            )
+        )
+        with pytest.raises(NativeEgressProtocolError):
+            await asyncio.wait_for(response.compact_result(), timeout=2)
+        assert client._request_sequence == 1
+        assert not client._streams
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "options",
     [
         NativeSseOptions(0, 1),
@@ -895,6 +938,7 @@ async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path,
         NativeSseOptions(float("inf"), 1),
         NativeSseOptions(1, 0),
         NativeSseOptions(1, True),
+        NativeSseOptions(1, 1024, collect_compact=True),
     ],
 )
 async def test_native_sse_options_are_validated_before_start(tmp_path: Path, options: NativeSseOptions) -> None:

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -425,7 +425,8 @@ async def test_client_close_is_idempotent_and_prevents_restart(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_buffered_body_burst_reaches_active_consumer(tmp_path: Path) -> None:
+async def test_buffered_body_burst_reaches_active_consumer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_egress_module, "_NATIVE_STREAM_QUEUE_LIMIT", 64)
     helper = tmp_path / "native-helper"
     _write_helper(
         helper,
@@ -1099,10 +1100,13 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
 
 
 @pytest.mark.asyncio
-async def test_burst_of_small_events_does_not_trip_the_queue_while_the_consumer_drains(tmp_path: Path) -> None:
+async def test_burst_of_small_events_does_not_trip_the_queue_while_the_consumer_drains(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Hundreds of tiny framed deltas buffered in the helper pipe must not fail
     a healthy consumer (the pre-budget 64-event cap did exactly that on a
     saturated event loop, #2167)."""
+    monkeypatch.setattr(native_egress_module, "_NATIVE_STREAM_QUEUE_LIMIT", 64)
     helper = tmp_path / "native-helper"
     _write_helper(
         helper,
@@ -1133,8 +1137,6 @@ for line in sys.stdin:
     )
     client = SubprocessNativeEgressClient(helper)
     response = await client.request(NativeEgressRequest(method="GET", url="https://example.test/burst", headers={}))
-    # Let the whole burst land in the pipe before the consumer starts reading.
-    await asyncio.sleep(0.2)
     body = await asyncio.wait_for(response.read(), timeout=5.0)
     assert body == b"delta" * 2000
     await asyncio.wait_for(client.aclose(), timeout=2.0)


### PR DESCRIPTION
Compact SSE currently crosses IPC event by event so Python can collect output items. This change collects those items in a reusable synchronous Rust Responses library and sends one fragmented result, returning on the terminal event without waiting for HTTP EOF.

The native path requires `http_compact_collect_v1`. Indexed replacement/order, unindexed items, terminal-output precedence, unknown fields, and large integers are preserved. Python retains public shape normalization, error translation, archives, routing, and settlement. Raw JSON/error bodies and pre-dispatch missing-helper fallback keep their existing behavior. The adapter and packaged helper must ship together.

Validation: 252 native/client/packaging/shared-fixture and real-worker integration tests plus 101 existing compact regressions passed. Escaped Unicode keys remain opaque during assembly and retain existing public validation behavior. Rust workspace tests (21), locked release build, fmt, Clippy, dependency audit, Ruff, ty, architecture/cancellation/timing checks and all 58 strict OpenSpec specs passed. Twenty shared cases are compared through Python and Rust, including direct/routed public compact results. Large results, trailing oversized events, malformed IPC, cancellation and no-replay paths are covered. Full local `make ci` was not run; the complete cloud CI remains the readiness gate.

Synthetic loopback baseline (2,049 events, same release helper): sequential median 431.6 ms with Python collection versus 9.8 ms with native collection. At concurrency 8: 3,441.1 ms versus 40.5 ms. These isolate HTTP/IPC/collection, exclude model latency, and are not whole-service performance claims. Memory was recorded jointly and does not establish a reduction.

OpenSpec: `openspec/changes/archive/2026-09-08-migrate-compact-response-collection/` (verified and synced). This is one scoped capability; much of the diff is shared fixtures and specifications. No new operator settings or UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native compact Responses collection is now supported for compatible connections.
  * Large compact results are delivered in fragments and reconstructed safely.
  * Completed responses can be returned as soon as the terminal event arrives, without waiting for the stream to close.

* **Bug Fixes**
  * Improved handling of indexed and unindexed output items while preserving ordering and response fields.
  * Malformed, incomplete, oversized, and terminal-error results are rejected consistently without retrying requests.
  * Capability negotiation prevents unsupported connections from using native compact collection.
  * Streaming queues now enforce event-count and data-size limits for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->