### PR TITLE
chore: release v2.0.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.5"  # x-release-please-version
+__version__ = "2.0.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.5
-appVersion: 1.25.0-beta.5
+version: 2.0.0-beta.1
+appVersion: 2.0.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.5",
+  "version": "2.0.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.5"
+version = "2.0.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0-beta.5"
+version = "2.0.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v2.0.0-beta.1 for the 2.0.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v2.0.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.24.0
- fix(api-keys): preserve usage on limit patches (#1888) (
b72afb)
- fix(proxy): own cancellable usage refresh sessions (#1887) (
48eff5)
- fix(ui): restore settings dialog focus (#1883) (
5dc49e)
- fix(tooling): reject dashboard smoke runs without rebuild (#1880) (
37a9cd)
- fix(proxy): release cancelled embeddings reservations (#1874) (
b55189)
- fix(settings): show initial load failures (#1873) (
00c07f)
- fix(settings): allow clearing capacity overrides (#1871) (
e3fc08)
- fix(proxy): settle keyed mid-loop health after reservation (#1861) (
19dad4)
- fix(proxy): release grouped terminal append barriers on hard spool errors (#1860) (
5b3e07)
- fix(helm): default Codex prewarm off to match Settings (#1855) (
8cb0f2)
- fix(helm): honor external database port in network policy (#1838) (
a9a474)
- fix(proxy): preserve explicit null embedding fields (#1836) (
254839)
- fix(ui): restore scroll on route navigation (#1882) (
501eae)
- fix(proxy): enforce OpenSpec architecture ratchets (#1892) (
c3c1db)
- fix(proxy): recover stale previous response anchors (#1863) (
a34791)
- fix(proxy): exclude previous_response_id from model-source routing (#1859) (
09dd93)
- fix(ui): constrain API key dialog to viewport (#1884) (
ef1130)
- fix(proxy): defer keyed pre-created retry health writes until settlement (#1926) (
f9965f)
- fix(proxy): keep source Responses SSE alive and normalized (#1854) (
6d7886)
- fix(dashboard): contain mobile usage donuts (#1937) (
6c00ac)
- fix(proxy): release cancelled audio reservations (#1936) (
50ddee)
- feat(db): add chunk transcript reader (#1930) (
57d908)
- feat(proxy): fall back to HTTP transport when the upstream websocket is unavailable (#1886) (
9bc5cf)
- feat(proxy): enable chunk transcript writer (#1931) (
c7916f)
- fix(proxy): preserve agent-control outputs during slimming (takeover of #1893) (#1940) (
4e0332)
- fix(proxy): surface continuity_owner_conflict ahead of affinity (takeover of #1732) (#1941) (
2268f8)
- fix(retention): bound durable bridge cleanup work (#1929) (
02113f)
- fix(proxy): enforce prohibited priority service tier (#1961) (
d6fe7e)
- fix(accounts): probe with a valid upstream token floor (#1963) (
2a1668)
- fix(proxy): stop defer-cancellation shield waits from starving the event loop (#1969) (
6abb2a)
- fix(http-bridge): retire denied anchors without redispatch (#1902) (
dc016c)
- fix(db): clean stale SQLite sidecars during recovery (#1906) (
1d9332)
- fix(proxy): stop holding pending_lock across the settings-cache DB await (#1972) (
69f08d)
- fix(proxy): name the pre-response eventless timeout honestly and derive its budget from settings (#1974) (
0d283d)
- fix(http-bridge): re-check liveness before retiring a stale pending session (#1973) (
68d372)
- fix(proxy): refuse disabled model sources and spare account health from model-scoped rejections (#1978) (
54fca6)
- fix(quota,ops): expirable warmup claims, post-drain cleanup budget, bounded shutdown drain (#1977) (
343d8f)
- fix(proxy): pin same-owner stale-anchor replay (#1957) (
806b74)
- fix(proxy): quarantine the bridge key when the retry circuit opens on a poisoned anchor (#1891) (
b5adf3)
- fix(db): skip SQLite scan after verified clean shutdown (#1907) (
d35799)
- fix(proxy): preserve stale-anchor error shape presence (#1955) (
03515b)
- fix(proxy): preserve recovery spool fence during local rebind (#1956) (
48ea38)
- fix(images): release API-key reservation when cancelled before first SSE frame (#1970) (
8297d1)
- fix(security): bind firewall to raw peer (#1987) (
40fda3)
- fix(middleware): bound zstd decoded output (#1983) (
601f17)
- fix(helm): default global backpressure off (#1984) (
267bca)
- fix(oauth): fence stale dashboard poll generations (#1985) (
32e45f)
- fix(api-keys): enforce generated key format (#1980) (
45ac3e)
- fix(api-keys): serve unslashed collection routes (#1982) (
3ea07e)
- fix(proxy): recover Codex edge-challenge WebSocket failures (#1994) (
b1f099)
- fix(auth): keep reauth-required accounts routable (#1877) (
182966)
- feat(dashboard): weekly runway model + per-key burn attribution (#1797) (
ebd2e5)
- feat(nix): add flake.nix (#1948) (
fcdd63)
- feat(dashboard): redesign weekly pace card as runway timeline (#1798) (
0bade4)
- feat(ui): persisted dashboard refresh cadence and smooth quota percent (#1996) (
973770)
- feat(proxy): add native Codex traffic parity (#1995) (
82a58a)
- fix(transcribe): make subscription transcription reservation release cancellation-safe (#1966) (
a6b499)
- fix(proxy): defer Live cancellation through lease release (#1986) (
0e0782)
- fix(proxy): type required HTTP-bridge reconnect owner provenance (#1988) (
4440a5)
- fix(auth): reject duplicate trusted identity fields (#2010) (
695ece)
- fix(oauth): stop callback query secrets from reaching logs (#2011) (
000201)
- fix(api): preserve OpenAI root error envelopes (#2013) (
8c4f5a)
- fix(proxy): release reset-credit claims on cancellation (#2015) (
630c3a)
- fix(proxy): preserve warmup usage on cancellation (#2016) (
9c3306)
- fix(request-logs): keep rolling windows current (#2019) (
58665a)
- fix(metrics): aggregate latency histogram buckets (#2020) (
23f106)
- fix(config): reject invalid operator values (#2023) (
3eafbc)
- fix(proxy): cancel uvicorn keep-alive timer on every connection_lost and lower --timeout-keep-alive default (
02b61d)
- fix(proxy): release the aiohttp ClientResponse when a routed SSE stream stops before EOF (
8afe06)
- perf(proxy): share one process-wide SSLContext across per-call Codex sessions (
862efa)
- perf(proxy-responses): stamp the account installation id once per request via identity memo and client_metadata splice (
0b127a)
- perf(proxy): replace the last BaseHTTPMiddleware (image route started_at) with a pure ASGI middleware (
d771aa)
- perf(proxy-responses): compute to_payload once per bridge prepare and early-exit the 8 KiB usage estimate (
f39539)
- perf(dashboard): bound projection history to the EWMA tail plus a 3h floor and cheapen per-row hydration/signature (
4808f6)
- perf(proxy-responses): parse each bridge SSE event once and relay unchanged upstream JSON text without re-dump (
55db6d)
- perf(proxy-responses): reuse the reader wakeup task and use fast_acquire locks in the HTTP-bridge relay loop (
2cf2ef)
- perf(proxy): clone selection-cache Account/UsageHistory rows via new_instance + instance_dict instead of the ORM constructor (
4d6fad)
- perf(proxy): stop deep-validating and re-dumping passthrough JSON fields (input/tools/messages) in request models (
972a73)
- fix(proxy): keep proxy credentials out of aiohttp ConnectionKey and redact URL userinfo in rendered logs (
9c188d)
- fix(logging): redact secrets in asyncio loop exception-handler context and harden proxy username validation (
6ecbd8)
- fix(audit): restrict log access to admins (#2022) (
0ca5c7)
- fix(api-keys): prevent caching returned secrets (#2021) (
a07ce5)
- fix(proxy): prevent level-cancellation busy spins (#1958) (
887cba)
- fix(dashboard): recover failed routes (#2018) (
628b62)
- fix(proxy): retire cooldown-suppressed HTTP bridge sessions (#2072) (
018659)
- fix(http-bridge): abandon expired ambiguous operations (#2071) (
dd28d7)
- fix(metrics): bound request metric path and method label cardinality (#1967) (
fed547)
- fix(proxy): settle keyed streams before health (#1989) (
da1dce)
- fix(proxy): settle accepted background JSON (#2014) (
b328cc)
- fix(proxy): report duplicate tool-call replay terminal (#2082) (
be9fa0)
- fix(http-bridge): reject unsafe forwarded headers (#2087) (
63ac6a)
- fix(proxy): normalize native HTTP compression (#2012) (
dee12b)
- fix(dashboard): recover from overview load errors (#2017) (
80265f)
- fix(logging): bound secret patterns to the current line (#2091) (
8d02c8)
- fix(openspec): repair and enforce canonical validation (#2025) (
1c54f9)
- fix(proxy): normalize SDK transcription headers (#2031) (
e9100e)
- fix(compact): fail over revoked refresh accounts (#2080) (
b2c5ff)
- fix(proxy): forward canonical prompt-cache continuations (#2036) (
aec4d7)
- fix(usage): deactivate accounts only on explicit terminal signals, not bare 404/402 (#2055) (
caad3d)
- fix(proxy): ignore detached durable bridge rows as continuity owner evidence (#2063) (
7e1c1e)
- fix(http-bridge): treat usage_limit_reached as a terminal in the account capacity wait (#2124) (
80ea67)
- feat(usage): coalesced on-demand account refresh after usage_limit_reached (#2125) (
35ccf8)
- fix(deps): require anyio>=4.14 to close Lock cancelled-waiter deadlock (#2129) (
c08517)
- fix(proxy): stop level-cancel cascade from respinning deferred probe cleanup (#2130) (
8dc74b)
- perf(quota-planner): reduce demand history per slot inside the database (#2138) (
3d4d11)
- fix(routing): deprioritize accounts upstream keeps rejecting as overloaded for fresh selection (#2137) (
7b0f71)
- fix(proxy): bound the detached-session retire sweep's pending_lock wait (#2139) (
58c6a2)
- fix(proxy): retry accepted output-free capacity failures with a single response lifecycle (#2127) (
dafc1a)
- feat(proxy): allow plaintext proxy credentials and surface a dashboard warning (#2144) (
a8339c)
- fix(http-bridge): keep accepted output-free replays on a hard sticky owner instead of excluding it (#2150) (
ae330b)
- fix(balancer): isolate sustained-overload accounts and weight selection by error rate (#2166) (
3de4be)
- fix(egress): bound the native stream queue by a byte budget instead of 64 events (#2173) (
0ebf03)
- fix(model-registry): warm the Codex client version cache on every replica and track the current release (#2174) (
90e987)
- fix(proxy): prevent exhausted accounts from reactivating (#2078) (
3d3409)
- fix(native): prevent false backpressure on buffered response bursts (#2143) (
9703ef)
- fix(db): avoid reclaiming completed SQLite teardown (#2030) (
ed2b36)
- fix(oauth): expire abandoned browser callback listeners (#2079) (
565003)
- fix(proxy): keep tool_search_output in public responses (#2092) (
0e14c2)
- fix(proxy): filter vendor events from public Responses streams (#2114) (
ec3458)
- fix(build): make local CI work in Nix shell (#2148) (
c4e58b)
- feat(db): add subscription-overflow schema (model_source_pins, dashboard_settings columns) (#2165) (
c1da68)
- feat(settings): subscription-overflow model source setting, preflight and drain deadline (inert) (#2176) (
788baa)
- perf(egress): batch ready SSE output writes (
c47610)
- fix(settings): make dashboard values authoritative — NULL-inherit caps, telemetry decision wins over env (#2186) (
8038e6)
- fix(settings)!: remove CODEX_LB_UPSTREAM_STREAM_TRANSPORT; dashboard owns upstream transport (#2192) (
39a8b9)
- fix(db): merge overflow and transport migration heads (#2198) (
05a669)

## Release-candidate validation
Validated candidate: a22c34a6a454f672444ea612d9b580247e124b17

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==2.0.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:2.0.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 2.0.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 2.0.0.
