### PR TITLE
fix(model-registry): warm the Codex client version cache on every replica and track the current release

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -430,7 +430,7 @@ class Settings(BaseSettings):
     # Must stay >= the highest ``minimal_client_version`` in the bootstrap
     # catalog (GPT-5.6 requires 0.144.0) or a degraded-startup refresh would
     # receive an upstream catalog without those models.
-    model_registry_client_version: str = "0.144.0"
+    model_registry_client_version: str = "0.153.4"
     # Persisted registry snapshots older than this are ignored at load time
     # (bootstrap catalog remains the floor until the next leader refresh).
     model_registry_snapshot_max_age_seconds: int = Field(default=86400, gt=0)

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -10,6 +10,7 @@ from typing import Protocol, TypeVar, cast
 
 from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_MODEL_REGISTRY, get_cache_invalidation_poller
+from app.core.clients.codex_version import get_codex_version_cache
 from app.core.clients.http import refresh_http_client
 from app.core.clients.model_fetcher import ModelFetchError, fetch_models_for_plan
 from app.core.config.settings import get_settings
@@ -63,6 +64,25 @@ def _get_leader_election() -> _LeaderElectionLike:
     return cast(_LeaderElectionLike, module.get_leader_election())
 
 
+async def _warm_codex_version_cache() -> None:
+    """Refresh the in-process Codex client version on every replica.
+
+    The version is presented as the outbound fingerprint of non-native
+    requests (``codex_cli_rs/<version>``); upstream gates newer models on it.
+    It used to be fetched only inside the leader's model refresh, so a
+    non-leader replica -- for instance the live color of a blue/green pair
+    whose standby still holds the scheduler lease -- served the configured
+    fallback version indefinitely and had its non-native ``gpt-6-astra``
+    requests rejected with "requires a newer version of Codex". The fetch is
+    a public GitHub/npm lookup (no account token) cached for an hour, so
+    every replica may perform it, and it must never fail the tick.
+    """
+    try:
+        await get_codex_version_cache().get_version()
+    except Exception:  # pragma: no cover - the cache itself already logs and falls back
+        logger.warning("Codex client version warm-up failed; keeping the cached or default version", exc_info=True)
+
+
 @dataclass(slots=True)
 class ModelRefreshScheduler:
     interval_seconds: int
@@ -89,6 +109,7 @@ class ModelRefreshScheduler:
 
     async def _run_loop(self) -> None:
         while not self._stop.is_set():
+            await _warm_codex_version_cache()
             await self._refresh_once()
             try:
                 await asyncio.wait_for(self._stop.wait(), timeout=self.interval_seconds)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -191,7 +191,7 @@ the env-file locations have to be known before env files are read.
 | Environment variable | Type | Default |
 | --- | --- | --- |
 | `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` | `dict[str, int]` | `{}` |
-| `CODEX_LB_MODEL_REGISTRY_CLIENT_VERSION` | `str` | `'0.144.0'` |
+| `CODEX_LB_MODEL_REGISTRY_CLIENT_VERSION` | `str` | `'0.153.4'` |
 | `CODEX_LB_MODEL_REGISTRY_ENABLED` | `bool` | `True` |
 | `CODEX_LB_MODEL_REGISTRY_SNAPSHOT_MAX_AGE_SECONDS` | `int` | `86400` |
 

--- a/openspec/changes/warm-codex-client-version-on-every-replica/proposal.md
+++ b/openspec/changes/warm-codex-client-version-on-every-replica/proposal.md
@@ -1,0 +1,23 @@
+# Warm the Codex Client Version on Every Replica
+
+## Why
+
+Non-native SDK requests are forwarded with the Codex CLI fingerprint `codex_cli_rs/<version>`; upstream gates newer models on that version. The version cache (`CodexVersionCache`) was only ever filled inside the leader's model refresh (`fetch_models_for_plan`). A replica that is not the scheduler leader therefore never fetched it and fell back to `model_registry_client_version` (`0.144.0`) forever. On soju07 the live color (`green`, 1.25.0-beta.5) was exactly that: the standby (`blue`) still held the lease, `green` logged no version fetch for an hour, and 346 of 14,904 non-native `gpt-6-astra` requests in 24 h were rejected with "The 'gpt-6-astra' model requires a newer version of Codex" while native `codex_cli_rs/0.153.4` traffic was never rejected (#2170).
+
+## What Changes
+
+- The model refresh loop warms the Codex client version cache on every tick, before the leader-gated refresh, on every replica. The lookup is the existing public GitHub/npm release lookup (no account credential), cached for an hour, and a failure is logged without stopping the tick.
+- The fallback `model_registry_client_version` moves from `0.144.0` to the current public release `0.153.4`, so even a cold cache no longer presents a version upstream already gates.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `outbound-http-clients`: the cached fingerprint version is warmed and refreshed per replica regardless of leadership; the fallback tracks the current release.
+
+## Impact
+
+- `app/core/openai/model_refresh_scheduler.py` (`_warm_codex_version_cache`, called from `_run_loop`), `app/core/config/settings.py` (default bump), `docs/reference/settings.md` regenerated, tests in `tests/unit/test_model_refresh_scheduler.py` and `tests/unit/test_codex_version.py`.
+- No new settings, schema, API or dashboard changes. One extra public HTTPS lookup per replica per hour.
+
+Fixes #2170.

