### PR TITLE
refactor(config): route every environment read through Settings

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -12,7 +12,7 @@ from typing import Annotated, Literal
 from urllib.parse import urlparse
 
 from dotenv import dotenv_values
-from pydantic import Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from app.core.auth.dashboard_mode import DashboardAuthMode, normalize_dashboard_auth_proxy_header
@@ -311,6 +311,12 @@ class Settings(BaseSettings):
     token_refresh_interval_days: int = 8
     usage_fetch_timeout_seconds: float = 10.0
     usage_fetch_max_retries: int = 2
+    # T1 (topology). Path to a JSON registry of additional usage quota keys
+    # that replaces the bundled ``config/additional_quota_registry.json``.
+    # Unset (or blank) keeps the bundled registry. The Alembic backfill
+    # migration ``20260312_000000`` reads the same env name directly because
+    # migrations must not depend on ``Settings``.
+    additional_quota_registry_file: Path | None = None
     usage_refresh_enabled: bool = True
     usage_refresh_interval_seconds: int = Field(default=60, gt=0)
     live_usage_ingestion_enabled: bool = True
@@ -443,6 +449,19 @@ class Settings(BaseSettings):
         default_factory=lambda: ["127.0.0.1/32", "::1/128"]
     )
     firewall_ip_cache_ttl_seconds: int = Field(default=30, gt=0)
+    # T1 (topology). Uvicorn-compatible proxy-projection trust list consumed by
+    # ``TrustedProxyHeadersMiddleware``. Semantics are Uvicorn's, unchanged:
+    # unset trusts ``127.0.0.1``, empty trusts no peer, ``*`` trusts every
+    # peer, anything else is a comma-separated host/network list. The bare
+    # ``FORWARDED_ALLOW_IPS`` env name stays authoritative for compatibility
+    # with Uvicorn deployments; ``CODEX_LB_FORWARDED_ALLOW_IPS`` is the
+    # prefixed alias. This governs ``scope["client"]``/scheme projection only;
+    # ``firewall_trusted_proxy_cidrs`` governs firewall and auth client
+    # resolution from the raw socket peer.
+    forwarded_allow_ips: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("FORWARDED_ALLOW_IPS", "CODEX_LB_FORWARDED_ALLOW_IPS"),
+    )
     dashboard_auth_mode: DashboardAuthMode = DashboardAuthMode.STANDARD
     dashboard_trust_loopback_host_header_for_long_sessions: bool = False
 
@@ -480,6 +499,10 @@ class Settings(BaseSettings):
     bulkhead_proxy_limit: int = Field(default=512, ge=0)
     bulkhead_dashboard_limit: int = Field(default=50, ge=0)
     dashboard_bootstrap_token: str | None = None
+    # T1 (topology). Address the dashboard tells operators to point clients at
+    # (``GET /api/settings/runtime/connect-address``). Unset derives it from
+    # the request host; a blank value collapses to unset.
+    connect_address: str | None = None
     proxy_token_refresh_limit: int = Field(default=64, ge=0)
     proxy_upstream_websocket_connect_limit: int = Field(default=128, ge=0)
     proxy_response_create_limit: int = Field(default=256, ge=0)
@@ -616,6 +639,14 @@ class Settings(BaseSettings):
                         normalized.append(host)
             return normalized
         raise TypeError("image_inline_allowed_hosts must be a list or comma-separated string")
