### PR TITLE
fix(egress): bound the native stream queue by a byte budget instead of 64 events

### DIFF
--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -82,11 +82,13 @@ class _BoundedEventQueue(asyncio.Queue[dict[str, object] | BaseException]):
     def put_nowait(self, item: dict[str, object] | BaseException) -> None:
         # The byte budget is enforced against the projected total, so a queue
         # just under budget rejects an event that would carry it past, while a
-        # zero-byte terminal (``end``/``error``) at exactly the budget is still
-        # accepted as long as the event cap has room. An event arriving at an
+        # zero-byte event (``end``/``error``/``cancelled`` or a failure object)
+        # is always accepted as long as the event cap has room so a complete
+        # response is never discarded at the boundary. An event arriving at an
         # empty queue is always accepted (the SSE event size cap bounds it
         # separately) so a lone large chunk is never a failure.
-        if not self.empty() and self.queued_bytes + _event_payload_size(item) > self._max_bytes:
+        size = _event_payload_size(item)
+        if size and not self.empty() and self.queued_bytes + size > self._max_bytes:
             raise asyncio.QueueFull
         super().put_nowait(item)
 

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -79,14 +79,13 @@ class _BoundedEventQueue(asyncio.Queue[dict[str, object] | BaseException]):
         self._max_bytes = max_bytes
         self.queued_bytes = 0
 
-    def full(self) -> bool:
-        return super().full() or self.queued_bytes >= self._max_bytes
-
     def put_nowait(self, item: dict[str, object] | BaseException) -> None:
-        # Account for the incoming event too: a queue just under budget must
-        # not accept an event that carries it far past the budget. An event
-        # arriving at an empty queue is always accepted (the SSE event size cap
-        # bounds it separately) so a lone large chunk is never a failure.
+        # The byte budget is enforced against the projected total, so a queue
+        # just under budget rejects an event that would carry it past, while a
+        # zero-byte terminal (``end``/``error``) at exactly the budget is still
+        # accepted as long as the event cap has room. An event arriving at an
+        # empty queue is always accepted (the SSE event size cap bounds it
+        # separately) so a lone large chunk is never a failure.
         if not self.empty() and self.queued_bytes + _event_payload_size(item) > self._max_bytes:
             raise asyncio.QueueFull
         super().put_nowait(item)

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -53,13 +53,17 @@ _NATIVE_WEBSOCKET_COMMAND_TIMEOUT_SECONDS = 30.0
 
 
 def _event_payload_size(item: object) -> int:
-    """Approximate queued payload bytes of one helper event (its body field)."""
+    """Queued payload bytes of one helper event: its base64 ``data`` (ASCII, so
+    the string length is the byte length) or its UTF-8 encoded SSE ``text``."""
     if not isinstance(item, dict):
         return 0
-    payload = item.get("data")
-    if not isinstance(payload, str):
-        payload = item.get("text")
-    return len(payload) if isinstance(payload, str) else 0
+    data = item.get("data")
+    if isinstance(data, str):
+        return len(data)
+    text = item.get("text")
+    if isinstance(text, str):
+        return len(text.encode("utf-8"))
+    return 0
 
 
 class _BoundedEventQueue(asyncio.Queue[dict[str, object] | BaseException]):
@@ -77,6 +81,15 @@ class _BoundedEventQueue(asyncio.Queue[dict[str, object] | BaseException]):
 
     def full(self) -> bool:
         return super().full() or self.queued_bytes >= self._max_bytes
+
+    def put_nowait(self, item: dict[str, object] | BaseException) -> None:
+        # Account for the incoming event too: a queue just under budget must
+        # not accept an event that carries it far past the budget. An event
+        # arriving at an empty queue is always accepted (the SSE event size cap
+        # bounds it separately) so a lone large chunk is never a failure.
+        if not self.empty() and self.queued_bytes + _event_payload_size(item) > self._max_bytes:
+            raise asyncio.QueueFull
+        super().put_nowait(item)
 
     def _put(self, item: dict[str, object] | BaseException) -> None:
         super()._put(item)

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -36,10 +36,60 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
     }
 )
 _NATIVE_EVENT_LINE_LIMIT = 24 * 1024 * 1024
