### PR TITLE
perf(egress): batch ready SSE output writes

### DIFF
--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -7,6 +7,7 @@ use codex_lb_responses::compact::{CompactCollector, CompactResult};
 use codex_lb_responses::stream::interpret;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
+use crate::output::EventBatch;
 use crate::runtime::{Output, RequestError, emit};
 use crate::sse::{SseEventTooLarge, SseFramer, text_fragments};
 
@@ -155,6 +156,7 @@ async fn execute_sse_body(
     let idle_timeout = Duration::from_millis(options.idle_timeout_ms);
     let mut framer = SseFramer::new(options.max_event_bytes);
     let mut collector = options.collect_compact.then(CompactCollector::default);
+    let mut batch = EventBatch::default();
     loop {
         let chunk = tokio::time::timeout(idle_timeout, response.chunk())
             .await
@@ -173,16 +175,22 @@ async fn execute_sse_body(
                             &text,
                             &mut collector,
                             options.interpret_responses,
+                            &mut batch,
                         )
                         .await?
                         {
+                            batch.flush(output).await?;
                             return Ok(None);
                         }
                     }
                     Ok(None) => break,
-                    Err(error) => return Ok(Some(error)),
+                    Err(error) => {
+                        batch.flush(output).await?;
+                        return Ok(Some(error));
+                    }
                 }
             }
+            batch.flush(output).await?;
         }
     }
     match framer.finish() {
@@ -193,15 +201,18 @@ async fn execute_sse_body(
                 &text,
                 &mut collector,
                 options.interpret_responses,
+                &mut batch,
             )
             .await?
             {
+                batch.flush(output).await?;
                 return Ok(None);
             }
         }
         Ok(None) => {}
         Err(error) => return Ok(Some(error)),
     }
+    batch.flush(output).await?;
     if let Some(collector) = collector {
         emit_compact(output, request_id, collector.finish()).await?;
     }
