### PR TITLE
ci: do not restart the full matrix on PR metadata edits

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -213,8 +213,11 @@ Before a PR is squash-merged into `main`:
    fine" is not a green CI; rerun, fix, or wait. The Helm / migration /
    PostgreSQL test jobs are part of the gate, not optional. The
    `CI Required` check is the branch-protection check to require: it
-   depends on every CI job and also runs for merge queue synthetic merge
-   groups, so a stale PR head cannot bypass a broken merge result.
+   depends on every `ci.yml` job and also runs for merge queue synthetic merge
+   groups, so a stale PR head cannot bypass a broken merge result. The release
+   guards (`Beta release guard`, `Stable release guard`) run from
+   `release-guards.yml` so an edited release PR body re-checks them without
+   restarting the matrix; they are separate contexts, not part of `CI Required`.
 2. **Actionable CodeRabbit findings must be fixed or explicitly addressed
    or dismissed in-thread on the merge-target head.** Review the current-head
    CodeRabbit findings before merging; no finding may be silently skipped.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,16 @@ name: CI
 on:
   push:
     branches: ["main"]
-  # `edited` must stay: release-guard evidence (validation checklist + exact
-  # head SHA) is added by editing the release PR body, and CI Required only
-  # reruns for that PR via an `edited` event (scripts/guard_beta_release.py).
-  # Known cost: a body edit right after a push starts a duplicate run for the
-  # same head SHA and concurrency cancels the older one. Do NOT "fix" this by
-  # skipping edited runs for non-release PRs: skipped or all-skipped
-  # "CI Required" check runs still satisfy branch protection, so a body-only
-  # edit could mint a passing check for a red or untested head.
+  # No `edited`: a PR title/body edit (agents finalizing descriptions, review
+  # bots rewriting summaries) must not cancel the in-flight matrix and re-queue
+  # ~30 jobs for an unchanged head. The only jobs that read PR metadata are the
+  # release guards; they live in release-guards.yml, which does handle `edited`.
+  # Do NOT bring `edited` back here with `if: github.event.action != 'edited'`
+  # on the heavy jobs: skipped check runs still satisfy branch protection, so a
+  # body-only edit could mint a passing check for a red or untested head. Not
+  # triggering at all leaves the head's existing check runs authoritative.
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   merge_group:
 
 concurrency:
@@ -77,59 +77,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: python .github/scripts/check_all_contributors.py
-
-  beta-release-guard:
-    name: Beta release guard
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Fetch PR base branch
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
-
-      - name: Require validated canonical beta release PRs
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          python -m scripts.guard_beta_release \
-            --mode pr \
-            --base-ref "origin/${BASE_REF}" \
-            --head-ref "${HEAD_REF}"
-
-  stable-release-guard:
-    name: Stable release guard
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Fetch PR base branch
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
-
-      - name: Require complete release-please stable promotions
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          python -m scripts.guard_stable_release \
-            --base-ref "origin/${BASE_REF}" \
-            --head-ref "${HEAD_REF}"
 
   openspec:
     name: OpenSpec validation
@@ -932,7 +879,6 @@ jobs:
     needs:
       - changes
       - contributors
-      - beta-release-guard
       - openspec
       - frontend-lint
       - frontend-typecheck

--- a/.github/workflows/release-guards.yml
+++ b/.github/workflows/release-guards.yml
@@ -1,0 +1,92 @@
+name: Release guards
+
+# The release PR guards live outside ci.yml on purpose.
+#
+# The beta guard (scripts/guard_beta_release.py) reads the PR body: release
+# candidate validation evidence (the checked checklist plus the exact head SHA)
+# is recorded by editing the release PR description, so the guard has to re-run
+# on `pull_request: edited`. While these jobs lived in ci.yml, that meant every
+# PR title/body edit — agents finalizing descriptions, review bots rewriting
+# summaries — cancelled the in-flight matrix (ci.yml is cancel-in-progress) and
+# re-queued ~30 jobs for an unchanged head. Both guards are stdlib-only and
+# finish in seconds, so re-running them on metadata edits costs nothing.
+#
+# Check context names ("Beta release guard", "Stable release guard") are the
+# same as when the jobs lived in ci.yml. They no longer feed ci.yml's
+# "CI Required" aggregate (cross-workflow `needs` is impossible); require them
+# in the ruleset directly if they must gate merges. The publish-time guard in
+# publish-beta-release.yml remains the hard gate for tags either way.
+#
+# push/merge_group are kept for parity with the former ci.yml jobs: the guards
+# are no-ops without a pull_request payload, and a context that has never
+# reported on main cannot be added to the required-checks ruleset.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  beta-release-guard:
+    name: Beta release guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR base branch
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
+
+      - name: Require validated canonical beta release PRs
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          python -m scripts.guard_beta_release \
+            --mode pr \
+            --base-ref "origin/${BASE_REF}" \
+            --head-ref "${HEAD_REF}"
+
+  stable-release-guard:
+    name: Stable release guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR base branch
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
+
+      - name: Require complete release-please stable promotions
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          python -m scripts.guard_stable_release \
+            --base-ref "origin/${BASE_REF}" \
+            --head-ref "${HEAD_REF}"

