### PR TITLE
test(frontend): use a valid upstream transport in subscription-overflow settings fixtures

### DIFF
--- a/frontend/src/features/settings/schemas.test.ts
+++ b/frontend/src/features/settings/schemas.test.ts
@@ -635,7 +635,7 @@ describe("subscription overflow fields", () => {
   it("defaults the designation and drain deadline to null for older backends", () => {
     const parsed = DashboardSettingsSchema.parse({
       stickyThreadsEnabled: true,
-      upstreamStreamTransport: "default",
+      upstreamStreamTransport: "auto",
       preferEarlierResetAccounts: false,
       routingStrategy: "round_robin",
       openaiCacheAffinityMaxAgeSeconds: 300,
@@ -654,7 +654,7 @@ describe("subscription overflow fields", () => {
   it("round-trips a designation, an ISO drain deadline and the derived pin expiry", () => {
     const parsed = DashboardSettingsSchema.parse({
       stickyThreadsEnabled: true,
-      upstreamStreamTransport: "default",
+      upstreamStreamTransport: "auto",
       preferEarlierResetAccounts: false,
       routingStrategy: "round_robin",
       openaiCacheAffinityMaxAgeSeconds: 300,


### PR DESCRIPTION
## Summary
Two `settings/schemas.test.ts` cases added by #2176 build fixtures with `upstreamStreamTransport: "default"`. #2192 removed the `default` sentinel from the transport enum (`auto|http|websocket`), so main's frontend vitest job fails on those two cases. This switches the fixtures to `auto`; the tests are about the subscription-overflow designation/drain-deadline fields and are otherwise unchanged.

## Type of change
- [x] `test:` — test-only change

## OpenSpec
- [x] Not applicable — docs / CI / chore only

## Changes
- `frontend/src/features/settings/schemas.test.ts`: `upstreamStreamTransport: "default"` → `"auto"` in two fixtures (lines 638, 657).

## Test plan
```
bun run vitest run src/features/settings/schemas.test.ts   # 33 passed (was 2 failed on main 713fa5648)
```

Semantic conflict between #2176 and #2192 (both merged 2026-09-08). Part of the slop-removal campaign 0908 follow-ups.