### PR TITLE
feat(auth): restrict guest-visible sensitive surfaces and make guest sessions revocable

### DIFF
--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -201,6 +201,7 @@ async def validate_dashboard_session(request: Request) -> DashboardPrincipal:
         state is not None
         and state.role == DashboardRole.GUEST
         and guest_access_enabled
+        and state.guest_session_generation == settings.guest_session_generation
         and ((not guest_password_required and passwordless_guest_fallback_allowed) or state.guest_verified)
     ):
         return _set_dashboard_principal(request, guest_principal())

--- a/app/db/alembic/versions/20260908_000000_add_guest_session_generation.py
+++ b/app/db/alembic/versions/20260908_000000_add_guest_session_generation.py
@@ -1,0 +1,37 @@
+"""Add dashboard_settings.guest_session_generation for guest session revocation.
+
+Revision ID: 20260908_000000_add_guest_session_generation
+Revises: 20260830_000000_add_quota_warmup_claim_expiry
+Create Date: 2026-09-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260908_000000_add_guest_session_generation"
+down_revision = "20260910_000000_request_logs_missing_cost_index"
+branch_labels = None
+depends_on = None
+
+_TABLE = "dashboard_settings"
+_COLUMN = "guest_session_generation"
+
+
+def _columns(bind: sa.engine.Connection) -> set[str]:
+    return {column["name"] for column in sa.inspect(bind).get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN not in _columns(bind):
+        with op.batch_alter_table(_TABLE) as batch_op:
+            batch_op.add_column(sa.Column(_COLUMN, sa.Integer(), server_default=sa.text("0"), nullable=False))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN in _columns(bind):
+        with op.batch_alter_table(_TABLE) as batch_op:
+            batch_op.drop_column(_COLUMN)

--- a/app/db/alembic/versions/20260908_000000_add_guest_session_generation.py
+++ b/app/db/alembic/versions/20260908_000000_add_guest_session_generation.py
@@ -1,7 +1,7 @@
 """Add dashboard_settings.guest_session_generation for guest session revocation.
 
 Revision ID: 20260908_000000_add_guest_session_generation
-Revises: 20260830_000000_add_quota_warmup_claim_expiry
+Revises: 20260910_010000_dashboard_spool_retention
 Create Date: 2026-09-08
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260908_000000_add_guest_session_generation"
-down_revision = "20260910_000000_request_logs_missing_cost_index"
+down_revision = "20260910_010000_dashboard_spool_retention"
 branch_labels = None
 depends_on = None
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1029,6 +1029,16 @@ class DashboardSettings(Base):
         nullable=False,
     )
     guest_password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Bumped whenever guest credentials or guest access change so every