--- a/openspec/changes/split-release-guards-from-ci-matrix/design.md
+++ b/openspec/changes/split-release-guards-from-ci-matrix/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`ci.yml` is one workflow with a per-ref concurrency group and
+`cancel-in-progress: true`. Two of its jobs (the beta and stable release guards)
+depend on pull-request metadata: the beta guard validates a checklist and head
+SHA recorded in the release PR body, and both check the head branch name. Every
+other job depends only on the head tree. GitHub fires `pull_request: edited` for
+title, body, and base changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A PR title/body edit never cancels or restarts the CI matrix.
+- Release-evidence edits are still revalidated automatically.
+- Every check context name stays the same.
+
+**Non-Goals:**
+
+- Changing the branch ruleset or which checks are required.
+- Changing what the guards validate.
+- Deduplicating same-head runs caused by `synchronize` (a real push must run).
+
+## Decisions
+
+- **Remove `edited` from `ci.yml` rather than skip jobs on `edited`.** A
+  `github.event.action != 'edited'` condition on heavy jobs would still create a
+  new run whose skipped jobs report success; branch protection reads the newest
+  check run per context, so a body-only edit could turn a red head green. Not
+  triggering at all leaves the head's existing check runs authoritative. This
+  is the hazard the old `ci.yml` header warned about, and the split honors it.
+- **Separate workflow for the guards, mirroring `simplicity-budgets.yml`.** That
+  workflow already isolates `labeled`/`unlabeled` from the matrix for the same
+  reason. The guards are stdlib-only and finish in seconds, so re-running them
+  on every metadata edit is free.
+- **Keep `push`/`merge_group` on the guard workflow.** The guards are no-ops
+  without a `pull_request` payload, so this costs two trivial jobs per push, but
+  it keeps parity with the old placement and lets a maintainer add the contexts
+  to the ruleset (GitHub cannot require a context that has never reported).
+- **`CI Required` loses the beta guard.** Cross-workflow `needs` is impossible.
+  Neither `CI Required` nor the guards are ruleset-required today, so this
+  removes no enforcement; the publish-time guard stays the hard gate for tags.
+  If a pre-merge hard gate is wanted, require `Beta release guard` directly.
+- **Pin the split with a unit test.** `tests/unit/test_ci_workflow_required_checks.py`
+  already asserts structural properties of `ci.yml`; two new tests assert the
+  trigger sets and job placement so the regression is machine-caught.
+
+## Risks / Trade-offs
+
+- [Risk] A release PR whose body is edited to add evidence no longer gets a
+  fresh `CI Required` run. → `CI Required` never depended on the body except via
+  the guard; the head's matrix result is unchanged by an edit, and the guard
+  re-runs on its own.
+- [Risk] Base-branch retarget (`edited` with `changes.base`) no longer re-runs
+  the matrix. → Retargets are rare here (release PRs target `main`); a push or
+  manual re-run covers it, and the merge queue still runs the full suite.

