### PR TITLE
refactor(responses): interpret HTTP stream events in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "=0.12.28", default-features = false, features = ["http2",
 rustls = { version = "=0.23.36", default-features = false, features = ["aws_lc_rs", "prefer-post-quantum", "std", "tls12"] }
 rustls-native-certs = "0.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.149", features = ["raw_value"] }
+serde_json = { version = "1.0.149", features = ["raw_value", "preserve_order"] }
 tokio = { version = "=1.49.0", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = { version = "=0.26.4", default-features = false, features = ["aws_lc_rs", "tls12"] }
 tokio-tungstenite = { version = "0.28.0", features = ["proxy", "rustls-tls-native-roots"] }

--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -32,6 +32,7 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
         "http_compact_collect_v1",
         "http_compact_sse_v1",
         "http_sse_v1",
+        "http_responses_events_v1",
         "websocket",
         "websocket_send_ack",
     }
@@ -55,7 +56,7 @@ _NATIVE_WEBSOCKET_COMMAND_TIMEOUT_SECONDS = 30.0
 
 def _event_payload_size(item: object) -> int:
     """Queued payload bytes of one helper event: its base64 ``data`` (ASCII, so
-    the string length is the byte length) or its UTF-8 encoded SSE ``text``."""
+    the string length is the byte length) or UTF-8 SSE text and type metadata."""
     if not isinstance(item, dict):
         return 0
     data = item.get("data")
@@ -63,7 +64,9 @@ def _event_payload_size(item: object) -> int:
         return len(data)
     text = item.get("text")
     if isinstance(text, str):
-        return len(text.encode("utf-8"))
+        kind = item.get("event_type")
+        metadata_size = len(kind.encode("utf-8")) if isinstance(kind, str) else 0
+        return len(text.encode("utf-8")) + metadata_size
     return 0
 
 
@@ -148,6 +151,7 @@ class NativeSseOptions:
     max_event_bytes: int
     content_type_aware: bool = False
     collect_compact: bool = False
+    interpret_responses: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,6 +193,19 @@ class NativeEgressClient(Protocol):
     async def websocket(self, request: NativeWebSocketRequest) -> NativeEgressWebSocket: ...
 
 
+class NativeResponsesEvent(str):
+    """A complete SSE block with interpretation metadata from the Rust owner."""
+
+    event_type: str | None
+    python_normalization: bool
+
+    def __new__(cls, text: str, event_type: str | None, python_normalization: bool) -> NativeResponsesEvent:
+        block = super().__new__(cls, text)
+        block.event_type = event_type
+        block.python_normalization = python_normalization
+        return block
+
+
 class NativeEgressResponse:
     """One response stream multiplexed through a persistent native helper."""
 
@@ -206,6 +223,7 @@ class NativeEgressResponse:
         events: asyncio.Queue[dict[str, object] | BaseException],
         sse_framed: bool = False,
         compact_collected: bool = False,
+        responses_interpreted: bool = False,
     ) -> None:
         self.status = status
         self.http_version = http_version
@@ -214,6 +232,7 @@ class NativeEgressResponse:
         self.content = _NativeEgressContent(self)
         self.sse_framed = sse_framed
         self.compact_collected = compact_collected
+        self.responses_interpreted = responses_interpreted
         self._client = client
         self._request_id = request_id
         self._generation = generation
@@ -238,7 +257,8 @@ class NativeEgressResponse:
     async def iter_sse_events(self) -> AsyncGenerator[str, None]:
         if not self.sse_framed or self.compact_collected:
             raise NativeEgressProtocolError("native response did not request SSE framing")
-        async with contextlib.aclosing(self._iter_text_results("sse")) as results:
+        event_kind = "responses_event" if self.responses_interpreted else "sse"
+        async with contextlib.aclosing(self._iter_text_results(event_kind)) as results:
             async for text in results:
                 yield text
 
@@ -268,8 +288,24 @@ class NativeEgressResponse:
                 more = event.get("more")
                 if not isinstance(text, str) or type(more) is not bool:
                     raise NativeEgressProtocolError(f"native {event_type} fragment has an invalid shape")
-                if event_type == "compact" and len(text.encode("utf-8")) > 16 * 1024:
-                    raise NativeEgressProtocolError("native compact fragment exceeds the text limit")
+                if event_type in {"compact", "responses_event"} and len(text.encode("utf-8")) > 16 * 1024:
+                    raise NativeEgressProtocolError(f"native {event_type} fragment exceeds the text limit")
+                if event_type == "responses_event":
+                    kind = event.get("event_type")
+                    python_normalization = event.get("python_normalization")
+                    if (
+                        "event_type" not in event
+                        or (kind is not None and not isinstance(kind, str))
+                        or (isinstance(kind, str) and len(kind.encode("utf-8")) > 16 * 1024)
+                        or type(python_normalization) is not bool
+                        or (more and (kind is not None or python_normalization))
+                    ):
+                        raise NativeEgressProtocolError("native Responses event has invalid metadata")
+                    if not more:
+                        text = "".join(fragments) + text
+                        fragments.clear()
+                        yield NativeResponsesEvent(text, kind, python_normalization)
+                        continue
                 if more:
                     fragments.append(text)
                 elif fragments:
@@ -664,6 +700,8 @@ class SubprocessNativeEgressClient:
         if request.response_head_timeout_seconds is not None and request.response_head_timeout_seconds <= 0:
             raise ValueError("native egress response_head_timeout_seconds must be positive")
         if request.sse is not None:
+            if request.sse.collect_compact and request.sse.interpret_responses:
+                raise ValueError("native compact collection cannot interpret streaming Responses")
             if request.sse.collect_compact and not request.sse.content_type_aware:
                 raise ValueError("native compact collection requires content-type-aware framing")
             if not math.isfinite(request.sse.idle_timeout_seconds) or request.sse.idle_timeout_seconds <= 0:
@@ -698,6 +736,7 @@ class SubprocessNativeEgressClient:
                     "max_event_bytes": request.sse.max_event_bytes,
                     "content_type_aware": request.sse.content_type_aware,
                     "collect_compact": request.sse.collect_compact,
+                    "interpret_responses": request.sse.interpret_responses,
                 }
                 if request.sse is not None
                 else None
@@ -762,6 +801,7 @@ class SubprocessNativeEgressClient:
             events=events,
             sse_framed=sse_framed,
             compact_collected=sse_framed and request.sse is not None and request.sse.collect_compact,
+            responses_interpreted=sse_framed and request.sse is not None and request.sse.interpret_responses,
         )
 
     async def websocket(self, request: NativeWebSocketRequest) -> NativeEgressWebSocket:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -58,6 +58,7 @@ from app.core.clients.native_egress import (
     NativeEgressResponse,
     NativeEgressTransportError,
     NativeEgressUnavailable,
+    NativeResponsesEvent,
     NativeSseOptions,
     discover_native_egress_client,
 )
@@ -2058,6 +2059,8 @@ def _normalize_multi_data_sse_block(
 
 
 def _normalize_sse_event_block(event_block: str) -> str:
+    if isinstance(event_block, NativeResponsesEvent) and not event_block.python_normalization:
+        return event_block
     if not event_block:
         return event_block
 
@@ -2158,6 +2161,8 @@ def _normalize_stream_payload_for_http_block(
     *,
     enforce_openai_sdk_contract: bool = True,
 ) -> tuple[str, str | None]:
+    if isinstance(event_block, NativeResponsesEvent) and not event_block.python_normalization:
+        return event_block, event_block.event_type
     # Cheap path for the dominant delta traffic: a canonically framed block
     # exposes its event type on the `event:` line, so no JSON parse is needed.
     # Full parsing remains for `error` frames and any block carrying an
@@ -3827,7 +3832,7 @@ async def _stream_responses_with_session(
                 }
                 if not non_streaming_http:
                     request_kwargs["native_sse"] = NativeSseOptions(
-                        effective_idle_timeout, settings.max_sse_event_bytes
+                        effective_idle_timeout, settings.max_sse_event_bytes, interpret_responses=True
                     )
                 request_with_metadata = getattr(active_codex_client, "request_with_route_metadata", None)
                 if callable(request_with_metadata):
@@ -3977,7 +3982,9 @@ async def _stream_responses_with_session(
                             response_head_timeout_seconds=current_timeout.sock_read,
                             proxy_url=resolve_http_proxy_from_env(url),
                             sse=(
-                                NativeSseOptions(effective_idle_timeout, settings.max_sse_event_bytes)
+                                NativeSseOptions(
+                                    effective_idle_timeout, settings.max_sse_event_bytes, interpret_responses=True
+                                )
                                 if not non_streaming_http
                                 else None
                             ),

--- a/crates/codex-lb-egress-worker/tests/http_protocol.rs
+++ b/crates/codex-lb-egress-worker/tests/http_protocol.rs
@@ -104,6 +104,7 @@ fn sse_request(
             max_event_bytes,
             content_type_aware: false,
             collect_compact: false,
+            interpret_responses: false,
         }),
     })
 }

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use base64::Engine as _;
 use codex_lb_protocol::{NativeEvent, NativeRequest, NativeSseOptions};
 use codex_lb_responses::compact::{CompactCollector, CompactResult};
+use codex_lb_responses::stream::interpret;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::runtime::{Output, RequestError, emit};
@@ -166,7 +167,15 @@ async fn execute_sse_body(
             loop {
                 match framer.next_event() {
                     Ok(Some(text)) => {
-                        if consume_sse(output, request_id, &text, &mut collector).await? {
+                        if consume_sse(
+                            output,
+                            request_id,
+                            &text,
+                            &mut collector,
+                            options.interpret_responses,
+                        )
+                        .await?
+                        {
                             return Ok(None);
                         }
                     }
@@ -178,7 +187,15 @@ async fn execute_sse_body(
     }
     match framer.finish() {
         Ok(Some(text)) => {
-            if consume_sse(output, request_id, &text, &mut collector).await? {
+            if consume_sse(
+                output,
+                request_id,
+                &text,
+                &mut collector,
+                options.interpret_responses,
+            )
+            .await?
+            {
                 return Ok(None);
             }
         }
@@ -196,11 +213,36 @@ async fn consume_sse(
     request_id: &str,
     text: &str,
     collector: &mut Option<CompactCollector>,
+    interpret_responses: bool,
 ) -> Result<bool, std::io::Error> {
     if let Some(collector) = collector {
         if let Some(result) = collector.push(text) {
             emit_compact(output, request_id, result).await?;
             return Ok(true);
+        }
+    } else if interpret_responses {
+        let mut event = interpret(text);
+        // Type metadata is not fragmented; keep it within the text budget too.
+        if event
+            .event_type
+            .as_ref()
+            .is_some_and(|kind| kind.len() > SSE_IPC_TEXT_FRAGMENT_SIZE)
+        {
+            event.event_type = None;
+            event.python_normalization = true;
+        }
+        for (fragment, more) in text_fragments(&event.text, SSE_IPC_TEXT_FRAGMENT_SIZE) {
+            emit(
+                output,
+                &NativeEvent::ResponsesEvent {
+                    request_id: request_id.to_owned(),
+                    text: fragment.to_owned(),
+                    more,
+                    event_type: if more { None } else { event.event_type.clone() },
+                    python_normalization: !more && event.python_normalization,
+                },
+            )
+            .await?;
         }
     } else {
         emit_sse(output, request_id, text).await?;

--- a/crates/codex-lb-egress/src/runtime.rs
+++ b/crates/codex-lb-egress/src/runtime.rs
@@ -90,6 +90,7 @@ pub async fn run_stdio() -> Result<(), RequestError> {
                             || request.sse.is_some_and(|options| {
                                 options.idle_timeout_ms == 0 || options.max_event_bytes == 0
                                     || (options.collect_compact && !options.content_type_aware)
+                                    || (options.collect_compact && options.interpret_responses)
                             })
                         {
                             emit_error(

--- a/crates/codex-lb-protocol/src/lib.rs
+++ b/crates/codex-lb-protocol/src/lib.rs
@@ -13,6 +13,7 @@ pub const CAPABILITIES: &[&str] = &[
     "http_compact_collect_v1",
     "http_compact_sse_v1",
     "http_sse_v1",
+    "http_responses_events_v1",
     "websocket",
     "websocket_send_ack",
 ];
@@ -69,6 +70,8 @@ pub struct NativeSseOptions {
     pub content_type_aware: bool,
     #[serde(default)]
     pub collect_compact: bool,
+    #[serde(default)]
+    pub interpret_responses: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -104,6 +107,13 @@ pub enum NativeEvent {
         request_id: String,
         text: String,
         more: bool,
+    },
+    ResponsesEvent {
+        request_id: String,
+        text: String,
+        more: bool,
+        event_type: Option<String>,
+        python_normalization: bool,
     },
     SseEventTooLarge {
         request_id: String,

--- a/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
+++ b/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
@@ -14,6 +14,7 @@
       "http_compact_collect_v1",
       "http_compact_sse_v1",
       "http_sse_v1",
+      "http_responses_events_v1",
       "websocket",
       "websocket_send_ack"
     ]

--- a/crates/codex-lb-responses/src/lib.rs
+++ b/crates/codex-lb-responses/src/lib.rs
@@ -1,3 +1,4 @@
 //! Responses semantics independent of transport, process lifecycle, and routing.
 
 pub mod compact;
+pub mod stream;

--- a/crates/codex-lb-responses/src/stream.rs
+++ b/crates/codex-lb-responses/src/stream.rs
@@ -1,0 +1,247 @@
+//! Interpret framed HTTP Responses events without owning request policy.
+
+use std::borrow::Cow;
+use std::fmt::Write;
+
+use serde::Deserialize;
+use serde_json::Value;
+use serde_json::value::RawValue;
+
+const ALIASES: [(&str, &str); 3] = [
+    ("response.text.delta", "response.output_text.delta"),
+    ("response.audio.delta", "response.output_audio.delta"),
+    (
+        "response.audio_transcript.delta",
+        "response.output_audio_transcript.delta",
+    ),
+];
+
+/// Interpreted text plus a handoff for Python's context-dependent normalization.
+#[derive(Debug)]
+pub struct StreamEvent<'a> {
+    pub text: Cow<'a, str>,
+    pub event_type: Option<String>,
+    pub python_normalization: bool,
+}
+
+#[derive(Deserialize)]
+struct Payload<'a> {
+    #[serde(default, borrow, rename = "type")]
+    kind: Option<&'a RawValue>,
+    #[serde(default, borrow)]
+    error: Option<&'a RawValue>,
+}
+
+/// Preserve Python's alias and canonical-frame classification, including its
+/// fast path. Error conversion still needs Python's request context.
+pub fn interpret(block: &str) -> StreamEvent<'_> {
+    let Ok(text) = normalize_aliases(block) else {
+        return StreamEvent {
+            text: Cow::Borrowed(block),
+            event_type: None,
+            python_normalization: true,
+        };
+    };
+    if let Some(kind) = canonical_type(&text)
+        && kind != "error"
+        && alias(kind).is_none()
+        && !text.contains("\"error\"")
+    {
+        let event_type = Some(kind.to_owned());
+        return StreamEvent {
+            text,
+            event_type,
+            python_normalization: false,
+        };
+    }
+    let data = data_text(&text);
+    let payload = parse_payload(&data);
+    let event_type = payload
+        .as_ref()
+        .and_then(|p| p.kind)
+        .and_then(|kind| serde_json::from_str::<String>(kind.get()).ok());
+    let python_normalization = payload.is_none()
+        || (event_type.is_none()
+            && payload
+                .as_ref()
+                .and_then(|p| p.kind)
+                .is_some_and(|kind| kind.get().starts_with('"')))
+        || event_type.as_deref() == Some("error")
+        || payload
+            .as_ref()
+            .and_then(|p| p.error)
+            .is_some_and(|error| error.get().starts_with('{'))
+        || event_type
+            .as_deref()
+            .is_some_and(|kind| alias(kind).is_some());
+    StreamEvent {
+        text,
+        event_type,
+        python_normalization,
+    }
+}
+
+fn alias(kind: &str) -> Option<&'static str> {
+    ALIASES
+        .iter()
+        .find_map(|(old, new)| (*old == kind).then_some(*new))
+}
+
+fn parse_payload(data: &str) -> Option<Payload<'_>> {
+    // Serde also deserializes structs from arrays; Python accepts objects only.
+    data.trim_start()
+        .starts_with('{')
+        .then(|| serde_json::from_str(data).ok())
+        .flatten()
+}
+
+fn lines(block: &str) -> Vec<&str> {
+    // CRLF is one boundary. Other Unicode separators are ordinary content.
+    let mut result = Vec::new();
+    let bytes = block.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if matches!(bytes[i], b'\r' | b'\n') {
+            result.push(&block[start..i]);
+            if bytes[i] == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
+                i += 1;
+            }
+            start = i + 1;
+        }
+        i += 1;
+    }
+    result.push(&block[start..]);
+    result
+}
+
+fn data_text(block: &str) -> String {
+    lines(block)
+        .into_iter()
+        .filter_map(|line| {
+            let (field, value) = line.split_once(':').unwrap_or((line, ""));
+            (field == "data").then(|| value.strip_prefix(' ').unwrap_or(value))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn canonical_type(block: &str) -> Option<&str> {
+    let body = block.strip_prefix("event: ")?;
+    let (kind, data) = body.split_once("\ndata: {")?;
+    let data = data.strip_suffix("\n\n")?;
+    (!kind.is_empty() && !kind.contains(['\r', '\n']) && !data.contains(['\r', '\n']))
+        .then_some(kind)
+}
+
+fn normalize_aliases(block: &str) -> Result<Cow<'_, str>, ()> {
+    if !ALIASES.iter().any(|(old, _)| block.contains(old)) {
+        return Ok(Cow::Borrowed(block));
+    }
+    let (separator, terminator) = if block.ends_with("\r\n\r\n") {
+        ("\r\n", "\r\n\r\n")
+    } else if block.ends_with("\n\n") {
+        ("\n", "\n\n")
+    } else if block.ends_with("\r\r") {
+        ("\r", "\r\r")
+    } else {
+        (if block.contains("\r\n") { "\r\n" } else { "\n" }, "")
+    };
+    let parts = lines(&block[..block.len() - terminator.len()]);
+    let multiline = parts
+        .iter()
+        .filter(|line| line.starts_with("data:"))
+        .count()
+        > 1;
+    let replacement = if multiline {
+        let data = data_text(block);
+        // Preserve Python's valid-JSON-object gate for all multiline rewrites.
+        let Some(payload) = parse_payload(&data) else {
+            return Err(());
+        };
+        rewrite_payload(&data, &payload)?
+    } else {
+        None
+    };
+    let mut emitted = false;
+    let mut changed = false;
+    let mut normalized = Vec::new();
+    for line in parts {
+        if multiline && line.starts_with("data:") {
+            if let Some(ref replacement) = replacement {
+                if !emitted {
+                    normalized.push(format!("data: {replacement}"));
+                    emitted = true;
+                    changed = true;
+                }
+            } else {
+                normalized.push(line.to_owned());
+            }
+            continue;
+        }
+        if !multiline && let Some(data) = line.strip_prefix("data:") {
+            if let Some(payload) = parse_payload(data.trim()) {
+                if let Some(value) = rewrite_payload(data.trim(), &payload)? {
+                    normalized.push(format!("data: {value}"));
+                    changed = true;
+                    continue;
+                }
+            } else {
+                // Python accepts some JSON strings/numbers that serde does not.
+                return Err(());
+            }
+        }
+        if let Some(kind) = line.strip_prefix("event:")
+            && let Some(kind) = alias(kind.strip_prefix(' ').unwrap_or(kind))
+        {
+            normalized.push(format!("event: {kind}"));
+            changed = true;
+        } else {
+            normalized.push(line.to_owned());
+        }
+    }
+    Ok(if changed {
+        Cow::Owned(normalized.join(separator) + terminator)
+    } else {
+        Cow::Borrowed(block)
+    })
+}
+
+fn rewrite_payload(data: &str, payload: &Payload<'_>) -> Result<Option<String>, ()> {
+    let Some(kind) = payload
+        .kind
+        .and_then(|kind| serde_json::from_str::<String>(kind.get()).ok())
+    else {
+        return Ok(None);
+    };
+    let Some(normalized) = alias(&kind) else {
+        return Ok(None);
+    };
+    let mut value: Value = serde_json::from_str(data).map_err(|_| ())?;
+    if !exact_json_domain(&value) {
+        return Err(());
+    }
+    value["type"] = Value::String(normalized.to_owned());
+    let text = serde_json::to_string(&value).map_err(|_| ())?;
+    // Match json.dumps(ensure_ascii=True, separators=(',', ':')).
+    let mut ascii = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_ascii() && ch != '\x7f' {
+            ascii.push(ch);
+        } else {
+            for unit in ch.encode_utf16(&mut [0; 2]) {
+                write!(ascii, "\\u{unit:04x}").expect("write to String");
+            }
+        }
+    }
+    Ok(Some(ascii))
+}
+
+fn exact_json_domain(value: &Value) -> bool {
+    match value {
+        Value::Number(number) => number.is_i64() || number.is_u64(),
+        Value::Array(items) => items.iter().all(exact_json_domain),
+        Value::Object(fields) => fields.values().all(exact_json_domain),
+        _ => true,
+    }
+}

--- a/crates/codex-lb-responses/src/stream.rs
+++ b/crates/codex-lb-responses/src/stream.rs
@@ -42,6 +42,8 @@ pub fn interpret(block: &str) -> StreamEvent<'_> {
             python_normalization: true,
         };
     };
+    // Mirror Python's literal-key fast path, including escaped error keys.
+    // Noncanonical frames still decode keys before selecting the error handoff.
     if let Some(kind) = canonical_type(&text)
         && kind != "error"
         && alias(kind).is_none()

--- a/crates/codex-lb-responses/tests/fixtures/stream-v1.json
+++ b/crates/codex-lb-responses/tests/fixtures/stream-v1.json
@@ -1,0 +1,876 @@
+[
+  {
+    "name": "canonical",
+    "block": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\ud55c\uae00\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\ud55c\uae00\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\ud55c\uae00\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\ud55c\uae00\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "data_only",
+    "block": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.text.delta'\\n'",
+    "block": "event: response.text.delta\ndata: {\"type\": \"response.text.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.text.delta'\\r'",
+    "block": "event: response.text.delta\rdata: {\"type\": \"response.text.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\r",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\rdata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\rdata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\rdata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.text.delta'\\r\\n'",
+    "block": "event: response.text.delta\r\ndata: {\"type\": \"response.text.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\n\r\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio.delta'\\n'",
+    "block": "event: response.audio.delta\ndata: {\"type\": \"response.audio.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio.delta\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+    "native_type": "response.output_audio.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio.delta\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_audio.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio.delta\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_audio.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio.delta'\\r'",
+    "block": "event: response.audio.delta\rdata: {\"type\": \"response.audio.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\r",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio.delta\rdata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+    "native_type": "response.output_audio.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio.delta\rdata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_audio.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio.delta\rdata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_audio.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio.delta'\\r\\n'",
+    "block": "event: response.audio.delta\r\ndata: {\"type\": \"response.audio.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\n\r\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio.delta\r\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+    "native_type": "response.output_audio.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio.delta\r\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_audio.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio.delta\r\ndata: {\"type\":\"response.output_audio.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_audio.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio_transcript.delta'\\n'",
+    "block": "event: response.audio_transcript.delta\ndata: {\"type\": \"response.audio_transcript.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio_transcript.delta\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+    "native_type": "response.output_audio_transcript.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio_transcript.delta\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_audio_transcript.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio_transcript.delta\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\n\n",
+        "event_type": "response.output_audio_transcript.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio_transcript.delta'\\r'",
+    "block": "event: response.audio_transcript.delta\rdata: {\"type\": \"response.audio_transcript.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\r",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio_transcript.delta\rdata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+    "native_type": "response.output_audio_transcript.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio_transcript.delta\rdata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_audio_transcript.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio_transcript.delta\rdata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\r",
+        "event_type": "response.output_audio_transcript.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.audio_transcript.delta'\\r\\n'",
+    "block": "event: response.audio_transcript.delta\r\ndata: {\"type\": \"response.audio_transcript.delta\", \"delta\": \"\ud55c\uae00\ud83d\ude00\u2028\u007f\"}\r\n\r\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_audio_transcript.delta\r\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+    "native_type": "response.output_audio_transcript.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_audio_transcript.delta\r\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_audio_transcript.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_audio_transcript.delta\r\ndata: {\"type\":\"response.output_audio_transcript.delta\",\"delta\":\"\\ud55c\\uae00\\ud83d\\ude00\\u2028\\u007f\"}\r\n\r\n",
+        "event_type": "response.output_audio_transcript.delta"
+      }
+    ]
+  },
+  {
+    "name": "multiline",
+    "block": "event: response.text.delta\ndata: {\"type\":\"response.text.delta\",\ndata: \"delta\":\"hi\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "malformed_multiline",
+    "block": "event: response.text.delta\ndata: {\"type\":\"response.te\ndata: xt.delta\"}\n\n",
+    "python_normalization": true,
+    "native_text": "event: response.text.delta\ndata: {\"type\":\"response.te\ndata: xt.delta\"}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.text.delta\ndata: {\"type\":\"response.te\ndata: xt.delta\"}\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "event: response.text.delta\ndata: {\"type\":\"response.te\ndata: xt.delta\"}\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "comment_id",
+    "block": "id: 2\n: note\nevent: response.text.delta\ndata: {\"type\":\"response.text.delta\",\"delta\":\"hi\"}\n\n",
+    "python_normalization": false,
+    "native_text": "id: 2\n: note\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "id: 2\n: note\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "id: 2\n: note\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "mismatch_canonical",
+    "block": "event: response.completed\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.completed\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+    "native_type": "response.completed",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.completed\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.completed"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.completed\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.completed"
+      }
+    ]
+  },
+  {
+    "name": "malformed_canonical",
+    "block": "event: response.completed\ndata: {broken\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.completed\ndata: {broken\n\n",
+    "native_type": "response.completed",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.completed\ndata: {broken\n\n",
+        "event_type": "response.completed"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.completed\ndata: {broken\n\n",
+        "event_type": "response.completed"
+      }
+    ]
+  },
+  {
+    "name": "malformed_data",
+    "block": "data: not json\n\n",
+    "python_normalization": true,
+    "native_text": "data: not json\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: not json\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "data: not json\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "done",
+    "block": "data: [DONE]\n\n",
+    "python_normalization": true,
+    "native_text": "data: [DONE]\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: [DONE]\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "data: [DONE]\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "comment",
+    "block": ": keepalive\n\n",
+    "python_normalization": true,
+    "native_text": ": keepalive\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": ": keepalive\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": ": keepalive\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "error",
+    "block": "data: {\"type\":\"error\",\"message\":\"boom\"}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"error\",\"message\":\"boom\"}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"error\",\"message\":\"boom\"}\n\n",
+        "event_type": "error"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"object\":\"response\",\"status\":\"failed\",\"error\":{\"message\":\"boom\",\"type\":\"server_error\",\"code\":\"upstream_error\"},\"incomplete_details\":null,\"created_at\":1700000000}}\n\n",
+        "event_type": "response.failed"
+      }
+    ]
+  },
+  {
+    "name": "error_envelope",
+    "block": "data: {\"type\":\"response.output_text.delta\",\"error\":{\"message\":\"boom\"}}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.output_text.delta\",\"error\":{\"message\":\"boom\"}}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"error\":{\"message\":\"boom\"}}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"object\":\"response\",\"status\":\"failed\",\"error\":{\"message\":\"boom\",\"type\":\"server_error\",\"code\":\"upstream_error\"},\"incomplete_details\":null,\"created_at\":1700000000}}\n\n",
+        "event_type": "response.failed"
+      }
+    ]
+  },
+  {
+    "name": "typeless_error",
+    "block": "data: {\"error\":{\"message\":\"boom\"}}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"error\":{\"message\":\"boom\"}}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"error\":{\"message\":\"boom\"}}\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"object\":\"response\",\"status\":\"failed\",\"error\":{\"message\":\"boom\",\"type\":\"server_error\",\"code\":\"upstream_error\"},\"incomplete_details\":null,\"created_at\":1700000000}}\n\n",
+        "event_type": "response.failed"
+      }
+    ]
+  },
+  {
+    "name": "alias_float",
+    "block": "data: {\"type\":\"response.text.delta\",\"n\":1e-7}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.text.delta\",\"n\":1e-7}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":1e-07}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":1e-07}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "alias_huge_int",
+    "block": "data: {\"type\":\"response.text.delta\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.text.delta\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "alias_surrogate",
+    "block": "data: {\"type\":\"response.text.delta\",\"x\":\"\\ud800\"}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.text.delta\",\"x\":\"\\ud800\"}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"x\":\"\\ud800\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"x\":\"\\ud800\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "unknown_huge_int",
+    "block": "data: {\"type\":\"vendor.event\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"vendor.event\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+    "native_type": "vendor.event",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"vendor.event\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+        "event_type": "vendor.event"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"vendor.event\",\"n\":10000000000000000000000000000000000000000000000000000000000000000000000}\n\n",
+        "event_type": "vendor.event"
+      }
+    ]
+  },
+  {
+    "name": "unknown_surrogate",
+    "block": "data: {\"type\":\"vendor.event\",\"x\":\"\\ud800\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"vendor.event\",\"x\":\"\\ud800\"}\n\n",
+    "native_type": "vendor.event",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"vendor.event\",\"x\":\"\\ud800\"}\n\n",
+        "event_type": "vendor.event"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"vendor.event\",\"x\":\"\\ud800\"}\n\n",
+        "event_type": "vendor.event"
+      }
+    ]
+  },
+  {
+    "name": "duplicate_type",
+    "block": "data: {\"type\":\"wrong\",\"type\":\"response.text.delta\",\"delta\":\"ok\"}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"wrong\",\"type\":\"response.text.delta\",\"delta\":\"ok\"}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "alias_nested",
+    "block": "data: {\"delta\":{\"z\":[true,null,123],\"a\":\"text\"},\"type\":\"response.text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"delta\":{\"z\":[true,null,123],\"a\":\"text\"},\"type\":\"response.output_text.delta\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"delta\":{\"z\":[true,null,123],\"a\":\"text\"},\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"delta\":{\"z\":[true,null,123],\"a\":\"text\"},\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "empty_type",
+    "block": "data: {\"type\":\"\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"\"}\n\n",
+    "native_type": "",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"\"}\n\n",
+        "event_type": ""
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"\"}\n\n",
+        "event_type": ""
+      }
+    ]
+  },
+  {
+    "name": "numeric_type",
+    "block": "data: {\"type\":17}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":17}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":17}\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":17}\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "escaped_alias",
+    "block": "data: {\"type\":\"response.\\u0074ext.delta\"}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.\\u0074ext.delta\"}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.\\u0074ext.delta\"}\n\n",
+        "event_type": "response.text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "alias_with_marker_elsewhere",
+    "block": "data: {\"type\":\"response.\\u0074ext.delta\",\"delta\":\"response.text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"response.text.delta\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"response.text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"response.text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "event_only_alias",
+    "block": "event: response.text.delta\n\n",
+    "python_normalization": true,
+    "native_text": "event: response.text.delta\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "no_colon_data",
+    "block": "data\nevent: response.text.delta\ndata: {\"type\":\"response.text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "response.completed",
+    "block": "data: {\"type\": \"response.completed\", \"response\": {\"id\": \"x\"}}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\": \"response.completed\", \"response\": {\"id\": \"x\"}}\n\n",
+    "native_type": "response.completed",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\": \"response.completed\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.completed"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\": \"response.completed\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.completed"
+      }
+    ]
+  },
+  {
+    "name": "response.failed",
+    "block": "data: {\"type\": \"response.failed\", \"response\": {\"id\": \"x\"}}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\": \"response.failed\", \"response\": {\"id\": \"x\"}}\n\n",
+    "native_type": "response.failed",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\": \"response.failed\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.failed"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\": \"response.failed\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.failed"
+      }
+    ]
+  },
+  {
+    "name": "response.incomplete",
+    "block": "data: {\"type\": \"response.incomplete\", \"response\": {\"id\": \"x\"}}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\": \"response.incomplete\", \"response\": {\"id\": \"x\"}}\n\n",
+    "native_type": "response.incomplete",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\": \"response.incomplete\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.incomplete"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\": \"response.incomplete\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "response.incomplete"
+      }
+    ]
+  },
+  {
+    "name": "vendor.event",
+    "block": "data: {\"type\": \"vendor.event\", \"response\": {\"id\": \"x\"}}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\": \"vendor.event\", \"response\": {\"id\": \"x\"}}\n\n",
+    "native_type": "vendor.event",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\": \"vendor.event\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "vendor.event"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\": \"vendor.event\", \"response\": {\"id\": \"x\"}}\n\n",
+        "event_type": "vendor.event"
+      }
+    ]
+  },
+  {
+    "name": "mixed_unchanged",
+    "block": "id: 2\r\nevent: vendor.event\ndata: {\"type\":\"vendor.event\",\"note\":\"response.text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "id: 2\r\nevent: vendor.event\ndata: {\"type\":\"vendor.event\",\"note\":\"response.text.delta\"}\n\n",
+    "native_type": "vendor.event",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "id: 2\r\nevent: vendor.event\ndata: {\"type\":\"vendor.event\",\"note\":\"response.text.delta\"}\n\n",
+        "event_type": "vendor.event"
+      },
+      {
+        "sdk": true,
+        "text": "id: 2\r\nevent: vendor.event\ndata: {\"type\":\"vendor.event\",\"note\":\"response.text.delta\"}\n\n",
+        "event_type": "vendor.event"
+      }
+    ]
+  },
+  {
+    "name": "mixed_changed",
+    "block": "id: 2\r\nevent: response.text.delta\ndata: {\"type\":\"response.text.delta\"}\n\n",
+    "python_normalization": false,
+    "native_text": "id: 2\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "id: 2\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "id: 2\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "array_payload",
+    "block": "data: [\"response.completed\",null]\n\n",
+    "python_normalization": true,
+    "native_text": "data: [\"response.completed\",null]\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: [\"response.completed\",null]\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "data: [\"response.completed\",null]\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "array_alias",
+    "block": "data: [\"response.text.delta\",null]\n\n",
+    "python_normalization": true,
+    "native_text": "data: [\"response.text.delta\",null]\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: [\"response.text.delta\",null]\n\n",
+        "event_type": null
+      },
+      {
+        "sdk": true,
+        "text": "data: [\"response.text.delta\",null]\n\n",
+        "event_type": null
+      }
+    ]
+  },
+  {
+    "name": "duplicate_nested",
+    "block": "data: {\"type\":\"response.text.delta\",\"delta\":{\"z\":1,\"a\":2,\"z\":3}}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"response.output_text.delta\",\"delta\":{\"z\":3,\"a\":2}}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":{\"z\":3,\"a\":2}}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"delta\":{\"z\":3,\"a\":2}}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "alias_negative_zero",
+    "block": "data: {\"type\":\"response.text.delta\",\"n\":-0}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.text.delta\",\"n\":-0}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":0}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"n\":0}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "unicode_separator",
+    "block": "data: {\"type\":\"vendor.event\",\"delta\":\"x\u2028y\u0085z\"}\n\n",
+    "python_normalization": false,
+    "native_text": "data: {\"type\":\"vendor.event\",\"delta\":\"x\u2028y\u0085z\"}\n\n",
+    "native_type": "vendor.event",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"vendor.event\",\"delta\":\"x\u2028y\u0085z\"}\n\n",
+        "event_type": "vendor.event"
+      },
+      {
+        "sdk": true,
+        "text": "data: {\"type\":\"vendor.event\",\"delta\":\"x\u2028y\u0085z\"}\n\n",
+        "event_type": "vendor.event"
+      }
+    ]
+  }
+]

--- a/crates/codex-lb-responses/tests/fixtures/stream-v1.json
+++ b/crates/codex-lb-responses/tests/fixtures/stream-v1.json
@@ -872,5 +872,43 @@
         "event_type": "vendor.event"
       }
     ]
+  },
+  {
+    "name": "canonical_escaped_error_key",
+    "block": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+    "python_normalization": false,
+    "native_text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+    "native_type": "response.output_text.delta",
+    "expected": [
+      {
+        "sdk": false,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+        "event_type": "response.output_text.delta"
+      }
+    ]
+  },
+  {
+    "name": "data_only_escaped_error_key",
+    "block": "data: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+    "python_normalization": true,
+    "native_text": "data: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+    "native_type": null,
+    "expected": [
+      {
+        "sdk": false,
+        "text": "data: {\"type\":\"response.output_text.delta\",\"\\u0065rror\":{\"message\":\"boom\"}}\n\n",
+        "event_type": "response.output_text.delta"
+      },
+      {
+        "sdk": true,
+        "text": "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"object\":\"response\",\"status\":\"failed\",\"error\":{\"message\":\"boom\",\"type\":\"server_error\",\"code\":\"upstream_error\"},\"incomplete_details\":null,\"created_at\":1700000000}}\n\n",
+        "event_type": "response.failed"
+      }
+    ]
   }
 ]

--- a/crates/codex-lb-responses/tests/stream.rs
+++ b/crates/codex-lb-responses/tests/stream.rs
@@ -1,0 +1,28 @@
+use codex_lb_responses::stream::interpret;
+use serde_json::Value;
+
+#[test]
+fn shared_stream_fixtures() {
+    let cases: Vec<Value> = serde_json::from_str(include_str!("fixtures/stream-v1.json")).unwrap();
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let event = interpret(case["block"].as_str().unwrap());
+        assert_eq!(
+            event.python_normalization,
+            case["python_normalization"].as_bool().unwrap(),
+            "{name}: handoff"
+        );
+        if !event.python_normalization {
+            assert_eq!(
+                event.text,
+                case["native_text"].as_str().unwrap(),
+                "{name}: text"
+            );
+            assert_eq!(
+                event.event_type.as_deref(),
+                case["native_type"].as_str(),
+                "{name}: type"
+            );
+        }
+    }
+}

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -37,9 +37,20 @@ that migration reaches the application shell.
 Direct and account-routed streaming and compact Responses requests delegate SSE byte framing to egress.
 The adapter requires `http_sse_v1` and supplies the existing idle timeout and
 event byte limit as per-request options. Rust owns the deadline between body
-reads, including partial events; for ordinary streaming Python consumes framed text and retains event
-normalization, terminal detection, archives, and public error mapping. HTTP
-error bodies and non-streaming requests keep the raw chunk contract.
+reads, including partial events. Ordinary HTTP streaming additionally requires
+`http_responses_events_v1`: the synchronous Responses library normalizes legacy
+text/audio/audio-transcript aliases and classifies event types. Unchanged event
+text stays byte-for-byte intact. Python retains terminal detection, archives,
+and request-context-dependent public error mapping. HTTP error bodies and
+non-streaming requests keep the raw chunk contract.
+
+Interpreted events carry the effective type and an explicit Python-normalization
+marker on the final fragment. Error conversion and JSON representations that
+cannot be rewritten exactly (such as alias payloads containing floats, huge
+integers, or escaped surrogate strings) use that marker without replaying the
+request. Type metadata is limited to 16 KiB too; longer types use the same
+handoff. Shared Python/Rust fixtures pin SDK and native passthrough behavior.
+WebSocket interpretation remains a later transport slice.
 
 Compact requests additionally require `http_compact_sse_v1`. Their
 `content_type_aware` framing option preserves raw JSON success bodies, while

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/context.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/context.md
@@ -1,0 +1,25 @@
+# Context
+
+The existing synchronous Responses library owns ordinary HTTP event alias
+normalization and classification. The transport opts in through a capability;
+Python still owns SDK error conversion because it uses request IDs, timestamps,
+and public error policy. The same library boundary can serve WebSocket later.
+
+Canonical event-line classification deliberately retains the Python fast path,
+including mismatched or malformed canonical JSON. Other frames use joined SSE
+data fields. Struct deserialization is gated to JSON objects because serde also
+accepts arrays. Alias reserialization preserves insertion order, compact JSON,
+and Python ASCII escaping. Floats, out-of-range integers, escaped surrogates,
+and ambiguous duplicate classification fields use an explicit Python handoff.
+Unchanged mixed line endings remain untouched. For example, ordinary
+`response.text.delta` becomes `response.output_text.delta` in Rust, while an
+alias payload containing `1e-7` uses Python's existing serialization.
+
+The helper emits bounded text fragments and final-fragment metadata. A type
+larger than 16 KiB uses a handoff without metadata; metadata consumes queue bytes.
+Malformed metadata fails the request without replay. Existing original-byte
+limits, body-read idle deadlines, terminal handling and cancellation still apply.
+
+This slice reduces Python ownership; it does not establish a throughput gain.
+Synthetic measurements show remaining IPC and scheduling costs; see verification.
+No operator setting or new application policy is introduced.

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/proposal.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/proposal.md
@@ -1,0 +1,25 @@
+# Migrate Responses stream event interpretation
+
+## Why
+
+Rust frames ordinary Responses SSE bytes but Python still scans each event for
+legacy aliases and determines its event type. The synchronous Responses library
+can own this work for direct and routed native HTTP, with shared compatibility
+fixtures defining the boundary.
+
+## What Changes
+
+- Add a pure Responses event interpreter that preserves unchanged event bytes,
+  normalizes supported legacy aliases, and extracts the effective event type.
+- Negotiate typed normalized SSE events with bounded text fragments.
+- Keep request-context-dependent public error conversion in Python. Explicitly
+  hand off alias payloads whose JSON representation cannot be reproduced by the
+  Rust serializer (floats, out-of-range integers, escaped surrogate strings).
+- Preserve the missing-helper Python path and existing native/SDK modes. Reuse
+  the library for WebSocket in a later transport slice.
+
+## Impact
+
+Responses library, egress/protocol, Python adapter and HTTP stream consumption,
+shared fixtures, direct/routed integration and architecture documentation.
+No routing, retry, settlement, database, or operator setting changes.

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/specs/outbound-http-clients/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Interpreted Responses SSE is negotiated across IPC
+
+The adapter MUST require `http_responses_events_v1` before requesting interpreted
+Responses events. Ordinary framing and compact collection MUST retain their
+separate contracts. Interpreted text fragments MUST remain at most 16 KiB of
+UTF-8. Type metadata MUST remain at most 16 KiB of UTF-8 and count toward the
+queue byte budget; longer types MUST use Python normalization without metadata.
+Only the final fragment MAY carry a type or request Python normalization.
+Event type and Python-normalization metadata MUST be validated before use;
+malformed or truncated events MUST fail without replay. Body-read deadlines,
+original-byte event limits, cancellation and ready-consumer scheduling MUST remain
+active. Missing-helper fallback MUST occur only before dispatch.
+
+#### Scenario: Fragmented interpreted event
+
+- **WHEN** one interpreted event spans multiple IPC fragments
+- **THEN** the adapter emits one complete event with its validated metadata
+- **AND** an active consumer can drain a burst beyond queue capacity
+
+#### Scenario: Incompatible installed helper
+
+- **WHEN** the installed helper lacks the required interpretation capability
+- **THEN** the adapter rejects negotiation before dispatch without Python replay

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/specs/responses-api-compat/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Native HTTP interprets Responses stream events compatibly
+
+Native direct and routed HTTP Responses streams MUST preserve the existing event
+classification and legacy text/audio/audio-transcript alias normalization.
+Unmodified events MUST retain their original text. SSE field parsing MUST
+recognize only CR, LF, and CRLF boundaries and join data fields with LF.
+Canonical event-line classification, malformed JSON, native passthrough mode,
+unknown fields, and terminal behavior MUST match the Python path.
+
+The synchronous Rust Responses library MUST own eligible alias normalization and
+event classification. Python MUST retain request-context-dependent error mapping.
+When alias serialization contains floating numbers, integers outside the Rust
+JSON integer domain, or escaped surrogate strings, the interpreter MUST signal
+Python normalization of the original event rather than lose data or reinterpret
+its representation. This handoff MUST NOT replay the request.
+
+#### Scenario: Legacy alias on framing and payload
+
+- **WHEN** an event uses a supported legacy alias in its event line or payload
+- **THEN** both surfaces are normalized according to the existing Python rules
+- **AND** unrelated data and fields retain their values
+
+#### Scenario: Unsupported alias JSON representation
+
+- **WHEN** rewriting an alias requires a JSON representation outside the native serializer's supported domain
+- **THEN** Python receives the original event and an explicit normalization marker
+- **AND** the public result matches the ordinary Python transport
+
+#### Scenario: Native error passthrough
+
+- **WHEN** native passthrough receives an error event
+- **THEN** it remains an error event and ends the stream under the existing policy
+- **AND** SDK mode retains the existing request-context-dependent error conversion

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/tasks.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/tasks.md
@@ -1,0 +1,5 @@
+- [x] Capture Python event classification and alias behavior in shared fixtures.
+- [x] Implement the pure Rust event interpreter and fixture parity tests.
+- [x] Negotiate bounded interpreted SSE events and consume them through both HTTP paths.
+- [x] Verify malformed IPC, fallback parity, cancellation, terminal and byte-limit behavior.
+- [x] Measure the changed stream path, sync specs, record verification, and archive.

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/verification.md
@@ -1,0 +1,40 @@
+# Verification
+
+- Shared Python/Rust corpus: 46 cases, including aliases, all SSE newline forms,
+  errors in SDK/native modes, malformed input, unknown fields, escaped JSON,
+  duplicate keys, mixed line endings, arrays and serialization handoffs.
+- Python/native adapter, fixtures, packaging contract, Codex client, direct/routed
+  integration and proxy utility tests: **1,878 passed**. Public native/missing-helper
+  differential coverage runs each shared case through direct/routed HTTP and both
+  SDK modes. Real helper tests cover fragmented large events, early terminal close,
+  cancellation, idle deadlines, original-byte limits and no replay.
+- Additional invalid metadata checks cover UTF-8 type-size limits and intermediate
+  handoff flags: **10 focused checks passed**. Queue tests account for metadata bytes and release them on drain.
+- Rust: format, Clippy with warnings denied, all **22** workspace tests, locked
+  release worker build and cargo-deny passed. Cargo-deny reports existing duplicate
+  dependency warnings; advisory, ban, license and source checks pass.
+- Full repository Ruff lint/format and ty passed. Proxy architecture, cancellation
+  safety and timing seam checks passed. All 58 strict OpenSpec specifications and
+  simplicity budgets passed; the change is synced and archived.
+
+## Synthetic stream measurement
+
+Same release helper in both modes; loopback HTTP and real IPC. Baseline requests
+native framing and runs Python normalization; interpreted mode requests native
+interpretation. Each request contains 2,048 small deltas. Four warmups and 20
+measured requests per mode/shape, alternating order, under CPython 3.13 with uvloop.
+The shared host was busy; these figures are not production capacity evidence.
+Parent CPU excludes the helper. No model delay is included.
+
+| Shape | Python median / p95 ms | Native median / p95 ms | Python parent CPU ms | Native parent CPU ms |
+|---|---:|---:|---:|---:|
+| Canonical | 436.4 / 501.6 | 448.6 / 493.5 | 123.9 | 127.4 |
+| Data only | 495.6 / 534.8 | 498.8 / 582.4 | 141.7 | 131.9 |
+| Legacy alias | 493.8 / 571.9 | 537.7 / 621.7 | 164.4 | 133.7 |
+
+The alias case reduces parent CPU by 18.7% but increases median elapsed time by
+8.9%; canonical adds 2.8% median and parent CPU. An earlier asyncio-loop run also
+showed no elapsed-time improvement (canonical/data-only/alias medians changed
+414.5→420.1, 390.0→429.2, 403.2→450.6 ms). The result supports ownership migration,
+not a speed claim. IPC overhead and full application benchmarks remain follow-up
+work before claiming improved throughput.

--- a/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/verification.md
+++ b/openspec/changes/archive/2026-09-08-migrate-responses-stream-events/verification.md
@@ -1,6 +1,6 @@
 # Verification
 
-- Shared Python/Rust corpus: 46 cases, including aliases, all SSE newline forms,
+- Shared Python/Rust corpus: 48 cases, including aliases, all SSE newline forms,
   errors in SDK/native modes, malformed input, unknown fields, escaped JSON,
   duplicate keys, mixed line endings, arrays and serialization handoffs.
 - Python/native adapter, fixtures, packaging contract, Codex client, direct/routed
@@ -38,3 +38,13 @@ showed no elapsed-time improvement (canonical/data-only/alias medians changed
 414.5→420.1, 390.0→429.2, 403.2→450.6 ms). The result supports ownership migration,
 not a speed claim. IPC overhead and full application benchmarks remain follow-up
 work before claiming improved throughput.
+
+## Review parity check
+
+CodeRabbit questioned escaped `error` keys on canonical blocks. Python's existing
+canonical fast path also checks the literal `"error"` substring and returns these
+blocks unchanged in both SDK modes. Parsing first only in Rust would diverge.
+Added shared canonical and data-only escaped-key cases: the canonical case stays
+unchanged; the data-only case uses Python error conversion. Rust fixture parity
+and all 10 Python direct/routed/SDK checks passed. After merging current main,
+481 native/public Responses contract tests and all 58 strict specs passed.

--- a/openspec/specs/outbound-http-clients/context.md
+++ b/openspec/specs/outbound-http-clients/context.md
@@ -27,7 +27,7 @@ into the existing Rust egress library. Python supplies the configured idle
 interval and event byte limit; Rust applies them while reading the body.
 For example, an event split over several active body reads must not time out
 just because Python has not yet received a complete event. Python retains
-normalization, terminal detection, archives, selection, health, and replay.
+terminal detection, archives, selection, health, and replay policy.
 
 Complete events cross IPC as UTF-8 text fragments of at most 16 KiB, with a
 `more` flag. This bounds line/queue expansion for control characters and invalid
@@ -37,7 +37,7 @@ residue, and limits measured in original body bytes. The adapter only joins
 text fragments. An incomplete IPC event at clean EOF fails the protocol.
 
 HTTP error bodies and requests without SSE options retain raw body delivery.
-Compact framing remains a separate future cutover. Missing helpers
+Compact requests use separate content-aware framing and collection capabilities. Missing helpers
 keep the pre-dispatch Python fallback; installed helpers without the capability
 fail before dispatch. No dispatched request is replayed through that fallback.
 Response close finishes its owned cancellation handshake even inside an already
@@ -51,3 +51,23 @@ type avoids the raw-body wrapper hiding its framed-event interface. Endpoint
 fallback and trace metadata remain Python-owned. The locally created client
 finishes asynchronous session close before propagating cancellation; borrowed
 clients retain their caller's lifecycle ownership.
+
+## Native HTTP stream interpretation
+
+`http_responses_events_v1` adds `interpret_responses` to framing options and a
+`responses_event` IPC result. The final text fragment includes `event_type` and
+`python_normalization`; intermediate fragments have no type and a false marker.
+Both text and type metadata are bounded at 16 KiB of UTF-8 and count toward the
+queue byte budget. A longer type uses a Python handoff with no type metadata.
+Missing or malformed metadata, mixed compact/stream options, and truncated
+fragments fail before an event is trusted.
+
+For example, a `response.text.delta` payload with ordinary text becomes
+`response.output_text.delta` in Rust; Python can use the attached classification
+without scanning SSE or parsing that payload. Error conversion needs request
+context and stays in Python. An alias payload containing a float, oversized
+integer, or escaped surrogate uses Python serialization to preserve its exact
+legacy representation. Neither handoff starts a second HTTP request. Unchanged
+mixed-line-ending events preserve their text; JSON arrays never become objects.
+The Python transport remains the missing-helper implementation, and WebSocket
+event interpretation is deferred to the next transport slice.

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -804,3 +804,27 @@ bounded queue and fail independently without blocking sibling requests.
 - **WHEN** framed SSE events, raw JSON success chunks, or raw HTTP error chunks arrive in a buffered burst exceeding queue capacity
 - **THEN** an active consumer receives ordered SSE events, the complete JSON response, or the original HTTP error respectively
 - **AND** the response is not replaced by a consumer-backpressure error
+
+### Requirement: Interpreted Responses SSE is negotiated across IPC
+
+The adapter MUST require `http_responses_events_v1` before requesting interpreted
+Responses events. Ordinary framing and compact collection MUST retain their
+separate contracts. Interpreted text fragments MUST remain at most 16 KiB of
+UTF-8. Type metadata MUST remain at most 16 KiB of UTF-8 and count toward the
+queue byte budget; longer types MUST use Python normalization without metadata.
+Only the final fragment MAY carry a type or request Python normalization.
+Event type and Python-normalization metadata MUST be validated before use;
+malformed or truncated events MUST fail without replay. Body-read deadlines,
+original-byte event limits, cancellation and ready-consumer scheduling MUST remain
+active. Missing-helper fallback MUST occur only before dispatch.
+
+#### Scenario: Fragmented interpreted event
+
+- **WHEN** one interpreted event spans multiple IPC fragments
+- **THEN** the adapter emits one complete event with its validated metadata
+- **AND** an active consumer can drain a burst beyond queue capacity
+
+#### Scenario: Incompatible installed helper
+
+- **WHEN** the installed helper lacks the required interpretation capability
+- **THEN** the adapter rejects negotiation before dispatch without Python replay

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5847,3 +5847,37 @@ public shape normalization, error translation, archives, routing, and settlement
 
 - **WHEN** the native helper is unavailable before dispatch
 - **THEN** Python transport and collection preserve the same output assembly contract
+
+### Requirement: Native HTTP interprets Responses stream events compatibly
+
+Native direct and routed HTTP Responses streams MUST preserve the existing event
+classification and legacy text/audio/audio-transcript alias normalization.
+Unmodified events MUST retain their original text. SSE field parsing MUST
+recognize only CR, LF, and CRLF boundaries and join data fields with LF.
+Canonical event-line classification, malformed JSON, native passthrough mode,
+unknown fields, and terminal behavior MUST match the Python path.
+
+The synchronous Rust Responses library MUST own eligible alias normalization and
+event classification. Python MUST retain request-context-dependent error mapping.
+When alias serialization contains floating numbers, integers outside the Rust
+JSON integer domain, or escaped surrogate strings, the interpreter MUST signal
+Python normalization of the original event rather than lose data or reinterpret
+its representation. This handoff MUST NOT replay the request.
+
+#### Scenario: Legacy alias on framing and payload
+
+- **WHEN** an event uses a supported legacy alias in its event line or payload
+- **THEN** both surfaces are normalized according to the existing Python rules
+- **AND** unrelated data and fields retain their values
+
+#### Scenario: Unsupported alias JSON representation
+
+- **WHEN** rewriting an alias requires a JSON representation outside the native serializer's supported domain
+- **THEN** Python receives the original event and an explicit normalization marker
+- **AND** the public result matches the ordinary Python transport
+
+#### Scenario: Native error passthrough
+
+- **WHEN** native passthrough receives an error event
+- **THEN** it remains an error event and ends the stream under the existing policy
+- **AND** SDK mode retains the existing request-context-dependent error conversion

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -233,8 +233,9 @@ async def test_buffered_native_burst_preserves_responses_result(
         "               'http_version': 'HTTP/2.0', 'headers': [['content-type',\n"
         "               'text/event-stream' if kind == 'sse' else 'application/json']]}]\n"
         "    if kind == 'sse':\n"
-        "        events.extend({'type': 'sse', 'text': 'data: ' + json.dumps(payload) + '\\n\\n',\n"
-        "                       'more': False} for payload in payloads)\n"
+        "        events.extend({'type': 'responses_event', 'text': 'data: ' + json.dumps(payload) + '\\n\\n',\n"
+        "                       'more': False, 'event_type': payload['type'], 'python_normalization': False}\n"
+        "                      for payload in payloads)\n"
         "    else:\n"
         "        body = body.encode() + b' ' * 256\n"
         "        events.extend({'type': 'chunk', 'data': base64.b64encode(body[i:i+1]).decode()}\n"
@@ -1291,3 +1292,132 @@ async def test_native_compact_routed_fallback_keeps_metadata_and_never_replays_a
     assert not replays
     assert trace == proxy_module.UpstreamProxyRouteTrace("account_bound", "compact-fallback", "selected", True)
     assert not native_worker._streams
+
+
+_STREAM_CASES = json.loads(
+    (Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/stream-v1.json").read_text()
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _STREAM_CASES, ids=[case["name"] for case in _STREAM_CASES])
+@pytest.mark.parametrize("sdk", [False, True])
+async def test_native_stream_interpretation_matches_public_python_result(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    case: dict[str, Any],
+    sdk: bool,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("app.core.errors.time.time", lambda: 1700000000)
+    body = case["block"].encode() + b'data: {"type":"response.completed","response":{"id":"end"}}\n\n'
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, body)
+        await _finish_chunks(writer)
+
+    async def outcome(base_url: str, worker: SubprocessNativeEgressClient, session: aiohttp.ClientSession) -> list[str]:
+        route = (
+            ResolvedUpstreamRoute(
+                mode="account_bound",
+                pool_id="stream-parity",
+                endpoint=ResolvedProxyEndpoint("stream-proxy", "http", "127.0.0.1", urlsplit(base_url).port or 80),
+            )
+            if routed
+            else None
+        )
+        return await _collect(
+            stream_responses(
+                _request("interpretation"),
+                {"authorization": "Bearer test"},
+                "test-access-token",
+                "test-account",
+                base_url="http://upstream.invalid" if routed else base_url,
+                session=session,
+                route=route,
+                codex_client=CodexClient(session, native_egress_client=worker) if routed else None,
+                upstream_stream_transport_override="http",
+                allow_direct_egress=False,
+                suppress_live_usage=True,
+                native_egress_client=worker,
+                enforce_openai_sdk_contract=sdk,
+            )
+        )
+
+    async with _serve_http(handler) as base_url, aiohttp.ClientSession() as session:
+        missing = SubprocessNativeEgressClient(tmp_path / "missing-helper")
+        expected = await outcome(base_url, missing, session)
+        assert await outcome(base_url, native_worker, session) == expected
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+async def test_native_interpretation_drains_large_fragments_without_python_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+) -> None:
+    monkeypatch.setattr(native_module, "_NATIVE_STREAM_QUEUE_LIMIT", 2)
+    block = 'data: {"type":"response.text.delta","delta":' + json.dumps("한글😀" * 12000) + "}\n\n"
+    expected = proxy_module._normalize_sse_event_block(block)
+    terminal = 'data: {"type":"response.completed","response":{"id":"done"}}\n\n'
+    fragments: list[int] = []
+    read = native_module._read_event
+
+    async def record(stdout: asyncio.StreamReader) -> dict[str, object]:
+        event = await read(stdout)
+        if event.get("type") == "responses_event":
+            fragments.append(len(str(event["text"]).encode()))
+        return event
+
+    monkeypatch.setattr(native_module, "_read_event", record)
+    normalizer = proxy_module._normalize_sse_event_block
+    classifier = proxy_module._normalize_stream_payload_for_http_block
+
+    def require_native(block: str) -> str:
+        assert isinstance(block, native_module.NativeResponsesEvent)
+        assert not block.python_normalization
+        return normalizer(block)
+
+    def require_metadata(block: str, *, enforce_openai_sdk_contract: bool = True) -> tuple[str, str | None]:
+        assert isinstance(block, native_module.NativeResponsesEvent)
+        assert not block.python_normalization
+        return classifier(block, enforce_openai_sdk_contract=enforce_openai_sdk_contract)
+
+    monkeypatch.setattr(proxy_module, "_normalize_sse_event_block", require_native)
+    monkeypatch.setattr(proxy_module, "_normalize_stream_payload_for_http_block", require_metadata)
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, (block + terminal).encode())
+        await reader.read()  # Completion must release the response before EOF.
+
+    async with _serve_http(handler) as base_url:
+        result = await asyncio.wait_for(_collect(_stream(base_url, native_worker, "interpreted", routed=routed)), 5)
+    assert result == [expected, terminal]
+    assert len(fragments) > 2
+    assert max(fragments) <= 16 * 1024
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+async def test_native_long_event_type_uses_bounded_python_handoff(
+    native_worker: SubprocessNativeEgressClient, routed: bool
+) -> None:
+    kind = "vendor." + "x" * (20 * 1024)
+    block = f'event: {kind}\ndata: {{"type":"{kind}"}}\n\n'
+    terminal = 'data: {"type":"response.completed","response":{"id":"end"}}\n\n'
+
+    async def handler(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, (block + terminal).encode())
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url:
+        result = await _collect(_stream(base_url, native_worker, "long-kind", routed=routed))
+    assert result == [block, terminal]
+    assert isinstance(result[0], native_module.NativeResponsesEvent)
+    assert result[0].event_type is None
+    assert result[0].python_normalization

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -45,6 +45,7 @@ print(json.dumps({
         "http_compact_collect_v1",
         "http_compact_sse_v1",
         "http_sse_v1",
+        "http_responses_events_v1",
         "websocket",
         "websocket_send_ack",
     ],
@@ -848,7 +849,7 @@ for line in sys.stdin:
         print(json.dumps({{"type": "cancelled", "request_id": request_id}}), flush=True)
         continue
     assert command["sse"] == {{"idle_timeout_ms": 1000, "max_event_bytes": 1024,
-                              "content_type_aware": False, "collect_compact": False}}
+                              "content_type_aware": False, "collect_compact": False, "interpret_responses": False}}
     print(json.dumps({{"type": "head", "request_id": request_id, "status": 200,
                        "http_version": "HTTP/1.1", "headers": []}}), flush=True)
     for event in {events!r}:
@@ -913,7 +914,9 @@ async def test_native_sse_failure_releases_owned_stream(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("capability", ["http_sse_v1", "http_compact_sse_v1", "http_compact_collect_v1"])
+@pytest.mark.parametrize(
+    "capability", ["http_sse_v1", "http_compact_sse_v1", "http_compact_collect_v1", "http_responses_events_v1"]
+)
 async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path, capability: str) -> None:
     helper = tmp_path / "native-helper"
     preamble = _HELPER_PROTOCOL_PREAMBLE.replace(f'        "{capability}",\n', "")
@@ -981,6 +984,7 @@ async def test_native_compact_rejects_broken_result_without_replay(
         NativeSseOptions(1, 0),
         NativeSseOptions(1, True),
         NativeSseOptions(1, 1024, collect_compact=True),
+        NativeSseOptions(1, 1024, content_type_aware=True, collect_compact=True, interpret_responses=True),
     ],
 )
 async def test_native_sse_options_are_validated_before_start(tmp_path: Path, options: NativeSseOptions) -> None:
@@ -1089,6 +1093,15 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     # Text payloads are measured in UTF-8 bytes, not code points.
     queue.put_nowait({"type": "sse", "text": "\u00e9\u00e9"})
     assert queue.queued_bytes == 4
+    # Interpreted event metadata consumes the same byte budget as its text.
+    interpreted = {"type": "responses_event", "text": "hi", "event_type": "\u00e9\u00e9"}
+    queue.put_nowait(interpreted)
+    assert queue.queued_bytes == 10
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait(interpreted)
+    queue.get_nowait()
+    assert queue.get_nowait() == interpreted
+    assert queue.queued_bytes == 0
     # A lone event larger than the whole budget is accepted at an empty queue
     # (the SSE event size cap bounds it), so a single big chunk never fails;
     # anything but a zero-byte event is then rejected until it drains.
@@ -1177,3 +1190,73 @@ for line in sys.stdin:
     body = await asyncio.wait_for(response.read(), timeout=10.0)
     assert len(body) == 16 * 3 * 512 * 1024
     await asyncio.wait_for(client.aclose(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "events",
+    [
+        [{"type": "responses_event", "text": "data: {}\n\n", "more": False}],
+        [{"type": "responses_event", "text": "x", "more": False, "event_type": 1, "python_normalization": False}],
+        [
+            {
+                "type": "responses_event",
+                "text": "x",
+                "more": True,
+                "event_type": "response.completed",
+                "python_normalization": False,
+            }
+        ],
+        [{"type": "responses_event", "text": "x", "more": False, "event_type": None, "python_normalization": "false"}],
+        [
+            {
+                "type": "responses_event",
+                "text": "x",
+                "more": False,
+                "event_type": "é" * (8 * 1024 + 1),
+                "python_normalization": False,
+            }
+        ],
+        [{"type": "responses_event", "text": "x", "more": True, "event_type": None, "python_normalization": True}],
+        [
+            {
+                "type": "responses_event",
+                "text": "x" * (16 * 1024 + 1),
+                "more": False,
+                "event_type": None,
+                "python_normalization": False,
+            }
+        ],
+        [
+            {
+                "type": "responses_event",
+                "text": "unfinished",
+                "more": True,
+                "event_type": None,
+                "python_normalization": False,
+            },
+            {"type": "end"},
+        ],
+        [{"type": "sse", "text": "data: {}\n\n", "more": False}],
+    ],
+)
+async def test_interpreted_sse_rejects_invalid_metadata_without_replay(
+    tmp_path: Path, events: list[dict[str, object]]
+) -> None:
+    helper = tmp_path / "native-helper"
+    source = _sse_helper_source(events).replace('"interpret_responses": False', '"interpret_responses": True')
+    _write_helper(helper, source)
+    client = SubprocessNativeEgressClient(helper)
+    try:
+        response = await client.request(
+            NativeEgressRequest(
+                "GET", "https://example.test", {}, sse=NativeSseOptions(1, 1024, interpret_responses=True)
+            )
+        )
+        with pytest.raises(NativeEgressProtocolError):
+            async for _ in response.iter_sse_events():
+                pass
+        assert client._request_sequence == 1
+        assert not client._streams
+    finally:
+        await client.aclose()

--- a/tests/unit/test_native_stream_fixtures.py
+++ b/tests/unit/test_native_stream_fixtures.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.core.clients import proxy
+
+FIXTURES = Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/stream-v1.json"
+CASES = json.loads(FIXTURES.read_text())
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+def test_stream_fixture_matches_python(case: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.core.errors.time.time", lambda: 1700000000)
+    normalized = proxy._normalize_sse_event_block(case["block"])
+    for expected in case["expected"]:
+        text, kind = proxy._normalize_stream_payload_for_http_block(
+            normalized, enforce_openai_sdk_contract=expected["sdk"]
+        )
+        assert (text, kind) == (expected["text"], expected["event_type"])


### PR DESCRIPTION
## Summary

Move ordinary direct and routed HTTP Responses event classification and legacy text/audio alias normalization into the synchronous Rust Responses library. For example, `response.text.delta` becomes `response.output_text.delta` in Rust; unchanged event text and the existing SDK/native error behavior are preserved.

- Negotiate `http_responses_events_v1` and deliver interpreted events in bounded UTF-8 fragments, with validated type/handoff metadata only on the final fragment. Metadata counts toward queue memory limits.
- Keep request-context error conversion and exact-serialization handoffs in Python. Missing-helper fallback remains pre-dispatch; malformed IPC, cancellation and post-dispatch failures never replay the request.
- Pin compatibility with 48 shared Python/Rust fixtures and public direct/routed differential tests. WebSocket interpretation is a later slice.

## OpenSpec

- [x] Synced and archived `openspec/changes/archive/2026-09-08-migrate-responses-stream-events/`.
- [x] Preserves existing SSE and SDK/native compatibility behavior; architecture docs describe the boundary.
- [x] Zero configuration; no new settings or setup steps. Adapter and bundled helper must be upgraded together, as with existing capability changes.

## Validation

- 1,878 related Python tests passed; 10 additional focused metadata/queue checks passed. After merging current main, 481 native/public-contract tests passed; 10 escaped-error-key parity checks also passed.
- All 22 Rust workspace tests, format, Clippy with warnings denied, locked release build and cargo-deny passed.
- Full repository Ruff/ty, architecture/cancellation/timing checks, all 58 strict OpenSpec specs and simplicity budgets passed.

A same-helper uvloop loopback measurement (2,048 deltas/request, four warmups and 20 samples per mode) reduced alias-case parent CPU by 18.7% but increased median elapsed time by 8.9%. Canonical median increased 2.8%. This PR establishes Rust ownership, not a throughput improvement; shared-host synthetic measurements and IPC costs are recorded in the archived verification. No production rollout is included.
