### PR TITLE
ci: keep CodeRabbit summaries in review comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true

--- a/.github/simplicity-budgets.toml
+++ b/.github/simplicity-budgets.toml
@@ -36,6 +36,7 @@ allowed = [
   ".agents",
   ".all-contributorsrc",
   ".claude",
+  ".coderabbit.yaml",
   ".dockerignore",
   ".env.example",
   ".gitattributes",

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/context.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/context.md
@@ -1,0 +1,8 @@
+The CodeRabbit schema documents `reviews.high_level_summary_in_walkthrough` as
+placing the summary in the walkthrough comment. The default is false. Set it
+true while keeping `high_level_summary` true. Avoid changing workflow execution
+or synthesizing required checks merely to suppress a bot's description edit.
+
+Sources checked on 2026-09-08:
+- https://docs.coderabbit.ai/reference/configuration
+- https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/proposal.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/proposal.md
@@ -16,5 +16,6 @@ required check names, and release-evidence validation.
 ## Impact
 
 - Configuration: `.coderabbit.yaml`.
+- Register the vendor-required root configuration in the root-entry allowlist.
 - Owning capability: `github-automation`.
 - No application behavior, dependencies, operator settings, or UI changes.

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/proposal.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/proposal.md
@@ -1,0 +1,20 @@
+# Keep CodeRabbit summaries out of PR bodies
+
+## Why
+
+CodeRabbit's automatic release-note summary edits the PR description after a
+push. CI intentionally handles `pull_request.edited` for release validation, so
+the edit cancels an in-flight run and starts the full matrix again for the same
+head. PR #2171 encountered this repeatedly.
+
+## What Changes
+
+Configure CodeRabbit to put its high-level summary in the walkthrough comment.
+Keep summary generation and review enabled. Preserve CI triggers, concurrency,
+required check names, and release-evidence validation.
+
+## Impact
+
+- Configuration: `.coderabbit.yaml`.
+- Owning capability: `github-automation`.
+- No application behavior, dependencies, operator settings, or UI changes.

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/specs/github-automation/spec.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/specs/github-automation/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Automated review summaries avoid PR-body CI restarts
+
+Repository CodeRabbit configuration MUST place generated high-level summaries
+in the walkthrough comment rather than automatically updating the PR body.
+Summary generation and automated review MUST remain enabled. CI MUST continue
+handling PR edits so release evidence is revalidated; this optimization MUST NOT
+skip or manufacture successful required CI checks.
+
+#### Scenario: Review completes after a push
+
+- **WHEN** CodeRabbit generates its automatic high-level summary
+- **THEN** its configured destination is the walkthrough comment
+- **AND** summary generation does not require an automatic PR-body update
+
+#### Scenario: Release evidence is edited
+
+- **WHEN** a maintainer edits a release PR's validation evidence
+- **THEN** the existing edited-event CI and release guards remain active

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/tasks.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/tasks.md
@@ -1,0 +1,3 @@
+- [x] Configure generated summaries in the CodeRabbit walkthrough.
+- [x] Validate configuration against the vendor schema and check CI invariants.
+- [x] Sync the requirement, record verification, and archive.

--- a/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/verification.md
+++ b/openspec/changes/archive/2026-09-08-keep-coderabbit-summary-out-of-pr-body/verification.md
@@ -1,0 +1,6 @@
+# Verification
+
+- Both configuration keys and boolean values validated against CodeRabbit’s official v2 schema.
+- Existing required CI contexts and beta/stable release guard tests: 29 passed.
+- CI workflows and release scripts are unchanged; no skipped green checks are introduced.
+- Runtime bot behavior will be observable after repository configuration is applied; local validation verifies the documented configuration contract.

--- a/openspec/specs/github-automation/spec.md
+++ b/openspec/specs/github-automation/spec.md
@@ -468,3 +468,21 @@ Before performing writes for a classified decision (label changes, legacy label 
 - **WHEN** apply-time reclassification of one pull request fails with a GitHub read error
 - **THEN** the decision is logged and skipped without failing the run
 
+### Requirement: Automated review summaries avoid PR-body CI restarts
+
+Repository CodeRabbit configuration MUST place generated high-level summaries
+in the walkthrough comment rather than automatically updating the PR body.
+Summary generation and automated review MUST remain enabled. CI MUST continue
+handling PR edits so release evidence is revalidated; this optimization MUST NOT
+skip or manufacture successful required CI checks.
+
+#### Scenario: Review completes after a push
+
+- **WHEN** CodeRabbit generates its automatic high-level summary
+- **THEN** its configured destination is the walkthrough comment
+- **AND** summary generation does not require an automatic PR-body update
+
+#### Scenario: Release evidence is edited
+
+- **WHEN** a maintainer edits a release PR's validation evidence
+- **THEN** the existing edited-event CI and release guards remain active


### PR DESCRIPTION
CodeRabbit's generated release-note summary edits PR bodies after pushes, restarting CI and cancelling in-flight checks for the same head. Configure the high-level summary to live in the walkthrough comment so reviews and summaries continue without automatic description edits.

CI triggers, concurrency, required contexts, and release guards are unchanged. Human edits to release validation evidence still trigger the existing full gate. The two settings and boolean values were checked against CodeRabbit's official v2 schema; 29 required-context and beta/stable guard tests and all 58 strict specs passed. Bot destination behavior will be verified through the PR review. OpenSpec is synced and archived under `2026-09-08-keep-coderabbit-summary-out-of-pr-body`.