--- a/openspec/changes/split-release-guards-from-ci-matrix/proposal.md
+++ b/openspec/changes/split-release-guards-from-ci-matrix/proposal.md
@@ -1,0 +1,54 @@
+# Split the release guards out of the CI matrix
+
+## Why
+
+`ci.yml` subscribed to `pull_request: edited` because the beta release guard
+reads validation evidence out of the release PR body. With
+`cancel-in-progress: true` on the per-ref concurrency group, every PR title or
+body edit — agents finalizing a description after pushing, review bots
+rewriting summaries — cancelled the in-flight matrix and re-queued ~30 jobs for
+an unchanged head. On 2026-09-08 this happened on eight campaign PRs (nine
+cancelled runs, see `EXEC-REPORT` §4.2 of the slop-removal campaign) and
+starved the runner queue for hours. Moving CodeRabbit's summary out of the PR
+body (`keep-coderabbit-summary-out-of-pr-body`) removed one editor; it did not
+remove the trigger.
+
+## What Changes
+
+- Remove `edited` from `ci.yml`'s `pull_request` trigger types. Keep `opened`,
+  `reopened`, `synchronize`, `ready_for_review`, `push` to `main`, and
+  `merge_group`.
+- Move the `Beta release guard` and `Stable release guard` jobs — the only jobs
+  that read PR metadata — into a new lightweight `release-guards.yml` workflow
+  with its own concurrency group. It subscribes to `edited` (plus the same
+  events as before) so release-evidence edits are still revalidated within
+  seconds.
+- Drop `beta-release-guard` from the `CI Required` aggregate (cross-workflow
+  `needs` is impossible). Check context names are unchanged.
+- Add a unit test that pins the trigger split so `edited` cannot quietly return
+  to `ci.yml`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-automation`: the CI matrix workflow must not restart on PR metadata
+  edits; PR-metadata-dependent jobs live in a separate workflow that does. The
+  CodeRabbit summary requirement's "edited-event CI" wording is updated to point
+  at the release guards workflow.
+
+## Impact
+
+- `.github/workflows/ci.yml`, new `.github/workflows/release-guards.yml`,
+  `tests/unit/test_ci_workflow_required_checks.py`, `.github/CONTRIBUTING.md`.
+- Branch ruleset: unchanged. None of the 19 required contexts is a release
+  guard or `CI Required`; every required context still comes from `ci.yml` or
+  `simplicity-budgets.yml`.
+- Behavior change for release PRs: a body edit no longer re-runs the matrix,
+  only the guards. `CI Required` no longer reflects the beta guard; the
+  publish-time guard in `publish-beta-release.yml` remains the hard gate.
+- No application, dependency, setting, or UI changes.

--- a/openspec/changes/split-release-guards-from-ci-matrix/specs/github-automation/spec.md
+++ b/openspec/changes/split-release-guards-from-ci-matrix/specs/github-automation/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Automated review summaries avoid PR-body CI restarts
+
+Repository CodeRabbit configuration MUST place generated high-level summaries
+in the walkthrough comment rather than automatically updating the PR body.
+Summary generation and automated review MUST remain enabled. Release evidence
+edits MUST still be revalidated by the release guards workflow on the
+`pull_request` `edited` event; this optimization MUST NOT skip or manufacture
+successful required CI checks.
+
+#### Scenario: Review completes after a push
+
+- **WHEN** CodeRabbit generates its automatic high-level summary
+- **THEN** its configured destination is the walkthrough comment
+- **AND** summary generation does not require an automatic PR-body update
+
+#### Scenario: Release evidence is edited
+
+- **WHEN** a maintainer edits a release PR's validation evidence
+- **THEN** the release guards workflow re-runs for that pull request
+- **AND** the CI matrix workflow does not start a new run for the unchanged head
+
+## ADDED Requirements
+
+### Requirement: PR metadata edits do not restart the CI matrix
+
+The CI matrix workflow (`ci.yml`) MUST NOT subscribe to the `pull_request`
+`edited` event. Jobs that read pull-request metadata (title, body, head branch)
+MUST live in a separate lightweight workflow with its own concurrency group
+that subscribes to `opened`, `reopened`, `synchronize`, `edited`, and
+`ready_for_review`. The split MUST keep every check context name unchanged.
+The matrix workflow MUST NOT achieve this by keeping `edited` and skipping jobs
+conditionally, because skipped check runs satisfy branch protection and a
+body-only edit could then mint passing checks for a red or untested head.
+
+#### Scenario: PR description is edited while the matrix is running
+
+- **GIVEN** a CI matrix run is in progress for a pull request head
+- **WHEN** the pull request title or body is edited
+- **THEN** no new CI matrix run is created and the in-progress run is not cancelled
+- **AND** the release guards workflow runs against the edited metadata
+
+#### Scenario: New commits still run the full matrix
+
+- **WHEN** a pull request receives new commits
+- **THEN** the CI matrix workflow runs for the new head
+- **AND** the superseded run for the same ref is cancelled by the concurrency group
+
+#### Scenario: Release guard contexts keep their names
+
+- **WHEN** the release guards run from their own workflow
+- **THEN** they report as `Beta release guard` and `Stable release guard`
+- **AND** the branch ruleset's required contexts are unchanged

--- a/openspec/changes/split-release-guards-from-ci-matrix/tasks.md
+++ b/openspec/changes/split-release-guards-from-ci-matrix/tasks.md
@@ -1,0 +1,16 @@
+## 1. Split the workflows
+
+- [x] 1.1 Remove `edited` from `ci.yml`'s `pull_request` types and replace the header rationale.
+- [x] 1.2 Move `beta-release-guard` and `stable-release-guard` into `release-guards.yml` with `edited`, its own concurrency group, and unchanged job names.
+- [x] 1.3 Drop `beta-release-guard` from the `ci-required` aggregate.
+
+## 2. Guard the split
+
+- [x] 2.1 Add unit tests asserting `ci.yml` never subscribes to `edited` and the guards live in `release-guards.yml`.
+- [x] 2.2 Update `github-automation` spec/context and `CONTRIBUTING.md` merge-gate wording.
+
+## 3. Verification
+
+- [x] 3.1 YAML parse + actionlint on both workflows; `uv run pytest tests/unit/test_ci_workflow_required_checks.py`.
+- [x] 3.2 Confirm the ruleset's required contexts are all still produced (`gh api repos/Soju06/codex-lb/rules/branches/main`).
+- [ ] 3.3 After merge: confirm a PR body edit creates only a `Release guards` run, and that `Beta release guard` reports on `main`.

--- a/openspec/specs/github-automation/context.md
+++ b/openspec/specs/github-automation/context.md
@@ -1,8 +1,8 @@
 # Context: github-automation
 
 Normative requirements live in [`spec.md`](./spec.md). This document currently
-covers the Simplicity budgets check; the codex-review label-sync machinery is
-summarized in the spec's Purpose.
+covers the Simplicity budgets check and the Release guards workflow; the
+codex-review label-sync machinery is summarized in the spec's Purpose.
 
 ## Simplicity budgets check
 
@@ -83,3 +83,52 @@ one-line, reviewable diff rather than an argument.
   graph (not stdlib-only) — deferred to the simplicity backlog.
 - Docs-site pages are intentionally unbudgeted: depth is supposed to move
   there.
+
+## Release guards workflow
+
+### Purpose
+
+`release-guards.yml` runs `scripts/guard_beta_release.py --mode pr` and
+`scripts/guard_stable_release.py` for pull requests. The beta guard reads the
+release PR body (checked validation checklist + exact head SHA), so it must
+re-run when the body is edited. Those two jobs used to live in `ci.yml`, which
+therefore had to subscribe to `pull_request: edited`.
+
+### Decisions
+
+- **Separate workflow, never ci.yml — same reasoning as Simplicity budgets.**
+  `ci.yml` uses a per-ref concurrency group with `cancel-in-progress: true`, so
+  every PR title/body edit cancelled the in-flight matrix and re-queued ~30
+  jobs for an unchanged head. On 2026-09-08 eight campaign PRs each lost at
+  least one run this way (runs 34216592285, 34216916484, 34217216971,
+  34218615301, 34223748971, 34223782953, 34225099491, 34226177365,
+  34226719090 all show `cancelled` for the head that later went green) and the
+  runner queue was starved for hours. Agents finalizing descriptions after a
+  push and review bots rewriting summaries both PATCH the body. The guards are
+  stdlib-only and finish in seconds, so re-running them per edit is free.
+- **Remove `edited` from ci.yml instead of skipping jobs on it.** A
+  `github.event.action != 'edited'` condition would still create a new run in
+  which every heavy job reports `skipped`; branch protection reads the newest
+  check run per context and treats skipped as satisfied, so a body-only edit
+  could turn a red or untested head green. Not triggering at all leaves the
+  head's existing check runs authoritative. `tests/unit/test_ci_workflow_required_checks.py`
+  pins both halves of this decision.
+- **Check context names unchanged.** `Beta release guard` and
+  `Stable release guard` report exactly as before. They no longer feed
+  `CI Required` (cross-workflow `needs` is impossible). Neither the guards nor
+  `CI Required` are in the `protect main` ruleset today, so no enforcement was
+  removed; the publish-time guard in `publish-beta-release.yml` is the hard
+  gate for tags. To make the beta guard a pre-merge hard gate, require
+  `Beta release guard` in the ruleset directly.
+- **`push`/`merge_group` kept.** The guards are no-ops without a
+  `pull_request` payload, but keeping the events preserves parity with the old
+  placement and gives the contexts a report on `main` (a context that has never
+  reported cannot be added to the ruleset).
+
+### Failure modes
+
+- A base-branch retarget also arrives as `edited`; it now re-runs only the
+  guards. A push or manual re-run refreshes the matrix, and the merge queue
+  runs the full suite regardless.
+- If the guards ever need the matrix result, do not fold them back into
+  `ci.yml`; gate on the separate contexts instead.

--- a/tests/unit/test_ci_workflow_required_checks.py
+++ b/tests/unit/test_ci_workflow_required_checks.py
@@ -110,3 +110,45 @@ def test_rust_job_runs_native_routed_wire_probe_with_built_helper() -> None:
         "CODEX_LB_NATIVE_EGRESS_TEST_BINARY: ${{ github.workspace }}/target/debug/codex-lb-native-egress"
     ) in rust_job
     assert "- rust" in required_job
+
+
+RELEASE_GUARDS_WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "release-guards.yml"
+
+
+def _pull_request_trigger_types(text: str) -> set[str]:
+    trigger_block = text.split("concurrency:", maxsplit=1)[0]
+    pull_request_block = trigger_block.split("  pull_request:", maxsplit=1)[1]
+    types_match = re.search(r"^    types: \[(?P<types>[^\]]*)\]$", pull_request_block, re.MULTILINE)
+    assert types_match is not None
+    return {item.strip() for item in types_match.group("types").split(",")}
+
+
+def test_ci_matrix_does_not_restart_on_pr_metadata_edits() -> None:
+    workflow = _ci_workflow_text()
+
+    # ci.yml cancels the in-flight run per ref, so any extra trigger type
+    # restarts ~30 jobs for an unchanged head. `edited` (title/body PATCH by
+    # agents and review bots) must therefore never be a ci.yml trigger.
+    assert "cancel-in-progress: true" in workflow
+    assert _pull_request_trigger_types(workflow) == {"opened", "reopened", "synchronize", "ready_for_review"}
+
+    # The PR-body-dependent release guards live in release-guards.yml, and the
+    # aggregate must not reference a job that no longer exists here.
+    assert re.search(r"^  beta-release-guard:\n", workflow, re.MULTILINE) is None
+    assert re.search(r"^  stable-release-guard:\n", workflow, re.MULTILINE) is None
+    assert "- beta-release-guard" not in _job_block(workflow, "ci-required")
+
+
+def test_release_guards_revalidate_pr_metadata_edits_in_their_own_workflow() -> None:
+    workflow = RELEASE_GUARDS_WORKFLOW.read_text(encoding="utf-8")
+
+    assert _pull_request_trigger_types(workflow) == {"opened", "reopened", "synchronize", "edited", "ready_for_review"}
+    assert "group: ${{ github.workflow }}-${{ github.ref }}" in workflow
+
+    beta_job = _job_block(workflow, "beta-release-guard")
+    stable_job = _job_block(workflow, "stable-release-guard")
+    # Check context names are unchanged from their ci.yml days.
+    assert "name: Beta release guard" in beta_job
+    assert "python -m scripts.guard_beta_release" in beta_job
+    assert "name: Stable release guard" in stable_job
+    assert "python -m scripts.guard_stable_release" in stable_job


### PR DESCRIPTION
## Summary

Remove `pull_request: edited` from `ci.yml` and move the two release-guard jobs (the only jobs that read PR metadata) into a new lightweight `release-guards.yml` that still handles `edited`, so a PR title/body edit never cancels and restarts the ~30-job matrix for an unchanged head.

## Type of change

- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging

Linked issue: slop-removal campaign 0908, task N11 (no issue)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/split-release-guards-from-ci-matrix/`