-_NATIVE_STREAM_QUEUE_LIMIT = 64
+# Per-request bound between the helper reader (one task draining the helper's
+# stdout for every in-flight request) and each request's consumer. The bound
+# is a *byte budget* with a generous event cap: framed SSE deltas are tens of
+# bytes each and arrive in bursts of hundreds when upstream flushes reasoning
+# output, while a non-SSE body (an image generation JSON) is a handful of
+# large chunks. Either shape must fit while a healthy consumer is merely late
+# for a scheduling turn on a saturated event loop; only a consumer that truly
+# stops draining (dead client) trips the bound and is failed so it cannot hold
+# the shared reader hostage.
+_NATIVE_STREAM_QUEUE_LIMIT = 4096
+_NATIVE_STREAM_QUEUE_BYTES_LIMIT = 32 * 1024 * 1024
 _NATIVE_WEBSOCKET_MESSAGE_QUEUE_LIMIT = 64
 _NATIVE_CANCEL_TIMEOUT_SECONDS = 2.0
 _NATIVE_WEBSOCKET_COMMAND_TIMEOUT_SECONDS = 30.0
+
+
+def _event_payload_size(item: object) -> int:
+    """Approximate queued payload bytes of one helper event (its body field)."""
+    if not isinstance(item, dict):
+        return 0
+    payload = item.get("data")
+    if not isinstance(payload, str):
+        payload = item.get("text")
+    return len(payload) if isinstance(payload, str) else 0
+
+
+class _BoundedEventQueue(asyncio.Queue[dict[str, object] | BaseException]):
+    """``asyncio.Queue`` whose ``full()`` also trips on a queued-bytes budget.
+
+    ``put_nowait`` consults ``full()`` before enqueueing, so the reader's
+    existing ``QueueFull`` handling covers both the event cap and the byte
+    budget without any change to the put/get call sites.
+    """
+
+    def __init__(self, *, max_events: int, max_bytes: int) -> None:
+        super().__init__(maxsize=max_events)
+        self._max_bytes = max_bytes
+        self.queued_bytes = 0
+
+    def full(self) -> bool:
+        return super().full() or self.queued_bytes >= self._max_bytes
+
+    def _put(self, item: dict[str, object] | BaseException) -> None:
+        super()._put(item)
+        self.queued_bytes += _event_payload_size(item)
+
+    def _get(self) -> dict[str, object] | BaseException:
+        item = super()._get()
+        self.queued_bytes -= _event_payload_size(item)
+        return item
+
+
+def _new_stream_queue() -> _BoundedEventQueue:
+    return _BoundedEventQueue(max_events=_NATIVE_STREAM_QUEUE_LIMIT, max_bytes=_NATIVE_STREAM_QUEUE_BYTES_LIMIT)
 
 
 class NativeEgressError(Exception):
@@ -579,7 +629,7 @@ class SubprocessNativeEgressClient:
         process, generation = await self._ensure_process()
         self._request_sequence += 1
         request_id = f"{generation}:{self._request_sequence}"