@@ -214,6 +225,7 @@ async fn consume_sse(
     text: &str,
     collector: &mut Option<CompactCollector>,
     interpret_responses: bool,
+    batch: &mut EventBatch,
 ) -> Result<bool, std::io::Error> {
     if let Some(collector) = collector {
         if let Some(result) = collector.push(text) {
@@ -232,20 +244,21 @@ async fn consume_sse(
             event.python_normalization = true;
         }
         for (fragment, more) in text_fragments(&event.text, SSE_IPC_TEXT_FRAGMENT_SIZE) {
-            emit(
-                output,
-                &NativeEvent::ResponsesEvent {
-                    request_id: request_id.to_owned(),
-                    text: fragment.to_owned(),
-                    more,
-                    event_type: if more { None } else { event.event_type.clone() },
-                    python_normalization: !more && event.python_normalization,
-                },
-            )
-            .await?;
+            batch
+                .push(
+                    output,
+                    &NativeEvent::ResponsesEvent {
+                        request_id: request_id.to_owned(),
+                        text: fragment.to_owned(),
+                        more,
+                        event_type: if more { None } else { event.event_type.clone() },
+                        python_normalization: !more && event.python_normalization,
+                    },
+                )
+                .await?;
         }
     } else {
-        emit_sse(output, request_id, text).await?;
+        emit_sse(output, request_id, text, batch).await?;
     }
     Ok(false)
 }
@@ -270,17 +283,23 @@ async fn emit_compact(
     Ok(())
 }
 
-async fn emit_sse(output: &Output, request_id: &str, text: &str) -> Result<(), std::io::Error> {
+async fn emit_sse(
+    output: &Output,
+    request_id: &str,
+    text: &str,
+    batch: &mut EventBatch,
+) -> Result<(), std::io::Error> {
     for (fragment, more) in text_fragments(text, SSE_IPC_TEXT_FRAGMENT_SIZE) {
-        emit(
-            output,
-            &NativeEvent::Sse {
-                request_id: request_id.to_owned(),
-                text: fragment.to_owned(),
-                more,
-            },
-        )
-        .await?;
+        batch
+            .push(
+                output,
+                &NativeEvent::Sse {
+                    request_id: request_id.to_owned(),
+                    text: fragment.to_owned(),
+                    more,
+                },
+            )
+            .await?;
     }
     Ok(())
 }

--- a/crates/codex-lb-egress/src/lib.rs
+++ b/crates/codex-lb-egress/src/lib.rs
@@ -6,6 +6,7 @@
 //! the stdio worker binary.
 
 mod http;
+mod output;
 mod runtime;
 mod sse;
 mod websocket;

--- a/crates/codex-lb-egress/src/output.rs
+++ b/crates/codex-lb-egress/src/output.rs
@@ -1,0 +1,218 @@
+//! Ordered IPC writes whose accepted bytes survive cancellation of a producer.
+
+use std::io;
+use std::sync::Arc;
+
+use codex_lb_protocol::NativeEvent;
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter, Stdout};
+use tokio::sync::Mutex;
+
+pub(crate) type Output<W = BufWriter<Stdout>> = Arc<Mutex<FrameWriter<W>>>;
+
+pub(crate) fn stdout() -> Output {
+    Arc::new(Mutex::new(FrameWriter::new(BufWriter::new(
+        tokio::io::stdout(),
+    ))))
+}
+
+pub(crate) struct FrameWriter<W> {
+    writer: W,
+    pending: Vec<u8>,
+    written: usize,
+}
+
+impl<W: AsyncWrite + Unpin> FrameWriter<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer,
+            pending: Vec::new(),
+            written: 0,
+        }
+    }
+
+    async fn write(&mut self, bytes: Vec<u8>) -> io::Result<()> {
+        self.flush().await?;
+        // Ownership transfers before the first write can suspend. If this
+        // producer is cancelled, the next producer drains these bytes first.
+        self.pending = bytes;
+        self.flush().await
+    }
+
+    pub(crate) async fn flush(&mut self) -> io::Result<()> {
+        if self.pending.is_empty() {
+            return Ok(());
+        }
+        while self.written < self.pending.len() {
+            // write() is cancellation-safe; record each accepted prefix before
+            // the next await. write_all() would lose that progress on cancel.
+            let written = self.writer.write(&self.pending[self.written..]).await?;
+            if written == 0 {
+                return Err(io::ErrorKind::WriteZero.into());
+            }
+            self.written += written;
+        }
+        self.writer.flush().await?;
+        self.pending = Vec::new();
+        self.written = 0;
+        Ok(())
+    }
+}
+
+pub(crate) async fn emit(output: &Output, event: &NativeEvent) -> io::Result<()> {
+    let mut bytes = serde_json::to_vec(event)?;
+    bytes.push(b'\n');
+    emit_bytes(output, bytes).await
+}
+
+async fn emit_bytes<W: AsyncWrite + Unpin>(output: &Output<W>, bytes: Vec<u8>) -> io::Result<()> {
+    output.lock().await.write(bytes).await
+}
+
+const BATCH_BYTES: usize = 64 * 1024;
+const BATCH_RECORDS: usize = 32;
+
+/// Coalesce ready JSON lines only; the caller flushes before reading upstream.
+#[derive(Default)]
+pub(crate) struct EventBatch {
+    bytes: Vec<u8>,
+    records: usize,
+}
+
+impl EventBatch {
+    pub(crate) async fn push<W: AsyncWrite + Unpin>(
+        &mut self,
+        output: &Output<W>,
+        event: &NativeEvent,
+    ) -> io::Result<()> {
+        let mut record = serde_json::to_vec(event)?;
+        record.push(b'\n');
+        if self.records != 0 && self.bytes.len() + record.len() > BATCH_BYTES {
+            self.flush(output).await?;
+        }
+        if record.len() > BATCH_BYTES {
+            // Existing text/metadata bounds permit a single escaped JSON line
+            // larger than the batch budget; never accumulate peers alongside it.
+            return emit_bytes(output, record).await;
+        }
+        self.bytes.extend_from_slice(&record);
+        self.records += 1;
+        if self.records == BATCH_RECORDS {
+            self.flush(output).await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn flush<W: AsyncWrite + Unpin>(
+        &mut self,
+        output: &Output<W>,
+    ) -> io::Result<()> {
+        if self.records == 0 {
+            return Ok(());
+        }
+        self.records = 0;
+        emit_bytes(output, std::mem::take(&mut self.bytes)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::{AsyncReadExt, BufWriter, duplex};
+
+    use super::*;
+
+    fn record(text: String) -> NativeEvent {
+        NativeEvent::Sse {
+            request_id: "request".to_owned(),
+            text,
+            more: false,
+        }
+    }
+
+    fn encoded(event: &NativeEvent) -> Vec<u8> {
+        let mut bytes = serde_json::to_vec(event).unwrap();
+        bytes.push(b'\n');
+        bytes
+    }
+
+    #[tokio::test]
+    async fn cancelled_partial_write_finishes_before_sibling_record() {
+        // Exercise both a direct large write and buffered output suspended in flush.
+        for capacity in [4, 64 * 1024] {
+            assert_cancelled_write_finishes(capacity).await;
+        }
+    }
+
+    async fn assert_cancelled_write_finishes(capacity: usize) {
+        let (writer, mut reader) = duplex(8);
+        let output = Arc::new(Mutex::new(FrameWriter::new(BufWriter::with_capacity(
+            capacity, writer,
+        ))));
+        let first = encoded(&record("large\n".repeat(500)));
+        let next = encoded(&NativeEvent::Cancelled {
+            request_id: "sibling".to_owned(),
+        });
+        let expected = [first.as_slice(), next.as_slice()].concat();
+        let task_output = output.clone();
+        let producer = tokio::spawn(async move { emit_bytes(&task_output, first).await });
+        let mut prefix = [0; 8];
+        tokio::time::timeout(Duration::from_secs(2), reader.read_exact(&mut prefix))
+            .await
+            .unwrap()
+            .unwrap();
+        producer.abort();
+        assert!(producer.await.unwrap_err().is_cancelled());
+        let mut remainder = vec![0; expected.len() - prefix.len()];
+        tokio::time::timeout(Duration::from_secs(2), async {
+            let (write, read) =
+                tokio::join!(emit_bytes(&output, next), reader.read_exact(&mut remainder));
+            write.unwrap();
+            read.unwrap();
+        })
+        .await
+        .unwrap();
+        assert_eq!([prefix.as_slice(), &remainder].concat(), expected);
+        assert!(output.lock().await.pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ready_batches_enforce_encoded_byte_and_record_bounds() {
+        let output = Arc::new(Mutex::new(FrameWriter::new(Vec::new())));
+        let mut batch = EventBatch::default();
+        let small = record("data: {}\n\n".to_owned());
+        let mut expected = Vec::new();
+        for _ in 0..BATCH_RECORDS - 1 {
+            batch.push(&output, &small).await.unwrap();
+            expected.extend(encoded(&small));
+        }
+        assert!(output.lock().await.writer.is_empty());
+        batch.push(&output, &small).await.unwrap();
+        expected.extend(encoded(&small));
+        assert_eq!(output.lock().await.writer, expected);
+        assert_eq!(batch.records, 0);
+
+        // A maximum-sized text fragment can expand sixfold when JSON-escaped.
+        // Flush the ready prefix before emitting that record alone.
+        batch.push(&output, &small).await.unwrap();
+        expected.extend(encoded(&small));
+        let escaped = record("\0".repeat(16 * 1024));
+        assert!(encoded(&escaped).len() > BATCH_BYTES);
+        batch.push(&output, &escaped).await.unwrap();
+        expected.extend(encoded(&escaped));
+        assert_eq!(output.lock().await.writer, expected);
+        assert_eq!(batch.records, 0);
+
+        // Ordinary records must flush before their cumulative encoded size
+        // would exceed the budget, even before the record-count threshold.
+        let medium = record("\0".repeat(6000));
+        batch.push(&output, &medium).await.unwrap();
+        batch.push(&output, &medium).await.unwrap();
+        expected.extend(encoded(&medium));
+        assert_eq!(output.lock().await.writer, expected);
+        assert_eq!(batch.records, 1);
+        batch.flush(&output).await.unwrap();
+        expected.extend(encoded(&medium));
+        assert_eq!(output.lock().await.writer, expected);
+    }
+}

--- a/crates/codex-lb-egress/src/runtime.rs
+++ b/crates/codex-lb-egress/src/runtime.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use base64::Engine as _;
 use codex_lb_protocol::{CAPABILITIES, NativeCommand, NativeEvent, PROTOCOL_VERSION};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::{AbortHandle, JoinSet};
 use tokio_tungstenite::tungstenite::Message;
@@ -13,7 +13,7 @@ use crate::websocket::{
     WebSocketCommand, emit_websocket_error, emit_websocket_setup_error, execute_websocket,
 };
 
-pub(crate) type Output = Arc<Mutex<BufWriter<tokio::io::Stdout>>>;
+pub(crate) use crate::output::{Output, emit};
 type ActiveRequests = Arc<Mutex<HashMap<String, ActiveRequest>>>;
 pub type RequestError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -30,7 +30,7 @@ pub async fn run_stdio() -> Result<(), RequestError> {
         .install_default()
         .map_err(|_| "failed to install aws-lc-rs crypto provider")?;
 
-    let output = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
+    let output = crate::output::stdout();
     let active: ActiveRequests = Arc::new(Mutex::new(HashMap::new()));
     let mut clients = ClientPool::default();
     let mut tasks = JoinSet::new();
@@ -377,14 +377,6 @@ async fn emit_error(
         },
     )
     .await
-}
-
-pub(crate) async fn emit(output: &Output, event: &NativeEvent) -> Result<(), std::io::Error> {
-    let mut output = output.lock().await;
-    output.write_all(&serde_json::to_vec(event)?).await?;
-    output.write_all(b"\n").await?;
-    output.flush().await?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/context.md
+++ b/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/context.md
@@ -1,0 +1,75 @@
+# Ready SSE output batching
+
+## Design and limits
+
+The helper previously flushed Tokio stdout once per SSE record. Ready events now
+share an output write, capped at 32 records and 64 KiB of encoded JSON lines.
+Each existing 16 KiB upstream read slice flushes before processing another slice
+or awaiting upstream input. A single existing record can exceed 64 KiB after
+JSON escaping; it is emitted alone after the preceding batch. No timer or new
+operator setting is involved. Compact, raw HTTP and WebSocket records retain
+their immediate emission paths.
+
+The shared writer owns the accepted bytes and write offset across producer
+cancellation. A subsequent writer first completes that buffer, including the
+underlying buffered flush. This prevents a cancelled large write from leaving a
+truncated JSON line in front of a sibling event or cancellation acknowledgement.
+Output failures still propagate through the existing error path. Unaccepted
+request-local records may be discarded on cancellation.
+
+For example, 257 ready deltas followed by an upstream pause arrive in order
+before that upstream is allowed to finish. A valid event followed by an oversized
+event in the same read is flushed before the typed size error. The IPC grammar,
+capabilities, Python queue budgets/fairness, retry policy and event text bounds
+remain unchanged.
+
+## Verification (2026-09-08)
+
+- `make rust-check rust-audit`: formatting, warning-free workspace Clippy,
+  24 Rust tests, release worker build, and dependency audit passed.
+- 528 related Python tests passed across native HTTP/SSE/routed transport,
+  SSE/compact/stream fixtures, WebSocket client and streaming timeout behavior.
+  The final expanded quiet-upstream test passed all four direct/routed cases
+  (one event and an ordered 257-event burst).
+- Shared-writer tests force cancellation after a partial write using an 8-byte
+  duplex pipe, both while writing directly and while flushing a larger buffer.
+  The complete accepted record always precedes the sibling record.
+- Existing public oversized-event and cancellation/sibling tests passed.
+- Ruff, `ty check` with the project Python environment, architecture,
+  cancellation-safety, timing-seam and simplicity-budget checks passed.
+- Strict change validation passed before archiving; strict main-spec validation
+  is also required after syncing the delta.
+
+## Synthetic performance evidence
+
+Release helpers were built with Rust 1.96.0 from baseline `e987c56c8` and this
+change, using identical Python code and uvloop. A loopback chunked HTTP server
+sends 2,048 UTF-8 text deltas per request. Each shape uses four warmups and 20
+measured samples with alternating baseline/candidate order. The consumer checks
+event count and normalizes/classifies every event. Times below are medians in ms.
+Parent CPU includes the loopback server; helper CPU uses `/proc` clock ticks.
+
+| Workload | Elapsed before/after | Parent CPU before/after | Helper CPU before/after | First event before/after |
+|---|---:|---:|---:|---:|
+| Canonical, one request | 433.03 / 31.33 | 139.44 / 30.43 | 490 / 20 | 1.46 / 1.49 |
+| Alias, one request | 452.09 / 31.86 | 136.06 / 30.83 | 495 / 20 | 1.39 / 1.60 |
+| Canonical, four concurrent | 1656.28 / 127.13 | 519.61 / 126.61 | 1875 / 80 | 2.94 / 3.97 |
+
+Elapsed medians improve 92.3–93.0% in these ready-event bursts. First-event
+latency increases by about 1 ms at concurrency four; batching does not promise
+identical scheduler latency. The separate quiet-upstream regression verifies
+that output never depends on future input. These are shared-host measurements
+without model generation delay, not production latency predictions.
+
+A separate one-request `strace` run counted **2,051 → 74 stdout write calls**,
+including handshake/headers/end records. Traced timings are excluded above.
+Reproduction harness, raw measurements, traces and source/check manifests are
+preserved under the host's curated project storage at
+`projects/codex-lb/rust-migration/2026-09-08-native-sse-ipc/`.
+
+Binary SHA-256 values:
+
+- Baseline: `868a3db6dca23c694c12f4516919bd74a080a2e5a4dd690b2789a39f2052f669`
+- Candidate: `7c612377a1f56e716531b764c76343ad8e85a0f924889622162c4ca1c4230fa1`
+
+WebSocket event interpretation remains the next domain migration slice.

--- a/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/proposal.md
+++ b/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/proposal.md
@@ -1,0 +1,23 @@
+# Batch ready native SSE output
+
+## Why
+
+HTTP stream interpretation now lives in Rust, but every small SSE event still
+locks and flushes Tokio stdout separately. The last synthetic measurement reduced
+Python alias work without improving total elapsed time. Measure and reduce the
+ready-event IPC write overhead while preserving stream behavior.
+
+## What Changes
+
+- Coalesce only already available SSE records into bounded output writes.
+- Flush before another upstream body read and before terminal/error delivery;
+  introduce no timer, delay, protocol grammar, capability or operator setting.
+- Preserve a partially written output buffer across request cancellation so a
+  subsequent writer completes whole JSON lines before writing its own records.
+- Keep Python queue fairness, ordering, limits, cancellation and replay policy.
+
+## Impact
+
+Native egress output/SSE path, cancellation and direct/routed integration tests,
+benchmark evidence, and outbound client ownership documentation. WebSocket event
+interpretation remains the next domain migration slice after IPC optimization.

--- a/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/specs/outbound-http-clients/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Native SSE writes coalesce ready records without delaying delivery
+
+The native helper MAY coalesce SSE IPC records already available from the current
+body read. It MUST bound each coalesced write by encoded bytes and record count,
+allowing an individual existing protocol record larger than the batch byte budget
+to be written alone. It MUST flush all ready records before another upstream read
+and before terminal or framing-error delivery. It MUST NOT wait for another event
+or a batching timer. Existing JSON-line records, ordering, text-fragment bounds,
+consumer scheduling and replay rules MUST remain unchanged.
+
+Cancellation during an output write MUST NOT truncate or interleave IPC records.
+Any accepted but unfinished write MUST remain owned by the shared output until it
+completes or the output itself fails. A subsequent writer MUST finish that output
+before emitting its own record.
+
+#### Scenario: Quiet upstream after one event
+
+- **WHEN** one event arrives and the upstream waits for the next request action
+- **THEN** the event reaches the consumer without requiring another body read or EOF
+
+#### Scenario: Valid prefix before a framing failure
+
+- **WHEN** ready valid events precede an oversized event in the same body read
+- **THEN** the valid prefix arrives in order before the typed size failure
+
+#### Scenario: Cancel while output is backpressured
+
+- **WHEN** a request is cancelled after its output write starts
+- **THEN** a sibling event or cancellation acknowledgement follows complete JSON lines
+- **AND** unrelated requests retain valid streams

--- a/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/tasks.md
+++ b/openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/tasks.md
@@ -1,0 +1,5 @@
+- [x] Measure the current helper output cost with repeatable stream workloads.
+- [x] Implement bounded batching of ready SSE records and cancellation-safe output ownership.
+- [x] Verify immediate delivery, ordering, limits, cancellation and sibling isolation.
+- [x] Compare candidate and baseline elapsed time/CPU and validate relevant checks.
+- [x] Sync specs, record evidence and archive the verified change.

--- a/openspec/specs/outbound-http-clients/context.md
+++ b/openspec/specs/outbound-http-clients/context.md
@@ -71,3 +71,22 @@ legacy representation. Neither handoff starts a second HTTP request. Unchanged
 mixed-line-ending events preserve their text; JSON arrays never become objects.
 The Python transport remains the missing-helper implementation, and WebSocket
 event interpretation is deferred to the next transport slice.
+
+## Native SSE output writes
+
+The helper coalesces already framed SSE records into writes of at most 32 records
+and 64 KiB of encoded JSON lines, flushing each existing 16 KiB body-read slice
+before processing more input. A single protocol record that expands beyond the
+byte budget through JSON escaping is emitted alone. There is no batching timer:
+one ready event reaches the consumer even if upstream waits indefinitely for the
+consumer's next action. Valid records also precede a framing failure from the
+same read.
+
+Accepted output bytes and their write offset live in the shared writer. If a
+producer is cancelled during a partial write or buffered flush, the next writer
+finishes those bytes before emitting its own record. For example, cancellation
+of a large SSE event cannot splice a sibling request's JSON line into that event.
+Compact, raw HTTP and WebSocket messages keep immediate writes through this same
+cancellation-safe owner. Python queue fairness, bounds and replay policy are
+unchanged. Benchmark methodology and limitations are recorded in the archived
+`batch-ready-native-sse-output` change.

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -828,3 +828,34 @@ active. Missing-helper fallback MUST occur only before dispatch.
 
 - **WHEN** the installed helper lacks the required interpretation capability
 - **THEN** the adapter rejects negotiation before dispatch without Python replay
+
+### Requirement: Native SSE writes coalesce ready records without delaying delivery
+
+The native helper MAY coalesce SSE IPC records already available from the current
+body read. It MUST bound each coalesced write by encoded bytes and record count,
+allowing an individual existing protocol record larger than the batch byte budget
+to be written alone. It MUST flush all ready records before another upstream read
+and before terminal or framing-error delivery. It MUST NOT wait for another event
+or a batching timer. Existing JSON-line records, ordering, text-fragment bounds,
+consumer scheduling and replay rules MUST remain unchanged.
+
+Cancellation during an output write MUST NOT truncate or interleave IPC records.
+Any accepted but unfinished write MUST remain owned by the shared output until it
+completes or the output itself fails. A subsequent writer MUST finish that output
+before emitting its own record.
+
+#### Scenario: Quiet upstream after one event
+
+- **WHEN** one event arrives and the upstream waits for the next request action
+- **THEN** the event reaches the consumer without requiring another body read or EOF
+
+#### Scenario: Valid prefix before a framing failure
+
+- **WHEN** ready valid events precede an oversized event in the same body read
+- **THEN** the valid prefix arrives in order before the typed size failure
+
+#### Scenario: Cancel while output is backpressured
+
+- **WHEN** a request is cancelled after its output write starts
+- **THEN** a sibling event or cancellation acknowledgement follows complete JSON lines
+- **AND** unrelated requests retain valid streams

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -309,6 +309,42 @@ async def test_native_proxy_frames_large_non_utf8_sse_without_python_scanning(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ready_count", [1, 257])
+async def test_native_proxy_flushes_ready_event_before_reading_quiet_upstream(
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    ready_count: int,
+) -> None:
+    ready = [
+        f'data: {{"type":"response.output_text.delta","delta":"{index}"}}\n\n'.encode() for index in range(ready_count)
+    ]
+    completed = b'data: {"type":"response.completed","response":{"id":"resp_ready"}}\n\n'
+    release_upstream = asyncio.Event()
+
+    async def handler(
+        _reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        _head: bytes,
+        _body: bytes,
+    ) -> None:
+        await _start_chunked_response(writer)
+        await _write_chunk(writer, b"".join(ready))
+        await release_upstream.wait()
+        await _write_chunk(writer, completed)
+        await _finish_chunks(writer)
+
+    async with _serve_http(handler) as base_url:
+        events = _stream(base_url, native_worker, "ready-before-read", routed=routed)
+        try:
+            for block in ready:
+                assert await asyncio.wait_for(anext(events), timeout=2.0) == block.decode()
+            release_upstream.set()
+            assert await asyncio.wait_for(_collect(events), timeout=2.0) == [completed.decode()]
+        finally:
+            await cast(AsyncGenerator[str, None], events).aclose()
+
+
+@pytest.mark.asyncio
 async def test_native_proxy_reports_public_event_size_failure(
     monkeypatch: pytest.MonkeyPatch,
     native_worker: SubprocessNativeEgressClient,


### PR DESCRIPTION
## Summary

Ready SSE bursts currently flush Tokio stdout once per event. Coalesce already framed records into bounded writes (32 records / 64 KiB), flushing before the next upstream read and terminal or framing error. The shared writer also preserves accepted bytes and write progress across cancellation, so a sibling record cannot follow a truncated JSON line.

This follows #2184. No linked issue is closed.

## Changes

- Batch native raw-SSE and interpreted Responses event records without a timer or protocol changes; emit an individually oversized encoded record alone.
- Preserve pending output through cancellation during direct writes and buffered flushes.
- Exercise quiet upstream delivery, ordered 257-event bursts, partial-write cancellation, and batch bounds; retain existing public size-error and sibling-isolation coverage.

## Performance evidence

Identical Python/uvloop loopback consumer, release helpers, 2,048 events/request, four warmups and 20 alternating samples. Median milliseconds:

| Workload | Elapsed before → after | Parent CPU before → after | Helper CPU before → after | First event before → after |
|---|---:|---:|---:|---:|
| Canonical, one request | 433.03 → 31.33 | 139.44 → 30.43 | 490 → 20 | 1.46 → 1.49 |
| Alias, one request | 452.09 → 31.86 | 136.06 → 30.83 | 495 → 20 | 1.39 → 1.60 |
| Canonical, four concurrent | 1656.28 → 127.13 | 519.61 → 126.61 | 1875 → 80 | 2.94 → 3.97 |

A separate strace run counted **2,051 → 74 stdout writes**. These are synthetic ready-event bursts on a shared host, without model-generation delay; first-event latency increases about 1 ms at concurrency four. Traced timings are excluded. Methodology and limitations are in the archived change context.

## OpenSpec

- [x] Includes and archives a verified OpenSpec change.
- [x] Preserves upstream-equivalent SSE text, limits and error behavior.

Change: `openspec/changes/archive/2026-09-08-batch-ready-native-sse-output/`; synced into `outbound-http-clients`.

## Test plan

- `make rust-check rust-audit`: pass, including 24 Rust tests and release worker build.
- Native HTTP/SSE/routed, shared fixtures, WebSocket client, streaming-timeout Python tests: **528 passed**; final quiet-upstream expansion: **4 passed** (direct/routed × one/257 ready events).
- Ruff check/format, ty with the project Python environment, architecture/cancellation/timing checks, simplicity budgets: pass.
- `openspec validate --specs --strict`: **58 passed**.

## Simplicity

Zero-config optimization; no new setting, setup step, README section or dashboard surface. Python consumer queue budgets, scheduling and replay policy are preserved. CHANGELOG is unchanged.