`github-automation` explicitly required "edited-event CI" for release evidence (added by `keep-coderabbit-summary-out-of-pr-body`), so this is a spec change, not a pure chore: the requirement is reworded to point at the release guards workflow and a new requirement forbids `edited` on the matrix workflow.

## Observed cost

`ci.yml` has a per-ref concurrency group with `cancel-in-progress: true`. Any `edited` event (agents finalizing a description after pushing, CodeRabbit rewriting its summary before `.coderabbit.yaml` moved it to the walkthrough) created a duplicate run for the same head and cancelled the older one. On 2026-09-08 the slop-removal campaign lost at least nine runs across eight PRs this way — 34216592285, 34216916484, 34217216971, 34218615301, 34223748971, 34223782953, 34225099491, 34226177365, 34226719090 all show `cancelled` for a head that later went green — and the runner queue was starved for hours (EXEC-REPORT §4.2/§9). Same-head cancelled duplicates are still visible in the run list today (e.g. 34298266157 + 34298221951 for `1ba5fd6e8`, 34254386747 for `ad0ffae42`).

## Changes

- `.github/workflows/ci.yml`: `pull_request.types` is now `[opened, reopened, synchronize, ready_for_review]`. Header rationale rewritten. `beta-release-guard` and `stable-release-guard` jobs removed; `beta-release-guard` dropped from the `CI Required` `needs` list (cross-workflow `needs` is impossible).
- `.github/workflows/release-guards.yml` (new): both guards, verbatim steps, job names `Beta release guard` / `Stable release guard` unchanged. Triggers `push: main`, `pull_request: [opened, reopened, synchronize, edited, ready_for_review]`, `merge_group`; own concurrency group; `permissions: contents: read`; 10-minute timeouts.
- `tests/unit/test_ci_workflow_required_checks.py`: two tests pin the trigger sets and job placement so `edited` cannot quietly return to `ci.yml`.
- `openspec/specs/github-automation/context.md`, `.github/CONTRIBUTING.md`: record the decision and the "release guards are separate contexts, not part of `CI Required`" wording.