--- a/openspec/changes/warm-codex-client-version-on-every-replica/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/warm-codex-client-version-on-every-replica/specs/outbound-http-clients/spec.md
@@ -1,0 +1,162 @@
+# outbound-http-clients Delta
+
+## MODIFIED Requirements
+
+### Requirement: Non-native upstream requests use the Codex CLI client fingerprint
+
+The service MUST normalize the outbound client fingerprint to the first-party
+Codex CLI (`codex_cli_rs`) persona when forwarding a proxied request to the
+upstream Codex backend that did not originate from a native Codex client. This
+normalization MUST apply on every upstream egress path: the http builder, the
+internal auto-transport websocket builder, and the client-facing
+`/v1/responses` websocket egress builder
+(`app/core/clients/proxy_websocket.py`). With `upstream_stream_transport="auto"`
+a non-native client carrying a `x-codex-turn-state` continuity header is routed
+onto the internal websocket path, and a direct websocket SDK caller reaches
+upstream through the `/v1/responses` egress builder; normalizing only a subset
+of these paths would let the un-normalized path reach upstream with its
+downgraded fingerprint intact. The service MUST NOT modify the fingerprint of
+native Codex client requests on any transport.
+
+A request is considered **native** when its inbound `User-Agent` begins with a
+known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
+`codex_sdk_ts`, `codex_vscode`, `Codex Desktop`, or a value starting with
+`Codex `) OR it carries an `originator` header whose value is in the native
+Codex originator set (which MUST include every first-party originator the
+backend whitelists, e.g. `codex_cli_rs`, `codex_vscode`, `codex_sdk_ts`).
+Transport/continuity headers (`x-codex-turn-state` and other `x-codex-*`
+stream headers) MUST NOT be treated as a native signal, because a non-native
+client replays the upstream-issued `x-codex-turn-state` token for continuity;
+treating it as native would let that follow-up reach upstream with its
+downgraded fingerprint intact.
+
+For a non-native request, the service MUST:
+
+- Set the outbound `User-Agent` to
+  `codex_cli_rs/<version> (<os>; <arch>) <terminal>`, where `<version>` is the
+  cached Codex client version (falling back to the configured client-version
+  default when no cached version is available) and `<os>`, `<arch>`,
+  `<terminal>` are operator-configurable with defaults `Mac OS 26.5.0`,
+  `arm64`, and `iTerm.app/3.6.10`.
+- Remove SDK-only fingerprint headers `x-openai-client-version`,
+  `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`, and
+  `x-openai-client-user-agent`, as well as every `x-stainless-*` header (the
+  OpenAI SDK fingerprint family the API layer uses to detect SDK callers).
+- Remove inbound `originator` and `version` headers case-insensitively, then
+  set `originator: codex_cli_rs` and `version: <version>`, where `<version>` is
+  the same cached Codex client version used in the outbound `User-Agent`.
+- Emit the upstream account header as PascalCase `ChatGPT-Account-Id`.
+- Preserve continuity headers (`x-codex-turn-state` and other `x-codex-*`
+  stream headers) on the outbound request so sticky routing is unaffected.
+
+Resolving the fingerprint version for an outbound request MUST NOT perform a
+blocking network call on the request path; the version is read from an
+in-process cache. Every replica MUST warm that cache when its model refresh
+loop starts and MUST refresh it on every loop tick regardless of scheduler
+leadership (the lookup is a public release lookup that carries no account
+credential), so a non-leader replica never presents the configured
+client-version fallback beyond its first tick. A warm-up failure MUST NOT stop
+the model refresh tick. The configured fallback (`model_registry_client_version`)
+SHALL track the current public Codex CLI release.
+
+#### Scenario: non-native SDK http request is rewritten to the Codex CLI fingerprint
+
+- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`,
+  untrusted `originator` / mixed-case `Version` values, and
+  `x-openai-client-version` / `x-openai-client-os` / `x-stainless-os` headers
+- **THEN** the outbound `User-Agent` is `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** the `x-openai-client-version`, `x-openai-client-os`,
+  `x-openai-client-arch`, `x-openai-client-id`, and `x-openai-client-user-agent`
+  headers are absent from the outbound request
+- **AND** every `x-stainless-*` header is absent from the outbound request
+- **AND** the only outbound identity values are `originator: codex_cli_rs` and
+  `version: <version>` matching the version embedded in `User-Agent`
+
+#### Scenario: native Codex http request is left unchanged
+
+- **WHEN** an http upstream request arrives with `User-Agent: codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)`
+- **THEN** the outbound `User-Agent` equals the inbound `User-Agent`
+- **AND** the request fingerprint is not normalized
+
+#### Scenario: first-party Codex SDK request is left unchanged
+
+- **WHEN** an http upstream request carries an `originator: codex_sdk_ts` header
+  (a first-party originator the backend whitelists)
+- **THEN** the outbound request is treated as native
+- **AND** its `User-Agent` and `originator` header are not rewritten or stripped
+
+#### Scenario: non-native request replaying a continuity token is still normalized
+
+- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`
+  and an `x-codex-turn-state` continuity header
+- **THEN** the request is treated as non-native and its fingerprint is normalized
+- **AND** the `x-codex-turn-state` header is preserved on the outbound request
+
+#### Scenario: non-native websocket request carrying a continuity token is normalized
+
+- **WHEN** the upstream stream transport resolves to websocket for a non-native
+  request with `User-Agent: OpenAI/Python 2.24.0`, an `x-openai-client-version`
+  header, and an `x-codex-turn-state` continuity header
+- **THEN** the outbound websocket `User-Agent` is
+  `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** SDK identity headers are absent and the outbound request carries
+  `originator: codex_cli_rs` and `version: <version>`
+- **AND** the upstream account id is carried under the PascalCase header name
+  `ChatGPT-Account-Id`
+- **AND** the `x-codex-turn-state` header is preserved on the outbound request
+
+#### Scenario: native Codex websocket request is left unchanged
+
+- **WHEN** the upstream stream transport resolves to websocket for a request
+  with `User-Agent: codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10`
+- **THEN** the outbound websocket `User-Agent` equals the inbound `User-Agent`
+- **AND** the account id is carried under the lowercase header `chatgpt-account-id`
+
+#### Scenario: non-native client-facing responses websocket request is normalized
+
+- **WHEN** a non-native SDK connects directly to the `/v1/responses` websocket
+  endpoint with `User-Agent: OpenAI/Python 2.24.0`, `x-openai-client-version`,
+  and `x-stainless-*` headers
+- **THEN** the upstream responses websocket `User-Agent` is
+  `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** the `x-openai-client-*` and `x-stainless-*` headers are absent while
+  `originator: codex_cli_rs` and `version: <version>` are present
+- **AND** the upstream account id is carried under the PascalCase header name
+  `ChatGPT-Account-Id`
+- **AND** the required responses websocket beta header is still present
+
+#### Scenario: account header uses Codex CLI casing on a normalized request
+
+- **WHEN** a non-native http request is normalized and an upstream account id is present
+- **THEN** the outbound request carries the account id under the PascalCase
+  header name `ChatGPT-Account-Id`
+
+#### Scenario: per-account upstream diagnostics survive normalization
+
+- **WHEN** upstream request logging is enabled and a normalized non-native
+  request carries its account id under the PascalCase `ChatGPT-Account-Id` header
+- **THEN** the upstream request start/complete log entries record the account id
+  rather than `None`, so per-account diagnostics are preserved regardless of the
+  header casing produced by normalization
+
+#### Scenario: fingerprint version falls back to the configured default
+
+- **WHEN** the Codex version cache has no cached version
+- **AND** a non-native http request is normalized
+- **THEN** the outbound `User-Agent` uses the configured client-version default
+  for `<version>`
+- **AND** the outbound `version` header uses that same configured default
+- **AND** resolving the version does not perform a network call on the request path
+
+#### Scenario: Non-leader replica warms the client version itself
+
+- **GIVEN** a replica that does not hold the scheduler leader lease (for example the live color of a blue/green pair whose standby still holds the lease)
+- **WHEN** its model refresh loop ticks
+- **THEN** it fetches and caches the current Codex client version before the leader-gated model refresh
+- **AND** non-native requests it forwards carry that version in `User-Agent` and `version` instead of the configured fallback
+
+#### Scenario: Version warm-up failure does not stop the refresh tick
+
+- **GIVEN** the public release lookup fails on a replica
+- **WHEN** its model refresh loop ticks
+- **THEN** the failure is logged, the cached or fallback version is kept, and the leader-gated refresh (or non-leader reconcile) still runs

--- a/openspec/changes/warm-codex-client-version-on-every-replica/tasks.md
+++ b/openspec/changes/warm-codex-client-version-on-every-replica/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 `_warm_codex_version_cache()` in the model refresh scheduler; `_run_loop` awaits it before `_refresh_once` on every replica; failures are logged, never raised.
 - [x] 1.2 Bump `model_registry_client_version` default to `0.153.4`; regenerate `docs/reference/settings.md`.
-- [x] 1.3 Tests: non-leader loop tick warms the cache and still reconciles; a failing warm-up still reconciles; codex version fallback tests follow the new default.
+- [x] 1.3 Tests: non-leader loop tick warms the cache and still reconciles; a failing warm-up still reconciles; codex version fallback tests follow the new default; product path: after the warm-up the real shared cache feeds the non-native fingerprint (`User-Agent` + `version`) instead of the fallback (local codex review P2).
 - [x] 1.4 ruff, ty, strict OpenSpec validation.

--- a/openspec/changes/warm-codex-client-version-on-every-replica/tasks.md
+++ b/openspec/changes/warm-codex-client-version-on-every-replica/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1.1 `_warm_codex_version_cache()` in the model refresh scheduler; `_run_loop` awaits it before `_refresh_once` on every replica; failures are logged, never raised.
+- [x] 1.2 Bump `model_registry_client_version` default to `0.153.4`; regenerate `docs/reference/settings.md`.
+- [x] 1.3 Tests: non-leader loop tick warms the cache and still reconciles; a failing warm-up still reconciles; codex version fallback tests follow the new default.
+- [x] 1.4 ruff, ty, strict OpenSpec validation.

--- a/tests/unit/test_codex_version.py
+++ b/tests/unit/test_codex_version.py
@@ -101,7 +101,7 @@ async def test_rejects_invalid_version_name():
         version = await cache.get_version()
 
     # Invalid name falls back to settings default
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio
@@ -113,7 +113,7 @@ async def test_rejects_alpha_version_name():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio
@@ -149,7 +149,7 @@ async def test_fallback_to_settings_default_when_no_cache():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session_fail):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio
@@ -162,7 +162,7 @@ async def test_fallback_on_network_exception():
     ):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio
@@ -193,7 +193,7 @@ async def test_missing_name_field_falls_back():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 def test_ttl_must_be_positive():
@@ -239,7 +239,7 @@ async def test_npm_invalid_version_falls_back_to_settings_default():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_npm_missing_version_field_falls_back_to_settings_default():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.144.0"
+    assert version == "0.153.4"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import errno
 import logging
@@ -582,3 +583,46 @@ async def test_refresh_once_clears_registry_when_no_active_accounts(
 
     clear.assert_awaited_once_with()
     invalidate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_run_loop_warms_the_codex_version_cache_on_every_replica(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-leader replica never runs the leader refresh (the only place the
+    Codex client version used to be fetched), so it presented the configured
+    fallback version indefinitely. The loop tick warms the cache before the
+    leader-gated refresh, on every replica, and a warm-up failure never stops
+    the tick."""
+    get_version = AsyncMock(return_value="0.153.4")
+    monkeypatch.setattr(scheduler_module, "get_codex_version_cache", lambda: SimpleNamespace(get_version=get_version))
+
+    class _Follower:
+        async def run_if_leader(self, fn: Callable[[], Awaitable[object]]) -> object | None:
+            return None
+
+    reconcile = AsyncMock()
+    monkeypatch.setattr(scheduler_module, "_get_leader_election", lambda: _Follower())
+    monkeypatch.setattr(scheduler_module, "reconcile_model_registry_from_store", reconcile)
+
+    scheduler = scheduler_module.ModelRefreshScheduler(interval_seconds=3600, enabled=True)
+    await scheduler.start()
+    for _ in range(50):
+        if get_version.await_count and reconcile.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await scheduler.stop()
+    get_version.assert_awaited_once_with()
+    reconcile.assert_awaited_once_with()
+
+    # A failing warm-up is logged and the leader-gated refresh still runs.
+    failing = AsyncMock(side_effect=RuntimeError("github down"))
+    monkeypatch.setattr(scheduler_module, "get_codex_version_cache", lambda: SimpleNamespace(get_version=failing))
+    reconcile.reset_mock()
+    scheduler = scheduler_module.ModelRefreshScheduler(interval_seconds=3600, enabled=True)
+    await scheduler.start()
+    for _ in range(50):
+        if reconcile.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await scheduler.stop()
+    failing.assert_awaited_once_with()
+    reconcile.assert_awaited_once_with()

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -626,3 +626,39 @@ async def test_run_loop_warms_the_codex_version_cache_on_every_replica(monkeypat
     await scheduler.stop()
     failing.assert_awaited_once_with()
     reconcile.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_warmed_version_reaches_the_non_native_upstream_fingerprint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Product path of #2170: after the per-replica warm-up, a non-native SDK
+    request is forwarded with the fetched Codex version in ``User-Agent`` and
+    ``version`` instead of the configured fallback, using the real shared cache."""
+    from app.core.clients import proxy as proxy_module
+    from app.core.clients.codex_version import CodexVersionCache, get_codex_version_cache
+    from app.core.config.settings import get_settings
+
+    cache = get_codex_version_cache()
+    await cache.invalidate()
+    fallback = get_settings().model_registry_client_version
+    fetched = "9.9.9"
+    assert fetched != fallback
+
+    async def _stub_fetch(self: CodexVersionCache) -> str | None:
+        return fetched
+
+    monkeypatch.setattr(CodexVersionCache, "_fetch_latest_version", _stub_fetch)
+    try:
+        cold = {"user-agent": "OpenAI/Python 2.24.0", "version": "sdk"}
+        proxy_module._normalize_non_native_upstream_fingerprint(cold)
+        assert cold["User-Agent"].startswith(f"codex_cli_rs/{fallback} ")
+        assert cold["version"] == fallback
+
+        await scheduler_module._warm_codex_version_cache()
+
+        warm = {"user-agent": "OpenAI/Python 2.24.0", "version": "sdk"}
+        proxy_module._normalize_non_native_upstream_fingerprint(warm)
+        assert warm["User-Agent"].startswith(f"codex_cli_rs/{fetched} ")
+        assert warm["version"] == fetched
+        assert warm["originator"] == "codex_cli_rs"
+    finally:
+        await cache.invalidate()


### PR DESCRIPTION
## Why

Non-native SDK requests (OpenAI Python SDK, `omo`, hermes-graphiti) are forwarded with the Codex CLI fingerprint `codex_cli_rs/<version>`, and upstream gates newer models on that version. The version cache (`CodexVersionCache`) was only ever filled inside the **leader's** model refresh (`fetch_models_for_plan`). A non-leader replica never fetched it and presented the `model_registry_client_version` fallback (`0.144.0`) forever.

Production (soju07, 2026-09-08): the live color `green` (1.25.0-beta.5) was exactly that replica — the standby `blue` still held the scheduler lease, `green` logged no version fetch for an hour, and 346 of 14,904 non-native `gpt-6-astra` requests in 24 h were rejected with

```
The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.
```

while native `codex_cli_rs/0.153.4` traffic (14,260 requests) was never rejected. Fixes #2170.

## What

- `ModelRefreshScheduler._run_loop` awaits `_warm_codex_version_cache()` before the leader-gated `_refresh_once()` on **every** tick and **every** replica. The lookup is the existing public GitHub/npm release lookup (no account credential), cached for an hour; a failure is logged and never stops the tick.
- Fallback `model_registry_client_version` moves `0.144.0` → `0.153.4` (current public release) so a cold cache no longer presents a version upstream already gates. `docs/reference/settings.md` regenerated. No new settings.

## Verification

- `tests/unit/test_model_refresh_scheduler.py`: non-leader loop tick warms the cache and still reconciles; a failing warm-up still reconciles; **product path** — with the real shared cache and a stubbed release lookup, `_normalize_non_native_upstream_fingerprint` emits the fallback before the warm-up and the fetched version in `User-Agent` + `version` after it (local codex review P2).
- `tests/unit/test_codex_version.py` fallback assertions follow the new default.
- ruff, ty, full `tests/unit`, `openspec validate warm-codex-client-version-on-every-replica --strict`.

## OpenSpec

`openspec/changes/warm-codex-client-version-on-every-replica/` — MODIFIED `outbound-http-clients` "Non-native upstream requests use the Codex CLI client fingerprint": the cache is warmed per replica regardless of leadership; the fallback tracks the current release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated outbound requests to use the latest available Codex client version across all replicas and connection paths.
  * Prevented version-cache refresh failures from interrupting scheduled model refreshes.
  * Improved compatibility with models requiring newer Codex client versions.

* **Documentation**
  * Updated the documented default Codex client version to `0.153.4`.

* **Tests**
  * Added coverage for cache warming, fallback behavior, non-leader replicas, and outbound version propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->