+
+    @field_validator("connect_address", "additional_quota_registry_file", mode="before")
+    @classmethod
+    def _blank_optional_to_none(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
 
     @field_validator("firewall_trusted_proxy_cidrs", mode="before")
     @classmethod

--- a/app/core/middleware/trusted_proxy_headers.py
+++ b/app/core/middleware/trusted_proxy_headers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from collections.abc import Awaitable, Callable
 from typing import TypeAlias, cast
 
@@ -8,6 +7,7 @@ from fastapi import FastAPI
 from starlette.types import ASGIApp, Receive, Scope, Send
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
+from app.core.config.settings import get_settings
 from app.core.socket_peer import _capture_raw_socket_peer
 
 _UvicornASGIApp: TypeAlias = Callable[..., Awaitable[None]]
@@ -17,11 +17,12 @@ class TrustedProxyHeadersMiddleware:
     """Preserve the raw socket peer, then apply Uvicorn's proxy projection."""
 
     def __init__(self, app: ASGIApp) -> None:
+        trusted_hosts = get_settings().forwarded_allow_ips
         self._proxy_headers = cast(
             ASGIApp,
             ProxyHeadersMiddleware(
                 cast(_UvicornASGIApp, app),
-                trusted_hosts=os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1"),
+                trusted_hosts="127.0.0.1" if trusted_hosts is None else trusted_hosts,
             ),
         )
 

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ipaddress
-import os
 import socket
 import time
 
@@ -95,7 +94,7 @@ def _resolve_hostname_ipv4(hostname: str) -> str | None:
 
 
 def _resolve_runtime_connect_address(request: Request) -> str:
-    override = os.getenv("CODEX_LB_CONNECT_ADDRESS", "").strip()
+    override = get_app_settings().connect_address
     if override:
         return override
 

--- a/app/modules/usage/additional_quota_keys.py
+++ b/app/modules/usage/additional_quota_keys.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import TypedDict
+
+from app.core.config.settings import get_settings
 
 _NORMALIZE_PATTERN = re.compile(r"[^a-z0-9]+")
 ADDITIONAL_QUOTA_ROUTING_POLICIES = frozenset({"inherit", "burn_first", "normal", "preserve"})
@@ -63,9 +64,9 @@ def _default_registry_path() -> Path:
 
 
 def _registry_path() -> Path:
-    configured = os.environ.get("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", "").strip()
-    if configured:
-        return Path(configured).expanduser().resolve()
+    configured = get_settings().additional_quota_registry_file
+    if configured is not None:
+        return configured.expanduser().resolve()
     return _default_registry_path()
 
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -8,8 +8,9 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `app/core/config/settings.py`.
 
 codex-lb currently exposes 137 settings. Every setting is an environment
-variable with the `CODEX_LB_` prefix (process environment or `.env` /
-`.env.local` next to the process). All defaults work with zero configuration —
+variable, normally with the `CODEX_LB_` prefix (process environment or `.env` /
+`.env.local` next to the process); aliased settings list every accepted name.
+All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
 and treat everything else as advanced operational tunables.
 
@@ -34,19 +35,22 @@ the env-file locations have to be known before env files are read.
 
 These are third-party or POSIX conventions codex-lb honors without
 making them settings. They are read by their owning launcher, library, or
-frozen migration rather than through `Settings`, and are the only
-sanctioned environment reads outside `app/core/config/settings.py`.
+frozen migration rather than through `Settings`. Together with `Settings`
+itself this table is the allowlist of environment reads under `app/`;
+anything else belongs in `app/core/config/settings.py`.
 
 | Environment variable(s) | Consumer |
 | --- | --- |
 | `HOST`, `PORT`, `SSL_CERTFILE`, `SSL_KEYFILE`, `UVICORN_TIMEOUT_KEEP_ALIVE`, `UVICORN_WS_MAX_SIZE` | Uvicorn launch defaults read once by the `codex-lb` CLI (`app/cli.py`); host runs only. |
 | `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `WS_PROXY`, `NO_PROXY` (and lowercase) | Outbound proxy conventions honored by httpx/aiohttp/websockets for upstream egress. |
+| `REQUEST_METHOD` | CGI marker; when present `HTTP_PROXY` is ignored (httpoxy guard, mirrors the httpx/requests rule). |
 | `TZ` | POSIX process timezone; automation schedules with the `server_default` timezone resolve to it (falling back to the host local zone, then UTC). |
 | `PROMETHEUS_MULTIPROC_DIR` | prometheus_client multiprocess-mode convention. |
 | `GITHUB_TOKEN` | Optional bearer token for the GitHub latest-release version check. |
 | `POD_IP`, `POD_NAME`, `HOSTNAME`, `KUBERNETES_SERVICE_HOST` | Kubernetes/pod identity used for multi-replica validation and deployment-kind telemetry. |
 | `CODEX_HOME`, `USERPROFILE`, `WSL_DISTRO_NAME` | Codex CLI home discovery for the `codex-lb codex-sessions retag` tool. |
 | `CODEX_LB_TEST_DATABASE_URL` | Test-suite/CI only: overrides the database used by the test session factory. |
+| `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`, `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` (inside `app/db/alembic/versions/**` only) | Frozen Alembic migrations read the process environment directly because migrations must not depend on `Settings`; the live settings of the same name are documented in the tables below. |
 
 ## Core
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 134 settings. Every setting is an environment
+codex-lb currently exposes 137 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -29,6 +29,24 @@ of paths — overrides that discovery for installs whose module root cannot
 contain env files (the Nix package wrapper points it at the launch
 directory). It must be set in the process environment, not in an env file:
 the env-file locations have to be known before env files are read.
+
+## Process-level environment variables (not settings)
+
+These are third-party or POSIX conventions codex-lb honors without
+making them settings. They are read by their owning launcher, library, or
+frozen migration rather than through `Settings`, and are the only
+sanctioned environment reads outside `app/core/config/settings.py`.
+
+| Environment variable(s) | Consumer |
+| --- | --- |
+| `HOST`, `PORT`, `SSL_CERTFILE`, `SSL_KEYFILE`, `UVICORN_TIMEOUT_KEEP_ALIVE`, `UVICORN_WS_MAX_SIZE` | Uvicorn launch defaults read once by the `codex-lb` CLI (`app/cli.py`); host runs only. |
+| `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `WS_PROXY`, `NO_PROXY` (and lowercase) | Outbound proxy conventions honored by httpx/aiohttp/websockets for upstream egress. |
+| `TZ` | POSIX process timezone; automation schedules with the `server_default` timezone resolve to it (falling back to the host local zone, then UTC). |
+| `PROMETHEUS_MULTIPROC_DIR` | prometheus_client multiprocess-mode convention. |
+| `GITHUB_TOKEN` | Optional bearer token for the GitHub latest-release version check. |
+| `POD_IP`, `POD_NAME`, `HOSTNAME`, `KUBERNETES_SERVICE_HOST` | Kubernetes/pod identity used for multi-replica validation and deployment-kind telemetry. |
+| `CODEX_HOME`, `USERPROFILE`, `WSL_DISTRO_NAME` | Codex CLI home discovery for the `codex-lb codex-sessions retag` tool. |
+| `CODEX_LB_TEST_DATABASE_URL` | Test-suite/CI only: overrides the database used by the test session factory. |
 
 ## Core
 
@@ -159,6 +177,7 @@ the env-file locations have to be known before env files are read.
 
 | Environment variable | Type | Default |
 | --- | --- | --- |
+| `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE` | `Path \| None` | `None` |
 | `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED` | `bool` | `True` |
 | `CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_ENABLED` | `bool` | `True` |
 | `CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_INTERVAL_SECONDS` | `int` | `60` |
@@ -201,11 +220,13 @@ the env-file locations have to be known before env files are read.
 | `CODEX_LB_FIREWALL_IP_CACHE_TTL_SECONDS` | `int` | `30` |
 | `CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS` | `bool` | `False` |
 | `CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS` | `list[str]` | `['127.0.0.1/32', '::1/128']` |
+| `FORWARDED_ALLOW_IPS` (alias `CODEX_LB_FORWARDED_ALLOW_IPS`) | `str \| None` | `None` |
 
 ## Dashboard
 
 | Environment variable | Type | Default |
 | --- | --- | --- |
+| `CODEX_LB_CONNECT_ADDRESS` | `str \| None` | `None` |
 | `CODEX_LB_DASHBOARD_AUTH_MODE` | `'standard' \| 'trusted_header' \| 'disabled'` | `'standard'` |
 | `CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER` | `str` | `'Remote-User'` |
 | `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN` | `str \| None` | `None` |

--- a/openspec/changes/env-reads-through-settings/proposal.md
+++ b/openspec/changes/env-reads-through-settings/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Three environment variables were consumed by ad-hoc `os.environ` reads outside `app/core/config/settings.py` — `CODEX_LB_CONNECT_ADDRESS` (dashboard connect-address override), `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE` (additional quota registry path), and `FORWARDED_ALLOW_IPS` (Uvicorn proxy-projection trust list). None appeared in the generated settings reference, none could be set through `.env` / `.env.local`, and the removed-settings warning and reference generator could not see them. This is the config-silo slop catalogued as S9/S14 in the 0908 slop-removal inventory.
+
+## What Changes
+
+- Promote the three env names to `Settings` fields (`connect_address`, `additional_quota_registry_file`, `forwarded_allow_ips`) with the same env names. `FORWARDED_ALLOW_IPS` keeps its bare Uvicorn name as the primary alias and gains `CODEX_LB_FORWARDED_ALLOW_IPS` as the prefixed alias; its trust semantics are unchanged.
+- Consumers (`TrustedProxyHeadersMiddleware`, the connect-address resolver, the additional quota registry loader) read `get_settings()` instead of the process environment.
+- The settings reference generator renders alias env names and adds a "Process-level environment variables (not settings)" section documenting the remaining sanctioned bare env reads (Uvicorn launch knobs, outbound proxy family, `TZ`, `PROMETHEUS_MULTIPROC_DIR`, `GITHUB_TOKEN`, Kubernetes pod identity, Codex CLI home discovery, `CODEX_LB_TEST_DATABASE_URL`).
+- The settings-surface ratchet moves from 135 to 138 for the three promoted fields; they are existing knobs made visible, not new tunables.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: proxy projection trust is sourced from the `forwarded_allow_ips` setting (env `FORWARDED_ALLOW_IPS`, alias `CODEX_LB_FORWARDED_ALLOW_IPS`) with Uvicorn semantics preserved; the "MUST NOT introduce a new setting" clause scoped to the original capture-before-projection change is replaced by the setting-sourced contract.
+- `user-documentation`: the generated settings reference renders alias env names for settings whose primary env name is unprefixed and documents process-level environment conventions that are intentionally not settings.
+
+## Impact
+
+Affected code: `app/core/config/settings.py`, `app/core/middleware/trusted_proxy_headers.py`, `app/modules/settings/api.py`, `app/modules/usage/additional_quota_keys.py`, `scripts/generate_settings_reference.py`, `docs/reference/settings.md`, and the tests that set these env names (they now clear the `get_settings` cache). No API schema, database, dependency, or default-behaviour change: unset values resolve exactly as before. The Alembic backfill migration `20260312_000000` keeps its direct env read because migrations must not depend on `Settings`.

--- a/openspec/changes/env-reads-through-settings/proposal.md
+++ b/openspec/changes/env-reads-through-settings/proposal.md
@@ -6,7 +6,7 @@ Three environment variables were consumed by ad-hoc `os.environ` reads outside `
 
 - Promote the three env names to `Settings` fields (`connect_address`, `additional_quota_registry_file`, `forwarded_allow_ips`) with the same env names. `FORWARDED_ALLOW_IPS` keeps its bare Uvicorn name as the primary alias and gains `CODEX_LB_FORWARDED_ALLOW_IPS` as the prefixed alias; its trust semantics are unchanged.
 - Consumers (`TrustedProxyHeadersMiddleware`, the connect-address resolver, the additional quota registry loader) read `get_settings()` instead of the process environment.
-- The settings reference generator renders alias env names and adds a "Process-level environment variables (not settings)" section documenting the remaining sanctioned bare env reads (Uvicorn launch knobs, outbound proxy family, `TZ`, `PROMETHEUS_MULTIPROC_DIR`, `GITHUB_TOKEN`, Kubernetes pod identity, Codex CLI home discovery, `CODEX_LB_TEST_DATABASE_URL`).
+- The settings reference generator renders alias env names and adds a "Process-level environment variables (not settings)" section documenting the remaining sanctioned bare env reads (Uvicorn launch knobs, outbound proxy family, `TZ`, `PROMETHEUS_MULTIPROC_DIR`, `GITHUB_TOKEN`, `REQUEST_METHOD` httpoxy guard, Kubernetes pod identity, Codex CLI home discovery, `CODEX_LB_TEST_DATABASE_URL`, frozen Alembic migration reads).
 - The settings-surface ratchet moves from 135 to 138 for the three promoted fields; they are existing knobs made visible, not new tunables.
 
 ## Capabilities

--- a/openspec/changes/env-reads-through-settings/specs/deployment-installation/spec.md
+++ b/openspec/changes/env-reads-through-settings/specs/deployment-installation/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Owned launch paths preserve raw peer before proxy projection
+
+Every project-owned launch path for the main application MUST disable server-level proxy-header projection. The outermost application middleware MUST preserve the incoming HTTP or WebSocket `scope["client"]` before applying Uvicorn-compatible proxy projection exactly once. Downstream consumers MUST continue to observe Uvicorn's projected client and scheme. Projection trust MUST be sourced from the `forwarded_allow_ips` setting, whose primary environment name is the bare `FORWARDED_ALLOW_IPS` (for compatibility with Uvicorn deployments) and whose prefixed alias is `CODEX_LB_FORWARDED_ALLOW_IPS`; either name MAY be set in the process environment or in the env files `Settings` reads. Uvicorn's trust semantics MUST be preserved: unset MUST trust `127.0.0.1`, empty MUST trust no peer, `*` MUST trust every peer, and explicit hosts or networks MUST retain Uvicorn's parsing and trusted-chain behavior. The middleware MUST NOT read the process environment directly.
+
+#### Scenario: Owned launchers disable early projection
+
+- **WHEN** the main application starts through the project CLI, development Compose, or a shipped direct FastAPI/Uvicorn command
+- **THEN** server-level proxy-header projection is disabled
+- **AND** application capture and projection run exactly once
+
+#### Scenario: HTTP and WebSocket preserve both identities
+
+- **WHEN** a trusted peer sends valid `X-Forwarded-For` and `X-Forwarded-Proto` headers over HTTP or WebSocket
+- **THEN** the raw transport peer remains preserved
+- **AND** downstream handling observes Uvicorn's projected client and protocol-appropriate scheme
+
+#### Scenario: Forwarded allowlist behavior is unchanged
+
+- **WHEN** `FORWARDED_ALLOW_IPS` is unset, empty, `*`, or an explicit host/network list
+- **THEN** proxy projection follows Uvicorn's existing trust semantics
+
+#### Scenario: Prefixed alias is honored
+
+- **WHEN** `CODEX_LB_FORWARDED_ALLOW_IPS` is set and `FORWARDED_ALLOW_IPS` is unset
+- **THEN** proxy projection trusts the aliased value with the same semantics
+- **AND** the setting appears in the generated settings reference under both names

--- a/openspec/changes/env-reads-through-settings/specs/user-documentation/spec.md
+++ b/openspec/changes/env-reads-through-settings/specs/user-documentation/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Generated settings reference stays in sync with the code
+
+The documentation site SHALL include a settings reference page
+(`docs/reference/settings.md`) generated from `Settings.model_fields` by
+`scripts/generate_settings_reference.py`. The page SHALL list, for every
+setting, its environment variable name — the `CODEX_LB_`-prefixed name, or,
+for a setting declared with explicit validation aliases, the primary alias
+followed by the remaining aliases — its type, and its default
+(environment-derived defaults rendered symbolically), grouped by functional
+area; it SHALL document the bare `PORT` special case, SHALL list the
+process-level environment variables codex-lb honors without making them
+settings (third-party or POSIX conventions read by the launcher, libraries,
+or frozen migrations), and SHALL list the removed (`_REMOVED_SETTINGS`) and
+deprecated env names sourced from the code. The generated page SHALL be
+checked into the repository so the strict docs build stays hermetic, SHALL
+carry a header identifying it as generated, and SHALL link the owning
+OpenSpec capability. CI unit tests MUST fail when the checked-in page differs
+from regenerated output, when the settings surface exceeds its ratchet
+(lower-only without a simplicity-budget decision), or when an uncommented
+`.env.example` assignment differs from the code default.
+
+#### Scenario: Settings change without regeneration fails CI
+
+- **GIVEN** a change to `Settings` fields in `app/core/config/settings.py`
+- **WHEN** the unit test suite runs without regenerating `docs/reference/settings.md`
+- **THEN** the regenerate-and-diff test fails until the page is regenerated and committed
+
+#### Scenario: Reference page is reachable and generated
+
+- **WHEN** a reader opens the published settings reference page
+- **THEN** it is in the site navigation and linked from the Configuration page
+- **AND** it identifies itself as generated from `scripts/generate_settings_reference.py`
+- **AND** it links the owning OpenSpec capability
+
+#### Scenario: Settings surface growth trips the ratchet
+
+- **WHEN** the number of `Settings` fields exceeds the ratchet value
+- **THEN** the ratchet unit test fails, forcing a simplicity-budget discussion before the surface grows
+
+#### Scenario: Aliased setting renders every env name
+
+- **WHEN** a setting is declared with validation aliases (for example `forwarded_allow_ips`)
+- **THEN** the reference row shows the primary env name and each alias
+- **AND** an operator can find the setting by either name
+
+#### Scenario: Process-level conventions are documented but not settings
+
+- **WHEN** codex-lb honors an environment variable that is a third-party or POSIX convention
+- **THEN** the reference lists it in the process-level section with its consumer
+- **AND** it is not counted toward the settings ratchet

--- a/openspec/changes/env-reads-through-settings/tasks.md
+++ b/openspec/changes/env-reads-through-settings/tasks.md
@@ -1,0 +1,20 @@
+## 1. Settings surface
+
+- [x] 1.1 Add `connect_address`, `additional_quota_registry_file`, and `forwarded_allow_ips` fields with tier comments; blank `CODEX_LB_*` values collapse to unset, `FORWARDED_ALLOW_IPS` keeps empty-string-means-trust-none.
+- [x] 1.2 Give `forwarded_allow_ips` the `FORWARDED_ALLOW_IPS` / `CODEX_LB_FORWARDED_ALLOW_IPS` alias pair.
+- [x] 1.3 Raise the settings ratchet 135 -> 138 with the promotion justification.
+
+## 2. Consumers
+
+- [x] 2.1 `TrustedProxyHeadersMiddleware` reads `get_settings().forwarded_allow_ips` (unset -> `127.0.0.1`).
+- [x] 2.2 Connect-address resolver reads `get_settings().connect_address`.
+- [x] 2.3 Additional quota registry loader reads `get_settings().additional_quota_registry_file`.
+
+## 3. Documentation
+
+- [x] 3.1 Generator renders alias env names and the process-level environment section; regenerate `docs/reference/settings.md`.
+
+## 4. Verification
+
+- [x] 4.1 Tests that set the promoted env names clear the settings cache; add unit coverage for the new fields.
+- [x] 4.2 `make lint`, settings reference test, targeted unit/integration suites, `openspec validate`.

--- a/openspec/specs/deployment-installation/context.md
+++ b/openspec/specs/deployment-installation/context.md
@@ -144,8 +144,9 @@ upgrade with `terminationGracePeriodSeconds` absent.
 codex-lb captures the incoming ASGI client before delegating once to Uvicorn's
 proxy projection. Shipped launchers disable the outer server middleware so raw
 transport policy can use the original peer while downstream handlers still see
-the projected client and scheme. `FORWARDED_ALLOW_IPS` remains the sole trust
-input and is passed through unchanged.
+the projected client and scheme. The `forwarded_allow_ips` setting (env
+`FORWARDED_ALLOW_IPS`, alias `CODEX_LB_FORWARDED_ALLOW_IPS`, also loadable from
+`.env` files) is the sole trust input and keeps Uvicorn's semantics unchanged.
 
 For example, a TCP peer at `10.0.0.8` may project client `192.168.65.1` and
 scheme `https`; raw-peer authorization still evaluates `10.0.0.8`.

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -18,6 +18,7 @@ import typing
 from pathlib import Path
 from typing import cast
 
+from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
@@ -94,7 +95,50 @@ _EXACT_SECTIONS: dict[str, str] = {
     "data_dir": "Core",
     "trace": "Observability",
     "workers_per_instance": "Multi-replica",
+    "connect_address": "Dashboard",
+    "additional_quota_registry_file": "Usage & retention",
+    "forwarded_allow_ips": "Firewall",
 }
+
+# Process-level environment variables codex-lb honors that are NOT Settings
+# fields: third-party or POSIX conventions read by the launcher, libraries, or
+# frozen Alembic migrations. Listed so operators can find them and so the
+# ``os.environ``-outside-Settings lint allowlist has a documented source.
+_PROCESS_ENV_CONVENTIONS: tuple[tuple[str, str], ...] = (
+    (
+        "`HOST`, `PORT`, `SSL_CERTFILE`, `SSL_KEYFILE`, `UVICORN_TIMEOUT_KEEP_ALIVE`, `UVICORN_WS_MAX_SIZE`",
+        "Uvicorn launch defaults read once by the `codex-lb` CLI (`app/cli.py`); host runs only.",
+    ),
+    (
+        "`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `WS_PROXY`, `NO_PROXY` (and lowercase)",
+        "Outbound proxy conventions honored by httpx/aiohttp/websockets for upstream egress.",
+    ),
+    (
+        "`TZ`",
+        "POSIX process timezone; automation schedules with the `server_default` timezone resolve "
+        "to it (falling back to the host local zone, then UTC).",
+    ),
+    (
+        "`PROMETHEUS_MULTIPROC_DIR`",
+        "prometheus_client multiprocess-mode convention.",
+    ),
+    (
+        "`GITHUB_TOKEN`",
+        "Optional bearer token for the GitHub latest-release version check.",
+    ),
+    (
+        "`POD_IP`, `POD_NAME`, `HOSTNAME`, `KUBERNETES_SERVICE_HOST`",
+        "Kubernetes/pod identity used for multi-replica validation and deployment-kind telemetry.",
+    ),
+    (
+        "`CODEX_HOME`, `USERPROFILE`, `WSL_DISTRO_NAME`",
+        "Codex CLI home discovery for the `codex-lb codex-sessions retag` tool.",
+    ),
+    (
+        "`CODEX_LB_TEST_DATABASE_URL`",
+        "Test-suite/CI only: overrides the database used by the test session factory.",
+    ),
+)
 
 _SECTION_ORDER: tuple[str, ...] = (
     "Core",
@@ -150,6 +194,23 @@ def _render_type(annotation: object) -> str:
     return str(annotation)
 
 
+def _env_names(name: str, field: FieldInfo) -> list[str]:
+    alias = field.validation_alias
+    if isinstance(alias, AliasChoices):
+        return [choice for choice in alias.choices if isinstance(choice, str)]
+    if isinstance(alias, str):
+        return [alias]
+    return [f"{ENV_PREFIX}{name.upper()}"]
+
+
+def _render_env_cell(name: str, field: FieldInfo) -> str:
+    primary, *aliases = _env_names(name, field)
+    cell = f"`{primary}`"
+    if aliases:
+        cell += " (alias " + ", ".join(f"`{alias}`" for alias in aliases) + ")"
+    return cell
+
+
 def _render_default(name: str, field: FieldInfo) -> str:
     symbolic = _SYMBOLIC_DEFAULTS.get(name)
     if symbolic is not None:
@@ -176,7 +237,7 @@ def _render_section_table(names: list[str], fields: dict[str, FieldInfo]) -> lis
         lines.append("| --- | --- | --- |")
     for name in names:
         field = fields[name]
-        env_var = f"`{ENV_PREFIX}{name.upper()}`"
+        env_var = _render_env_cell(name, field)
         type_cell = _escape_cell(f"`{_render_type(field.annotation)}`")
         default_cell = _escape_cell(_render_default(name, field))
         row = f"| {env_var} | {type_cell} | {default_cell} |"
@@ -231,7 +292,18 @@ def render_settings_reference() -> str:
         "contain env files (the Nix package wrapper points it at the launch",
         "directory). It must be set in the process environment, not in an env file:",
         "the env-file locations have to be known before env files are read.",
+        "",
+        "## Process-level environment variables (not settings)",
+        "",
+        "These are third-party or POSIX conventions codex-lb honors without",
+        "making them settings. They are read by their owning launcher, library, or",
+        "frozen migration rather than through `Settings`, and are the only",
+        "sanctioned environment reads outside `app/core/config/settings.py`.",
+        "",
+        "| Environment variable(s) | Consumer |",
+        "| --- | --- |",
     ]
+    lines.extend(f"| {names} | {_escape_cell(purpose)} |" for names, purpose in _PROCESS_ENV_CONVENTIONS)
 
     for section in _SECTION_ORDER:
         names = sections.get(section)

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -114,6 +114,10 @@ _PROCESS_ENV_CONVENTIONS: tuple[tuple[str, str], ...] = (
         "Outbound proxy conventions honored by httpx/aiohttp/websockets for upstream egress.",
     ),
     (
+        "`REQUEST_METHOD`",
+        "CGI marker; when present `HTTP_PROXY` is ignored (httpoxy guard, mirrors the httpx/requests rule).",
+    ),
+    (
         "`TZ`",
         "POSIX process timezone; automation schedules with the `server_default` timezone resolve "
         "to it (falling back to the host local zone, then UTC).",
@@ -137,6 +141,12 @@ _PROCESS_ENV_CONVENTIONS: tuple[tuple[str, str], ...] = (
     (
         "`CODEX_LB_TEST_DATABASE_URL`",
         "Test-suite/CI only: overrides the database used by the test session factory.",
+    ),
+    (
+        "`CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`, `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` "
+        "(inside `app/db/alembic/versions/**` only)",
+        "Frozen Alembic migrations read the process environment directly because migrations must not "
+        "depend on `Settings`; the live settings of the same name are documented in the tables below.",
     ),
 )
 
@@ -271,8 +281,9 @@ def render_settings_reference() -> str:
         "`app/core/config/settings.py`.",
         "",
         f"codex-lb currently exposes {len(fields)} settings. Every setting is an environment",
-        f"variable with the `{ENV_PREFIX}` prefix (process environment or `.env` /",
-        "`.env.local` next to the process). All defaults work with zero configuration —",
+        f"variable, normally with the `{ENV_PREFIX}` prefix (process environment or `.env` /",
+        "`.env.local` next to the process); aliased settings list every accepted name.",
+        "All defaults work with zero configuration —",
         "start from [Configuration](../configuration.md) for the handful that matter,",
         "and treat everything else as advanced operational tunables.",
         "",
@@ -297,8 +308,9 @@ def render_settings_reference() -> str:
         "",
         "These are third-party or POSIX conventions codex-lb honors without",
         "making them settings. They are read by their owning launcher, library, or",
-        "frozen migration rather than through `Settings`, and are the only",
-        "sanctioned environment reads outside `app/core/config/settings.py`.",
+        "frozen migration rather than through `Settings`. Together with `Settings`",
+        "itself this table is the allowlist of environment reads under `app/`;",
+        "anything else belongs in `app/core/config/settings.py`.",
         "",
         "| Environment variable(s) | Consumer |",
         "| --- | --- |",

--- a/tests/integration/test_api_firewall_middleware.py
+++ b/tests/integration/test_api_firewall_middleware.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.testclient import WebSocketDenialResponse
 
+from app.core.config.settings import get_settings
 from app.db.session import get_background_session
 from app.modules.firewall.repository import FirewallRepository
 
@@ -22,6 +23,7 @@ def test_protected_websocket_route_denies_unlisted_raw_peer_after_projection(
 ) -> None:
     # Given: the real app stack projects an allowlisted forwarded client over an unlisted raw peer.
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    get_settings.cache_clear()
     with TestClient(app_instance, client=("127.0.0.1", 50001)) as client:
         assert client.portal is not None
         client.portal.call(_add_firewall_ip, "203.0.113.9")

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -305,6 +305,7 @@ async def test_proxy_family_consensus_controls_local_proxy_and_dashboard_access(
 ) -> None:
     monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "10.0.0.2")
+    get_settings.cache_clear()
     _set_dashboard_auth_env(
         monkeypatch,
         mode=DashboardAuthMode.STANDARD,
@@ -377,6 +378,7 @@ async def test_proxy_unauthenticated_client_cidr_rejects_projected_client_when_r
     monkeypatch,
 ):
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    get_settings.cache_clear()
     _set_proxy_unauthenticated_client_cidrs_env(
         monkeypatch,
         cidrs="192.168.65.1/32",

--- a/tests/unit/test_additional_model_limits.py
+++ b/tests/unit/test_additional_model_limits.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from app.core.config.settings import get_settings
 from app.modules.proxy.additional_model_limits import (
     get_additional_display_label_for_model,
     get_additional_model_limit,
@@ -83,6 +84,7 @@ def test_registry_normalizes_configured_quota_key(monkeypatch, tmp_path: Path) -
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     resolved = get_additional_model_limit("gpt-5.3-codex-spark")
@@ -111,6 +113,7 @@ def test_registry_resolves_legacy_quota_key_alias(monkeypatch, tmp_path: Path) -
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     assert canonicalize_additional_quota_key(quota_key="codex_spark") == "spark_enterprise"
@@ -135,6 +138,7 @@ def test_routing_policy_resolves_legacy_limit_alias(monkeypatch, tmp_path: Path)
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     assert get_additional_quota_routing_policy("codex_other", overrides=None) == "burn_first"
@@ -159,6 +163,7 @@ def test_registry_reloads_when_config_file_changes(monkeypatch, tmp_path: Path) 
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     assert canonicalize_additional_quota_key(limit_name="codex_other") == "codex_spark"
@@ -206,6 +211,7 @@ def test_registry_rejects_duplicate_aliases(monkeypatch, tmp_path: Path) -> None
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     with pytest.raises(ValueError, match="duplicate additional quota alias"):
@@ -228,6 +234,7 @@ def test_reload_additional_quota_registry_returns_status(monkeypatch, tmp_path: 
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
 
     status = reload_additional_quota_registry()
 

--- a/tests/unit/test_additional_usage_repo.py
+++ b/tests/unit/test_additional_usage_repo.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.core.config.settings import get_settings
 from app.db.models import AdditionalUsageHistory, Base
 from app.modules.usage.additional_quota_keys import clear_additional_quota_registry_cache
 from app.modules.usage.repository import AdditionalUsageRepository
@@ -247,6 +248,7 @@ async def test_latest_by_account_reads_rows_under_legacy_quota_key_alias(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     repo = AdditionalUsageRepository(async_session)
@@ -281,6 +283,7 @@ async def test_latest_by_account_merges_alias_rows_conservatively(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     repo = AdditionalUsageRepository(async_session)
@@ -325,6 +328,7 @@ async def test_latest_by_account_sqlite_fast_path_uses_depletion_tie_breaker(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     db_path = tmp_path / "usage.db"
@@ -378,6 +382,7 @@ async def test_latest_by_account_sqlite_fast_path_preserves_newer_raw_alias(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     db_path = tmp_path / "usage.db"
@@ -432,6 +437,7 @@ async def test_latest_by_account_prefers_newer_alias_row_after_reset(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     repo = AdditionalUsageRepository(async_session)
@@ -783,6 +789,7 @@ async def test_history_since_reads_rows_under_legacy_quota_key_alias(
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     repo = AdditionalUsageRepository(async_session)
@@ -964,6 +971,7 @@ async def test_delete_for_account_and_quota_key_removes_rows_under_legacy_quota_
     registry = tmp_path / "additional_quota_registry.json"
     _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     repo = AdditionalUsageRepository(async_session)

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -18,6 +18,7 @@ from sqlalchemy import exc as sa_exc
 from sqlalchemy.engine import Connection
 
 import app.db.migrate as migrate_module
+from app.core.config.settings import get_settings
 from app.db.alembic.revision_ids import OLD_TO_NEW_REVISION_MAP
 from app.db.backup import create_sqlite_pre_migration_backup, list_sqlite_pre_migration_backups
 from app.db.migrate import (
@@ -1749,6 +1750,7 @@ def test_run_upgrade_backfills_additional_usage_quota_key_from_configured_regist
     )
 
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry_path))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     run_upgrade(url, "20260309_000000_add_additional_usage_history", bootstrap_legacy=False)
@@ -1871,6 +1873,7 @@ def test_run_upgrade_rejects_duplicate_additional_quota_aliases_in_registry(
     )
 
     monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry_path))
+    get_settings.cache_clear()
     clear_additional_quota_registry_cache()
 
     run_upgrade(url, "20260309_000000_add_additional_usage_history", bootstrap_legacy=False)

--- a/tests/unit/test_firewall_raw_peer.py
+++ b/tests/unit/test_firewall_raw_peer.py
@@ -13,6 +13,7 @@ from starlette.types import Message, Receive, Scope, Send
 
 import app.core.middleware.api_firewall as api_firewall_module
 import app.modules.proxy.api as proxy_api_module
+from app.core.config.settings import get_settings
 from app.core.middleware.api_firewall import ApiFirewallMiddleware
 from app.core.middleware.firewall_cache import FirewallIPCache
 from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
@@ -132,6 +133,7 @@ async def test_http_firewall_uses_raw_peer_when_projection_differs(
     # Given: an allowlist and capture-then-project transport with opposing peer identities.
     _configure_firewall_backend(monkeypatch, case.allowlist)
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    get_settings.cache_clear()
     projected_scope: list[tuple[str | None, str]] = []
 
     async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
@@ -174,6 +176,7 @@ async def test_websocket_firewall_uses_raw_peer_when_projection_differs(
     # Given: the same allowlist and capture-then-project identities on a protected WebSocket scope.
     _configure_firewall_backend(monkeypatch, case.allowlist)
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    get_settings.cache_clear()
     monkeypatch.setattr(
         proxy_api_module,
         "get_settings",

--- a/tests/unit/test_path_rewrite_middleware.py
+++ b/tests/unit/test_path_rewrite_middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.core.config.settings import get_settings
 from app.core.middleware.path_rewrite import (
     BackendApiCodexV1AliasMiddleware,
     _canonicalize_backend_api_codex_path,
@@ -350,6 +351,7 @@ async def test_trusted_proxy_projection_precedes_live_scope_redaction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    get_settings.cache_clear()
     inner = _RecordingApp()
     middleware = TrustedProxyHeadersMiddleware(BackendApiCodexV1AliasMiddleware(inner))
     original_path = "/v1/live/not/a-valid-call-id"

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -17,6 +17,7 @@ import app.core.request_locality as request_locality
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.request_policy as proxy_request_policy
 from app.core.clients.proxy import ProxyResponseError
+from app.core.config.settings import get_settings
 from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError
 from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
@@ -294,6 +295,7 @@ async def test_websocket_auth_uses_raw_peer_and_identity_consensus(
     denied: bool,
 ) -> None:
     monkeypatch.setenv("FORWARDED_ALLOW_IPS", forwarded_allow_ips)
+    get_settings.cache_clear()
     _configure_disabled_proxy_auth(
         monkeypatch,
         trusted_proxy_cidr=trusted_proxy_cidr,

--- a/tests/unit/test_settings_connect_address.py
+++ b/tests/unit/test_settings_connect_address.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import pytest
 
+from app.core.config.settings import get_settings
 from app.modules.settings.api import _resolve_runtime_connect_address
 
 pytestmark = pytest.mark.unit
@@ -43,18 +44,21 @@ def _fake_request(hostname: str | None) -> Any:
 
 def test_env_override_wins_over_request_host(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CODEX_LB_CONNECT_ADDRESS", "lb.internal.example:2455")
+    get_settings.cache_clear()
     request = _fake_request("10.0.0.5")
     assert _resolve_runtime_connect_address(request) == "lb.internal.example:2455"
 
 
 def test_env_override_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CODEX_LB_CONNECT_ADDRESS", "  lb.internal:2455  ")
+    get_settings.cache_clear()
     request = _fake_request("127.0.0.1")
     assert _resolve_runtime_connect_address(request) == "lb.internal:2455"
 
 
 def test_env_override_ignored_when_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CODEX_LB_CONNECT_ADDRESS", "   ")
+    get_settings.cache_clear()
     request = _fake_request("10.0.0.5")
     assert _resolve_runtime_connect_address(request) == "10.0.0.5"
 
@@ -64,6 +68,7 @@ def test_env_override_ignored_when_empty_string(monkeypatch: pytest.MonkeyPatch)
 
 def test_non_loopback_ipv4_host_returned_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     request = _fake_request("192.168.1.42")
     # No need to mock getaddrinfo — the helper must short-circuit before
     # calling it for an IPv4 host.
@@ -89,6 +94,7 @@ def _patch_resolver(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, list[str
 
 def test_resolvable_hostname_returns_resolved_ipv4(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     _patch_resolver(monkeypatch, {"lb.internal": ["10.0.0.5"]})
     request = _fake_request("lb.internal")
     assert _resolve_runtime_connect_address(request) == "10.0.0.5"
@@ -98,6 +104,7 @@ def test_resolvable_hostname_skips_loopback_ip(monkeypatch: pytest.MonkeyPatch) 
     """If DNS returns 127.0.0.1 alongside a real IP, the real IP wins;
     if it returns only loopback IPs, the hostname is returned verbatim."""
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     _patch_resolver(monkeypatch, {"lb.internal": ["127.0.0.1", "10.0.0.5"]})
     request = _fake_request("lb.internal")
     assert _resolve_runtime_connect_address(request) == "10.0.0.5"
@@ -107,6 +114,7 @@ def test_hostname_resolving_only_to_loopback_falls_back_to_hostname(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     _patch_resolver(monkeypatch, {"lb.internal": ["127.0.0.1"]})
     request = _fake_request("lb.internal")
     assert _resolve_runtime_connect_address(request) == "lb.internal"
@@ -114,6 +122,7 @@ def test_hostname_resolving_only_to_loopback_falls_back_to_hostname(
 
 def test_unresolvable_hostname_falls_back_to_hostname(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     _patch_resolver(monkeypatch, {})  # empty mapping -> OSError for any host
     request = _fake_request("lb.unknown")
     assert _resolve_runtime_connect_address(request) == "lb.unknown"
@@ -128,17 +137,20 @@ def test_unresolvable_hostname_falls_back_to_hostname(monkeypatch: pytest.Monkey
 )
 def test_loopback_host_returns_placeholder(monkeypatch: pytest.MonkeyPatch, hostname: str) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     request = _fake_request(hostname)
     assert _resolve_runtime_connect_address(request) == "<codex-lb-ip-or-dns>"
 
 
 def test_missing_host_returns_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     request = _fake_request(None)
     assert _resolve_runtime_connect_address(request) == "<codex-lb-ip-or-dns>"
 
 
 def test_empty_host_returns_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_CONNECT_ADDRESS", raising=False)
+    get_settings.cache_clear()
     request = _fake_request("")
     assert _resolve_runtime_connect_address(request) == "<codex-lb-ip-or-dns>"

--- a/tests/unit/test_settings_promoted_env.py
+++ b/tests/unit/test_settings_promoted_env.py
@@ -1,0 +1,71 @@
+"""Settings fields promoted from ad-hoc ``os.environ`` reads (slop-removal 0908).
+
+``CODEX_LB_CONNECT_ADDRESS``, ``CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`` and
+``FORWARDED_ALLOW_IPS`` used to be read directly by request/registry code. They
+are now ``Settings`` fields so env files, the reference generator, and the
+removed-settings warning govern them. These tests pin the env-name contract
+and the blank-value semantics each consumer relied on.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from app.core.config.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+_PROMOTED = (
+    "FORWARDED_ALLOW_IPS",
+    "CODEX_LB_FORWARDED_ALLOW_IPS",
+    "CODEX_LB_CONNECT_ADDRESS",
+    "CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE",
+)
+
+
+def _settings(**env: str) -> Settings:
+    clean = {k: v for k, v in os.environ.items() if k not in _PROMOTED}
+    clean.update(env)
+    with mock.patch.dict(os.environ, clean, clear=True):
+        return Settings(_env_file=None)
+
+
+def test_promoted_fields_default_to_unset() -> None:
+    settings = _settings()
+    assert settings.forwarded_allow_ips is None
+    assert settings.connect_address is None
+    assert settings.additional_quota_registry_file is None
+
+
+@pytest.mark.parametrize(
+    ("env_name", "value", "expected"),
+    [
+        ("FORWARDED_ALLOW_IPS", "10.0.0.0/8, 127.0.0.1", "10.0.0.0/8, 127.0.0.1"),
+        ("FORWARDED_ALLOW_IPS", "*", "*"),
+        # Empty means "trust no peer" for Uvicorn; it must not collapse to unset.
+        ("FORWARDED_ALLOW_IPS", "", ""),
+        ("CODEX_LB_FORWARDED_ALLOW_IPS", "192.0.2.1", "192.0.2.1"),
+    ],
+)
+def test_forwarded_allow_ips_keeps_uvicorn_env_contract(env_name: str, value: str, expected: str) -> None:
+    assert _settings(**{env_name: value}).forwarded_allow_ips == expected
+
+
+def test_forwarded_allow_ips_bare_name_wins_over_prefixed_alias() -> None:
+    settings = _settings(FORWARDED_ALLOW_IPS="10.0.0.1", CODEX_LB_FORWARDED_ALLOW_IPS="*")
+    assert settings.forwarded_allow_ips == "10.0.0.1"
+
+
+def test_connect_address_strips_and_blank_is_unset() -> None:
+    assert _settings(CODEX_LB_CONNECT_ADDRESS="  lb.internal:2455  ").connect_address == "lb.internal:2455"
+    assert _settings(CODEX_LB_CONNECT_ADDRESS="   ").connect_address is None
+
+
+def test_additional_quota_registry_file_is_path_and_blank_is_unset() -> None:
+    settings = _settings(CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE=" /etc/codex-lb/quota.json ")
+    assert settings.additional_quota_registry_file == Path("/etc/codex-lb/quota.json")
+    assert _settings(CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE="").additional_quota_registry_file is None

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -80,7 +80,14 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 # 135 -> 134: upstream_stream_transport removed (remove-upstream-stream-transport-env).
 # The dashboard row is the only source; the env var only ever fed the DB
 # "default" sentinel, which was two places to configure one value.
-MAX_SETTINGS_FIELDS = 134
+# 134 -> 137: connect_address, additional_quota_registry_file,
+# forwarded_allow_ips (slop-removal 0908, env reads outside Settings). Not new
+# knobs: all three env names were already consumed via ad-hoc ``os.environ``
+# reads in request/registry code without appearing in this reference; they are
+# promoted so the generator, ``.env`` files, and the removed-settings warning
+# govern them. The remaining bare env reads are third-party conventions listed
+# in the reference's process-level section.
+MAX_SETTINGS_FIELDS = 137
 
 
 def test_generated_settings_reference_matches_code() -> None:

--- a/tests/unit/test_trusted_proxy_headers_middleware.py
+++ b/tests/unit/test_trusted_proxy_headers_middleware.py
@@ -7,6 +7,7 @@ from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 import app.main as main
+from app.core.config.settings import get_settings
 from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
 from app.core.socket_peer import raw_socket_peer_host
 
@@ -35,6 +36,7 @@ async def test_projection_preserves_raw_peer_for_http_and_websocket(
     expected_scheme: str,
 ) -> None:
     monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    get_settings.cache_clear()
     observed = await _run(
         scope_type,
         client=("127.0.0.1", 43120),
@@ -69,6 +71,7 @@ async def test_forwarded_allow_ips_keeps_uvicorn_trust_semantics(
         monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
     else:
         monkeypatch.setenv("FORWARDED_ALLOW_IPS", trusted_hosts)
+    get_settings.cache_clear()
 
     observed = await _run(
         "http",


### PR DESCRIPTION
## Summary

Route the three codex-lb-owned environment reads that lived outside `app/core/config/settings.py` — `CODEX_LB_CONNECT_ADDRESS`, `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`, `FORWARDED_ALLOW_IPS` — through `Settings`, so they appear in the generated reference, work from `.env` files, and are governed by the same machinery as every other setting. Document the remaining bare env reads (third-party/POSIX conventions) as the sanctioned allowlist.

Kept as `refactor:` deliberately: nothing set today changes meaning. The only operator-visible additions are (1) the prefixed alias `CODEX_LB_FORWARDED_ALLOW_IPS` and (2) the three promoted names now also being loadable from `.env` / `.env.local`. Maintainer may retitle to `feat(config):` if these should land in release notes.

Part of the slop-removal campaign 0908; evidence: /home/ubuntu/work/codex-lb/slop-removal-0908 (local) — `04-config-inventory.md` Table 1a + §3.3 S9/S14, policy `05-config-policy.md` §6.5.

## Type of change

- [x] `refactor:` — internal refactor (no behavior change, no API change)

Linked issue: N/A — slop-removal campaign 0908 batch B6, no tracking issue

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/env-reads-through-settings/`

The `deployment-installation` requirement "Owned launch paths preserve raw peer before proxy projection" previously said "Projection MUST use `FORWARDED_ALLOW_IPS` unchanged … The change MUST NOT introduce a new setting" (a clause scoped to the original capture-before-projection change). The delta keeps Uvicorn's trust semantics verbatim (unset → `127.0.0.1`, empty → trust none, `*` → all, list → Uvicorn parsing) and sources them from the `forwarded_allow_ips` setting whose primary env name is still the bare `FORWARDED_ALLOW_IPS`. The `user-documentation` delta covers alias rendering and the new process-level section of the reference.

## Changes

**Settings (`app/core/config/settings.py`)** — three fields, each with a tier comment:
- `connect_address: str | None` (T1) — env `CODEX_LB_CONNECT_ADDRESS`; blank collapses to unset.
- `additional_quota_registry_file: Path | None` (T1) — env `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`; blank collapses to unset.
- `forwarded_allow_ips: str | None` (T1) — `Field(validation_alias=AliasChoices("FORWARDED_ALLOW_IPS", "CODEX_LB_FORWARDED_ALLOW_IPS"))`; empty string is preserved (Uvicorn "trust no peer").

**Consumers**
- `app/core/middleware/trusted_proxy_headers.py`: `ProxyHeadersMiddleware(trusted_hosts=...)` from `get_settings().forwarded_allow_ips` (None → `"127.0.0.1"`), no `os` import.
- `app/modules/settings/api.py::_resolve_runtime_connect_address`: reads `get_app_settings().connect_address`.
- `app/modules/usage/additional_quota_keys.py::_registry_path`: reads `get_settings().additional_quota_registry_file`.

**Reference generator (`scripts/generate_settings_reference.py`, `docs/reference/settings.md`)**
- Renders alias env names (`FORWARDED_ALLOW_IPS` (alias `CODEX_LB_FORWARDED_ALLOW_IPS`)); exact-section mapping for the three fields.
- New "Process-level environment variables (not settings)" section listing the sanctioned bare env reads (below), including the `REQUEST_METHOD` httpoxy guard and the path-scoped frozen Alembic migration reads, so PR B4 can derive its allowlist from the table.
- Intro wording: "Every setting is an environment variable, normally with the `CODEX_LB_` prefix; aliased settings list every accepted name".
- `openspec/specs/deployment-installation/context.md` narrative updated to name the `forwarded_allow_ips` setting as the trust input.

**Tests**
- Ratchet `MAX_SETTINGS_FIELDS` 135 → 138 with justification (promotions of already-consumed env names, not new knobs).
- Every test that `setenv`/`delenv`s one of the three names now also calls `get_settings.cache_clear()` (10 files).
- New `tests/unit/test_settings_promoted_env.py` pins the env-name contract and blank-value semantics.

### Classification of every `os.environ` read outside `settings.py` (for PR B4's lint allowlist)

Promoted to `Settings` in this PR (B4's allowlist can drop them once this merges):
- `CODEX_LB_CONNECT_ADDRESS` — `app/modules/settings/api.py`
- `CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE` — `app/modules/usage/additional_quota_keys.py`
- `FORWARDED_ALLOW_IPS` — `app/core/middleware/trusted_proxy_headers.py`

Exempt (third-party / POSIX / launch-site conventions — keep in the allowlist; now documented in `docs/reference/settings.md`):
- `HOST`, `PORT`, `SSL_CERTFILE`, `SSL_KEYFILE`, `UVICORN_TIMEOUT_KEEP_ALIVE`, `UVICORN_WS_MAX_SIZE` — `app/cli.py` (argparse defaults at the launch site; `PORT` also `app/main.py::_local_api_port`, `app/cli.py` re-export)
- `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`WS_PROXY`/`NO_PROXY` (+lowercase), `REQUEST_METHOD` — `app/core/utils/proxy_env.py`, `app/core/clients/http.py`, `app/core/clients/proxy_websocket.py` (httpx/aiohttp/websockets conventions)
- `TZ` — `app/modules/automations/service.py::_resolve_server_timezone_name` (POSIX; see deviations)
- `PROMETHEUS_MULTIPROC_DIR` — `app/core/metrics/prometheus.py` (prometheus_client convention)
- `GITHUB_TOKEN` — `app/modules/runtime/service.py` (GitHub API convention, name is an injectable ctor arg)
- `POD_IP`, `POD_NAME`, `HOSTNAME`, `KUBERNETES_SERVICE_HOST` — `app/modules/telemetry/snapshot.py` (k8s identity; the others live in `settings.py` already)
- `CODEX_HOME`, `USERPROFILE`, `WSL_DISTRO_NAME` — `app/codex_sessions_retag.py` (Codex CLI home discovery tool)
- `CODEX_LB_TEST_DATABASE_URL` — `app/db/session.py` (test/CI only)
- Frozen Alembic migrations: `app/db/alembic/versions/20260312_000000_*` (`CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE`), `20260310_120000_*` (`CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS`) — migrations must not depend on `Settings`; left untouched.

### Deviations from the batch brief

- `TZ` (S13) is **not** promoted. It is a POSIX process convention that Python's `datetime.astimezone()` already honors; the explicit read only recovers the IANA key. The `automations` spec says nothing about the source of the `server_default` timezone, and unifying it with `quota_planner_settings.timezone` would be a behaviour change that needs an owner decision. It is documented in the new reference section instead ("at minimum document").
- `HOST`/`SSL_*`/`UVICORN_*` are already read only at the launch site (`app/cli.py`), which is the brief's target state for (b); no change.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** (all three default to unset; behaviour with nothing set is byte-identical)
- [x] No new required setup step
- New setting(s) and why each can't be a default: `connect_address`, `additional_quota_registry_file`, `forwarded_allow_ips` → not new knobs; they were already consumed via ad-hoc `os.environ` reads and are promoted so the reference generator, env files, and the removed-settings warning govern them (05-config-policy §6.5). Ratchet 135 → 138 raised for exactly these three.
- [x] README sections / `.env.example` / dashboard nav within budget (`check_simplicity_budgets.py` OK; `.env.example` untouched)

## Test plan

```
$ make lint                                   # ruff check/format + architecture checks: all passed
$ python3 .github/scripts/check_simplicity_budgets.py
env example lines: 46/60 OK / core nav items: 5/5 OK / tracked root entries outside allowlist: 0/0 OK
$ uv run python scripts/generate_settings_reference.py && uv run pytest tests/unit/test_settings_reference.py -q
4 passed
$ uv run pytest tests/unit/test_settings_promoted_env.py tests/unit/test_settings_connect_address.py \
    tests/unit/test_trusted_proxy_headers_middleware.py tests/unit/test_firewall_raw_peer.py \
    tests/unit/test_path_rewrite_middleware.py tests/unit/test_proxy_api_websocket_auth.py \
    tests/unit/test_additional_model_limits.py tests/unit/test_additional_usage_repo.py \
    tests/unit/test_automations_service.py tests/unit/test_settings_*.py -q
261 passed (+ 8 new)
$ uv run pytest tests/unit/test_db_migrate.py -k additional -q
2 passed
$ uv run pytest tests/integration/test_api_firewall_middleware.py tests/integration/test_auth_middleware.py -q
40 passed
$ uv run pytest tests/unit -q -n 12
2 failed, 8398 passed, 3 skipped in 14m28s
  - test_proxy_http_bridge.py::test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses
    -> pre-existing: fails identically on origin/main (sqlite3.OperationalError: no such table: file_account_pins)
  - test_telemetry_consent.py::test_scheduler_sends_startup_and_interval_snapshots_with_one_undecided_notice
    -> timing flake under -n 12 (await_count 1 >= 2); passes 3/3 alone and the whole file passes on this branch
$ openspec validate env-reads-through-settings && openspec validate --specs
Change 'env-reads-through-settings' is valid / Totals: 58 passed, 0 failed

# review-fix round (docs/generator only): make lint all passed; test_settings_reference + test_settings_promoted_env 12 passed;
# openspec validate change + --specs OK; check_simplicity_budgets OK; codex review --base origin/main: "No actionable regressions were found. All 306 targeted tests passed, along with scoped lint checks and strict OpenSpec validation."
```

## Coordination

PR B4 (env-read lint) keeps an allowlist of the 14 Table-1a sites; after this merges that allowlist shrinks to the exempt set listed above.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above (N/A — campaign batch, no tracking issue).
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)