### Why not `if: github.event.action != 'edited'` on the heavy jobs

That is the trap the old `ci.yml` header warned about: the edited run would still be created and every heavy job would report `skipped`, which branch protection treats as satisfied. A body-only edit could turn a red or untested head green. Not triggering at all leaves the head's existing check runs authoritative. This PR honors that warning by removing the trigger rather than gating on it.

### Required checks verified

`gh api repos/Soju06/codex-lb/rules/branches/main` (ruleset `protect main`, id 11732824) lists 19 required contexts: Frontend lint/type check/tests/build, Lint (ruff), Type check (ty), Tests (pytest, unit/integration-core/integration-bridge/e2e/PostgreSQL), Migration check (alembic ×2), Package (build), Docker build, Helm lint + template + kubeconform, Helm smoke install (kind), GitGuardian Security Checks, Simplicity budgets. Neither `CI Required` nor either release guard is required. A script cross-checked every required context against the job names in `ci.yml` (incl. pytest matrix expansion) + `simplicity-budgets.yml`: 0 missing. No required check name changes.

Enforcement note: `CI Required` no longer reflects the beta guard. Neither was ruleset-required, so nothing is lost today; the publish-time guard in `publish-beta-release.yml` remains the hard gate for tags. If a pre-merge hard gate is wanted, add `Beta release guard` to the ruleset once it has reported on `main` (the `push: main` trigger is kept for exactly that).

## Test plan

```
python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml")); yaml.safe_load(open(".github/workflows/release-guards.yml"))'
actionlint .github/workflows/ci.yml .github/workflows/release-guards.yml      # clean
uv run pytest tests/unit/test_ci_workflow_required_checks.py tests/unit/test_guard_stable_release.py -q   # 14 passed
uv run ruff check / ruff format --check tests/unit/test_ci_workflow_required_checks.py
openspec validate split-release-guards-from-ci-matrix --strict                # valid
openspec validate --specs                                                     # 58 passed
python3 .github/scripts/check_simplicity_budgets.py                           # OK
```

Post-merge verification (tasks.md 3.3): edit a PR body and confirm only a `Release guards` run is created and the in-flight `CI` run is untouched; confirm `Beta release guard` reports on `main`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant subset locally (see Test plan).
- [x] If touching specs: `openspec validate --specs` passes.
- [x] Simplicity gates reviewed: no new setting, README section, nav item, or default.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
