### PR TITLE
refactor: consolidate duplicated helpers

### DIFF
--- a/app/core/auth/guardian.py
+++ b/app/core/auth/guardian.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
 import random
 import time
@@ -10,9 +9,15 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Protocol, TypeVar, cast
+from typing import Protocol, cast
 
 from app.core.auth.refresh import RefreshError
+from app.core.scheduling.leader_election_handle import (
+    LeaderElectionLike as _LeaderElectionLike,
+)
+from app.core.scheduling.leader_election_handle import (
+    get_leader_election as _get_leader_election,
+)
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import get_background_session
@@ -37,13 +42,6 @@ _FAILURE_BACKOFF_MAX_SECONDS = 3600.0
 # RATE_LIMITED and QUOTA_EXCEEDED recover to ACTIVE through usage-refresh
 # reconciliation, then become guardian-eligible within the max-age window.
 _AUTH_GUARDIAN_ELIGIBLE_STATUSES = frozenset({AccountStatus.ACTIVE, AccountStatus.PAUSED})
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
 
 
 class _AccountsRepositoryLike(Protocol):
@@ -299,11 +297,6 @@ def _auth_guardian_account_is_stale_eligible(
         return False
     age = to_utc_naive(now) - to_utc_naive(account.last_refresh)
     return age > timedelta(seconds=max_age_seconds)
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 async def _count_live_bridge_ring_members() -> int:

--- a/app/core/auth/refresh.py
+++ b/app/core/auth/refresh.py
@@ -24,7 +24,8 @@ from app.core.clients.codex import (
     create_codex_session,
     require_route_or_direct_egress_opt_in,
 )
-from app.core.clients.http import lease_http_session
+from app.core.clients.http import _safe_json, lease_http_session
+from app.core.clients.oauth import _extract_error_code, _extract_error_message
 from app.core.config.settings import AUTH_BASE_URL, OAUTH_CLIENT_ID, OAUTH_SCOPE, get_settings
 from app.core.resilience.network_recovery import (
     PROCESS_NETWORK_UNAVAILABLE_CODE,
@@ -344,15 +345,6 @@ def get_token_refresh_timeout_override() -> float | None:
     return _TOKEN_REFRESH_TIMEOUT_OVERRIDE.get()
 
 
-async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        return {"error": {"message": text.strip()}}
-    return data if isinstance(data, dict) else {"error": {"message": str(data)}}
-
-
 async def _safe_codex_json(resp: object) -> JsonObject:
     json_method = getattr(resp, "json", None)
     try:
@@ -393,23 +385,3 @@ def _effective_token_refresh_timeout(configured_timeout_seconds: float) -> float
     if override is None:
         return configured_timeout_seconds
     return max(0.001, min(configured_timeout_seconds, override))
-
-
-def _extract_error_code(payload: OAuthTokenPayload) -> str | None:
-    error = payload.error
-    if isinstance(error, dict):
-        code = error.get("code") or error.get("error")
-        return code if isinstance(code, str) else None
-    if isinstance(error, str):
-        return error
-    return payload.error_code or payload.code
-
-
-def _extract_error_message(payload: OAuthTokenPayload) -> str | None:
-    error = payload.error
-    if isinstance(error, dict):
-        message = error.get("message") or error.get("error_description")
-        return message if isinstance(message, str) else None
-    if isinstance(error, str):
-        return payload.error_description or error
-    return payload.message

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -19,6 +19,7 @@ from aiohttp_retry import RetryClient
 from aiohttp_socks import ProxyConnector
 
 from app.core.config.settings import Settings, get_settings
+from app.core.types import JsonObject
 
 logger = logging.getLogger(__name__)
 
@@ -487,3 +488,12 @@ def get_http_client() -> HttpClient:
     if _http_client is None:
         raise RuntimeError("HTTP client not initialized")
     return _http_client.client
+
+
+async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
+    try:
+        data = await resp.json(content_type=None)
+    except Exception:
+        text = await resp.text()
+        return {"error": {"message": text.strip()}}
+    return data if isinstance(data, dict) else {"error": {"message": str(data)}}

--- a/app/core/clients/model_fetcher.py
+++ b/app/core/clients/model_fetcher.py
@@ -21,7 +21,7 @@ from app.core.clients.native_egress import (
     NativeEgressUnavailable,
     discover_native_egress_client,
 )
-from app.core.clients.proxy import build_codex_user_agent
+from app.core.clients.proxy import _codex_response_status, build_codex_user_agent
 from app.core.config.settings import get_settings
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel
 from app.core.types import JsonValue
@@ -252,13 +252,6 @@ async def _fetch_models_direct_python(url: str, headers: dict[str, str]) -> obje
                 text = await resp.text()
                 raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
             return await resp.json(content_type=None)
-
-
-def _codex_response_status(response: object) -> int:
-    value = getattr(response, "status_code", getattr(response, "status", None))
-    if value is None:
-        return 0
-    return int(value)
 
 
 async def _codex_response_text(response: object) -> str:

--- a/app/core/clients/oauth.py
+++ b/app/core/clients/oauth.py
@@ -19,7 +19,7 @@ from app.core.clients.codex import (
     create_codex_session,
     require_route_or_direct_egress_opt_in,
 )
-from app.core.clients.http import lease_http_session
+from app.core.clients.http import _safe_json, lease_http_session
 from app.core.config.settings import (
     AUTH_BASE_URL,
     OAUTH_CLIENT_ID,
@@ -368,15 +368,6 @@ def _parse_tokens(payload: OAuthTokenPayload) -> OAuthTokens:
         refresh_token=payload.refresh_token,
         id_token=payload.id_token,
     )
-
-
-async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        return {"error": {"message": text.strip()}}
-    return data if isinstance(data, dict) else {"error": {"message": str(data)}}
 
 
 async def _codex_post(

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -47,12 +47,12 @@ from app.core.clients.proxy import (
     _is_native_codex_request,
     _is_upstream_edge_challenge,
     _normalize_non_native_upstream_fingerprint,
+    _openai_error_detail,
     filter_inbound_headers,
 )
 from app.core.config.settings import get_settings
 from app.core.conversation_archive import archive_bytes, archive_text
-from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
-from app.core.openai.models import OpenAIError
+from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.parsing import parse_error_payload
 from app.core.resilience.network_recovery import (
     PROCESS_NETWORK_UNAVAILABLE_CODE,
@@ -1389,22 +1389,3 @@ def _try_parse_handshake_error_payload(
     if error is None:
         return None
     return {"error": _openai_error_detail(error)}
-
-
-def _openai_error_detail(error: OpenAIError) -> OpenAIErrorDetail:
-    detail: OpenAIErrorDetail = {}
-    if error.message is not None:
-        detail["message"] = error.message
-    if error.type is not None:
-        detail["type"] = error.type
-    if error.code is not None:
-        detail["code"] = error.code
-    if error.param is not None:
-        detail["param"] = error.param
-    if error.plan_type is not None:
-        detail["plan_type"] = error.plan_type
-    if error.resets_at is not None:
-        detail["resets_at"] = error.resets_at
-    if error.resets_in_seconds is not None:
-        detail["resets_in_seconds"] = error.resets_in_seconds
-    return detail

--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 import aiohttp
-from aiohttp_retry import ExponentialRetry, RetryClient
+from aiohttp_retry import RetryClient
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from app.core.clients.codex import (
@@ -16,19 +16,18 @@ from app.core.clients.codex import (
     require_route_or_direct_egress_opt_in,
 )
 from app.core.clients.headers import build_chatgpt_auth_headers
-from app.core.clients.http import lease_retry_client
+from app.core.clients.http import _safe_json, lease_retry_client
+from app.core.clients.proxy import _codex_response_status
 from app.core.clients.usage import (
+    RETRYABLE_STATUS,
     _retry_delay_seconds,
+    _retry_options,
     _safe_codex_json,
 )
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.core.utils.request_id import get_request_id
-
-RETRYABLE_STATUS = {408, 429, 500, 502, 503, 504}
-RETRY_START_TIMEOUT = 0.5
-RETRY_MAX_TIMEOUT = 2.0
 
 logger = logging.getLogger(__name__)
 
@@ -273,15 +272,6 @@ def _consume_url(base_url: str) -> str:
     return f"{_reset_credits_url(base_url)}/consume"
 
 
-async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        return {"error": {"message": text.strip()}}
-    return data if isinstance(data, dict) else {"error": {"message": str(data)}}
-
-
 def _success_payload(payload: JsonObject) -> JsonObject:
     if "error" in payload:
         raise ValueError("success response carried error payload")
@@ -320,18 +310,6 @@ def _extract_error_code(payload: JsonObject) -> str | None:
             normalized = code.strip().lower()
             return normalized or None
     return None
-
-
-def _retry_options(attempts: int) -> ExponentialRetry:
-    return ExponentialRetry(
-        attempts=attempts,
-        start_timeout=RETRY_START_TIMEOUT,
-        max_timeout=RETRY_MAX_TIMEOUT,
-        factor=2.0,
-        statuses=RETRYABLE_STATUS,
-        exceptions={aiohttp.ClientError, asyncio.TimeoutError},
-        retry_all_server_errors=False,
-    )
 
 
 async def _fetch_reset_credits_via_codex(
@@ -430,10 +408,3 @@ async def _consume_reset_credit_via_codex(
             if callable(close):
                 await close()
     raise RuntimeError("unreachable reset credits consume retry state")
-
-
-def _codex_response_status(response: object) -> int:
-    value = getattr(response, "status_code", getattr(response, "status", None))
-    if value is None:
-        return 0
-    return int(value)

--- a/app/core/clients/usage.py
+++ b/app/core/clients/usage.py
@@ -15,7 +15,8 @@ from app.core.clients.codex import (
     require_route_or_direct_egress_opt_in,
 )
 from app.core.clients.headers import build_chatgpt_auth_headers
-from app.core.clients.http import lease_retry_client
+from app.core.clients.http import _safe_json, lease_retry_client
+from app.core.clients.proxy import _codex_response_status
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.upstream_proxy import ResolvedUpstreamRoute
@@ -323,13 +324,6 @@ def _consume_rate_limit_reset_response_or_raise(
         raise UsageFetchError(502, "Invalid usage limit reset payload") from exc
 
 
-def _codex_response_status(response: object) -> int:
-    value = getattr(response, "status_code", getattr(response, "status", None))
-    if value is None:
-        return 0
-    return int(value)
-
-
 async def _safe_codex_json(response: object) -> JsonObject:
     try:
         json_method = getattr(response, "json", None)
@@ -364,15 +358,6 @@ def _rate_limit_reset_url(base_url: str) -> str:
 
 def _usage_headers(access_token: str, account_id: str | None) -> dict[str, str]:
     return build_chatgpt_auth_headers(access_token, account_id)
-
-
-async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        return {"error": {"message": text.strip()}}
-    return data if isinstance(data, dict) else {"error": {"message": str(data)}}
 
 
 def _extract_error_message(payload: JsonObject) -> str | None:

--- a/app/core/openai/chat_requests.py
+++ b/app/core/openai/chat_requests.py
@@ -6,7 +6,7 @@ from typing import cast
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, SkipValidation, field_validator, model_validator
 
 from app.core.openai.contracts import OpenAIMessage
-from app.core.openai.message_coercion import coerce_messages
+from app.core.openai.message_coercion import _content_parts, coerce_messages
 from app.core.openai.requests import (
     PassthroughJsonList,
     PassthroughJsonValue,
@@ -23,12 +23,6 @@ from app.core.utils.json_guards import is_json_list, is_json_mapping
 
 _SUPPORTED_CHAT_ROLES = frozenset({"system", "developer", "user", "assistant", "tool"})
 _TEXT_CONTENT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
-
-
-def _content_parts(content: JsonValue) -> list[JsonValue]:
-    if is_json_list(content):
-        return content
-    return [content]
 
 
 def _part_type(part: Mapping[str, JsonValue]) -> str | None:

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Protocol, TypeVar, cast
 
 from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_MODEL_REGISTRY, get_cache_invalidation_poller
@@ -25,6 +22,7 @@ from app.core.openai.model_registry_store import (
     persist_registry_snapshot,
     reconcile_model_registry_from_store,
 )
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.upstream_proxy import ResolvedUpstreamRoute, resolve_upstream_route
 from app.db.models import Account, AccountStatus
 from app.db.session import detach_session_objects, get_background_session
@@ -41,13 +39,6 @@ logger = logging.getLogger(__name__)
 _REFRESH_INTERVAL_SECONDS = 300
 
 
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
 @dataclass(slots=True)
 class _TransportRecoveryState:
     attempted: bool = False
@@ -57,11 +48,6 @@ class _TransportRecoveryState:
 class _FetchResult:
     models: list[UpstreamModel]
     account_models: dict[str, tuple[str, list[UpstreamModel]]]
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 async def _warm_codex_version_cache() -> None:

--- a/app/core/retention/scheduler.py
+++ b/app/core/retention/scheduler.py
@@ -2,29 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Protocol, TypeVar, cast
 
 from app.core.retention.job import run_retention_pass
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 
 logger = logging.getLogger(__name__)
 
 RETENTION_INTERVAL_SECONDS = 3600
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/core/scheduling/leader_election_handle.py
+++ b/app/core/scheduling/leader_election_handle.py
@@ -1,0 +1,25 @@
+"""Lazy handle onto the process-wide scheduler leader election.
+
+Background schedulers resolve the election at call time instead of importing
+:mod:`app.core.scheduling.leader_election` at module load, so importing a
+scheduler never drags in the election's database session dependencies. Every
+scheduler binds :func:`get_leader_election` to a module global named
+``_get_leader_election`` so tests can swap in a fake leader per module.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Awaitable, Callable
+from typing import Protocol, TypeVar, cast
+
+_T = TypeVar("_T")
+
+
+class LeaderElectionLike(Protocol):
+    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
+
+
+def get_leader_election() -> LeaderElectionLike:
+    module = importlib.import_module("app.core.scheduling.leader_election")
+    return cast(LeaderElectionLike, module.get_leader_election())

--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
 import time
-from collections.abc import Awaitable, Callable, Collection
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Protocol, TypeVar, cast
+from typing import Any, AsyncIterator, Protocol, cast
 
 from app.core.balancer.logic import RATE_LIMITED_MIN_COOLDOWN_SECONDS
 from app.core.config.settings import get_settings
 from app.core.plan_types import normalize_account_plan_type
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.usage import capacity_for_plan
 from app.core.utils.time import naive_utc_to_epoch
 from app.db.models import Account, AccountLimitWarmup, AccountStatus, UsageHistory
@@ -40,18 +40,11 @@ _RECOVERABLE_ACCOUNT_STATUSES = frozenset({AccountStatus.RATE_LIMITED, AccountSt
 _BLOCK_RESET_MATCH_TOLERANCE_SECONDS = 5
 
 
-_T = TypeVar("_T")
-
-
 @dataclass(frozen=True, slots=True)
 class _MonthlyResetEvidence:
     baseline: UsageHistory
     before: UsageHistory
     after: UsageHistory
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
 
 
 class _RecoverableAccountsRepository(Protocol):
@@ -135,11 +128,6 @@ class _BackgroundRequestLogsRepository:
     async def add_log(self, *args: Any, **kwargs: Any) -> object:
         async with get_background_session() as session:
             return await RequestLogsRepository(session).add_log(*args, **kwargs)
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.core.clients.native_egress import close_discovered_native_egress_client
 from app.core.config.key_fingerprint import verify_encryption_key_fingerprint
 from app.core.config.settings import (
     _bridge_advertise_hostname_is_replica_specific,
+    _parse_port_value,
     get_settings,
     warn_removed_settings,
 )
@@ -1100,16 +1101,6 @@ def _local_api_port() -> int | None:
     port = _parse_port_value(raw.strip()) if raw is not None else None
     if port is None:
         port = _port_from_argv()
-    return port
-
-
-def _parse_port_value(raw: str) -> int | None:
-    try:
-        port = int(raw)
-    except ValueError:
-        return None
-    if port <= 0:
-        return None
     return port
 
 

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -52,17 +52,16 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Protocol, TypeVar, cast
 
 from sqlalchemy import Select, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidation_poller
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
 from app.db.models import (
@@ -106,17 +105,6 @@ DELETE_BATCH_SIZE = 1_000
 # transactions back-to-back.
 INTER_ROUND_PAUSE_RATIO = 0.25
 INTER_ROUND_PAUSE_CAP_SECONDS = 2.0
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 async def run_account_deletion_pass(*, batch_size: int = DELETE_BATCH_SIZE) -> dict[str, str]:

--- a/app/modules/accounts/usage_rollup_scheduler.py
+++ b/app/modules/accounts/usage_rollup_scheduler.py
@@ -2,30 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Protocol, TypeVar, cast
 
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.modules.accounts.usage_rollup import run_fold_pass
 from app.modules.accounts.usage_time_rollup import run_conversation_fold_pass, run_hourly_fold_pass
 
 logger = logging.getLogger(__name__)
 
 FOLD_INTERVAL_SECONDS = 900
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/modules/api_keys/reset_scheduler.py
+++ b/app/modules/api_keys/reset_scheduler.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Protocol, TypeVar, cast
 
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.utils.time import utcnow
 from app.db.session import get_background_session
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -23,18 +21,6 @@ _STALE_USAGE_RESERVATION_AGE = timedelta(hours=6)
 # exempt its reservation from the stale cutoff above. No legitimate request
 # holds a usage reservation anywhere near this long.
 _MAX_USAGE_RESERVATION_AGE = timedelta(hours=24)
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/modules/automations/scheduler.py
+++ b/app/modules/automations/scheduler.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Protocol, TypeVar, cast
 
 from app.core.config.settings import get_settings
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.automations.repository import AutomationsRepository
@@ -21,18 +19,6 @@ logger = logging.getLogger(__name__)
 # scheduler keeps ``interval_seconds`` as a constructor field so tests can
 # exercise the loop with a short interval.
 _INTERVAL_SECONDS = 30
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -766,6 +766,33 @@ def _service_get_settings_cache() -> Any:
     return _service_global_or("get_settings_cache", get_settings_cache)()
 
 
+def _http_bridge_server_anchored_replay_enabled(request_state: _WebSocketRequestState) -> bool:
+    """Return whether the one permitted server-side anchored replay is unused."""
+    settings = _service_get_settings()
+    return (
+        getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "fail_closed")
+        in {"server_anchored_replay_once", "server_indefinite_recovery"}
+        and request_state.previous_response_id is not None
+        and request_state.response_id is None
+        and request_state.response_event_count == 0
+        and (
+            request_state.replay_count == 0
+            or getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "")
+            == "server_indefinite_recovery"
+        )
+    )
+
+
+def _http_bridge_client_full_history_recovery_error() -> OpenAIErrorEnvelope:
+    payload = openai_error(
+        "previous_response_not_found",
+        "Previous response was not found; retry without previous_response_id.",
+        error_type="invalid_request_error",
+    )
+    payload["error"]["param"] = "previous_response_id"
+    return payload
+
+
 def _proxy_admission_wait_timeout_seconds(settings: Any | None = None) -> float:
     return cast(Callable[[Any | None], float], _service_global("_proxy_admission_wait_timeout_seconds"))(settings)
 

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -87,6 +87,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _bind_http_bridge_proxy_injected_anchor,
     _build_http_bridge_prewarm_text,
     _http_bridge_abandonment_may_settle_circuit,
+    _http_bridge_client_full_history_recovery_error,
     _http_bridge_denied_anchor_fence_advanced,
     _http_bridge_durable_lease_ttl_seconds,
     _http_bridge_is_previous_response_owner_unavailable,
@@ -316,22 +317,6 @@ def _http_bridge_client_full_history_recovery_enabled(request_state: _WebSocketR
     )
 
 
-def _http_bridge_server_anchored_replay_enabled(request_state: _WebSocketRequestState) -> bool:
-    settings = _service_get_settings()
-    return (
-        getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "fail_closed")
-        in {"server_anchored_replay_once", "server_indefinite_recovery"}
-        and request_state.previous_response_id is not None
-        and request_state.response_id is None
-        and request_state.response_event_count == 0
-        and (
-            request_state.replay_count == 0
-            or getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "")
-            == "server_indefinite_recovery"
-        )
-    )
-
-
 def _http_bridge_operation_fence_for_hard_continuity_enabled(request_state: _WebSocketRequestState) -> bool:
     """Return whether a hard turn-state request may use the durable replay fence."""
     if not request_state.hard_continuity_anchor:
@@ -394,16 +379,6 @@ def _http_bridge_terminal_hard_turn_response_id(
         return None
     response_id = getattr(operation, "response_id", None)
     return response_id if isinstance(response_id, str) and response_id else None
-
-
-def _http_bridge_client_full_history_recovery_error() -> OpenAIErrorEnvelope:
-    payload = openai_error(
-        "previous_response_not_found",
-        "Previous response was not found; retry without previous_response_id.",
-        error_type="invalid_request_error",
-    )
-    payload["error"]["param"] = "previous_response_id"
-    return payload
 
 
 def _http_bridge_hard_continuity_full_history_recovery_error() -> OpenAIErrorEnvelope:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -39,7 +39,6 @@ from app.core.clients.proxy_websocket import UpstreamWebSocketTransportError
 from app.core.clock import Clock, Scheduler, clock_for, scheduler_for
 from app.core.errors import (
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
-    OpenAIErrorEnvelope,
     openai_error,
     response_failed_event,
 )
@@ -86,6 +85,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _capture_http_bridge_denied_anchor_fence,
     _effective_http_bridge_idle_ttl_seconds,
     _http_bridge_abandonment_may_settle_circuit,
+    _http_bridge_client_full_history_recovery_error,
     _http_bridge_continuity_bound_without_safe_replay,
     _http_bridge_durable_lease_ttl_seconds,
     _http_bridge_durable_lookup_allows_turn_state_takeover,
@@ -106,6 +106,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_requires_cluster_registration,
     _http_bridge_retry_circuit_attempt_selection_for_pending_requests,
     _http_bridge_runtime_config,
+    _http_bridge_server_anchored_replay_enabled,
     _http_bridge_should_attempt_local_bootstrap_rebind,
     _http_bridge_should_attempt_local_previous_response_recovery,
     _http_bridge_should_attempt_soft_affinity_reroute,
@@ -469,33 +470,6 @@ def _http_bridge_client_full_history_recovery_enabled(request_state: _WebSocketR
         and request_state.response_event_count == 0
         and not request_state.fresh_upstream_request_is_retry_safe
     )
-
-
-def _http_bridge_server_anchored_replay_enabled(request_state: _WebSocketRequestState) -> bool:
-    """Return whether the one permitted server-side anchored replay is unused."""
-    settings = _service_get_settings()
-    return (
-        getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "fail_closed")
-        in {"server_anchored_replay_once", "server_indefinite_recovery"}
-        and request_state.previous_response_id is not None
-        and request_state.response_id is None
-        and request_state.response_event_count == 0
-        and (
-            request_state.replay_count == 0
-            or getattr(settings, "http_responses_session_bridge_ambiguous_continuation_recovery_mode", "")
-            == "server_indefinite_recovery"
-        )
-    )
-
-
-def _http_bridge_client_full_history_recovery_error() -> OpenAIErrorEnvelope:
-    payload = openai_error(
-        "previous_response_not_found",
-        "Previous response was not found; retry without previous_response_id.",
-        error_type="invalid_request_error",
-    )
-    payload["error"]["param"] = "previous_response_id"
-    return payload
 
 
 _HTTP_BRIDGE_DEAD_OWNER_NOT_FOUND_DETAIL = "The previous bridge owner is no longer available."

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from app.core.clients.proxy import (
     _AGENT_CONTROL_OUTPUT_ITEM_TYPES,
+    _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE,
     CODEX_INSTALLATION_ID_HEADER,
     ImageFetchSession,
     ProxyResponseError,
@@ -22,13 +23,18 @@ from app.core.clients.proxy import (
     _finalize_responses_lite_reasoning_context,
     _historical_agent_control_output_occurrences,
     _inline_content_images,
+    _is_inline_image_reference,
     _normalize_responses_lite_websocket_client_metadata,
     _payload_has_responses_lite_websocket_marker,
     _payload_uses_responses_lite,
+    _response_create_inline_image_notice_item,
+    _response_create_recent_suffix_start,
+    _response_create_too_large_error_envelope,
+    _should_slim_historical_tool_output,
+    _slim_historical_response_content,
     apply_codex_installation_metadata,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, get_settings
-from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_mapping
@@ -48,10 +54,6 @@ _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
 _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
     "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"
 )
-_RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
-    "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
-)
-_RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
 _OVERSIZED_RESPONSE_CREATE_DUMP_DIR: Path | None = None
 _RESPONSE_CREATE_DUMP_SUFFIX = ".response-create.json.gz"
 _RESPONSE_CREATE_META_SUFFIX = ".meta.json"
@@ -437,35 +439,6 @@ def _response_output_item_done_tool_call(payload: dict[str, JsonValue] | None) -
     return call_id, item_type
 
 
-def _response_create_too_large_error_envelope(
-    actual_bytes: int,
-    max_bytes: int,
-) -> OpenAIErrorEnvelope:
-    payload = openai_error(
-        "payload_too_large",
-        (
-            "response.create is too large for upstream websocket "
-            f"({actual_bytes} bytes > {max_bytes} bytes). "
-            "Reduce historical images/screenshots or compact the thread."
-        ),
-        error_type="invalid_request_error",
-    )
-    payload["error"]["param"] = "input"
-    return payload
-
-
-def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
-    last_user_index: int | None = None
-    for index, item in enumerate(input_items):
-        if not is_json_mapping(item):
-            continue
-        if item.get("role") == "user":
-            last_user_index = index
-    if last_user_index is not None:
-        return last_user_index
-    return 0
-
-
 def _slim_historical_response_input_item(
     item: JsonValue,
     *,
@@ -515,50 +488,6 @@ def _slim_historical_response_input_item(
     return item_mapping, tool_outputs_slimmed, images_slimmed
 
 
-def _slim_historical_response_content(content: JsonValue) -> tuple[JsonValue, int]:
-    if is_json_mapping(content):
-        return _slim_historical_response_content_part(content)
-    if not isinstance(content, list):
-        return content, 0
-
-    slimmed_parts: list[JsonValue] = []
-    images_slimmed = 0
-    for part in content:
-        slimmed_part, part_images_slimmed = _slim_historical_response_content_part(part)
-        slimmed_parts.append(slimmed_part)
-        images_slimmed += part_images_slimmed
-    return slimmed_parts, images_slimmed
-
-
-def _slim_historical_response_content_part(part: JsonValue) -> tuple[JsonValue, int]:
-    if not is_json_mapping(part):
-        return part, 0
-
-    part_mapping = dict(cast(dict[str, JsonValue], deepcopy(part)))
-    part_type = part_mapping.get("type")
-    if part_type == "input_image" and _is_inline_image_reference(part_mapping.get("image_url")):
-        return _response_create_inline_image_notice_part(), 1
-
-    if part_type == "image_url":
-        image_url_value = part_mapping.get("image_url")
-        if is_json_mapping(image_url_value):
-            image_url = image_url_value.get("url")
-        else:
-            image_url = image_url_value
-        if _is_inline_image_reference(image_url):
-            return _response_create_inline_image_notice_part(), 1
-
-    return part_mapping, 0
-
-
-def _response_create_inline_image_notice_part() -> dict[str, JsonValue]:
-    return {"type": "input_text", "text": _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}
-
-
-def _response_create_inline_image_notice_item() -> dict[str, JsonValue]:
-    return {"role": "user", "content": [_response_create_inline_image_notice_part()]}
-
-
 def _response_create_history_omission_notice_item(count: int) -> dict[str, JsonValue]:
     return {
         "role": "assistant",
@@ -569,10 +498,6 @@ def _response_create_history_omission_notice_item(count: int) -> dict[str, JsonV
             }
         ],
     }
-
-
-def _is_inline_image_reference(value: JsonValue) -> bool:
-    return isinstance(value, str) and value.startswith("data:image/")
 
 
 async def _inline_top_level_input_image_urls(
@@ -624,10 +549,6 @@ def _count_external_image_urls(payload: dict[str, JsonValue]) -> int:
             if isinstance(image_url, str) and image_url.startswith(("http://", "https://")):
                 count += 1
     return count
-
-
-def _should_slim_historical_tool_output(output: str) -> bool:
-    return "data:image/" in output or len(output.encode("utf-8")) > 32 * 1024
 
 
 def _enforce_response_create_size_limit(request_state: _WebSocketRequestState) -> None:

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from app.core import usage as usage_core
 from app.core.balancer.types import ClassifiedFailure, FailureClass, FailurePhase, UpstreamError
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorParam
+from app.core.openai.chat_responses import _coerce_number
 from app.core.openai.models import OpenAIError
 from app.core.plan_types import normalize_rate_limit_plan_type
 from app.core.types import JsonValue
@@ -338,17 +339,6 @@ def _openai_error_param(error: OpenAIError | None) -> OpenAIErrorParam:
 
 def _coerce_str(value: JsonValue) -> str | None:
     return value if isinstance(value, str) else None
-
-
-def _coerce_number(value: JsonValue) -> int | float | None:
-    if isinstance(value, (int, float)):
-        return value
-    if isinstance(value, str):
-        try:
-            return float(value.strip())
-        except ValueError:
-            return None
-    return None
 
 
 def _apply_error_metadata(target: OpenAIErrorDetail, error: OpenAIError | None) -> None:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -162,8 +162,8 @@ from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
 from app.modules.quota_planner.logic import PlannerSettings
 from app.modules.usage.additional_quota_keys import (
     canonicalize_additional_quota_key,
-    get_additional_quota_definition,
     get_additional_quota_routing_policy,
+    normalize_additional_quota_key,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
 
@@ -2178,15 +2178,6 @@ def _additional_quota_routing_policy_override(limit_name: str | None, policies: 
     return policy
 
 
-def _normalize_additional_quota_key(raw_quota_key: str) -> str | None:
-    canonical_key = canonicalize_additional_quota_key(quota_key=raw_quota_key, limit_name=raw_quota_key)
-    if canonical_key is None:
-        return None
-    if get_additional_quota_definition(canonical_key) is None:
-        return None
-    return canonical_key
-
-
 def _parse_additional_quota_routing_policies(raw_policies: str) -> dict[str, str]:
     if not raw_policies:
         return {}
@@ -2200,7 +2191,7 @@ def _parse_additional_quota_routing_policies(raw_policies: str) -> dict[str, str
     for quota_key, policy in parsed.items():
         if not isinstance(quota_key, str) or not isinstance(policy, str):
             continue
-        normalized_key = _normalize_additional_quota_key(quota_key)
+        normalized_key = normalize_additional_quota_key(quota_key)
         normalized_policy = policy.strip().lower()
         if normalized_key and normalized_policy in _ADDITIONAL_QUOTA_ROUTING_POLICIES:
             policies[normalized_key] = normalized_policy

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -27,6 +27,12 @@ from app.core.balancer import (
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
 from app.core.clients.files import finalize_file as core_finalize_file  # noqa: F401
 from app.core.clients.http import lease_http_session as lease_http_session  # noqa: F401
+from app.core.clients.proxy import (
+    _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE as _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE,
+)
+from app.core.clients.proxy import (
+    _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE as _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE,
+)
 from app.core.clients.proxy import CodexControlRequestPrivacyPolicy as CodexControlRequestPrivacyPolicy
 from app.core.clients.proxy import CodexControlResponse as CodexControlResponse
 from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
@@ -44,6 +50,30 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     push_compact_timeout_overrides,
     push_stream_timeout_overrides,
     push_transcribe_timeout_overrides,
+)
+from app.core.clients.proxy import (
+    _is_inline_image_reference as _is_inline_image_reference,
+)
+from app.core.clients.proxy import (
+    _response_create_inline_image_notice_item as _response_create_inline_image_notice_item,
+)
+from app.core.clients.proxy import (
+    _response_create_inline_image_notice_part as _response_create_inline_image_notice_part,
+)
+from app.core.clients.proxy import (
+    _response_create_recent_suffix_start as _response_create_recent_suffix_start,
+)
+from app.core.clients.proxy import (
+    _response_create_too_large_error_envelope as _response_create_too_large_error_envelope,
+)
+from app.core.clients.proxy import (
+    _should_slim_historical_tool_output as _should_slim_historical_tool_output,
+)
+from app.core.clients.proxy import (
+    _slim_historical_response_content as _slim_historical_response_content,
+)
+from app.core.clients.proxy import (
+    _slim_historical_response_content_part as _slim_historical_response_content_part,
 )
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
@@ -366,6 +396,9 @@ from app.modules.proxy._service.refresh import (
     ensure_fresh_with_budget as _recover_fresh_account,
 )
 from app.modules.proxy._service.request_log import (
+    _normalize_session_id as _normalize_session_id,
+)
+from app.modules.proxy._service.request_log import (
     _RequestLogMixin,
 )
 from app.modules.proxy._service.response_create import (
@@ -382,12 +415,6 @@ from app.modules.proxy._service.response_create import (
 )
 from app.modules.proxy._service.response_create import (
     _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE as _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE,
-)
-from app.modules.proxy._service.response_create import (
-    _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE as _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE,
-)
-from app.modules.proxy._service.response_create import (
-    _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE as _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE,
 )
 from app.modules.proxy._service.response_create import (
     _UPSTREAM_RESPONSE_CREATE_MAX_BYTES as _UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
@@ -417,9 +444,6 @@ from app.modules.proxy._service.response_create import (
     _input_part_is_image as _input_part_is_image,
 )
 from app.modules.proxy._service.response_create import (
-    _is_inline_image_reference as _is_inline_image_reference,
-)
-from app.modules.proxy._service.response_create import (
     _json_size_bytes as _json_size_bytes,
 )
 from app.modules.proxy._service.response_create import (
@@ -441,15 +465,6 @@ from app.modules.proxy._service.response_create import (
     _response_create_history_omission_notice_item as _response_create_history_omission_notice_item,
 )
 from app.modules.proxy._service.response_create import (
-    _response_create_inline_image_notice_item as _response_create_inline_image_notice_item,
-)
-from app.modules.proxy._service.response_create import (
-    _response_create_inline_image_notice_part as _response_create_inline_image_notice_part,
-)
-from app.modules.proxy._service.response_create import (
-    _response_create_recent_suffix_start as _response_create_recent_suffix_start,
-)
-from app.modules.proxy._service.response_create import (
     _response_create_text as _response_create_text,
 )
 from app.modules.proxy._service.response_create import (
@@ -457,9 +472,6 @@ from app.modules.proxy._service.response_create import (
 )
 from app.modules.proxy._service.response_create import (
     _response_create_text_with_size_guard as _response_create_text_with_size_guard,
-)
-from app.modules.proxy._service.response_create import (
-    _response_create_too_large_error_envelope as _response_create_too_large_error_envelope,
 )
 from app.modules.proxy._service.response_create import (
     _response_output_item_done_tool_call as _response_output_item_done_tool_call,
@@ -475,15 +487,6 @@ from app.modules.proxy._service.response_create import (
 )
 from app.modules.proxy._service.response_create import (
     _should_dump_oversized_response_create as _should_dump_oversized_response_create,
-)
-from app.modules.proxy._service.response_create import (
-    _should_slim_historical_tool_output as _should_slim_historical_tool_output,
-)
-from app.modules.proxy._service.response_create import (
-    _slim_historical_response_content as _slim_historical_response_content,
-)
-from app.modules.proxy._service.response_create import (
-    _slim_historical_response_content_part as _slim_historical_response_content_part,
 )
 from app.modules.proxy._service.response_create import (
     _slim_historical_response_input_item as _slim_historical_response_input_item,
@@ -600,6 +603,9 @@ from app.modules.proxy._service.support import (
 )
 from app.modules.proxy._service.support import (
     _HTTPBridgeOwnerForward as _HTTPBridgeOwnerForward,
+)
+from app.modules.proxy._service.support import (
+    _raise_proxy_unavailable_for_account as _raise_proxy_unavailable_for_account,
 )
 from app.modules.proxy._service.support import (
     _websocket_route_log_kwargs as _websocket_route_log_kwargs,
@@ -2109,13 +2115,6 @@ def _message_mentions_previous_response_id(message: str | None, previous_respons
     )
 
 
-def _normalize_session_id(session_id: str | None) -> str | None:
-    if not isinstance(session_id, str):
-        return None
-    stripped = session_id.strip()
-    return stripped or None
-
-
 _MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES = (
     "no tool output found for function call call_",
     "no tool output found for custom tool call call_",
@@ -2385,15 +2384,6 @@ def _raise_proxy_unavailable(message: str) -> NoReturn:
 
 
 _FAILED_ACCOUNT_ATTR = "_codex_lb_failed_account"
-
-
-def _raise_proxy_unavailable_for_account(message: str, account: Account) -> NoReturn:
-    exc = ProxyResponseError(
-        502,
-        openai_error("upstream_unavailable", message),
-    )
-    setattr(exc, _FAILED_ACCOUNT_ATTR, account)
-    raise exc
 
 
 def _proxy_response_failed_account(exc: ProxyResponseError, fallback: Account) -> Account:

--- a/app/modules/quota_planner/scheduler.py
+++ b/app/modules/quota_planner/scheduler.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import json
 import logging
 import time
-from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
-from typing import Protocol, TypeVar, cast
 
 from app.core.config.settings import get_settings
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.utils.time import to_utc_naive
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
@@ -25,18 +23,6 @@ logger = logging.getLogger(__name__)
 # keeps ``interval_seconds`` as a constructor field so tests can exercise the
 # loop with a short interval.
 _TICK_SECONDS = 300
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 class QuotaPlannerScheduler:

--- a/app/modules/rate_limit_reset_credits/store.py
+++ b/app/modules/rate_limit_reset_credits/store.py
@@ -4,7 +4,11 @@ from datetime import datetime
 
 import anyio
 
-from app.core.clients.rate_limit_reset_credits import RateLimitResetCreditsSnapshot, ResetCreditItem
+from app.core.clients.rate_limit_reset_credits import (
+    RateLimitResetCreditsSnapshot,
+    ResetCreditItem,
+    _nearest_available_expires_at,
+)
 
 
 class RateLimitResetCreditsStore:
@@ -108,10 +112,3 @@ def _mark_credit_redeemed(
         matched = True
         updated.append(credit.model_copy(update={"status": "redeemed", "redeemed_at": redeemed_at}))
     return updated, matched
-
-
-def _nearest_available_expires_at(credits: list[ResetCreditItem]) -> datetime | None:
-    candidates = [
-        credit.expires_at for credit in credits if credit.status == "available" and credit.expires_at is not None
-    ]
-    return min(candidates) if candidates else None

--- a/app/modules/settings/service.py
+++ b/app/modules/settings/service.py
@@ -7,8 +7,7 @@ from datetime import datetime
 from app.core.config.settings import get_settings
 from app.modules.settings.repository import SettingsRepository
 from app.modules.usage.additional_quota_keys import (
-    canonicalize_additional_quota_key,
-    get_additional_quota_definition,
+    normalize_additional_quota_key,
 )
 
 
@@ -388,15 +387,6 @@ def _effective_retention_days(value: int | None) -> int:
     return 0 if value is None else value
 
 
-def _normalize_additional_quota_key(raw_quota_key: str) -> str | None:
-    canonical_key = canonicalize_additional_quota_key(quota_key=raw_quota_key, limit_name=raw_quota_key)
-    if canonical_key is None:
-        return None
-    if get_additional_quota_definition(canonical_key) is None:
-        return None
-    return canonical_key
-
-
 def _parse_additional_quota_routing_policies(raw: str | None) -> dict[str, str]:
     if not raw:
         return {}
@@ -410,7 +400,7 @@ def _parse_additional_quota_routing_policies(raw: str | None) -> dict[str, str]:
     for quota_key, policy in parsed.items():
         if not isinstance(quota_key, str) or not isinstance(policy, str):
             continue
-        normalized_quota_key = _normalize_additional_quota_key(quota_key)
+        normalized_quota_key = normalize_additional_quota_key(quota_key)
         policy = policy.strip().lower()
         if normalized_quota_key and policy in _ROUTING_POLICIES:
             policies[normalized_quota_key] = policy
@@ -422,7 +412,7 @@ def _dump_additional_quota_routing_policies(policies: dict[str, str]) -> str:
     for quota_key, policy in policies.items():
         if not isinstance(quota_key, str) or not isinstance(policy, str):
             continue
-        normalized_quota_key = _normalize_additional_quota_key(quota_key)
+        normalized_quota_key = normalize_additional_quota_key(quota_key)
         normalized_policy = policy.strip().lower()
         if normalized_quota_key is not None and normalized_policy in _ROUTING_POLICIES:
             normalized[normalized_quota_key] = normalized_policy

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
 import time
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Literal, Protocol, TypeVar, cast
+from typing import Literal
 
 from app.core import startup as startup_module
 from app.core.config.settings import Settings, get_settings
@@ -19,6 +17,7 @@ from app.core.metrics.prometheus import (
     http_bridge_spool_cleanup_duration_seconds,
     http_bridge_spool_cleanup_runs_total,
 )
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
 from app.db.session import SessionLocal, get_background_session
@@ -178,18 +177,6 @@ def _next_cleanup_delay_seconds(
 
 def _merge_backlog_signal(previous: bool, attempted: bool | None) -> bool:
     return previous if attempted is None else attempted
-
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 def _abandoned_bridge_retention_seconds(

--- a/app/modules/telemetry/scheduler.py
+++ b/app/modules/telemetry/scheduler.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib
 import logging
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Protocol, TypeVar, cast
 
+from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.db.session import get_background_session
 from app.modules.telemetry.consent import TelemetryConsentStore
 from app.modules.telemetry.sender import TelemetrySender
@@ -18,17 +16,6 @@ logger = logging.getLogger(__name__)
 
 TELEMETRY_INTERVAL_SECONDS = 24 * 60 * 60
 TELEMETRY_FIELDS_DOCUMENTATION = "https://soju06.github.io/codex-lb/telemetry/"
-
-_T = TypeVar("_T")
-
-
-class _LeaderElectionLike(Protocol):
-    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
-
-
-def _get_leader_election() -> _LeaderElectionLike:
-    module = importlib.import_module("app.core.scheduling.leader_election")
-    return cast(_LeaderElectionLike, module.get_leader_election())
 
 
 @dataclass(slots=True)

--- a/app/modules/usage/additional_quota_keys.py
+++ b/app/modules/usage/additional_quota_keys.py
@@ -327,6 +327,16 @@ def get_additional_quota_definition(quota_key: str | None) -> AdditionalQuotaDef
     return by_quota_key.get(resolved_key)
 
 
+def normalize_additional_quota_key(raw_quota_key: str) -> str | None:
+    """Canonicalize a user-supplied quota key and require a registered definition."""
+    canonical_key = canonicalize_additional_quota_key(quota_key=raw_quota_key, limit_name=raw_quota_key)
+    if canonical_key is None:
+        return None
+    if get_additional_quota_definition(canonical_key) is None:
+        return None
+    return canonical_key
+
+
 def get_additional_quota_query_scope(
     *,
     quota_key: str | None = None,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -30,7 +30,7 @@ from app.core.utils.shared_future import wait_on_shared_future
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
-from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
+from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager, _clean_optional
 from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
@@ -1182,13 +1182,6 @@ def _plan_downgrade_observation_store() -> PlanDowngradeObservationStorePort:
 
 async def _clear_workspace_less_free_plan_observations(account_id: str) -> None:
     await _plan_downgrade_observation_store().clear(account_id)
-
-
-def _clean_optional(value: str | None) -> str | None:
-    if not isinstance(value, str):
-        return None
-    cleaned = value.strip()
-    return cleaned or None
 
 
 def _usage_entry_written(entry: UsageHistory | None) -> bool:


### PR DESCRIPTION
## Summary

Consolidates copy-pasted module-level helpers (identical signature + body, both copies live) into a single canonical implementation and imports it at the former copy sites. Pure refactor: no behaviour change, no API change. Every module keeps the same attribute names, so existing monkeypatch seams (notably each scheduler's module-level `_get_leader_election`) keep working.

Evidence: AST scan of `app/` for identical `(signature + body)` hashes across files (slop-removal audit C7), re-verified on current `main`.

## Type of change

- [x] `refactor:` — internal refactor (no behavior change, no API change)

## OpenSpec

- [x] Not applicable — no observable behaviour, contract or schema change (pure code motion; `scripts/check_proxy_architecture.py` still passes)

## Changes

| Duplicate (copies) | Canonical home | LOC removed |
|---|---|---|
| `_get_leader_election` + `_LeaderElectionLike` (×11 scheduler modules) | new `app/core/scheduling/leader_election_handle.py` (`get_leader_election`, `LeaderElectionLike`), imported as `_get_leader_election` so per-module test seams are unchanged | ~160 (−25 for the new module) |
| response.create slimming: `_response_create_too_large_error_envelope`, `_response_create_recent_suffix_start`, `_slim_historical_response_content{,_part}`, `_response_create_inline_image_notice_{item,part}`, `_is_inline_image_reference`, `_should_slim_historical_tool_output` + 2 notice constants (`core/clients/proxy.py` vs `_service/response_create.py`) | `app/core/clients/proxy.py` (response_create already imported 12 names from it); `service.py` re-exports them from proxy directly | ~86 |
| `_http_bridge_server_anchored_replay_enabled`, `_http_bridge_client_full_history_recovery_error` (`request_submit.py` vs `streaming.py`) | `app/modules/proxy/_service/http_bridge/helpers.py` | ~54 (−27) |
| `_safe_json` (×4: `auth/refresh`, `clients/oauth`, `clients/usage`, `clients/rate_limit_reset_credits`) | `app/core/clients/http.py` | 28 (−10) |
| `_openai_error_detail` (`proxy.py` vs `proxy_websocket.py`) | `app/core/clients/proxy.py` | 21 |
| `_extract_error_code` / `_extract_error_message` (`auth/refresh.py` vs `clients/oauth.py`) | `app/core/clients/oauth.py` | 16 |
| `_codex_response_status` (×3: `usage`, `rate_limit_reset_credits`, `model_fetcher`) | `app/core/clients/proxy.py` (existing identical copy) | 15 |
| `_retry_options` + `RETRYABLE_STATUS`/`RETRY_START_TIMEOUT`/`RETRY_MAX_TIMEOUT` (`rate_limit_reset_credits` vs `usage`) | `app/core/clients/usage.py` (rlrc already imported `_retry_delay_seconds` from it) | 13 |
| `_normalize_additional_quota_key` (`proxy/load_balancer.py` vs `settings/service.py`) | public `normalize_additional_quota_key` in `app/modules/usage/additional_quota_keys.py` | 14 (−10) |
| `_coerce_number` (`core/openai/chat_responses.py` vs `proxy/helpers.py`) | `app/core/openai/chat_responses.py` (`proxy/helpers` still exposes the name for its unit test) | 11 |
| `_parse_port_value` (`main.py` vs `core/config/settings.py`) | `app/core/config/settings.py` | 10 |
| `_nearest_available_expires_at` (`core/clients/rate_limit_reset_credits.py` vs `modules/rate_limit_reset_credits/store.py`) | `app/core/clients/rate_limit_reset_credits.py` | 8 |
| `_clean_optional` (`accounts/auth_manager.py` vs `usage/updater.py`) | `app/modules/accounts/auth_manager.py` | 8 |
| `_content_parts` (`core/openai/chat_requests.py` vs `message_coercion.py`) | `app/core/openai/message_coercion.py` | 7 |
| `_raise_proxy_unavailable_for_account` (`proxy/service.py` vs `_service/support.py`) | `app/modules/proxy/_service/support.py`; `service.py` re-exports | 7 |
| `_normalize_session_id` (`proxy/service.py` vs `_service/request_log.py`) | `app/modules/proxy/_service/request_log.py`; `service.py` re-exports (service_stubs still resolves it via the service global) | 5 |

Import directions follow the existing graph (lower layer / already-imported module wins); `scripts/check_proxy_architecture.py` cross-domain rules are respected (all `_service` moves stay within `http_bridge` or go through `support`/`app.core`). Fresh-interpreter imports of every touched module were verified (no cycles).

### Looks duplicated but differs (intentionally left alone)

- **Façade family** (`_service_module`, `_service_global`, `_service_global_or`, `_service_get_settings*`, `_service_time`, `_remaining_budget_seconds`, `_raise_proxy_budget_exhausted`, `_raise_proxy_unavailable`, `_request_log_failure_metadata`, `_proxy_response_failed_account`, `_refresh_error_failed_account`, `_routing_strategy`, `_prefer_earlier_reset_window`, `_facade`, `_maybe_log_proxy_service_tier_trace`, and the 2-line `service_stubs.py` trampolines) — deliberate late-binding seams onto `app.modules.proxy.service` globals used by tests and the timing-seam ratchet.
- `_slim_historical_response_input_item` — same body, but keyed on independently-owned sets (`_SLIMMABLE_TOOL_CALL_OUTPUT_ITEM_TYPES` in proxy.py vs `_PENDING_TOOL_CALL_OUTPUT_ITEM_TYPES` in support.py); equal today, separately maintained.
- `_ensure_text_only_content` (`chat_requests` vs `message_coercion`) — raises `ValueError` vs `ClientPayloadError(param="messages")`.
- `_extract_error_code/_message` in `clients/usage.py` and `clients/rate_limit_reset_credits.py` — different envelope models and `.strip().lower()` normalisation.
- `_codex_response_json` / `_codex_response_text` (`proxy.py` vs `model_fetcher.py`) — proxy variant special-cases aiohttp/SSE responses and `content_type`.
- `_http_bridge_client_full_history_recovery_enabled` — `request_submit` gates on `propagate_http_errors`, `streaming` on `not fresh_upstream_request_is_retry_safe`.
- `_resolve_upstream_route_for_account` (`model_refresh_scheduler` vs `usage/updater`) — identical, but tests monkeypatch each module's `get_background_session`, which this helper closes over; hoisting it would silently bypass that seam.
- `_usage_refresh_interval_seconds` — 3 LOC inside load_balancer's deliberately forked mapper cluster (`_extract_credit_status`, `_first_not_none` differ).
- `_await_*_deferring_cancellation` 4-line wrappers — ratchet seams for `check_cancellation_safety.py`.

## Test plan

```
make lint                       # architecture / cancellation / timing-seam / settings-tier checks + ruff: pass
uv run ty check                 # All checks passed
uv run pytest tests/unit -q -x -n auto
# 8514 passed, 3 skipped (pre-rebase); post-rebase targeted scheduler/client/proxy subset 1923 passed
uv run pytest -n 4 tests/integration/test_proxy_responses.py test_proxy_websocket_responses.py test_http_responses_bridge.py \
  test_proxy_chat_completions.py test_proxy_compact.py test_usage_refresh_scheduler_scope.py test_multi_replica.py \
  test_model_registry_replication.py test_rate_limit_reset_credits_api.py test_v1_reset_credit.py \
  test_reset_credits_replica_safety.py test_settings_api.py test_additional_usage_flow.py test_oauth_flow.py \
  test_token_refresh_claims.py test_data_retention.py test_account_deletion_background.py test_account_usage_rollup.py \
  test_automations_api.py test_quota_planner_api.py test_auth_guardian_multi_replica.py test_load_balancer_integration.py \
  test_codex_usage_api.py
# 916 passed, 3 skipped, 1 xdist-order flake (test_settings_api::test_account_proxy_binding_reactivation_invalidates_after_commit)
# which passes in isolation on both this branch and untouched main, and in a serial run of the whole file (49 passed)
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No new tests: pure code motion covered by the existing suites above.
- [x] Ran the relevant `make lint` / `uv run ty check` / pytest subsets locally.
- [x] No settings, README, dashboard or default changes (Simplicity section N/A).
- [x] CHANGELOG not edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)