### PR TITLE
fix(db): merge overflow and transport migration heads

### DIFF
--- a/app/db/alembic/versions/20260908_020000_merge_overflow_transport_heads.py
+++ b/app/db/alembic/versions/20260908_020000_merge_overflow_transport_heads.py
@@ -1,0 +1,27 @@
+"""Merge the subscription-overflow and transport-sentinel heads.
+
+Revision ID: 20260908_020000_merge_overflow_transport_heads
+Revises: 20260908_000000_add_subscription_overflow,
+    20260908_000000_replace_upstream_stream_transport_default_sentinel
+Create Date: 2026-09-08
+"""
+
+from __future__ import annotations
+
+revision = "20260908_020000_merge_overflow_transport_heads"
+down_revision = (
+    "20260908_000000_add_subscription_overflow",
+    "20260908_000000_replace_upstream_stream_transport_default_sentinel",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Join revision tracking after both parents have completed."""
+    pass
+
+
+def downgrade() -> None:
+    """Restore both parent stamps without changing their schema or data."""
+    pass

--- a/openspec/changes/merge-overflow-transport-migration-heads/context.md
+++ b/openspec/changes/merge-overflow-transport-migration-heads/context.md
@@ -1,0 +1,20 @@
+# Overflow and transport graph repair
+
+Pinned main `713fa5648d23a47087381204b6fb841bd36cbe88` contains two heads.
+Both descend from `20260830_000000_add_quota_warmup_claim_expiry`. The repair
+adds a shared forward merge rather than editing either already-merged parent.
+
+The merge itself has no DDL or DML. An upgrade from just one parent still runs
+the other parent's original operations. In particular, the transport parent
+normalizes the retired `default` sentinel to `auto`; the merge does not change
+that decision. An existing explicit transport choice must survive.
+
+Downgrading the merge to either immediate parent unmerges revision tracking.
+Alembic retains both parent stamps and both parent schemas. This is not a
+rollback to an image that knows only one branch, nor a promise that downgrading
+the original subscription-overflow migration preserves its pins. Re-upgrade
+only restores the merge stamp.
+
+Tests observe Alembic revisions, real SQLite schema and populated rows. Hosted
+migration policy and PostgreSQL checks supply the second-dialect evidence.
+No live database or deployment is part of this work.

--- a/openspec/changes/merge-overflow-transport-migration-heads/proposal.md
+++ b/openspec/changes/merge-overflow-transport-migration-heads/proposal.md
@@ -1,0 +1,22 @@
+# Merge the overflow and transport migration heads
+
+## Why
+
+Main contains two already-merged revisions descending from the quota-warmup
+revision: subscription-overflow from #2165 and transport-sentinel replacement
+from #2192. A normal upgrade to `head` cannot choose between them. Reparenting
+unmerged feature migrations does not repair that shared graph.
+
+## What changes
+
+Add one forward merge revision joining both heads, with no schema or data
+operations. Keep both merged migrations unchanged. Verify populated upgrades
+from either parent and from both parents, plus downgrade of the merge itself
+to either parent and re-upgrade.
+
+## Scope and non-goals
+
+Only Alembic graph repair, its regression tests and OpenSpec records are in
+scope. This adds no settings, new setup step, routing or receipt policy.
+PR #1954 remains unchanged and dependent on upstream acceptance of this repair.
+Its lease-policy and late-receipt recovery limitations are not resolved here.

--- a/openspec/changes/merge-overflow-transport-migration-heads/specs/database-migrations/spec.md
+++ b/openspec/changes/merge-overflow-transport-migration-heads/specs/database-migrations/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Overflow and transport migration heads converge without rewriting history
+
+The migration graph MUST join `20260908_000000_add_subscription_overflow` and
+`20260908_000000_replace_upstream_stream_transport_default_sentinel` through a
+new merge revision. Both existing revisions MUST remain unchanged. The merge
+revision's upgrade and downgrade MUST NOT execute application schema or data
+operations.
+
+#### Scenario: An existing parent upgrades to the merged head
+
+- **GIVEN** a populated database at either parent, or at both parents
+- **WHEN** the normal migration runner upgrades to `head`
+- **THEN** it MUST apply any missing parent according to that parent's existing
+  behavior and finish at the single merge head
+- **AND** it MUST preserve existing application rows except for data changes
+  already required by a missing parent's migration
+- **AND** the resulting schema MUST match the current ORM metadata
+
+#### Scenario: Downgrading only the merge preserves both parents
+
+- **GIVEN** a populated database at the merge revision
+- **WHEN** Alembic downgrades to either immediate parent
+- **THEN** it MUST undo only the merge revision and retain both parent revision
+  stamps and both parent schemas
+- **AND** application data MUST remain unchanged
+- **AND** upgrading to `head` again MUST restore the single merge stamp without
+  repeating either parent's schema or data operations

--- a/openspec/changes/merge-overflow-transport-migration-heads/tasks.md
+++ b/openspec/changes/merge-overflow-transport-migration-heads/tasks.md
@@ -1,0 +1,13 @@
+## 1. Contract
+
+- [x] 1.1 Record the two-parent forward merge and data-preservation boundary.
+
+## 2. Implementation and proof
+
+- [x] 2.1 Add the no-operation merge revision without editing either parent.
+- [x] 2.2 Verify the sole graph head and populated upgrade paths from each
+  parent and both parents, including original parent normalization behavior.
+- [x] 2.3 Verify downgrade of the merge to either parent preserves both parent
+  schemas and data, restores both revision stamps, and permits re-upgrade.
+- [x] 2.4 Run migration policy, drift, relevant tests and strict OpenSpec checks.
+- [x] 2.5 Complete independent Input and Standards review.

--- a/openspec/specs/database-migrations/context.md
+++ b/openspec/specs/database-migrations/context.md
@@ -60,6 +60,15 @@
 - Emergency toggle:
   - `CODEX_LB_DATABASE_ALEMBIC_AUTO_REMAP_ENABLED=false` disables auto-remap.
 
+## September overflow and transport merge
+
+The subscription-overflow and transport-sentinel revisions both descended from
+the quota-warmup revision. A forward merge joins them without changing their
+operations. An upgrade from one parent applies the other parent normally;
+downgrading only the merge restores both parent stamps while preserving both
+schemas and their data. This is not a rollback to a build that knows only one
+branch. See the [repair context](../../changes/merge-overflow-transport-migration-heads/context.md).
+
 ## Example
 
 Branch A and B each create migration revisions in parallel. After merge, CI detects multiple heads and fails. The resolver adds a merge revision, reruns CI, and proceeds. During deployment, a DB still storing old `013_add_dashboard_settings_routing_strategy` in `alembic_version` is auto-remapped to `20260225_000000_add_dashboard_settings_routing_strategy` before upgrade.

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -332,3 +332,31 @@ When the application builds an Alembic `Config` for migration inspection or upgr
 - **WHEN** the escape and decode round-trip is applied
 - **THEN** the URL is unchanged and migration behavior is identical to before
 
+### Requirement: Overflow and transport migration heads converge without rewriting history
+
+The migration graph MUST join `20260908_000000_add_subscription_overflow` and
+`20260908_000000_replace_upstream_stream_transport_default_sentinel` through a
+new merge revision. Both existing revisions MUST remain unchanged. The merge
+revision's upgrade and downgrade MUST NOT execute application schema or data
+operations.
+
+#### Scenario: An existing parent upgrades to the merged head
+
+- **GIVEN** a populated database at either parent, or at both parents
+- **WHEN** the normal migration runner upgrades to `head`
+- **THEN** it MUST apply any missing parent according to that parent's existing
+  behavior and finish at the single merge head
+- **AND** it MUST preserve existing application rows except for data changes
+  already required by a missing parent's migration
+- **AND** the resulting schema MUST match the current ORM metadata
+
+#### Scenario: Downgrading only the merge preserves both parents
+
+- **GIVEN** a populated database at the merge revision
+- **WHEN** Alembic downgrades to either immediate parent
+- **THEN** it MUST undo only the merge revision and retain both parent revision
+  stamps and both parent schemas
+- **AND** application data MUST remain unchanged
+- **AND** upgrading to `head` again MUST restore the single merge stamp without
+  repeating either parent's schema or data operations
+

--- a/tests/integration/test_migration_merge_overflow_transport.py
+++ b/tests/integration/test_migration_merge_overflow_transport.py
@@ -1,0 +1,208 @@
+"""Exercise the overflow/transport merge from each populated branch state."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Connection, Engine
+
+from app.db.migrate import _build_alembic_config, check_schema_drift, run_upgrade
+
+pytestmark = pytest.mark.integration
+
+_COMMON_PARENT = "20260830_000000_add_quota_warmup_claim_expiry"
+_OVERFLOW = "20260908_000000_add_subscription_overflow"
+_TRANSPORT = "20260908_000000_replace_upstream_stream_transport_default_sentinel"
+_PARENTS = (_OVERFLOW, _TRANSPORT)
+_MERGE = "20260908_020000_merge_overflow_transport_heads"
+
+
+@dataclass
+class _MigrationDatabase:
+    url: str
+    engine: Engine
+    starting_revisions: tuple[str, ...]
+
+
+def _seed_settings_and_retry(connection: Connection) -> None:
+    connection.execute(
+        text(
+            "UPDATE dashboard_settings SET upstream_stream_transport = 'default', "
+            "sticky_threads_enabled = 0 WHERE id = 1"
+        )
+    )
+    seeded = dict(connection.execute(text("SELECT * FROM dashboard_settings WHERE id = 1")).mappings().one())
+    columns = ", ".join(seeded)
+    parameters = ", ".join(f":{column}" for column in seeded)
+    for row_id, transport in enumerate(("http", "websocket", "auto"), start=2):
+        connection.execute(
+            text(f"INSERT INTO dashboard_settings ({columns}) VALUES ({parameters})"),
+            {**seeded, "id": row_id, "upstream_stream_transport": transport},
+        )
+    connection.execute(
+        text(
+            """
+            INSERT INTO http_bridge_retry_circuits (
+                session_key_kind, session_key_hash, api_key_scope, consecutive_failures,
+                cooldown_until_epoch, last_detail, updated_at_epoch, admission_generation
+            ) VALUES ('session_header', 'retained-retry', '__anonymous__', 2,
+                      1300.0, 'stream_incomplete', 1200.0, 7)
+            """
+        )
+    )
+
+
+def _seed_overflow(connection: Connection) -> None:
+    connection.execute(
+        text(
+            "UPDATE dashboard_settings SET subscription_overflow_source_id = 'retained-source', "
+            "subscription_overflow_drain_until = '2026-09-09 12:00:00' WHERE id = 1"
+        )
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO model_source_pins (
+                pin_key, kind, source_id, api_key_id, created_at, last_seen_at, expires_at, purge_at
+            ) VALUES (:pin_key, :kind, 'retained-source', :api_key_id,
+                      '2026-09-08 10:00:00', '2026-09-08 10:30:00',
+                      '2026-09-09 10:00:00', '2026-09-10 10:00:00')
+            """
+        ),
+        [
+            {"pin_key": "retained-thread", "kind": "thread", "api_key_id": None},
+            {"pin_key": "retained-anchor", "kind": "anchor", "api_key_id": "retained-api-key"},
+        ],
+    )
+
+
+def _revisions(engine: Engine) -> tuple[str, ...]:
+    with engine.connect() as connection:
+        return tuple(connection.execute(text("SELECT version_num FROM alembic_version ORDER BY version_num")).scalars())
+
+
+def _state(engine: Engine) -> dict[str, Any]:
+    with engine.connect() as connection:
+        inspector = inspect(connection)
+        has_pins = inspector.has_table("model_source_pins")
+        tables = ("dashboard_settings", "model_source_pins") if has_pins else ("dashboard_settings",)
+        return {
+            "settings": [
+                dict(row) for row in connection.execute(text("SELECT * FROM dashboard_settings ORDER BY id")).mappings()
+            ],
+            "pins": (
+                [
+                    dict(row)
+                    for row in connection.execute(text("SELECT * FROM model_source_pins ORDER BY pin_key")).mappings()
+                ]
+                if has_pins
+                else None
+            ),
+            "retry": tuple(
+                connection.execute(
+                    text("SELECT * FROM http_bridge_retry_circuits WHERE session_key_hash = 'retained-retry'")
+                ).one()
+            ),
+            "schema": {
+                table: {
+                    "columns": [
+                        (column["name"], str(column["type"]), column["nullable"], column["default"])
+                        for column in inspector.get_columns(table)
+                    ],
+                    "primary_key": inspector.get_pk_constraint(table),
+                    "foreign_keys": inspector.get_foreign_keys(table),
+                    "indexes": inspector.get_indexes(table),
+                }
+                for table in tables
+            },
+        }
+
+
+@pytest.fixture(
+    params=[(_OVERFLOW,), (_TRANSPORT,), _PARENTS],
+    ids=["overflow-parent", "transport-parent", "both-parents"],
+)
+def branch_database(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[_MigrationDatabase]:
+    database_path = tmp_path / "merge-parents.sqlite"
+    url = f"sqlite+aiosqlite:///{database_path}"
+    engine = create_engine(f"sqlite:///{database_path}")
+    try:
+        run_upgrade(url, _COMMON_PARENT, bootstrap_legacy=False)
+        with engine.begin() as connection:
+            _seed_settings_and_retry(connection)
+        starting_revisions = request.param
+        for revision in starting_revisions:
+            run_upgrade(url, revision, bootstrap_legacy=False)
+            if revision == _OVERFLOW:
+                with engine.begin() as connection:
+                    _seed_overflow(connection)
+        assert _revisions(engine) == tuple(sorted(starting_revisions))
+        yield _MigrationDatabase(url, engine, starting_revisions)
+    finally:
+        engine.dispose()
+
+
+def test_overflow_transport_merge_is_the_only_head_with_both_original_parents(tmp_path: Path) -> None:
+    config = _build_alembic_config(f"sqlite+aiosqlite:///{tmp_path / 'graph.sqlite'}")
+    script = ScriptDirectory.from_config(config)
+    assert script.get_heads() == [_MERGE]
+    merge = script.get_revision(_MERGE)
+    assert merge is not None and merge.down_revision == _PARENTS
+    for revision in _PARENTS:
+        parent = script.get_revision(revision)
+        assert parent is not None and parent.down_revision == _COMMON_PARENT
+
+
+def test_populated_parent_upgrade_and_direct_downgrades_preserve_both_branches(
+    branch_database: _MigrationDatabase,
+) -> None:
+    database = branch_database
+    before = _state(database.engine)
+    expected_settings = [dict(row) for row in before["settings"]]
+    for row in expected_settings:
+        if _TRANSPORT not in database.starting_revisions and row["upstream_stream_transport"] == "default":
+            row["upstream_stream_transport"] = "auto"
+        if _OVERFLOW not in database.starting_revisions:
+            row["subscription_overflow_source_id"] = None
+            row["subscription_overflow_drain_until"] = None
+
+    result = run_upgrade(database.url, "head", bootstrap_legacy=False)
+    assert result.current_revision == _MERGE
+    assert _revisions(database.engine) == (_MERGE,)
+    merged = _state(database.engine)
+    assert merged["settings"] == expected_settings
+    assert [row["upstream_stream_transport"] for row in merged["settings"]] == ["auto", "http", "websocket", "auto"]
+    assert merged["pins"] == (before["pins"] if before["pins"] is not None else [])
+    assert merged["retry"] == before["retry"]
+    assert check_schema_drift(database.url) == ()
+
+    # Populate the newly created overflow schema too, so every starting state
+    # tests direct downgrade with retained settings and non-empty pins.
+    if _OVERFLOW not in database.starting_revisions:
+        with database.engine.begin() as connection:
+            _seed_overflow(connection)
+    populated = _state(database.engine)
+    assert len(populated["pins"]) == 2
+    assert populated["settings"][0]["subscription_overflow_source_id"] == "retained-source"
+
+    for parent in _PARENTS:
+        command.downgrade(_build_alembic_config(database.url), parent)
+        # A direct downgrade to either immediate parent executes only the
+        # no-op merge downgrade. Alembic records both unmerged parent heads;
+        # it does not execute either parent's schema-removing downgrade.
+        assert _revisions(database.engine) == tuple(sorted(_PARENTS))
+        assert _state(database.engine) == populated
+        assert check_schema_drift(database.url) == ()
+
+        result = run_upgrade(database.url, "head", bootstrap_legacy=False)
+        assert result.current_revision == _MERGE
+        assert _revisions(database.engine) == (_MERGE,)
+        assert _state(database.engine) == populated
+        assert check_schema_drift(database.url) == ()


### PR DESCRIPTION
## Problem

Main at `713fa5648` has two Alembic heads. The subscription-overflow migration from #2165 and transport-sentinel migration from #2192 both revise the quota-warmup migration. A normal upgrade to `head` cannot select a single target.

## Why this PR exists

The shared graph needs a forward repair before feature migrations can safely follow it. Reparenting #1954 alone cannot repair both upstream heads. This is a prerequisite for #1954, not a resolution of that PR's receipt-policy or recovery limitations.

Refs #1954, #2165, #2192. Graph repair only.

## How this PR solves it

- Add `20260908_020000_merge_overflow_transport_heads` with both existing heads as parents.
- Leave both merged migrations byte-unchanged. The new revision performs no schema or data operations.
- Test populated upgrades from either parent and both parents. Existing parent behavior, including `default` to `auto` normalization, remains unchanged.
- Test downgrade of the merge to each immediate parent and re-upgrade. Both parent stamps, schemas and data survive. This does not promise rollback to an application build that knows only one branch.

## Scope

Only the merge revision, migration regression tests and OpenSpec records. No new configuration, setup step, dashboard change, runtime routing, or receipt policy. No deployment or live-database changes.

OpenSpec: `openspec/changes/merge-overflow-transport-migration-heads/`, with the normative requirement also synced into `database-migrations`.

## Verification

- Isolated SQLite URLs verified for foreground, background and test engines before execution.
- CLI `upgrade head` and `check`: migration policy passes, no schema drift.
- Migration unit/integration suites: 96 passed, 7 PostgreSQL-only skips. Four new cases cover graph ancestry and the populated branch transitions.
- `make lint typecheck` passed.
- Strict OpenSpec change and capability validation passed.
- Independent Input and Standards reviews: zero findings on tree `7f7f86b8`.

## Current status

Local candidate verified; current-head hosted CI, PostgreSQL checks and formal reviews are pending. #1954 stays unchanged until this repair is accepted upstream or maintainers explicitly accept another dependency strategy. No merge or deployment is authorized.