-        events: asyncio.Queue[dict[str, object] | BaseException] = asyncio.Queue(maxsize=_NATIVE_STREAM_QUEUE_LIMIT)
+        events: asyncio.Queue[dict[str, object] | BaseException] = _new_stream_queue()
         self._streams[request_id] = (generation, events)
         request_event = {
             "type": "request",
@@ -682,7 +732,7 @@ class SubprocessNativeEgressClient:
         process, generation = await self._ensure_process()
         self._request_sequence += 1
         request_id = f"{generation}:{self._request_sequence}"
-        events: asyncio.Queue[dict[str, object] | BaseException] = asyncio.Queue(maxsize=_NATIVE_STREAM_QUEUE_LIMIT)
+        events: asyncio.Queue[dict[str, object] | BaseException] = _new_stream_queue()
         self._streams[request_id] = (generation, events)
         try:
             await self._send_command(

--- a/openspec/changes/bound-native-egress-stream-queue-by-bytes/proposal.md
+++ b/openspec/changes/bound-native-egress-stream-queue-by-bytes/proposal.md
@@ -1,0 +1,23 @@
+# Bound the Native Egress Stream Queue by Bytes
+
+## Why
+
+The native egress helper streams every in-flight request's events through one stdout pipe; a single Python reader task fans them out into a per-request queue that the request's consumer drains. That queue was capped at 64 *events*. Framed SSE deltas are tens of bytes each and arrive in bursts of hundreds when upstream flushes reasoning output, and a non-SSE body such as an image-generation JSON is a handful of large chunks -- so on a saturated event loop a perfectly healthy consumer that is merely late for one scheduling turn hit the cap. The reader then failed the request with `native stream consumer exceeded the bounded event queue` (`consumer_backpressure`), which is not a retryable code and reached clients as a 502 / a truncated SSE body ("error decoding response body"). On soju07 this went from 6 to 205 requests a day when the host saturated (#2167): 183 in a single hour, gpt-6-astra and `/v1/images/generations` included.
+
+## What Changes
+
+- The per-request stream queue becomes a **byte budget** (32 MiB of queued payload) with a generous event cap (4096) instead of a 64-event cap. The reader's existing `QueueFull` handling is unchanged: only a consumer that truly stops draining (dead client) trips the bound and is failed so it cannot hold the shared reader hostage.
+- Both HTTP/SSE stream queues and WebSocket connect event queues use the new bound; the WebSocket message queue is unchanged (never tripped in production).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `outbound-http-clients`: native helper per-request event queue bound.
+
+## Impact
+
+- `app/core/clients/native_egress.py` (`_BoundedEventQueue`, `_new_stream_queue`, limits); tests in `tests/unit/test_native_egress.py` (byte-budget unit test, 2000-event burst drains without failure, overflow test moved onto the byte budget).
+- Worst-case queued memory per request rises from 64 events to 32 MiB; queued bytes are released as the consumer drains. No settings, schema or API changes.
+
+Fixes #2167 (queue bound); the second ask in #2167 (retrying a pre-output overflow) is unchanged: with the byte budget the overflow only fires for a consumer that stopped draining, where a retry would not help.

--- a/openspec/changes/bound-native-egress-stream-queue-by-bytes/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/bound-native-egress-stream-queue-by-bytes/specs/outbound-http-clients/spec.md
@@ -1,0 +1,20 @@
+# outbound-http-clients Delta
+
+## ADDED Requirements
+
+### Requirement: Native helper stream events are bounded per request by a byte budget
+
+Events the native egress helper emits for one request MUST be buffered between the shared helper reader and that request's consumer in a per-request queue bounded by a queued-payload byte budget (32 MiB) together with an event-count cap (4096). Queued bytes MUST be released as the consumer drains. A burst of small framed events or a body made of large chunks that fits the byte budget MUST NOT fail a consumer that is still draining. Only when a request's queue exceeds its budget MAY the reader fail that request with `consumer_backpressure`, drop its queued events, cancel the helper-side request, and continue serving other requests.
+
+#### Scenario: Burst of small framed events drains without failure
+
+- **GIVEN** the helper has 2000 small body events for one request buffered in its output pipe
+- **WHEN** the consumer starts reading after the burst landed
+- **THEN** the consumer receives the complete body and the request is not failed
+
+#### Scenario: A consumer that stops draining is bounded by bytes
+
+- **GIVEN** a request whose consumer does not read while the helper emits 48 chunks of 1 MiB
+- **WHEN** the queued payload exceeds 32 MiB
+- **THEN** that request fails with `consumer_backpressure`
+- **AND** other requests on the same helper keep being served

--- a/openspec/changes/bound-native-egress-stream-queue-by-bytes/tasks.md
+++ b/openspec/changes/bound-native-egress-stream-queue-by-bytes/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] 1.1 `_BoundedEventQueue` (event cap + queued-bytes budget, bytes released on get) and `_new_stream_queue()`; HTTP/SSE and WebSocket connect queues use it.
+- [x] 1.2 Tests: byte/event trip and release semantics; a 2000-event burst buffered in the helper pipe drains without failing the consumer; the existing overflow test trips on the byte budget (48 x 1 MiB) and client close still does not hang.
+- [x] 1.3 ruff, ty, strict OpenSpec validation.

--- a/openspec/changes/bound-native-egress-stream-queue-by-bytes/tasks.md
+++ b/openspec/changes/bound-native-egress-stream-queue-by-bytes/tasks.md
@@ -3,3 +3,4 @@
 - [x] 1.1 `_BoundedEventQueue` (event cap + queued-bytes budget, bytes released on get) and `_new_stream_queue()`; HTTP/SSE and WebSocket connect queues use it.
 - [x] 1.2 Tests: byte/event trip and release semantics; a 2000-event burst buffered in the helper pipe drains without failing the consumer; the existing overflow test trips on the byte budget (48 x 1 MiB) and client close still does not hang.
 - [x] 1.3 ruff, ty, strict OpenSpec validation.
+- [x] 1.4 Local codex review P2 x2: the incoming event counts toward the budget (a queue just under budget rejects an event that would carry it past; an event at an empty queue is always accepted); SSE `text` payloads are measured in UTF-8 bytes.

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import anyio
 import pytest
 
+import app.core.clients.native_egress as native_egress_module
 from app.core.clients.native_egress import (
     NativeEgressError,
     NativeEgressProtocolError,
@@ -442,10 +443,13 @@ for line in sys.stdin:
         "http_version": "HTTP/2.0", "headers": [],
     }), flush=True)
     if command["url"].endswith("/slow-consumer"):
