### PR TITLE
chore: release v1.25.0-beta.6

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.5"  # x-release-please-version
+__version__ = "1.25.0-beta.6"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.5
-appVersion: 1.25.0-beta.5
+version: 1.25.0-beta.6
+appVersion: 1.25.0-beta.6
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.5",
+  "version": "1.25.0-beta.6",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.5"
+version = "1.25.0-beta.6"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0-beta.5"
+version = "1.25.0-beta.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.6 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.6 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.5
- fix(egress): bound the native stream queue by a byte budget instead of 64 events (#2173) (
0ebf03)
- fix(model-registry): warm the Codex client version cache on every replica and track the current release (#2174) (
90e987)
- fix(proxy): prevent exhausted accounts from reactivating (#2078) (
3d3409)
- fix(native): prevent false backpressure on buffered response bursts (#2143) (
9703ef)
- fix(db): avoid reclaiming completed SQLite teardown (#2030) (
ed2b36)
- fix(oauth): expire abandoned browser callback listeners (#2079) (
565003)
- fix(proxy): keep tool_search_output in public responses (#2092) (
0e14c2)
- fix(proxy): filter vendor events from public Responses streams (#2114) (
ec3458)
- fix(build): make local CI work in Nix shell (#2148) (
c4e58b)
- feat(db): add subscription-overflow schema (model_source_pins, dashboard_settings columns) (#2165) (
c1da68)
- feat(settings): subscription-overflow model source setting, preflight and drain deadline (inert) (#2176) (
788baa)
- perf(egress): batch ready SSE output writes (
c47610)
- fix(settings): make dashboard values authoritative — NULL-inherit caps, telemetry decision wins over env (#2186) (
8038e6)
- fix(settings)!: remove CODEX_LB_UPSTREAM_STREAM_TRANSPORT; dashboard owns upstream transport (#2192) (
39a8b9)
- fix(db): merge overflow and transport migration heads (#2198) (
05a669)
- refactor(config): remove dead and deprecated CODEX_LB_* env fields, rotate removed-settings warning list (#2190) (
fe2915)
- feat(proxy): subscription-overflow core modules and hardened direct model-source routing (#2208) (
5e6f3d)
- feat(settings): expose setting provenance and unify inheritable resolver (#2214) (
ad4a08)
- fix(model-sources): own the chat-completions source transport through the streamed response and tidy WP-C1 residuals (#2222) (
2a0931)
- feat(settings): manage resilience toggles from the dashboard (#2220) (
c38e4d)
- feat(settings): manage upstream timeouts and request budgets from the dashboard (#2221) (
5794d8)
- feat(settings): manage routing weights and overload isolation from the dashboard (#2224) (
09b48e)
- perf(reports): serve historical reports from permanent aggregates (#2227) (
3987ab)
- fix(proxy): restore trusted Codex routing hints (#2242) (
0083bc)
- fix(proxy): back off code-less upstream 429 bursts instead of passing them through (#2240) (
2a4303)

## Release-candidate validation
Validated candidate: c724591fd8eeae56f62357bbb30b7a551e128766

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b6" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.6
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.6 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