+    # outstanding guest session cookie (which carries the generation it was
+    # issued under) stops validating. Sessions are stateless Fernet cookies, so
+    # this counter is the only server-side revocation handle for guests.
+    guest_session_generation: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        server_default=text("0"),
+        nullable=False,
+    )
     bootstrap_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     bootstrap_token_hash: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     api_key_auth_enabled: Mapped[bool] = mapped_column(

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -5,7 +5,7 @@ import logging
 from fastapi import APIRouter, Depends, Request, Response
 
 from app.core.audit.service import AuditService
-from app.core.auth.dashboard_access import Permission
+from app.core.auth.dashboard_access import DashboardPrincipal, Permission
 from app.core.auth.dependencies import (
     require_dashboard_permission,
     require_dashboard_write_access,
@@ -99,9 +99,12 @@ _ACCOUNT_IMPORT_OPENAPI_EXTRA = {
 
 @router.get("", response_model=AccountsResponse)
 async def list_accounts(
+    principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountsResponse:
-    accounts = await context.service.list_accounts()
+    accounts = await context.service.list_accounts(
+        redact_identity=not principal.has(Permission.ACCOUNTS_WRITE),
+    )
     return AccountsResponse(accounts=accounts)
 
 

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -45,6 +45,7 @@ def build_account_summaries(
     encryptor: TokenEncryptor,
     include_auth: bool = True,
     reset_credits_store: RateLimitResetCreditsStore | None = None,
+    redact_identity: bool = False,
 ) -> list[AccountSummary]:
     store = reset_credits_store or get_rate_limit_reset_credits_store()
     duplicate_keys = _duplicate_detection_keys_appearing_more_than_once(accounts)
@@ -61,9 +62,18 @@ def build_account_summaries(
             include_auth=include_auth,
             is_email_duplicate=_duplicate_detection_key(account) in duplicate_keys,
             reset_credits_snapshot=_reset_credits_snapshot_for_account(account, store),
+            redact_identity=redact_identity,
         )
         for account in accounts
     ]
+
+
+def mask_email(email: str) -> str:
+    """Keep the first character of the local part and the domain: ``a***@example.com``."""
+
+    local, sep, domain = email.partition("@")
+    prefix = local[:1] if local else ""
+    return f"{prefix}***{sep}{domain}" if sep else f"{prefix}***"
 
 
 def _duplicate_detection_keys_appearing_more_than_once(accounts: list[Account]) -> set[tuple[str, str, str | None]]:
@@ -108,8 +118,12 @@ def _account_to_summary(
     include_auth: bool = True,
     is_email_duplicate: bool = False,
     reset_credits_snapshot: RateLimitResetCreditsSnapshot | None = None,
+    redact_identity: bool = False,
 ) -> AccountSummary:
     plan_type = coerce_account_plan_type(account.plan_type, DEFAULT_PLAN)
+    # Principals without account write access see the account, its status and
+    # quota, but not who it belongs to upstream.
+    email = mask_email(account.email) if redact_identity else account.email
     auth_status = _build_auth_status(account, encryptor) if include_auth else None
     effective_primary_usage, effective_secondary_usage = _effective_usage_windows(
         primary_usage,
@@ -252,12 +266,12 @@ def _account_to_summary(
 
     return AccountSummary(
         account_id=account.id,
-        chatgpt_account_id=account.chatgpt_account_id,
-        email=account.email,
+        chatgpt_account_id=None if redact_identity else account.chatgpt_account_id,
+        email=email,
         alias=account.alias,
-        display_name=account.alias or account.email,
-        workspace_id=account.workspace_id,
-        workspace_label=account.workspace_label,
+        display_name=account.alias or email,
+        workspace_id=None if redact_identity else account.workspace_id,
+        workspace_label=None if redact_identity else account.workspace_label,
         seat_type=account.seat_type,
         plan_type=plan_type,
         status=effective_status.value,

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -131,7 +131,12 @@ class AccountsService:
         self._encryptor = TokenEncryptor()
         self._auth_manager = auth_manager
 
-    async def list_accounts(self, *, account_ids: list[str] | None = None) -> list[AccountSummary]:
+    async def list_accounts(
+        self,
+        *,
+        account_ids: list[str] | None = None,
+        redact_identity: bool = False,
+    ) -> list[AccountSummary]:
         accounts = (
             await self._repo.list_accounts_by_ids(account_ids)
             if account_ids is not None
@@ -231,6 +236,7 @@ class AccountsService:
             additional_quotas_by_account=additional_quotas_by_account,
             limit_warmups_by_account=limit_warmups_by_account,
             encryptor=self._encryptor,
+            redact_identity=redact_identity,
         )
 
     async def get_account_trends(self, account_id: str) -> AccountTrendsResponse | None:

--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from fastapi import APIRouter, Body, Depends, Request, Response
 
 from app.core.audit.service import AuditService
+from app.core.auth.dashboard_access import Permission
 from app.core.auth.dependencies import (
+    require_dashboard_permission,
     require_dashboard_write_access,
     set_dashboard_error_format,
     validate_dashboard_session,
@@ -33,7 +35,13 @@ from app.modules.api_keys.service import (
 router = APIRouter(
     prefix="/api/api-keys",
     tags=["dashboard"],
-    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+    dependencies=[
+        Depends(validate_dashboard_session),
+        # The key inventory (policies, assignments, limits, usage) is not a
+        # guest-safe read; every route here needs api_keys:read at minimum.
+        Depends(require_dashboard_permission(Permission.API_KEYS_READ)),
+        Depends(set_dashboard_error_format),
+    ],
 )
 
 

--- a/app/modules/dashboard/api.py
+++ b/app/modules/dashboard/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
 
-from app.core.auth.dashboard_access import Permission
+from app.core.auth.dashboard_access import DashboardPrincipal, Permission
 from app.core.auth.dependencies import (
     require_dashboard_permission,
     set_dashboard_error_format,
@@ -33,9 +33,13 @@ router = APIRouter(
 )
 async def get_overview(
     timeframe: DashboardOverviewTimeframeKey = Query("7d"),
+    principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: DashboardContext = Depends(get_dashboard_context),
 ) -> DashboardOverviewResponse:
-    return await context.service.get_overview(timeframe)
+    return await context.service.get_overview(
+        timeframe,
+        redact_identity=not principal.has(Permission.ACCOUNTS_WRITE),
+    )
 
 
 @router.get(

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -89,6 +89,8 @@ class DashboardService:
     async def get_overview(
         self,
         timeframe_key: DashboardOverviewTimeframeKey = "7d",
+        *,
+        redact_identity: bool = False,
     ) -> DashboardOverviewResponse:
         now = utcnow()
         overview_timeframe = resolve_overview_timeframe(timeframe_key)
@@ -108,6 +110,7 @@ class DashboardService:
                 limit_warmups_by_account=limit_warmups_by_account,
                 encryptor=self._encryptor,
                 include_auth=False,
+                redact_identity=redact_identity,
             ),
             key=lambda a: a.capacity_credits_primary or 0,
             reverse=True,

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import JSONResponse
 
+from app.core.audit.service import AuditService
 from app.core.auth.dashboard_access import (
     ADMIN_PERMISSIONS,
     GUEST_PERMISSIONS,
@@ -85,15 +86,19 @@ async def _create_dashboard_session(
     totp_verified: bool,
     role: DashboardRole = DashboardRole.ADMIN,
     guest_verified: bool = False,
+    guest_session_generation: int | None = None,
 ) -> tuple[str, int]:
     settings = await get_settings_cache().get()
     ttl_seconds = resolve_dashboard_session_ttl_seconds(request, settings.dashboard_session_ttl_seconds)
+    if role == DashboardRole.GUEST and guest_session_generation is None:
+        guest_session_generation = settings.guest_session_generation
     session_id = get_dashboard_session_store().create(
         password_verified=password_verified,
         totp_verified=totp_verified,
         ttl_seconds=ttl_seconds,
         role=role,
         guest_verified=guest_verified,
+        guest_session_generation=guest_session_generation if role == DashboardRole.GUEST else None,
     )
     return session_id, ttl_seconds
 
@@ -242,7 +247,11 @@ async def get_dashboard_auth_session(
             return _public_guest_response(decorated)
         if decorated.authenticated and decorated.role == DashboardRole.GUEST:
             session_state = get_dashboard_session_store().get(session_id)
-            if session_state is not None and session_state.guest_verified:
+            if (
+                session_state is not None
+                and session_state.guest_verified
+                and session_state.guest_session_generation == current_settings.guest_session_generation
+            ):
                 return decorated
         return _guest_login_required_response(decorated)
     bootstrap_token_configured = await has_active_bootstrap_token()
@@ -357,6 +366,10 @@ async def login_guest(
         totp_verified=False,
         role=DashboardRole.GUEST,
         guest_verified=guest_verified,
+        # Stamp the generation from the same DB row the credential check used, not
+        # the 5 s settings cache, so a bump committed on a peer replica cannot
+        # mint an already-stale cookie.
+        guest_session_generation=(await context.repository.get_settings()).guest_session_generation,
     )
     response = _decorate_session_response(
         await context.service.get_session_state(session_id),
@@ -462,6 +475,23 @@ async def remove_guest_password(
 ) -> JSONResponse:
     await context.service.clear_guest_password()
     await get_settings_cache().invalidate()
+    return JSONResponse(status_code=200, content={"status": "ok"})
+
+
+@router.post("/guest/logout-all")
+async def revoke_guest_sessions(
+    request: Request,
+    context: DashboardAuthContext = Depends(get_dashboard_auth_context),
+    _principal: DashboardPrincipal = Depends(require_dashboard_permission(Permission.SECURITY_WRITE)),
+) -> JSONResponse:
+    """Invalidate every outstanding guest session without touching guest settings."""
+
+    await context.service.revoke_guest_sessions()
+    await get_settings_cache().invalidate()
+    AuditService.log_async(
+        "guest_sessions_revoked",
+        actor_ip=request.client.host if request.client else None,
+    )
     return JSONResponse(status_code=200, content={"status": "ok"})
 
 

--- a/app/modules/dashboard_auth/repository.py
+++ b/app/modules/dashboard_auth/repository.py
@@ -59,12 +59,21 @@ class DashboardAuthRepository:
     async def set_guest_password_hash(self, password_hash: str) -> DashboardSettings:
         def _mutate(row: DashboardSettings) -> None:
             row.guest_password_hash = password_hash
+            # Changing the guest credential must log every current guest out.
+            row.guest_session_generation += 1
 
         return await self._mutate_settings_with_retry(_mutate)
 
     async def clear_guest_password_hash(self) -> DashboardSettings:
         def _mutate(row: DashboardSettings) -> None:
             row.guest_password_hash = None
+            row.guest_session_generation += 1
+
+        return await self._mutate_settings_with_retry(_mutate)
+
+    async def bump_guest_session_generation(self) -> DashboardSettings:
+        def _mutate(row: DashboardSettings) -> None:
+            row.guest_session_generation += 1
 
         return await self._mutate_settings_with_retry(_mutate)
 

--- a/app/modules/dashboard_auth/service.py
+++ b/app/modules/dashboard_auth/service.py
@@ -32,6 +32,7 @@ class DashboardAuthSettingsProtocol(Protocol):
     password_hash: str | None
     guest_access_enabled: bool
     guest_password_hash: str | None
+    guest_session_generation: int
     totp_required_on_login: bool
     totp_secret_encrypted: bytes | None
     totp_last_verified_step: int | None
@@ -49,6 +50,8 @@ class DashboardAuthRepositoryProtocol(Protocol):
     async def set_guest_password_hash(self, password_hash: str) -> DashboardAuthSettingsProtocol: ...
 
     async def clear_guest_password_hash(self) -> DashboardAuthSettingsProtocol: ...
+
+    async def bump_guest_session_generation(self) -> DashboardAuthSettingsProtocol: ...
 
     async def clear_password_and_totp(self) -> DashboardAuthSettingsProtocol: ...
 
@@ -100,6 +103,10 @@ class DashboardSessionState:
     totp_verified: bool
     role: DashboardRole = DashboardRole.ADMIN
     guest_verified: bool = False
+    #: Generation the guest cookie was issued under; ``None`` for admin
+    #: sessions and for guest cookies minted before generations existed (which
+    #: therefore never match and are rejected).
+    guest_session_generation: int | None = None
 
 
 class DashboardSessionStore:
@@ -119,18 +126,21 @@ class DashboardSessionStore:
         ttl_seconds: int,
         role: DashboardRole = DashboardRole.ADMIN,
         guest_verified: bool = False,
+        guest_session_generation: int | None = None,
     ) -> str:
+        if role == DashboardRole.GUEST and guest_session_generation is None:
+            raise ValueError("guest sessions must carry the current guest session generation")
         expires_at = int(time()) + ttl_seconds
-        payload = json.dumps(
-            {
-                "exp": expires_at,
-                "pw": password_verified,
-                "tv": totp_verified,
-                "role": role.value,
-                "gv": guest_verified,
-            },
-            separators=(",", ":"),
-        )
+        data: dict[str, object] = {
+            "exp": expires_at,
+            "pw": password_verified,
+            "tv": totp_verified,
+            "role": role.value,
+            "gv": guest_verified,
+        }
+        if role == DashboardRole.GUEST:
+            data["gg"] = guest_session_generation
+        payload = json.dumps(data, separators=(",", ":"))
         return self._get_encryptor().encrypt(payload).decode("ascii")
 
     def get(self, session_id: str | None) -> DashboardSessionState | None:
@@ -164,12 +174,16 @@ class DashboardSessionStore:
             return None
         if exp < int(time()):
             return None
+        gg = data.get("gg")
+        if gg is not None and (not isinstance(gg, int) or isinstance(gg, bool)):
+            return None
         return DashboardSessionState(
             expires_at=exp,
             password_verified=pw,
             totp_verified=tv,
             role=role,
             guest_verified=gv,
+            guest_session_generation=gg if role == DashboardRole.GUEST else None,
         )
 
     def is_password_verified(self, session_id: str | None) -> bool:
@@ -207,6 +221,7 @@ class DashboardAuthService:
             state is not None
             and state.role == DashboardRole.GUEST
             and guest_access_enabled
+            and state.guest_session_generation == settings.guest_session_generation
             and (not guest_password_required or state.guest_verified)
         ):
             authenticated = True
@@ -287,6 +302,11 @@ class DashboardAuthService:
 
     async def clear_guest_password(self) -> None:
         await self._repository.clear_guest_password_hash()
+
+    async def revoke_guest_sessions(self) -> None:
+        """Invalidate every outstanding guest session cookie."""
+
+        await self._repository.bump_guest_session_generation()
 
     async def remove_password(self, password: str) -> None:
         await self.verify_password(password)

--- a/app/modules/oauth/api.py
+++ b/app/modules/oauth/api.py
@@ -5,7 +5,9 @@ import logging
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import JSONResponse
 
+from app.core.auth.dashboard_access import Permission
 from app.core.auth.dependencies import (
+    require_dashboard_permission,
     require_dashboard_write_access,
     set_dashboard_error_format,
     validate_dashboard_session,
@@ -52,7 +54,11 @@ async def start_oauth(
         )
 
 
-@router.get("/status", response_model=OauthStatusResponse)
+@router.get(
+    "/status",
+    response_model=OauthStatusResponse,
+    dependencies=[Depends(require_dashboard_permission(Permission.ACCOUNTS_WRITE))],
+)
 async def oauth_status(
     flow_id: str | None = Query(default=None, alias="flowId"),
     context: OauthContext = Depends(get_oauth_context),

--- a/app/modules/request_logs/api.py
+++ b/app/modules/request_logs/api.py
@@ -113,6 +113,8 @@ async def list_request_logs(
         cache_mode="timeframe" if cache_timeframe is not None else "since",
         timeframe=cache_timeframe,
         include_sensitive_metadata=principal.has(Permission.CONVERSATIONS_READ),
+        include_account_identity=principal.has(Permission.ACCOUNTS_WRITE),
+        include_api_key_identity=principal.has(Permission.API_KEYS_READ),
     )
     return RequestLogsResponse(
         requests=page.requests,
@@ -133,6 +135,7 @@ async def list_request_log_filter_options(
     timeframe: str | None = Query(default=None, pattern="^(1h|24h|7d)$"),
     since: datetime | None = Query(default=None),
     until: datetime | None = Query(default=None),
+    principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: RequestLogsContext = Depends(get_request_logs_context),
 ) -> RequestLogFilterOptionsResponse:
     _ = status  # Keep input backward compatible but do not self-filter status facet.
@@ -156,10 +159,13 @@ async def list_request_log_filter_options(
             RequestLogModelOption(model=option.model, reasoning_effort=option.reasoning_effort)
             for option in options.model_options
         ],
+        # The API-key inventory (ids, names, prefixes) is an api_keys:read surface.
         api_keys=[
             RequestLogApiKeyOption(id=option.id, name=option.name, key_prefix=option.key_prefix)
             for option in options.api_keys
-        ],
+        ]
+        if principal.has(Permission.API_KEYS_READ)
+        else [],
         statuses=options.statuses,
     )
 

--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -38,6 +38,7 @@ def to_request_log_entry(
     *,
     api_key_name: str | None = None,
     include_sensitive_metadata: bool,
+    include_api_key_identity: bool = True,
 ) -> RequestLogEntry:
     log_like = typing_cast(RequestLogLike, log)
     cost_breakdown = cost_breakdown_from_log(log_like, precision=6)
@@ -46,8 +47,8 @@ def to_request_log_entry(
         conversation_id=log.conversation_id if include_sensitive_metadata else None,
         account_id=log.account_id,
         plan_type=log.plan_type,
-        api_key_id=log.api_key_id,
-        api_key_name=api_key_name,
+        api_key_id=log.api_key_id if include_api_key_identity else None,
+        api_key_name=api_key_name if include_api_key_identity else None,
         request_id=log.request_id,
         archive_request_id=log.archive_request_id if include_sensitive_metadata else None,
         request_kind=log.request_kind,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -1265,6 +1265,8 @@ class RequestLogsRepository:
         cache_mode: str = "since",
         timeframe: str | None = None,
         include_sensitive_metadata: bool = True,
+        include_account_identity: bool = True,
+        include_api_key_identity: bool = True,
     ) -> RequestLogsResult:
         since = _naive_utc(since) if since is not None else None
         until = _naive_utc(until) if until is not None else None
@@ -1285,6 +1287,8 @@ class RequestLogsRepository:
             error_codes_excluding=error_codes_excluding,
             exclude_soft_deleted=True,
             include_sensitive_metadata=include_sensitive_metadata,
+            include_account_identity=include_account_identity,
+            include_api_key_identity=include_api_key_identity,
         )
 
         stmt = select(RequestLog).order_by(RequestLog.requested_at.desc(), RequestLog.id.desc())
@@ -1337,6 +1341,8 @@ class RequestLogsRepository:
             tuple(sorted(error_codes_in)) if error_codes_in else None,
             tuple(sorted(error_codes_excluding)) if error_codes_excluding else None,
             include_sensitive_metadata,
+            include_account_identity,
+            include_api_key_identity,
         )
         total = _cached_recent_count(cache_key)
         if total is None:
@@ -1648,6 +1654,8 @@ class RequestLogsRepository:
         error_codes_excluding: list[str] | None = None,
         exclude_soft_deleted: bool = False,
         include_sensitive_metadata: bool = True,
+        include_account_identity: bool = True,
+        include_api_key_identity: bool = True,
     ) -> _RequestLogFilters:
         conditions = []
         if exclude_soft_deleted:
@@ -1704,7 +1712,6 @@ class RequestLogsRepository:
             search_pattern = f"%{search}%"
             search_conditions = [
                 RequestLog.account_id.ilike(search_pattern),
-                Account.email.ilike(search_pattern),
                 RequestLog.request_id.ilike(search_pattern),
                 RequestLog.model.ilike(search_pattern),
                 RequestLog.reasoning_effort.ilike(search_pattern),
@@ -1712,8 +1719,6 @@ class RequestLogsRepository:
                 RequestLog.status.ilike(search_pattern),
                 RequestLog.error_code.ilike(search_pattern),
                 RequestLog.error_message.ilike(search_pattern),
-                RequestLog.api_key_id.ilike(search_pattern),
-                ApiKey.name.ilike(search_pattern),
                 cast(RequestLog.requested_at, String).ilike(search_pattern),
                 cast(RequestLog.input_tokens, String).ilike(search_pattern),
                 cast(RequestLog.output_tokens, String).ilike(search_pattern),
@@ -1721,8 +1726,17 @@ class RequestLogsRepository:
                 cast(RequestLog.reasoning_tokens, String).ilike(search_pattern),
                 cast(RequestLog.latency_ms, String).ilike(search_pattern),
             ]
+            if include_api_key_identity:
+                # API-key ids and names are an api_keys:read surface; matching on
+                # them would let a guest enumerate the key inventory.
+                search_conditions.append(RequestLog.api_key_id.ilike(search_pattern))
+                search_conditions.append(ApiKey.name.ilike(search_pattern))
             if include_sensitive_metadata:
                 search_conditions.append(RequestLog.client_ip.ilike(search_pattern))
+            if include_account_identity:
+                # Account emails are redacted for principals without account
+                # write access; matching on them would be a membership oracle.
+                search_conditions.append(Account.email.ilike(search_pattern))
             conditions.append(or_(*search_conditions))
             return _RequestLogFilters(conditions=conditions, needs_related_search_joins=True)
         return _RequestLogFilters(conditions=conditions, needs_related_search_joins=False)

--- a/app/modules/request_logs/service.py
+++ b/app/modules/request_logs/service.py
@@ -102,6 +102,8 @@ class RequestLogsService:
         cache_mode: str = "since",
         timeframe: str | None = None,
         include_sensitive_metadata: bool,
+        include_account_identity: bool = True,
+        include_api_key_identity: bool = True,
     ) -> RequestLogsPage:
         status_filter = _map_status_filter(status)
         normalized_model_options = (
@@ -127,6 +129,8 @@ class RequestLogsService:
             cache_mode=cache_mode,
             timeframe=timeframe,
             include_sensitive_metadata=include_sensitive_metadata,
+            include_account_identity=include_account_identity,
+            include_api_key_identity=include_api_key_identity,
         )
         logs = result.logs
         total = result.total
@@ -137,13 +141,14 @@ class RequestLogsService:
                 request_count=total,
                 aggregated_cost_usd=result.aggregated_cost_usd,
             )
-        api_key_ids = [log.api_key_id for log in logs if log.api_key_id]
-        api_key_name_by_id = await self._repo.get_api_key_names_by_ids(api_key_ids)
+        api_key_ids = [log.api_key_id for log in logs if log.api_key_id] if include_api_key_identity else []
+        api_key_name_by_id = await self._repo.get_api_key_names_by_ids(api_key_ids) if api_key_ids else {}
         requests = [
             to_request_log_entry(
                 log,
                 api_key_name=api_key_name_by_id.get(log.api_key_id or ""),
                 include_sensitive_metadata=include_sensitive_metadata,
+                include_api_key_identity=include_api_key_identity,
             )
             for log in logs
         ]

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -365,12 +365,20 @@ async def get_subscription_overflow_preflight(
     return preflight
 
 
-@router.get("/runtime/connect-address", response_model=RuntimeConnectAddressResponse)
+@router.get(
+    "/runtime/connect-address",
+    response_model=RuntimeConnectAddressResponse,
+    dependencies=[Depends(require_dashboard_permission(Permission.OPS_WRITE))],
+)
 async def get_runtime_connect_address(request: Request) -> RuntimeConnectAddressResponse:
     return RuntimeConnectAddressResponse(connect_address=_resolve_runtime_connect_address(request))
 
 
-@router.get("/upstream-proxy", response_model=UpstreamProxyAdminResponse)
+@router.get(
+    "/upstream-proxy",
+    response_model=UpstreamProxyAdminResponse,
+    dependencies=[Depends(require_dashboard_permission(Permission.OPS_WRITE))],
+)
 async def get_upstream_proxy_admin(
     context: SettingsContext = Depends(get_settings_context),
 ) -> UpstreamProxyAdminResponse:

--- a/app/modules/settings/repository.py
+++ b/app/modules/settings/repository.py
@@ -389,6 +389,10 @@ class SettingsRepository:
         if weekly_pace_smoothing_minutes is not None:
             settings.weekly_pace_smoothing_minutes = weekly_pace_smoothing_minutes
         if guest_access_enabled is not None:
+            if settings.guest_access_enabled and not guest_access_enabled:
+                # Disabling guest access must not leave already-issued guest
+                # cookies valid for when it is re-enabled later.
+                settings.guest_session_generation += 1
             settings.guest_access_enabled = guest_access_enabled
         if limit_warmup_staggered_idle_enabled is not None:
             settings.limit_warmup_staggered_idle_enabled = limit_warmup_staggered_idle_enabled

--- a/app/modules/sticky_sessions/api.py
+++ b/app/modules/sticky_sessions/api.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, Query
 
+from app.core.auth.dashboard_access import Permission
 from app.core.auth.dependencies import (
+    require_dashboard_permission,
     require_dashboard_write_access,
     set_dashboard_error_format,
     validate_dashboard_session,
@@ -31,7 +33,11 @@ router = APIRouter(
 )
 
 
-@router.get("", response_model=StickySessionsListResponse)
+@router.get(
+    "",
+    response_model=StickySessionsListResponse,
+    dependencies=[Depends(require_dashboard_permission(Permission.OPS_WRITE))],
+)
 async def list_sticky_sessions(
     kind: StickySessionKind | None = Query(default=None),
     stale_only: bool = Query(default=False, alias="staleOnly"),

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,7 +24,7 @@ Ready-to-run Docker commands for both non-default modes are in [Docker deploymen
 
 ## Roles and permissions
 
-The dashboard has two built-in roles. **Admin** (the password, trusted-header, disabled-auth, or local-bootstrap principal) holds every permission. **Guest** (the optional read-only role) holds only `dashboard:read` and `accounts:read`: it can read dashboard overview and usage data and account status, but cannot read conversations, conversation archives, or the audit log, cannot export account credentials, and cannot change state.
+The dashboard has two built-in roles. **Admin** (the password, trusted-header, disabled-auth, or local-bootstrap principal) holds every permission. **Guest** (the optional read-only role) holds only `dashboard:read` and `accounts:read`: it can read dashboard overview and usage data, reports, redacted request logs, and account status. It cannot read conversations, conversation archives, the audit log, the API-key inventory, egress-proxy or sticky-session configuration, cannot export account credentials, and cannot change state. Account e-mails are masked for guests (`a***@example.com`) and upstream account identifiers are hidden. Changing or removing the guest password, turning guest access off, or calling `POST /api/dashboard-auth/guest/logout-all` logs every guest out immediately.
 
 Internally, authorization is expressed as fine-grained permissions such as `accounts:export`, `security:write`, `conversations:read`, and `audit:read`, each granted with an `all` or `own` scope. The session API still reports only the coarse `read` / `write` values. When a request lacks a specific permission the API answers `403` with error code `permission_required` and names the missing permission in `param`:
 

--- a/openspec/changes/restrict-guest-sensitive-surfaces/design.md
+++ b/openspec/changes/restrict-guest-sensitive-surfaces/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`expand-dashboard-permission-vocabulary` gave every sensitive route a named permission but deliberately left the guest read surface untouched. The guest grant table (`dashboard:read`, `accounts:read`) still lets a guest read the API-key inventory, egress-proxy topology, sticky bindings with account e-mails, and unmasked account identity. Guest sessions are Fernet cookies with a no-op `delete()`; the only way to end them today is to wait for expiry.
+
+## Goals / Non-Goals
+
+**Goals**
+- A guest sees aggregate health, usage, request logs (already redacted), reports, and account *status* — not who the accounts belong to upstream, not the key fleet, not network topology.
+- Operators can log every guest out, and every guest-credential or guest-access change does so automatically.
+- Zero configuration; built-in admin unchanged; frontend contract unchanged apart from masked/null identity fields that the client already tolerates.
+
+**Non-Goals**
+- Frontend changes (separate change `guest-ui-hides-restricted-surfaces`).
+- Admin session revocation (Phase 1, per-user `session_generation`).
+- Redacting operator-chosen `alias` (it is a label the operator wrote for exactly this audience).
+
+## Decisions
+
+### Gate by the permission the data belongs to, not by role
+
+`GET /api/api-keys*` is an `api_keys:read` surface; egress-proxy topology, connect address, and sticky bindings are operational configuration (`ops:write`); OAuth flow state belongs to account onboarding (`accounts:write`). Re-using the vocabulary means a future `operator`/`viewer` preset inherits the right answer without touching routes again. Guest lacks all three. The 403 shape is the existing `permission_required` + `param`.
+
+Alternative rejected: returning redacted/empty inventories to guests. An empty key list is a false statement about the system; a 403 is honest, and the client can hide the surface.
+
+### Redact identity in the single account mapper
+
+`build_account_summaries` already threads `include_auth`; `redact_identity` is a second flag on the same path, so both `GET /api/accounts` and the overview embed the same projection. `email` is masked rather than dropped because the client schema requires a string; masked values may collide (`alice@` and `adam@` both become `a***@example.com`), which is acceptable because the client keys rows by `accountId` and operators disambiguate with `alias`. `displayName` falls back to alias or the masked e-mail. Identity fields that are nullable in both schemas (`chatgptAccountId`, `workspaceId`, `workspaceLabel`) become null. `isEmailDuplicate` stays boolean-only.
+
+The gate signal is `accounts:write`, not `accounts:read`: reading account *status* is exactly what a viewer needs, but knowing *which* upstream seat it is only matters to whoever can act on it.
+
+### Close the request-log e-mail oracle and the options inventory
+
+Guest request-log rows were already redacted, but `search=` still matched `Account.email`, so a guest could confirm an e-mail by probing. The same applies to the key inventory: rows carried `apiKeyId`/`apiKeyName` and search matched `ApiKey.name`, so both are withheld without `api_keys:read` (`include_api_key_identity`). The filter builder gains `include_account_identity` (mirroring `include_sensitive_metadata`), keyed into the count cache so an admin's cached count cannot answer a guest. `GET /api/request-logs/options` keeps working for guests but returns `apiKeys: []` without `api_keys:read`; the schema requires the key to be present, so an empty array is the compatible shape.
+
+### Generation counter instead of a session table
+
+A `dashboard_settings.guest_session_generation` integer is the smallest thing that makes stateless guest cookies revocable: the cookie carries `gg`, validation compares it with the settings row (already cached and cross-replica invalidated via the `settings` namespace), and any trigger that changes what a guest is bumps the counter inside the same optimistic-locked UPDATE. Guest-password set/clear bump in the auth repository closures (which already retry once on version conflict, so `+= 1` stays a single net increment); the guest-access on→off transition bumps inside `SettingsRepository.update`; `POST /guest/logout-all` bumps explicitly. Re-saving `guestAccessEnabled=true` or unrelated settings does not bump.
+
+Legacy guest cookies have no `gg`; the store surfaces them with `None`, which never equals the stored integer, so they die at upgrade. Admin cookies never carry `gg` (creating a guest session without a generation is a programming error and raises). A per-user `session_generation` follows the same shape in Phase 1.
+
+### Migration shape
+
+`20260908_000000_add_guest_session_generation` adds the column with `server_default=text("0")`, `nullable=False`, inside `batch_alter_table` (SQLite rebuild / PG plain ALTER), guarded by an inspector check for idempotency; downgrade drops it under the same guard. The model uses the identical `server_default` so `check_schema_drift` stays clean. No backfill is needed: the seeded settings row gets 0.
+
+## Risks / Trade-offs
+
+- [Risk] Guest UI shows error cards until the client change lands. → Stacked PR `guest-ui-hides-restricted-surfaces` follows immediately; behaviour is a visible but harmless "failed to load" state, not a crash.
+- [Risk] A future viewer role that *should* see key names for filters. → `GET /api/request-logs/options` is the single place; grant `api_keys:read` or add a names-only projection then.
+- [Risk] A rolling upgrade where an old replica issues a guest cookie without `gg`. → The new replica rejects it; the guest re-logs in once. Acceptable for a read-only role.
+- [Trade-off] `alias` remains visible to guests. Intentional: it is operator-authored labelling for exactly this audience.

--- a/openspec/changes/restrict-guest-sensitive-surfaces/proposal.md
+++ b/openspec/changes/restrict-guest-sensitive-surfaces/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The built-in `guest` role exists so a team can share a monitoring-only view of the load balancer. Today that view still exposes surfaces a viewer has no business reading: the full API-key inventory (policies, assignments, limits, live usage), the upstream egress-proxy topology and proxy usernames, sticky-session bindings that carry account e-mails, OAuth flow state, the server's connect address, and — on every account list and the dashboard overview — upstream account e-mails and ChatGPT account identifiers. Separately, guest sessions are stateless cookies that cannot be revoked: changing or removing the guest password, or turning guest access off, leaves every already-issued guest cookie valid until it expires.
+
+## What Changes
+
+- Gate inventory and topology reads by the permission they belong to, so guests (who hold only `dashboard:read` and `accounts:read`) receive `403 permission_required`: `GET /api/api-keys*` → `api_keys:read`; `GET /api/settings/upstream-proxy`, `GET /api/settings/runtime/connect-address`, `GET /api/sticky-sessions` → `ops:write`; `GET /api/oauth/status` → `accounts:write`.
+- Redact upstream account identity for principals without `accounts:write`: `email` is masked (`a***@example.com`), `chatgptAccountId`, `workspaceId`, and `workspaceLabel` are null, in `GET /api/accounts` and the account list embedded in `GET /api/dashboard/overview`. Request-log free-text search no longer matches account e-mails for such principals; without `api_keys:read`, `GET /api/request-logs/options` returns an empty `apiKeys` list, request-log rows carry null `apiKeyId`/`apiKeyName`, and search does not match key ids or names.
+- Add `dashboard_settings.guest_session_generation` (integer, default 0, one Alembic revision). Guest session cookies carry the generation they were issued under and validate only while it matches. The counter is bumped when the guest password is set or removed, when guest access is switched off, and by a new `POST /api/dashboard-auth/guest/logout-all` (`security:write`, audited as `guest_sessions_revoked`). Guest cookies issued before this change carry no generation and stop validating on upgrade (guests simply re-enter).
+- Extend the route authorization matrix test with the newly gated routes.
+
+Built-in `admin` behaviour is unchanged. No new setting, env var, README section, or nav item. The dashboard client is adapted in the follow-up change `guest-ui-hides-restricted-surfaces`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-auth`: Guest-restricted read surfaces, account identity redaction, and generation-bound guest sessions.
+
+## Impact
+
+- Routes: `api_keys`, `settings`, `sticky_sessions`, `oauth`, `accounts`, `dashboard`, `request_logs`, `dashboard_auth` API modules.
+- Mapping: `build_account_summaries(redact_identity=...)`; request-log repository search filter and count cache key gain an `include_account_identity` flag.
+- Schema: one new NOT NULL integer column on `dashboard_settings` (`20260908_000000_add_guest_session_generation`), idempotent upgrade/downgrade.
+- Session store payload gains `gg` for guest cookies; `DashboardSessionState.guest_session_generation`.
+- Tests: guest revocation flows, redaction, search oracle, options inventory, gated reads, migration up/down, matrix expectations.
+- Until `guest-ui-hides-restricted-surfaces` lands, a guest opening the APIs page sees the standard "failed to load" card with a retry button, and the Settings page shows an inline error for the upstream-proxy query; no crash, no data.

--- a/openspec/changes/restrict-guest-sensitive-surfaces/specs/admin-auth/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-surfaces/specs/admin-auth/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Inventory and topology reads are not guest-safe
+
+The following dashboard reads MUST require the named permission at `all` scope; principals without it (including the built-in `guest`) MUST receive HTTP 403 with error code `permission_required` and `param` naming the permission:
+
+- `GET /api/api-keys`, `GET /api/api-keys/`, `GET /api/api-keys/{id}/trends`, `GET /api/api-keys/{id}/usage-7d` → `api_keys:read`
+- `GET /api/settings/upstream-proxy`, `GET /api/settings/runtime/connect-address`, `GET /api/sticky-sessions` → `ops:write`
+- `GET /api/oauth/status` → `accounts:write`
+
+`GET /api/request-logs/options` MUST remain readable by every dashboard principal but MUST return an empty `apiKeys` list to principals without `api_keys:read`, with every other facet unchanged. `GET /api/request-logs` MUST return `apiKeyId` and `apiKeyName` as null, and free-text search MUST NOT match API-key ids or names, for principals without `api_keys:read`. These routes are part of the route list verified by the route authorization matrix (see "Dashboard route authorization is machine-verified").
+
+#### Scenario: Guest cannot list API keys
+
+- **WHEN** a guest principal requests `GET /api/api-keys/`
+- **THEN** the response is HTTP 403 with error code `permission_required` and `param` `api_keys:read`
+- **AND** no key names, prefixes, policies, assignments, limits, or usage are returned
+
+#### Scenario: Guest cannot read egress topology or sticky bindings
+
+- **WHEN** a guest principal requests `GET /api/settings/upstream-proxy`, `GET /api/settings/runtime/connect-address`, or `GET /api/sticky-sessions`
+- **THEN** the response is HTTP 403 with error code `permission_required` and `param` `ops:write`
+
+#### Scenario: Guest request-log filter options omit the key inventory
+
+- **WHEN** a guest principal requests `GET /api/request-logs/options`
+- **THEN** the response succeeds with `apiKeys` equal to `[]`
+- **AND** account, model, and status options are unchanged
+
+#### Scenario: Guest request-log rows omit the key identity
+
+- **WHEN** a guest principal requests `GET /api/request-logs` for logs made with a named API key
+- **THEN** every row has null `apiKeyId` and `apiKeyName`
+- **AND** `GET /api/request-logs?search=<key name or key id>` returns no rows for the guest while the same search returns them for an admin
+
+### Requirement: Account identity is redacted without account write access
+
+For principals that do not hold `accounts:write`, every account summary returned by `GET /api/accounts` and embedded in `GET /api/dashboard/overview` MUST mask `email` to its first local-part character followed by `***` and the domain (`a***@example.com`), MUST return `chatgptAccountId`, `workspaceId`, and `workspaceLabel` as null, and MUST derive `displayName` from the alias or the masked e-mail. Account status, plan, alias, quota, and reset fields MUST be unchanged. Request-log free-text search MUST NOT match account e-mail addresses for such principals. Principals holding `accounts:write` MUST receive the unredacted summary.
+
+#### Scenario: Guest sees masked account identity
+
+- **WHEN** a guest principal requests `GET /api/accounts` for an account with e-mail `alice.smith@example.com` and a ChatGPT account id
+- **THEN** the returned summary has `email` `a***@example.com`, `displayName` `a***@example.com`, and null `chatgptAccountId`, `workspaceId`, `workspaceLabel`
+- **AND** the raw e-mail and ChatGPT account id appear nowhere in the response
+
+#### Scenario: Guest search cannot probe account e-mails
+
+- **WHEN** a guest principal requests `GET /api/request-logs?search=alice.smith` and a request log belongs to an account with that e-mail
+- **THEN** the search returns no rows for that term
+- **AND** the same request log is still found by its request id
+
+#### Scenario: Account writer sees full identity
+
+- **WHEN** a principal holding `accounts:write` requests `GET /api/accounts`
+- **THEN** `email`, `chatgptAccountId`, `workspaceId`, and `workspaceLabel` are returned unredacted
+
+### Requirement: Guest sessions are bound to a revocable generation
+
+The system SHALL persist an integer `guest_session_generation` on the dashboard settings row (default 0). Every guest session cookie MUST carry the generation current at issuance, and a guest cookie MUST authorize only while its generation equals the stored value; a guest cookie without a generation MUST NOT authorize. Admin sessions MUST NOT carry a generation. The system MUST increment the generation when the guest password is set, when the guest password is removed, when guest access transitions from enabled to disabled, and when `POST /api/dashboard-auth/guest/logout-all` is called. That endpoint MUST require `security:write`, MUST leave guest access and guest password settings unchanged, and MUST record the audit action `guest_sessions_revoked`. Saving unrelated settings, or re-saving guest access as enabled, MUST NOT change the generation. Every generation bump, including `POST /api/dashboard-auth/guest/logout-all`, MUST durably bump the `settings` cache-invalidation namespace before the response is returned, so peer replicas stop honoring the old generation within the invalidation-bus poll bound (the per-process settings cache TTL is the fallback bound). Guest login MUST stamp the generation from the same database row the credential check used, not from a possibly stale process cache.
+
+#### Scenario: Rotating the guest password logs guests out
+
+- **WHEN** a guest holds a valid password-authenticated guest session and an administrator sets a new guest password
+- **THEN** the guest's next dashboard request returns HTTP 401 `authentication_required`
+- **AND** logging in with the new password issues a working session
+
+#### Scenario: Disabling guest access invalidates sessions even after re-enabling
+
+- **WHEN** a guest session exists and guest access is switched off and then on again
+- **THEN** the pre-existing guest session no longer authorizes
+
+#### Scenario: Administrators can log every guest out
+
+- **WHEN** a principal with `security:write` calls `POST /api/dashboard-auth/guest/logout-all`
+- **THEN** every existing guest session stops authorizing
+- **AND** guest access and guest password settings are unchanged
+- **AND** a `guest_sessions_revoked` audit entry is written
+
+#### Scenario: Guests cannot revoke guests
+
+- **WHEN** a guest principal calls `POST /api/dashboard-auth/guest/logout-all`
+- **THEN** the response is HTTP 403 with error code `permission_required` and `param` `security:write`
+
+#### Scenario: Unrelated settings saves keep guest sessions
+
+- **WHEN** an administrator saves a non-guest setting or re-saves guest access as enabled
+- **THEN** existing guest sessions continue to authorize
+
+### Requirement: Guest session generation migration
+
+The Alembic revision `20260908_000000_add_guest_session_generation` MUST add `dashboard_settings.guest_session_generation` as a NOT NULL integer with server default 0, MUST be idempotent on re-run, and MUST drop the column on downgrade. Existing settings rows MUST read as generation 0 after upgrade.
+
+#### Scenario: Upgrade seeds zero and downgrade removes the column
+
+- **GIVEN** a database at the parent revision with a seeded settings row
+- **WHEN** the revision is applied
+- **THEN** the column exists and the row's value is 0
+- **AND** downgrading to the parent removes the column
+- **AND** upgrading to head passes through the revision on a single-head graph

--- a/openspec/changes/restrict-guest-sensitive-surfaces/tasks.md
+++ b/openspec/changes/restrict-guest-sensitive-surfaces/tasks.md
@@ -1,0 +1,24 @@
+## 1. Guest-restricted reads
+
+- [x] 1.1 Gate `GET /api/api-keys*` (list, trends, usage-7d) with `api_keys:read` at router level.
+- [x] 1.2 Gate `GET /api/settings/upstream-proxy`, `GET /api/settings/runtime/connect-address`, `GET /api/sticky-sessions` with `ops:write`; gate `GET /api/oauth/status` with `accounts:write`.
+- [x] 1.3 Redact account identity (`email` masked; `chatgptAccountId`, `workspaceId`, `workspaceLabel` null) for principals without `accounts:write` in `GET /api/accounts` and `GET /api/dashboard/overview` via `build_account_summaries(redact_identity=...)`.
+- [x] 1.4 Exclude `Account.email` from request-log free-text search for principals without `accounts:write` (flag threaded through service/repository and the count cache key); without `api_keys:read`, return `apiKeys: []` from `GET /api/request-logs/options`, null `apiKeyId`/`apiKeyName` on request-log rows, and exclude key ids/names from search.
+
+## 2. Generation-bound guest sessions
+
+- [x] 2.1 Add `dashboard_settings.guest_session_generation` (model + Alembic revision `20260908_000000_add_guest_session_generation`, idempotent up/down).
+- [x] 2.2 Carry `gg` in guest session cookies; validate equality in `validate_dashboard_session`, `DashboardAuthService.get_session_state`, and the `/session` guest branch; reject non-integer values; legacy guest cookies without `gg` never match.
+- [x] 2.3 Bump on guest password set/clear (auth repository), on guest access on→off (settings repository), and via `POST /api/dashboard-auth/guest/logout-all` (`security:write`, audit `guest_sessions_revoked`).
+
+## 3. Verification
+
+- [x] 3.1 Unit: session store round-trips `gg`, requires it for guest sessions, rejects non-integer values, leaves admin sessions without it.
+- [x] 3.2 Integration: guest sessions die after password rotation, password removal, guest access off→on, and logout-all; unrelated settings saves keep them; logout-all requires `security:write`.
+- [x] 3.3 Integration: guest sees masked identity, admin sees full identity; guest search cannot match e-mails; guest options omit API keys; guest gets `permission_required` on the gated reads while aggregate reads still work.
+- [x] 3.4 Migration up/down test and PostgreSQL drift contract; route matrix expectations extended.
+- [x] 3.5 `ruff`, `ty`, focused pytest suites, `openspec validate --strict`.
+
+## 4. Documentation
+
+- [x] 4.1 Update `docs/authentication.md` "Roles and permissions" (what a guest can read, masked identity, guest logout-all).

--- a/tests/integration/test_dashboard_permission_gates.py
+++ b/tests/integration/test_dashboard_permission_gates.py
@@ -50,13 +50,17 @@ def _principal_with_only(**grants: Scope) -> DashboardPrincipal:
     )
 
 
+# Captured at import time: once monkeypatched, the module attribute is a mock and
+# can no longer serve as the FastAPI override key.
+_ORIGINAL_VALIDATE_DASHBOARD_SESSION = auth_dependencies.validate_dashboard_session
+
+
 def _use_principal(app_instance: FastAPI, monkeypatch: pytest.MonkeyPatch, principal: DashboardPrincipal) -> None:
     # Router-level and permission dependencies resolve the module attribute at
     # call time; handler parameters captured ``Depends(validate_dashboard_session)``
     # at import time and need the FastAPI override as well.
-    original = auth_dependencies.validate_dashboard_session
     monkeypatch.setattr(auth_dependencies, "validate_dashboard_session", AsyncMock(return_value=principal))
-    monkeypatch.setitem(app_instance.dependency_overrides, original, lambda: principal)
+    monkeypatch.setitem(app_instance.dependency_overrides, _ORIGINAL_VALIDATE_DASHBOARD_SESSION, lambda: principal)
 
 
 def _assert_permission_required(response, permission: Permission) -> None:
@@ -220,3 +224,222 @@ async def test_admin_preset_is_unaffected(
     assert (await async_client.get("/api/dashboard/overview")).status_code == 200
     assert (await async_client.put("/api/settings", json={"stickyThreadsEnabled": True})).status_code == 200
     assert (await async_client.post("/api/accounts/missing/export/auth")).status_code == 404
+
+
+# --- PR-0a-2: guest-restricted surfaces ---------------------------------------
+
+
+async def _seed_account(email: str = "alice.smith@example.com") -> str:
+    from datetime import UTC, datetime
+
+    from app.db.models import Account, AccountStatus
+    from app.db.session import SessionLocal
+
+    account = Account(
+        id="acc-1",
+        chatgpt_account_id="chatgpt-account-123",
+        email=email,
+        alias=None,
+        workspace_id="ws-123",
+        workspace_label="Acme Workspace",
+        plan_type="plus",
+        status=AccountStatus.ACTIVE,
+        access_token_encrypted=b"",
+        refresh_token_encrypted=b"",
+        id_token_encrypted=b"",
+        last_refresh=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+    async with SessionLocal() as session:
+        session.add(account)
+        await session.commit()
+    return account.id
+
+
+@pytest.mark.asyncio
+async def test_guest_reads_masked_account_identity(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _seed_account()
+    _use_principal(app_instance, monkeypatch, guest_principal())
+
+    listing = await async_client.get("/api/accounts")
+    assert listing.status_code == 200, listing.text
+    [account] = listing.json()["accounts"]
+    assert account["email"] == "a***@example.com"
+    assert account["displayName"] == "a***@example.com"
+    assert account["chatgptAccountId"] is None
+    assert account["workspaceId"] is None
+    assert account["workspaceLabel"] is None
+    assert account["planType"] == "plus"
+    assert "alice" not in listing.text
+    assert "chatgpt-account-123" not in listing.text
+
+    overview = await async_client.get("/api/dashboard/overview")
+    assert overview.status_code == 200, overview.text
+    assert "alice" not in overview.text
+    assert "chatgpt-account-123" not in overview.text
+
+
+@pytest.mark.asyncio
+async def test_account_writer_reads_full_account_identity(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _seed_account()
+    _use_principal(app_instance, monkeypatch, admin_principal(auth_mode=DashboardAuthMode.STANDARD))
+
+    listing = await async_client.get("/api/accounts")
+    assert listing.status_code == 200
+    [account] = listing.json()["accounts"]
+    assert account["email"] == "alice.smith@example.com"
+    assert account["chatgptAccountId"] == "chatgpt-account-123"
+    assert account["workspaceLabel"] == "Acme Workspace"
+
+
+@pytest.mark.asyncio
+async def test_guest_request_log_search_does_not_match_account_email(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime
+
+    from app.db.models import RequestLog
+    from app.db.session import SessionLocal
+
+    account_id = await _seed_account()
+    async with SessionLocal() as session:
+        session.add(
+            RequestLog(
+                account_id=account_id,
+                request_id="req-email-oracle",
+                model="gpt-5",
+                status="success",
+                requested_at=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+
+    _use_principal(app_instance, monkeypatch, admin_principal(auth_mode=DashboardAuthMode.STANDARD))
+    admin_hits = await async_client.get("/api/request-logs", params={"search": "alice.smith"})
+    assert admin_hits.status_code == 200
+    assert admin_hits.json()["total"] == 1
+
+    _use_principal(app_instance, monkeypatch, guest_principal())
+    guest_hits = await async_client.get("/api/request-logs", params={"search": "alice.smith"})
+    assert guest_hits.status_code == 200
+    assert guest_hits.json()["total"] == 0
+    guest_by_request_id = await async_client.get("/api/request-logs", params={"search": "req-email-oracle"})
+    assert guest_by_request_id.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_guest_request_log_options_omit_api_key_inventory(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime
+
+    from app.db.models import RequestLog
+    from app.db.session import SessionLocal
+
+    _use_principal(app_instance, monkeypatch, admin_principal(auth_mode=DashboardAuthMode.STANDARD))
+    created = await async_client.post("/api/api-keys/", json={"name": "inventory-key"})
+    assert created.status_code in (200, 201), created.text
+    key_id = created.json()["id"]
+    # Filter options are derived from logged requests, so log one for the key.
+    async with SessionLocal() as session:
+        session.add(
+            RequestLog(
+                api_key_id=key_id,
+                request_id="req-inventory",
+                model="gpt-5",
+                status="success",
+                requested_at=datetime.now(UTC).replace(tzinfo=None),
+            )
+        )
+        await session.commit()
+    admin_options = await async_client.get("/api/request-logs/options")
+    assert admin_options.status_code == 200
+    assert [key["name"] for key in admin_options.json()["apiKeys"]] == ["inventory-key"]
+
+    _use_principal(app_instance, monkeypatch, guest_principal())
+    guest_options = await async_client.get("/api/request-logs/options")
+    assert guest_options.status_code == 200
+    guest_payload = guest_options.json()
+    assert guest_payload["apiKeys"] == []
+    assert "inventory-key" not in guest_options.text
+    admin_payload = admin_options.json()
+    for facet in ("accountIds", "modelOptions", "statuses"):
+        assert guest_payload[facet] == admin_payload[facet]
+
+    # Request-log rows are readable by guests but must not carry the key identity,
+    # and search must not match key ids or names.
+    guest_logs = await async_client.get("/api/request-logs")
+    assert guest_logs.status_code == 200
+    [entry] = guest_logs.json()["requests"]
+    assert entry["apiKeyId"] is None
+    assert entry["apiKeyName"] is None
+    assert "inventory-key" not in guest_logs.text
+    assert (await async_client.get("/api/request-logs", params={"search": "inventory-key"})).json()["total"] == 0
+    assert (await async_client.get("/api/request-logs", params={"search": key_id})).json()["total"] == 0
+
+    _use_principal(app_instance, monkeypatch, admin_principal(auth_mode=DashboardAuthMode.STANDARD))
+    admin_logs = await async_client.get("/api/request-logs")
+    [entry] = admin_logs.json()["requests"]
+    assert entry["apiKeyId"] == key_id
+    assert entry["apiKeyName"] == "inventory-key"
+    assert (await async_client.get("/api/request-logs", params={"search": "inventory-key"})).json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_request_log_count_cache_is_keyed_by_identity_visibility(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A warm admin count for an e-mail search must not be served to a guest."""
+
+    from datetime import UTC, datetime
+
+    from app.db.models import RequestLog
+    from app.db.session import SessionLocal
+    from app.modules.request_logs import repository as logs_repository_module
+
+    account_id = await _seed_account()
+    async with SessionLocal() as session:
+        session.add(
+            RequestLog(
+                account_id=account_id,
+                request_id="req-cache-oracle",
+                model="gpt-5",
+                status="success",
+                requested_at=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+    monkeypatch.setattr(logs_repository_module, "_COUNT_CACHE_TTL_SECONDS", 30.0)
+    logs_repository_module._clear_recent_count_cache()
+
+    _use_principal(app_instance, monkeypatch, admin_principal(auth_mode=DashboardAuthMode.STANDARD))
+    assert (await async_client.get("/api/request-logs", params={"search": "alice.smith"})).json()["total"] == 1
+
+    _use_principal(app_instance, monkeypatch, guest_principal())
+    assert (await async_client.get("/api/request-logs", params={"search": "alice.smith"})).json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_guest_cannot_read_inventory_and_topology_surfaces(
+    app_instance: FastAPI, async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _use_principal(app_instance, monkeypatch, guest_principal())
+
+    for path, permission in (
+        ("/api/api-keys/", Permission.API_KEYS_READ),
+        ("/api/api-keys/some-key/trends", Permission.API_KEYS_READ),
+        ("/api/api-keys/some-key/usage-7d", Permission.API_KEYS_READ),
+        ("/api/settings/upstream-proxy", Permission.OPS_WRITE),
+        ("/api/settings/runtime/connect-address", Permission.OPS_WRITE),
+        ("/api/sticky-sessions", Permission.OPS_WRITE),
+        ("/api/oauth/status", Permission.ACCOUNTS_WRITE),
+    ):
+        _assert_permission_required(await async_client.get(path), permission)
+
+    # Guest-safe aggregate reads keep working.
+    for path in ("/api/usage/summary", "/api/reports", "/api/request-logs", "/api/models"):
+        response = await async_client.get(path)
+        assert response.status_code == 200, (path, response.text)

--- a/tests/integration/test_dashboard_route_permission_matrix.py
+++ b/tests/integration/test_dashboard_route_permission_matrix.py
@@ -44,6 +44,7 @@ SESSION_EXEMPT_PREFIXES: tuple[str, ...] = (
 DASHBOARD_AUTH_GATED: dict[tuple[str, str], PermissionRequirement] = {
     ("POST", "/api/dashboard-auth/guest/password"): PermissionRequirement(Permission.SECURITY_WRITE),
     ("DELETE", "/api/dashboard-auth/guest/password"): PermissionRequirement(Permission.SECURITY_WRITE),
+    ("POST", "/api/dashboard-auth/guest/logout-all"): PermissionRequirement(Permission.SECURITY_WRITE),
 }
 
 #: Routes whose permission requirement is part of the security contract.
@@ -63,6 +64,15 @@ EXPECTED_REQUIREMENTS: dict[tuple[str, str], PermissionRequirement] = {
     ("POST", "/api/firewall/ips"): PermissionRequirement(Permission.SECURITY_WRITE),
     ("DELETE", "/api/firewall/ips/{ip_address}"): PermissionRequirement(Permission.SECURITY_WRITE),
     ("POST", "/api/settings/upstream-proxy/endpoints"): PermissionRequirement(Permission.SECURITY_WRITE),
+    # Guest-restricted reads (PR-0a-2): inventories and topology are not guest-safe.
+    ("GET", "/api/api-keys"): PermissionRequirement(Permission.API_KEYS_READ),
+    ("GET", "/api/api-keys/"): PermissionRequirement(Permission.API_KEYS_READ),
+    ("GET", "/api/api-keys/{key_id}/trends"): PermissionRequirement(Permission.API_KEYS_READ),
+    ("GET", "/api/api-keys/{key_id}/usage-7d"): PermissionRequirement(Permission.API_KEYS_READ),
+    ("GET", "/api/settings/upstream-proxy"): PermissionRequirement(Permission.OPS_WRITE),
+    ("GET", "/api/settings/runtime/connect-address"): PermissionRequirement(Permission.OPS_WRITE),
+    ("GET", "/api/sticky-sessions"): PermissionRequirement(Permission.OPS_WRITE),
+    ("GET", "/api/oauth/status"): PermissionRequirement(Permission.ACCOUNTS_WRITE),
     **DASHBOARD_AUTH_GATED,
 }
 

--- a/tests/integration/test_guest_session_generation.py
+++ b/tests/integration/test_guest_session_generation.py
@@ -1,0 +1,305 @@
+"""Guest session cookies are bound to ``dashboard_settings.guest_session_generation``.
+
+Guest sessions are stateless Fernet cookies, so the generation counter is the
+only server-side handle to log every guest out. Each trigger that changes what
+a guest is (credential change, guest access disabled, explicit revocation) must
+bump it, and a cookie minted under an older generation must stop validating.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+import app.modules.dashboard_auth.api as dashboard_auth_api_module
+from app.core.crypto import TokenEncryptor
+from app.db.models import DashboardSettings
+from app.db.session import SessionLocal
+from app.modules.dashboard_auth.service import DASHBOARD_SESSION_COOKIE, get_dashboard_session_store
+
+pytestmark = pytest.mark.integration
+
+GUEST_PASSWORD = "guest-password-123"
+ADMIN_PASSWORD = "admin-password-123"
+
+
+async def _stored_generation() -> int:
+    async with SessionLocal() as session:
+        row = (await session.execute(select(DashboardSettings))).scalar_one()
+        return row.guest_session_generation
+
+
+def _cookie_generation(client: AsyncClient) -> int | None:
+    state = get_dashboard_session_store().get(client.cookies.get(DASHBOARD_SESSION_COOKIE))
+    assert state is not None
+    return state.guest_session_generation
+
+
+async def _put_settings(client: AsyncClient, **changes: object) -> dict[str, object]:
+    current = (await client.get("/api/settings")).json()
+    current.update(changes)
+    response = await client.put("/api/settings", json=current)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def _remote_guest(app: FastAPI, host: str) -> AsyncClient:
+    transport = ASGITransport(app=app, client=(host, 50001))
+    return AsyncClient(transport=transport, base_url="http://lb.example")
+
+
+def _local(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app, client=("127.0.0.1", 50000)), base_url="http://localhost")
+
+
+async def _assert_guest_reads_ok(client: AsyncClient) -> None:
+    response = await client.get("/api/usage/summary")
+    assert response.status_code == 200, response.text
+
+
+async def _assert_guest_session_dead(client: AsyncClient) -> None:
+    response = await client.get("/api/usage/summary")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "authentication_required"
+    session = await client.get("/api/dashboard-auth/session")
+    assert session.json()["authenticated"] is False
+
+
+@pytest.mark.asyncio
+async def test_guest_password_change_revokes_existing_guest_sessions(app_instance: FastAPI) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            set_password = await local_client.post(
+                "/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD}
+            )
+            assert set_password.status_code == 200
+
+        async with await _remote_guest(app_instance, "203.0.113.31") as guest:
+            login = await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            assert login.status_code == 200
+            await _assert_guest_reads_ok(guest)
+
+            async with _local(app_instance) as local_client:
+                rotated = await local_client.post(
+                    "/api/dashboard-auth/guest/password", json={"password": "new-password-456"}
+                )
+                assert rotated.status_code == 200
+
+            await _assert_guest_session_dead(guest)
+
+            relogin = await guest.post("/api/dashboard-auth/guest/login", json={"password": "new-password-456"})
+            assert relogin.status_code == 200
+            await _assert_guest_reads_ok(guest)
+
+
+@pytest.mark.asyncio
+async def test_removing_guest_password_revokes_password_guest_sessions(app_instance: FastAPI) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        async with await _remote_guest(app_instance, "203.0.113.32") as guest:
+            assert (
+                await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+            await _assert_guest_reads_ok(guest)
+
+            before = await _stored_generation()
+            assert _cookie_generation(guest) == before
+
+            async with _local(app_instance) as local_client:
+                assert (await local_client.delete("/api/dashboard-auth/guest/password")).status_code == 200
+
+            # Clearing the credential is a bump: the cookie's generation no longer
+            # matches the stored one. Passwordless guest access is now open, so a
+            # fresh cookie-less principal still serves reads, but the stale cookie
+            # itself is never honoured.
+            after = await _stored_generation()
+            assert after == before + 1
+            assert _cookie_generation(guest) == before
+            stale = await guest.get("/api/dashboard-auth/session")
+            assert stale.status_code == 200
+            assert stale.json()["guestPasswordRequired"] is False
+
+
+@pytest.mark.asyncio
+async def test_disabling_guest_access_revokes_sessions_even_after_re_enable(app_instance: FastAPI) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        async with await _remote_guest(app_instance, "203.0.113.33") as guest:
+            assert (
+                await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+            await _assert_guest_reads_ok(guest)
+
+            async with _local(app_instance) as local_client:
+                await _put_settings(local_client, guestAccessEnabled=False)
+                await _put_settings(local_client, guestAccessEnabled=True)
+
+            await _assert_guest_session_dead(guest)
+
+
+@pytest.mark.asyncio
+async def test_logout_all_guests_requires_security_write_and_revokes(
+    app_instance: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        async with await _remote_guest(app_instance, "203.0.113.34") as guest:
+            assert (
+                await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+            await _assert_guest_reads_ok(guest)
+
+            # A guest cannot revoke guests.
+            denied = await guest.post("/api/dashboard-auth/guest/logout-all")
+            assert denied.status_code == 403
+            assert denied.json()["error"]["code"] == "permission_required"
+            assert denied.json()["error"]["param"] == "security:write"
+
+            audit_events: list[tuple[str, dict[str, object]]] = []
+            monkeypatch.setattr(
+                dashboard_auth_api_module.AuditService,
+                "log_async",
+                lambda event, **kwargs: audit_events.append((event, kwargs)),
+            )
+            assert audit_events == []  # the guest's 403 above wrote nothing
+
+            async with _local(app_instance) as local_client:
+                # A cookie-bearing admin must survive a guest generation bump.
+                assert (
+                    await local_client.post("/api/dashboard-auth/password/setup", json={"password": ADMIN_PASSWORD})
+                ).status_code == 200
+                assert (
+                    await local_client.post("/api/dashboard-auth/password/login", json={"password": ADMIN_PASSWORD})
+                ).status_code == 200
+                assert local_client.cookies.get(DASHBOARD_SESSION_COOKIE)
+
+                revoked = await local_client.post("/api/dashboard-auth/guest/logout-all")
+                assert revoked.status_code == 200
+                # Guest settings themselves are untouched.
+                settings = (await local_client.get("/api/settings")).json()
+                assert settings["guestAccessEnabled"] is True
+                assert settings["guestPasswordConfigured"] is True
+                assert (await local_client.get("/api/dashboard-auth/session")).json()["authenticated"] is True
+
+            revocations = [kwargs for event, kwargs in audit_events if event == "guest_sessions_revoked"]
+            assert len(revocations) == 1
+            assert revocations[0]["actor_ip"] == "127.0.0.1"
+
+            await _assert_guest_session_dead(guest)
+
+
+@pytest.mark.asyncio
+async def test_unrelated_settings_save_keeps_guest_sessions(app_instance: FastAPI) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        async with await _remote_guest(app_instance, "203.0.113.35") as guest:
+            assert (
+                await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+            async with _local(app_instance) as local_client:
+                current = (await local_client.get("/api/settings")).json()
+                await _put_settings(local_client, stickyThreadsEnabled=not current["stickyThreadsEnabled"])
+                # Re-saving guestAccessEnabled=True (no transition) is not a bump either.
+                await _put_settings(local_client, guestAccessEnabled=True)
+
+            await _assert_guest_reads_ok(guest)
+
+
+@pytest.mark.asyncio
+async def test_legacy_guest_cookie_without_generation_is_rejected_on_the_product_path(app_instance: FastAPI) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        legacy_payload = json.dumps(
+            {"exp": int(time.time()) + 3600, "pw": False, "tv": False, "role": "guest", "gv": True},
+            separators=(",", ":"),
+        )
+        legacy_cookie = TokenEncryptor().encrypt(legacy_payload).decode("ascii")
+
+        async with await _remote_guest(app_instance, "203.0.113.36") as guest:
+            guest.cookies.set(DASHBOARD_SESSION_COOKIE, legacy_cookie, domain="lb.example")
+            await _assert_guest_session_dead(guest)
+
+            # Logging in again issues a generation-bound cookie that works.
+            assert (
+                await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+            assert _cookie_generation(guest) == await _stored_generation()
+            await _assert_guest_reads_ok(guest)
+
+
+@pytest.mark.asyncio
+async def test_guest_login_stamps_generation_from_the_database_not_the_cache(
+    app_instance: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bump committed by a peer replica must not let this replica mint an already-stale cookie."""
+
+    from types import SimpleNamespace
+
+    async with app_instance.router.lifespan_context(app_instance):
+        async with _local(app_instance) as local_client:
+            await _put_settings(local_client, guestAccessEnabled=True)
+            assert (
+                await local_client.post("/api/dashboard-auth/guest/password", json={"password": GUEST_PASSWORD})
+            ).status_code == 200
+
+        # Freeze this replica's settings cache at the current generation, then
+        # simulate a peer replica's bump by writing the row directly.
+        async with SessionLocal() as session:
+            row = (await session.execute(select(DashboardSettings))).scalar_one()
+            stale_snapshot = SimpleNamespace(
+                guest_access_enabled=row.guest_access_enabled,
+                guest_password_hash=row.guest_password_hash,
+                guest_session_generation=row.guest_session_generation,
+                dashboard_session_ttl_seconds=row.dashboard_session_ttl_seconds,
+                password_hash=row.password_hash,
+                totp_required_on_login=row.totp_required_on_login,
+            )
+            stale_generation = row.guest_session_generation
+            row.guest_session_generation += 1
+            await session.commit()
+
+        class _StaleCache:
+            async def get(self) -> SimpleNamespace:
+                return stale_snapshot
+
+            async def invalidate(self, **_: object) -> None:
+                return None
+
+        monkeypatch.setattr(dashboard_auth_api_module, "get_settings_cache", lambda: _StaleCache())
+
+        async with await _remote_guest(app_instance, "203.0.113.37") as guest:
+            login = await guest.post("/api/dashboard-auth/guest/login", json={"password": GUEST_PASSWORD})
+            assert login.status_code == 200
+            assert _cookie_generation(guest) == stale_generation + 1

--- a/tests/integration/test_migration_merge_overflow_transport.py
+++ b/tests/integration/test_migration_merge_overflow_transport.py
@@ -182,14 +182,16 @@ def test_populated_parent_upgrade_and_direct_downgrades_preserve_both_branches(
     assert result.current_revision == head
     assert _revisions(database.engine) == (head,)
     merged = _state(database.engine)
-    # Revisions after the merge add nullable dashboard_settings columns (for
-    # example the resilience toggles); they must start NULL and are compared
-    # separately so this test keeps covering the two original branches.
+    # Revisions after the merge add dashboard_settings columns (the resilience
+    # toggles, the guest session counter, ...). Whether nullable or NOT NULL
+    # with a server default, each is backfilled uniformly, so it carries no
+    # per-row state: assert one value across rows and compare the rest
+    # separately, so this test keeps covering the two original branches.
     merged_settings = [dict(row) for row in merged["settings"]]
     added_columns = set(merged_settings[0]) - set(expected_settings[0])
-    for row in merged_settings:
-        for column in added_columns:
-            assert row.pop(column) is None
+    for column in added_columns:
+        backfilled = {row.pop(column) for row in merged_settings}
+        assert len(backfilled) == 1, (column, backfilled)
     assert merged_settings == expected_settings
     assert [row["upstream_stream_transport"] for row in merged["settings"]] == ["auto", "http", "websocket", "auto"]
     assert merged["pins"] == (before["pins"] if before["pins"] is not None else [])

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -3022,7 +3022,7 @@ async def test_guest_session_generation_migration_upgrade_and_downgrade(tmp_path
     from app.db.migrate import _build_alembic_config
 
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'guest-generation.sqlite'}"
-    parent_revision = "20260910_000000_request_logs_missing_cost_index"
+    parent_revision = "20260910_010000_dashboard_spool_retention"
     target_revision = "20260908_000000_add_guest_session_generation"
 
     async def _dashboard_columns(engine) -> set[str]:

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -3011,3 +3011,42 @@ async def test_missing_cost_index_upgrade_downgrade_and_query_plan(tmp_path):
         assert await to_thread.run_sync(lambda: check_schema_drift(db_url)) == ()
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_guest_session_generation_migration_upgrade_and_downgrade(tmp_path):
+    """Upgrade adds the NOT NULL guest_session_generation counter seeded at 0;
+    downgrade drops it; a final walk to head proves the single-head graph."""
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'guest-generation.sqlite'}"
+    parent_revision = "20260910_000000_request_logs_missing_cost_index"
+    target_revision = "20260908_000000_add_guest_session_generation"
+
+    async def _dashboard_columns(engine) -> set[str]:
+        async with engine.connect() as conn:
+            rows = await conn.execute(text("PRAGMA table_info('dashboard_settings')"))
+            return {row[1] for row in rows}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        assert "guest_session_generation" not in await _dashboard_columns(engine)
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, target_revision, bootstrap_legacy=False))
+        assert "guest_session_generation" in await _dashboard_columns(engine)
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text("SELECT guest_session_generation FROM dashboard_settings"))).all()
+            assert all(row == (0,) for row in rows)
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        assert "guest_session_generation" not in await _dashboard_columns(engine)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert "guest_session_generation" in await _dashboard_columns(engine)
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_dashboard_auth_api.py
+++ b/tests/unit/test_dashboard_auth_api.py
@@ -143,6 +143,7 @@ async def test_login_password_uses_configured_dashboard_session_ttl_for_cookie()
             totp_verified=False,
             role=DashboardRole.ADMIN,
             guest_verified=False,
+            guest_session_generation=None,
         ),
     )
     context = cast(
@@ -183,6 +184,7 @@ async def test_login_password_uses_configured_dashboard_session_ttl_for_cookie()
         ttl_seconds=7200,
         role=DashboardRole.ADMIN,
         guest_verified=False,
+        guest_session_generation=None,
     )
     limiter.check_and_increment.assert_awaited_once()
     limiter.clear_for_key.assert_awaited_once()
@@ -201,6 +203,7 @@ async def test_login_password_uses_one_year_ttl_for_direct_loopback_dashboard_re
             totp_verified=False,
             role=DashboardRole.ADMIN,
             guest_verified=False,
+            guest_session_generation=None,
         ),
     )
     context = cast(
@@ -252,6 +255,7 @@ async def test_login_password_uses_one_year_ttl_for_direct_loopback_dashboard_re
         ttl_seconds=DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
         role=DashboardRole.ADMIN,
         guest_verified=False,
+        guest_session_generation=None,
     )
     limiter.check_and_increment.assert_awaited_once()
     limiter.clear_for_key.assert_awaited_once()
@@ -270,6 +274,7 @@ async def test_login_password_caps_non_loopback_dashboard_session_ttl():
             totp_verified=False,
             role=DashboardRole.ADMIN,
             guest_verified=False,
+            guest_session_generation=None,
         ),
     )
     context = cast(
@@ -314,6 +319,7 @@ async def test_login_password_caps_non_loopback_dashboard_session_ttl():
         ttl_seconds=REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
         role=DashboardRole.ADMIN,
         guest_verified=False,
+        guest_session_generation=None,
     )
     limiter.check_and_increment.assert_awaited_once()
     limiter.clear_for_key.assert_awaited_once()
@@ -332,6 +338,7 @@ async def test_login_password_caps_later_duplicate_forwarded_identity_from_loopb
             totp_verified=False,
             role=DashboardRole.ADMIN,
             guest_verified=False,
+            guest_session_generation=None,
         ),
     )
     context = cast(
@@ -385,6 +392,7 @@ async def test_login_password_caps_later_duplicate_forwarded_identity_from_loopb
         ttl_seconds=REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
         role=DashboardRole.ADMIN,
         guest_verified=False,
+        guest_session_generation=None,
     )
     limiter.check_and_increment.assert_awaited_once()
     limiter.clear_for_key.assert_awaited_once()

--- a/tests/unit/test_dashboard_auth_password_service.py
+++ b/tests/unit/test_dashboard_auth_password_service.py
@@ -42,6 +42,7 @@ class _FakeSettings:
     password_hash: str | None = None
     guest_access_enabled: bool = False
     guest_password_hash: str | None = None
+    guest_session_generation: int = 0
     dashboard_auth_mode: DashboardAuthMode = DashboardAuthMode.STANDARD
     totp_required_on_login: bool = False
     totp_secret_encrypted: bytes | None = None
@@ -64,10 +65,16 @@ class _FakeRepository:
 
     async def set_guest_password_hash(self, password_hash: str) -> _FakeSettings:
         self.settings.guest_password_hash = password_hash
+        self.settings.guest_session_generation += 1
         return self.settings
 
     async def clear_guest_password_hash(self) -> _FakeSettings:
         self.settings.guest_password_hash = None
+        self.settings.guest_session_generation += 1
+        return self.settings
+
+    async def bump_guest_session_generation(self) -> _FakeSettings:
+        self.settings.guest_session_generation += 1
         return self.settings
 
     async def try_set_password_hash(self, password_hash: str) -> bool:

--- a/tests/unit/test_dashboard_session_store.py
+++ b/tests/unit/test_dashboard_session_store.py
@@ -35,6 +35,7 @@ def test_session_store_round_trip_with_guest_role(monkeypatch) -> None:
         totp_verified=False,
         ttl_seconds=12 * 60 * 60,
         role=DashboardRole.GUEST,
+        guest_session_generation=3,
     )
     state = store.get(session_id)
 
@@ -42,6 +43,48 @@ def test_session_store_round_trip_with_guest_role(monkeypatch) -> None:
     assert state.password_verified is False
     assert state.totp_verified is False
     assert state.role == DashboardRole.GUEST
+    assert state.guest_session_generation == 3
+
+
+def test_session_store_requires_generation_for_guest_sessions() -> None:
+    store = DashboardSessionStore()
+    with pytest.raises(ValueError, match="guest session generation"):
+        store.create(password_verified=False, totp_verified=False, ttl_seconds=60, role=DashboardRole.GUEST)
+
+
+def test_session_store_admin_sessions_carry_no_generation(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_auth_service_module, "time", lambda: 1_700_000_000)
+    store = DashboardSessionStore()
+    session_id = store.create(password_verified=True, totp_verified=True, ttl_seconds=60)
+    state = store.get(session_id)
+    assert state is not None
+    assert state.guest_session_generation is None
+
+
+def test_session_store_legacy_guest_cookie_without_generation_never_matches(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_auth_service_module, "time", lambda: 1_700_000_000)
+    store = DashboardSessionStore()
+    encryptor = TokenEncryptor()
+    legacy_payload = json.dumps(
+        {"exp": 1_700_000_100, "pw": False, "tv": False, "role": "guest", "gv": True},
+        separators=(",", ":"),
+    )
+    state = store.get(encryptor.encrypt(legacy_payload).decode("ascii"))
+    assert state is not None
+    assert state.role == DashboardRole.GUEST
+    assert state.guest_session_generation is None
+
+
+def test_session_store_rejects_non_integer_generation(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_auth_service_module, "time", lambda: 1_700_000_000)
+    store = DashboardSessionStore()
+    encryptor = TokenEncryptor()
+    for bad in ("1", True, 1.5):
+        payload = json.dumps(
+            {"exp": 1_700_000_100, "pw": False, "tv": False, "role": "guest", "gv": True, "gg": bad},
+            separators=(",", ":"),
+        )
+        assert store.get(encryptor.encrypt(payload).decode("ascii")) is None
 
 
 def test_session_store_rejects_legacy_cookie_without_password_flag(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Stacked on #2196 (`feat/dashboard-permission-vocabulary`). Second Phase-0 hardening PR of the dashboard RBAC plan: the read-only **guest** role stops seeing inventories, topology, and upstream account identity it has no business reading, and guest sessions become revocable. Backend only; the matching dashboard-client change follows in the next stacked PR (`guest-ui-hides-restricted-surfaces`).

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: groundwork for #673 (user management); no issue closed.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/restrict-guest-sensitive-surfaces/` (ADDED requirements only; `openspec validate --strict` passes)

## Changes

**Guest-restricted reads** (guest holds only `dashboard:read` + `accounts:read`, so these now return `403 permission_required` + `param`):
- `GET /api/api-keys*` (list, trends, usage-7d) → `api_keys:read` (router-level)
- `GET /api/settings/upstream-proxy`, `GET /api/settings/runtime/connect-address`, `GET /api/sticky-sessions` → `ops:write`
- `GET /api/oauth/status` → `accounts:write`

**Identity redaction without `accounts:write`** (`build_account_summaries(redact_identity=…)`, one mapping point for `GET /api/accounts` and the overview's account list): `email` → `a***@example.com`, `chatgptAccountId` / `workspaceId` / `workspaceLabel` → null, `displayName` → alias or masked e-mail. Status, plan, alias, quota, reset fields unchanged. The client schema already accepts these shapes.

**Request-log oracles closed**: free-text search no longer matches `Account.email` without `accounts:write`, nor `ApiKey.name` / `api_key_id` without `api_keys:read`; rows carry null `apiKeyId`/`apiKeyName` and `GET /api/request-logs/options` returns `apiKeys: []` without `api_keys:read`. Both flags are part of the count-cache key so a warm admin count is never served to a guest.

**Revocable guest sessions**: new column `dashboard_settings.guest_session_generation` (Alembic `20260908_000000_add_guest_session_generation`, NOT NULL default 0, batch mode, idempotent up/down). Guest cookies carry `gg`; `validate_dashboard_session`, `get_session_state`, and the `/session` guest branch require equality; guest cookies without `gg` (pre-upgrade) never match; admin cookies carry none. Bumps: guest password set/clear (auth repository closures, retry-safe), guest access on→off (`SettingsRepository.update`), and `POST /api/dashboard-auth/guest/logout-all` (`security:write`, audit `guest_sessions_revoked`). Guest login stamps the generation from the same DB row the credential check used, not the 5 s settings cache, so a peer replica's bump cannot mint a stale cookie. Every bump ends in the existing settings-cache invalidation (cross-replica via the `settings` namespace).

**Tests**: 7 integration flows for revocation (rotation, clear, off→on, logout-all incl. admin-cookie survival and audit assertion, unrelated saves keep sessions, legacy cookie rejected on the product path, DB-not-cache stamping); redaction/search/options/gated-reads tests with hand-built principals; count-cache key test; migration up/down; route matrix expectations extended. Also fixes a latent bug in the gate-test helper (override key captured at import time).

**Docs**: `docs/authentication.md` roles paragraph.

### Interim client behaviour (until the next stacked PR)
A guest opening the APIs page sees the standard "failed to load" card with a retry button, and the Settings page shows an inline error for the upstream-proxy query (plus the sticky-sessions section error if Advanced is expanded). No crash, no data. The next PR stops the client from requesting these surfaces for read-only sessions.

### Not in this PR
Frontend changes; admin session revocation (Phase 1); redacting operator-set `alias` (intentional — it is the label operators write for exactly this audience).

## Simplicity

- [x] Zero config; no new setting, env var, README section, or nav item.
- [x] No new required setup step (one automatic Alembic revision).
- New setting(s): none
- [x] Budgets unchanged.

## Test plan

```
uv run ruff check . && uv run ruff format --check .   # clean
uv run ty check                                        # clean
uv run pytest tests/unit tests/simulation tests/test_request_logs_options_api.py -q            # green (unit suite)
uv run pytest tests/integration/test_guest_session_generation.py \
  tests/integration/test_dashboard_permission_gates.py tests/integration/test_dashboard_route_permission_matrix.py \
  tests/integration/test_auth_middleware.py tests/integration/test_request_logs_api.py \
  tests/integration/test_conversations_api.py tests/integration/test_settings_audit_changed_fields.py \
  tests/integration/test_dashboard_password_auth.py tests/integration/test_accounts_api.py \
  tests/integration/test_migrations.py -q                                                       # green
openspec validate restrict-guest-sensitive-surfaces --strict                                   # valid
codex review --base feat/dashboard-permission-vocabulary                                       # clean
```

Adversarial review (45 agents, 5 lenses, 2 refuters per finding): 11 findings folded in — notably the remaining API-key inventory leak through request-log rows/search, stamping the guest generation from the DB row instead of the cache, and three vacuous/missing tests (clear-password bump, legacy cookie on the product path, count-cache key).

## Screenshots / output

No dashboard-visible change in this PR (backend only). Example denial and revocation:

```
GET /api/api-keys/  (guest)
HTTP/1.1 403 {"error":{"code":"permission_required","message":"Dashboard permission 'api_keys:read' is required","param":"api_keys:read"}}

POST /api/dashboard-auth/guest/logout-all  (admin)  → 200 {"status":"ok"}
GET /api/usage/summary  (guest, old cookie)          → 401 {"error":{"code":"authentication_required",...}}
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (lint, typecheck, architecture checks, unit suite, affected integration suites, migration check via tests).
- [x] If touching specs: `openspec validate --strict` passes.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is **not** edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