-        for _ in range(256):
+        # 48 x 1 MiB exceeds the 32 MiB per-request byte budget while staying
+        # far below the 4096-event cap: the byte budget is what trips here.
+        big = base64.b64encode(b"x" * (1024 * 1024)).decode()
+        for _ in range(48):
             print(json.dumps({
                 "type": "chunk", "request_id": request_id,
-                "data": base64.b64encode(b"x").decode(),
+                "data": big,
             }), flush=True)
     else:
         print(json.dumps({
@@ -972,3 +976,66 @@ for line in sys.stdin:
             task.cancel()
         await asyncio.gather(task, return_exceptions=True)
         await client.aclose()
+
+
+def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get() -> None:
+    queue = native_egress_module._BoundedEventQueue(max_events=3, max_bytes=10)
+    queue.put_nowait({"type": "chunk", "data": "abcd"})
+    queue.put_nowait({"type": "sse", "text": "efgh"})
+    assert queue.queued_bytes == 8 and not queue.full()
+    queue.put_nowait({"type": "chunk", "data": "ij"})  # 10 bytes reaches the budget
+    assert queue.full()
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait({"type": "end"})
+    assert queue.get_nowait() == {"type": "chunk", "data": "abcd"}
+    assert queue.queued_bytes == 6 and not queue.full()
+    # Non-payload events (end/error/exceptions) cost no bytes but count as events.
+    queue.put_nowait({"type": "end"})
+    assert queue.full()  # 3 events = the event cap
+    while not queue.empty():
+        queue.get_nowait()
+    assert queue.queued_bytes == 0
+    queue.put_nowait(RuntimeError("x"))
+    assert queue.queued_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_burst_of_small_events_does_not_trip_the_queue_while_the_consumer_drains(tmp_path: Path) -> None:
+    """Hundreds of tiny framed deltas buffered in the helper pipe must not fail
+    a healthy consumer (the pre-budget 64-event cap did exactly that on a
+    saturated event loop, #2167)."""
+    helper = tmp_path / "native-helper"
+    _write_helper(
+        helper,
+        """#!/usr/bin/env python3
+import base64
+import json
+import sys
+for line in sys.stdin:
+    command = json.loads(line)
+    request_id = command["request_id"]
+    if command["type"] == "cancel":
+        print(json.dumps({"type": "cancelled", "request_id": request_id}), flush=True)
+        continue
+    print(json.dumps({
+        "type": "head", "request_id": request_id, "status": 200,
+        "http_version": "HTTP/2.0", "headers": [],
+    }), flush=True)
+    out = []
+    for _ in range(2000):
+        out.append(json.dumps({
+            "type": "chunk", "request_id": request_id,
+            "data": base64.b64encode(b"delta").decode(),
+        }))
+    out.append(json.dumps({"type": "end", "request_id": request_id}))
+    sys.stdout.write("\\n".join(out) + "\\n")
+    sys.stdout.flush()
+""",
+    )
+    client = SubprocessNativeEgressClient(helper)
+    response = await client.request(NativeEgressRequest(method="GET", url="https://example.test/burst", headers={}))
+    # Let the whole burst land in the pipe before the consumer starts reading.
+    await asyncio.sleep(0.2)
+    body = await asyncio.wait_for(response.read(), timeout=5.0)
+    assert body == b"delta" * 2000
+    await asyncio.wait_for(client.aclose(), timeout=2.0)

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -983,7 +983,10 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     queue.put_nowait({"type": "chunk", "data": "abcd"})
     queue.put_nowait({"type": "sse", "text": "efgh"})
     assert queue.queued_bytes == 8 and not queue.full()
-    queue.put_nowait({"type": "chunk", "data": "ij"})  # 10 bytes reaches the budget
+    # The incoming event counts: 8 queued + 3 would exceed the 10-byte budget.
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait({"type": "chunk", "data": "klm"})
+    queue.put_nowait({"type": "chunk", "data": "ij"})  # exactly 10 bytes fills the budget
     assert queue.full()
     with pytest.raises(asyncio.QueueFull):
         queue.put_nowait({"type": "end"})
@@ -997,6 +1000,15 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     assert queue.queued_bytes == 0
     queue.put_nowait(RuntimeError("x"))
     assert queue.queued_bytes == 0
+    queue.get_nowait()
+    # Text payloads are measured in UTF-8 bytes, not code points.
+    queue.put_nowait({"type": "sse", "text": "\u00e9\u00e9"})
+    assert queue.queued_bytes == 4
+    # A lone event larger than the whole budget is accepted at an empty queue
+    # (the SSE event size cap bounds it), so a single big chunk never fails.
+    big = native_egress_module._BoundedEventQueue(max_events=8, max_bytes=10)
+    big.put_nowait({"type": "chunk", "data": "x" * 64})
+    assert big.full()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -979,7 +979,7 @@ for line in sys.stdin:
 
 
 def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get() -> None:
-    queue = native_egress_module._BoundedEventQueue(max_events=3, max_bytes=10)
+    queue = native_egress_module._BoundedEventQueue(max_events=4, max_bytes=10)
     queue.put_nowait({"type": "chunk", "data": "abcd"})
     queue.put_nowait({"type": "sse", "text": "efgh"})
     assert queue.queued_bytes == 8 and not queue.full()
@@ -987,14 +987,17 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     with pytest.raises(asyncio.QueueFull):
         queue.put_nowait({"type": "chunk", "data": "klm"})
     queue.put_nowait({"type": "chunk", "data": "ij"})  # exactly 10 bytes fills the budget
-    assert queue.full()
+    assert queue.queued_bytes == 10
+    # A zero-byte terminal at exactly the budget is still accepted (event cap has room)...
+    queue.put_nowait({"type": "end"})
+    assert queue.full()  # ...and 4 events is the event cap.
     with pytest.raises(asyncio.QueueFull):
-        queue.put_nowait({"type": "end"})
+        queue.put_nowait({"type": "cancelled"})
     assert queue.get_nowait() == {"type": "chunk", "data": "abcd"}
     assert queue.queued_bytes == 6 and not queue.full()
-    # Non-payload events (end/error/exceptions) cost no bytes but count as events.
-    queue.put_nowait({"type": "end"})
-    assert queue.full()  # 3 events = the event cap
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait({"type": "chunk", "data": "wxyz!"})  # 6 + 5 > 10
+    queue.put_nowait({"type": "chunk", "data": "wxyz"})  # 6 + 4 == 10
     while not queue.empty():
         queue.get_nowait()
     assert queue.queued_bytes == 0
@@ -1005,10 +1008,13 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     queue.put_nowait({"type": "sse", "text": "\u00e9\u00e9"})
     assert queue.queued_bytes == 4
     # A lone event larger than the whole budget is accepted at an empty queue
-    # (the SSE event size cap bounds it), so a single big chunk never fails.
+    # (the SSE event size cap bounds it), so a single big chunk never fails;
+    # anything but a zero-byte event is then rejected until it drains.
     big = native_egress_module._BoundedEventQueue(max_events=8, max_bytes=10)
     big.put_nowait({"type": "chunk", "data": "x" * 64})
-    assert big.full()
+    with pytest.raises(asyncio.QueueFull):
+        big.put_nowait({"type": "chunk", "data": "y"})
+    big.put_nowait({"type": "end"})
 
 
 @pytest.mark.asyncio
@@ -1050,4 +1056,41 @@ for line in sys.stdin:
     await asyncio.sleep(0.2)
     body = await asyncio.wait_for(response.read(), timeout=5.0)
     assert body == b"delta" * 2000
+    await asyncio.wait_for(client.aclose(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_response_landing_exactly_on_the_byte_budget_still_completes(tmp_path: Path) -> None:
+    """16 x 2 MiB of base64 payload is exactly the 32 MiB budget; the zero-byte
+    ``end`` that follows must still be accepted so the complete response is
+    delivered once the consumer drains."""
+    helper = tmp_path / "native-helper"
+    _write_helper(
+        helper,
+        """#!/usr/bin/env python3
+import base64
+import json
+import sys
+for line in sys.stdin:
+    command = json.loads(line)
+    request_id = command["request_id"]
+    if command["type"] == "cancel":
+        print(json.dumps({"type": "cancelled", "request_id": request_id}), flush=True)
+        continue
+    print(json.dumps({
+        "type": "head", "request_id": request_id, "status": 200,
+        "http_version": "HTTP/2.0", "headers": [],
+    }), flush=True)
+    chunk = base64.b64encode(b"z" * (3 * 512 * 1024)).decode()  # 2 MiB of base64
+    assert len(chunk) == 2 * 1024 * 1024
+    for _ in range(16):
+        print(json.dumps({"type": "chunk", "request_id": request_id, "data": chunk}), flush=True)
+    print(json.dumps({"type": "end", "request_id": request_id}), flush=True)
+""",
+    )
+    client = SubprocessNativeEgressClient(helper)
+    response = await client.request(NativeEgressRequest(method="GET", url="https://example.test/exact", headers={}))
+    await asyncio.sleep(1.0)  # let the whole body queue up before the consumer reads
+    body = await asyncio.wait_for(response.read(), timeout=10.0)
+    assert len(body) == 16 * 3 * 512 * 1024
     await asyncio.wait_for(client.aclose(), timeout=2.0)


### PR DESCRIPTION
## Why

The native egress helper streams every in-flight request's events through one stdout pipe; a single Python reader task fans them out into a per-request `asyncio.Queue` that the request's consumer drains. That queue was capped at **64 events**. Framed SSE deltas are tens of bytes each and arrive in bursts of hundreds when upstream flushes reasoning output; a non-SSE body such as an image-generation JSON is a handful of large chunks. On a saturated event loop a perfectly healthy consumer that was merely late for one scheduling turn hit the cap, and the reader failed the request with

```
native stream consumer exceeded the bounded event queue   (failure_phase=consumer_backpressure)
```

which is not a retryable code and reached clients as a 502 or a truncated SSE body ("Stream disconnected before completion: error decoding response body"). On soju07 this went from 6/day to 205/day when the host saturated — 183 in a single hour on 2026-09-08 (gpt-6-astra 145, `/v1/images/generations` included). Fixes #2167.

## What

- `_BoundedEventQueue`: an `asyncio.Queue` whose `full()` also trips on a **queued-payload byte budget** (32 MiB); bytes are counted in `_put` and released in `_get`. Event cap raised 64 → 4096 as a sanity bound. `put_nowait` consults `full()` before enqueueing, so the reader's existing `QueueFull` handling (fail that request, drop its events, cancel the helper-side request, keep serving others) is unchanged.
- HTTP/SSE stream queues and WebSocket connect event queues use it; the WebSocket message queue (never tripped in production) is unchanged.

Worst-case queued memory per request is now 32 MiB instead of 64 events; a consumer that truly stops draining (dead client) still trips the bound so it cannot hold the shared reader hostage.

## Verification

- `tests/unit/test_native_egress.py`: byte/event trip and release semantics of `_BoundedEventQueue`; a **2000-event burst** buffered in the helper pipe drains completely without failing the consumer (failed on `main`'s 64-event cap); the existing overflow test now trips on the byte budget (48 × 1 MiB) and client close still does not hang.
- ruff, ty, full `tests/unit`, `openspec validate bound-native-egress-stream-queue-by-bytes --strict`.

## OpenSpec

`openspec/changes/bound-native-egress-stream-queue-by-bytes/` — ADDED `outbound-http-clients` "Native helper stream events are bounded per request by a byte budget".

## Not in scope

The second ask in #2167 (retrying a pre-output overflow) is left as is: with the byte budget the overflow only fires for a consumer that stopped draining, where a retry would not help.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native HTTP and WebSocket streaming reliability by limiting queued data by both event count and total payload size.
  * Larger bursts of small streaming events can now be processed without prematurely failing healthy consumers.
  * Requests with stalled consumers now fail cleanly when queued data exceeds the safety limit, while other requests continue operating normally.
  * Streaming payload accounting now correctly handles encoded content and multibyte text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->