### PR TITLE
feat(auth): add dashboard role rows with code-defined preset grants

### DIFF
--- a/app/core/auth/dashboard_access.py
+++ b/app/core/auth/dashboard_access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -108,13 +109,86 @@ _WRITE_ALIAS_PERMISSIONS: frozenset[Permission] = frozenset(
     }
 )
 
+
+class PresetRoleSlug(StrEnum):
+    """The built-in roles. Their grants live in code, never in the database."""
+
+    ADMIN = "admin"
+    OPERATOR = "operator"
+    MEMBER = "member"
+    VIEWER = "viewer"
+    GUEST = "guest"
+
+
+#: Stable identifiers for the preset role rows (``dashboard_roles``), derived
+#: from the slug so every install and every replica agrees without coordination.
+_PRESET_ROLE_ID_NAMESPACE = uuid.UUID("6f1c0e4e-2b4a-4c1e-9c3b-7a5d2e8f0a11")
+
+
+def preset_role_id(slug: PresetRoleSlug) -> str:
+    """Deterministic id of a preset role row (UUIDv5 of the slug)."""
+
+    return str(uuid.uuid5(_PRESET_ROLE_ID_NAMESPACE, f"codex-lb:dashboard-role:{slug.value}"))
+
+
+PRESET_ROLE_IDS: Mapping[PresetRoleSlug, str] = MappingProxyType(
+    {slug: preset_role_id(slug) for slug in PresetRoleSlug}
+)
+
+PRESET_ROLE_NAMES: Mapping[PresetRoleSlug, str] = MappingProxyType(
+    {
+        PresetRoleSlug.ADMIN: "Admin",
+        PresetRoleSlug.OPERATOR: "Operator",
+        PresetRoleSlug.MEMBER: "Member",
+        PresetRoleSlug.VIEWER: "Viewer",
+        PresetRoleSlug.GUEST: "Guest",
+    }
+)
+
 ADMIN_GRANTS: Grants = _grants({permission: Scope.ALL for permission in Permission})
-GUEST_GRANTS: Grants = _grants(
+OPERATOR_GRANTS: Grants = _grants(
+    {
+        Permission.DASHBOARD_READ: Scope.ALL,
+        Permission.ACCOUNTS_READ: Scope.ALL,
+        Permission.ACCOUNTS_WRITE: Scope.ALL,
+        Permission.API_KEYS_READ: Scope.ALL,
+        Permission.API_KEYS_WRITE: Scope.ALL,
+        Permission.API_KEYS_ASSIGN: Scope.ALL,
+        Permission.OPS_WRITE: Scope.ALL,
+    }
+)
+MEMBER_GRANTS: Grants = _grants(
+    {
+        Permission.DASHBOARD_READ: Scope.OWN,
+        Permission.API_KEYS_READ: Scope.OWN,
+        Permission.API_KEYS_WRITE: Scope.OWN,
+    }
+)
+VIEWER_GRANTS: Grants = _grants(
     {
         Permission.DASHBOARD_READ: Scope.ALL,
         Permission.ACCOUNTS_READ: Scope.ALL,
     }
 )
+GUEST_GRANTS: Grants = VIEWER_GRANTS
+
+#: Grants of every preset role. The database stores preset *rows* (for foreign
+#: keys and listings) but never their grants: this table is the single truth,
+#: so an upgrade that adds a permission updates every preset by definition and
+#: replicas of different versions can never disagree about what ``admin`` means.
+PRESET_ROLE_GRANTS: Mapping[PresetRoleSlug, Grants] = MappingProxyType(
+    {
+        PresetRoleSlug.ADMIN: ADMIN_GRANTS,
+        PresetRoleSlug.OPERATOR: OPERATOR_GRANTS,
+        PresetRoleSlug.MEMBER: MEMBER_GRANTS,
+        PresetRoleSlug.VIEWER: VIEWER_GRANTS,
+        PresetRoleSlug.GUEST: GUEST_GRANTS,
+    }
+)
+
+#: Presets that may be assigned to a user account. Guest is the anonymous
+#: shared read-only session and is never a user's role.
+ASSIGNABLE_PRESET_ROLES: frozenset[PresetRoleSlug] = frozenset(PresetRoleSlug) - {PresetRoleSlug.GUEST}
 
 ROLE_GRANTS: Mapping[DashboardRole, Grants] = MappingProxyType(
     {
@@ -155,7 +229,7 @@ def validate_grants(grants: Grants) -> None:
             raise ValueError(f"{permission.value} requires {', '.join(missing)} at 'all' scope")
 
 
-for _role_grants in ROLE_GRANTS.values():
+for _role_grants in PRESET_ROLE_GRANTS.values():
     validate_grants(_role_grants)
 
 

--- a/app/core/auth/dashboard_access.py
+++ b/app/core/auth/dashboard_access.py
@@ -110,6 +110,13 @@ _WRITE_ALIAS_PERMISSIONS: frozenset[Permission] = frozenset(
 )
 
 
+class RoleKind(StrEnum):
+    """``dashboard_roles.kind``: presets resolve from code, custom roles from grant rows."""
+
+    PRESET = "preset"
+    CUSTOM = "custom"
+
+
 class PresetRoleSlug(StrEnum):
     """The built-in roles. Their grants live in code, never in the database."""
 

--- a/app/db/alembic/versions/20260909_000000_add_dashboard_roles.py
+++ b/app/db/alembic/versions/20260909_000000_add_dashboard_roles.py
@@ -1,0 +1,72 @@
+"""Add dashboard_roles and dashboard_role_grants with the five preset rows.
+
+Revision ID: 20260909_000000_add_dashboard_roles
+Revises: 20260908_000000_add_guest_session_generation
+Create Date: 2026-09-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.modules.dashboard_roles.seed import seed_preset_dashboard_roles
+
+revision = "20260909_000000_add_dashboard_roles"
+down_revision = "20260908_000000_add_guest_session_generation"
+branch_labels = None
+depends_on = None
+
+
+def _roles_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "dashboard_roles",
+        metadata,
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("slug", sa.String(length=32), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("assignable_to_users", sa.Boolean(), server_default=sa.true(), nullable=False),
+        sa.Column(
+            "cloned_from_role_id",
+            sa.String(),
+            sa.ForeignKey("dashboard_roles.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("permissions_version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    metadata = sa.MetaData()
+    roles = _roles_table(metadata)
+    if not inspector.has_table("dashboard_roles"):
+        roles.create(bind)
+    if not inspector.has_table("dashboard_role_grants"):
+        op.create_table(
+            "dashboard_role_grants",
+            sa.Column(
+                "role_id",
+                sa.String(),
+                sa.ForeignKey("dashboard_roles.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column("permission", sa.String(length=64), primary_key=True),
+            sa.Column("scope", sa.String(length=8), nullable=False),
+        )
+    # Outside the table guard so a re-run after a partial failure still seeds.
+    seed_preset_dashboard_roles(bind, roles)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("dashboard_role_grants"):
+        op.drop_table("dashboard_role_grants")
+    if inspector.has_table("dashboard_roles"):
+        op.drop_table("dashboard_roles")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -883,6 +883,59 @@ class CapabilityLineageMarker(Base):
     )
 
 
+class DashboardRoleRecord(Base):
+    """A dashboard role: one of the five presets or an operator-defined custom role.
+
+    Preset rows exist so users, invites, mappings and policies can reference a
+    role by foreign key and so listings have one source; their grants are the
+    code table ``PRESET_ROLE_GRANTS`` and are never stored. Only custom roles
+    carry ``dashboard_role_grants`` rows. ``kind`` is a plain string validated
+    by the application (adding a value must not need a database type change).
+    """
+
+    __tablename__ = "dashboard_roles"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    slug: Mapped[str] = mapped_column(String(32), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    assignable_to_users: Mapped[bool] = mapped_column(Boolean, default=True, server_default=true(), nullable=False)
+    cloned_from_role_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("dashboard_roles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    permissions_version: Mapped[int] = mapped_column(Integer, default=1, server_default=text("1"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    grants: Mapped[list["DashboardRoleGrant"]] = relationship(
+        "DashboardRoleGrant",
+        back_populates="role",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class DashboardRoleGrant(Base):
+    """One (permission, scope) grant of a custom dashboard role."""
+
+    __tablename__ = "dashboard_role_grants"
+
+    role_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("dashboard_roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    permission: Mapped[str] = mapped_column(String(64), primary_key=True)
+    scope: Mapped[str] = mapped_column(String(8), nullable=False)
+
+    role: Mapped["DashboardRoleRecord"] = relationship("DashboardRoleRecord", back_populates="grants")
+
+
 class DashboardSettings(Base):
     __tablename__ = "dashboard_settings"
 

--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,6 @@ from app.db.session import (
     SessionLocal,
     close_db,
     close_session,
-    engine,
     init_background_db,
     init_db,
     mark_sqlite_shutdown_clean,
@@ -97,7 +96,6 @@ from app.modules.automations.scheduler import build_automations_scheduler
 from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
-from app.modules.dashboard_roles.seed import ensure_preset_dashboard_roles
 from app.modules.firewall import api as firewall_api
 from app.modules.fleet import api as fleet_api
 from app.modules.health import api as health_api
@@ -511,8 +509,6 @@ async def lifespan(app: FastAPI):
     configure_replica_salt(settings.http_responses_session_bridge_instance_id)
     bridge_endpoint_base_url = settings.http_responses_session_bridge_advertise_base_url
     await init_db()
-    async with engine.begin() as connection:
-        await ensure_preset_dashboard_roles(connection)
     init_background_db()
     await verify_encryption_key_fingerprint()
     _auto_bootstrap_token = await ensure_auto_bootstrap_token()

--- a/app/main.py
+++ b/app/main.py
@@ -79,6 +79,7 @@ from app.db.session import (
     SessionLocal,
     close_db,
     close_session,
+    engine,
     init_background_db,
     init_db,
     mark_sqlite_shutdown_clean,
@@ -96,6 +97,7 @@ from app.modules.automations.scheduler import build_automations_scheduler
 from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
+from app.modules.dashboard_roles.seed import ensure_preset_dashboard_roles
 from app.modules.firewall import api as firewall_api
 from app.modules.fleet import api as fleet_api
 from app.modules.health import api as health_api
@@ -509,6 +511,8 @@ async def lifespan(app: FastAPI):
     configure_replica_salt(settings.http_responses_session_bridge_instance_id)
     bridge_endpoint_base_url = settings.http_responses_session_bridge_advertise_base_url
     await init_db()
+    async with engine.begin() as connection:
+        await ensure_preset_dashboard_roles(connection)
     init_background_db()
     await verify_encryption_key_fingerprint()
     _auto_bootstrap_token = await ensure_auto_bootstrap_token()

--- a/app/modules/dashboard_roles/repository.py
+++ b/app/modules/dashboard_roles/repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.db.models import DashboardRoleRecord
+
+
+class DashboardRolesRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_roles(self) -> Sequence[DashboardRoleRecord]:
+        stmt = (
+            select(DashboardRoleRecord)
+            .options(selectinload(DashboardRoleRecord.grants))
+            .order_by(DashboardRoleRecord.kind.desc(), DashboardRoleRecord.slug.asc())
+        )
+        return (await self._session.execute(stmt)).scalars().all()
+
+    async def get_role(self, role_id: str) -> DashboardRoleRecord | None:
+        stmt = (
+            select(DashboardRoleRecord)
+            .options(selectinload(DashboardRoleRecord.grants))
+            .where(DashboardRoleRecord.id == role_id)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_role_by_slug(self, slug: str) -> DashboardRoleRecord | None:
+        stmt = (
+            select(DashboardRoleRecord)
+            .options(selectinload(DashboardRoleRecord.grants))
+            .where(DashboardRoleRecord.slug == slug)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_preset_role(self, slug: PresetRoleSlug) -> DashboardRoleRecord | None:
+        return await self.get_role(PRESET_ROLE_IDS[slug])

--- a/app/modules/dashboard_roles/seed.py
+++ b/app/modules/dashboard_roles/seed.py
@@ -1,15 +1,14 @@
 """Idempotent seeding of the preset ``dashboard_roles`` rows.
 
-The migration, application startup and the test schema reset all call this so
-the five preset rows exist wherever the table exists. Rows are inserted with
+The Alembic revision (with its own revision-pinned table definition) and the
+test schema reset (which builds the schema with ``create_all`` instead of
+Alembic) both call this so the five preset rows exist wherever the table does. Rows are inserted with
 "do nothing on conflict" semantics and are never updated: preset grants live
 in code (``PRESET_ROLE_GRANTS``), so there is nothing version-dependent to
 reconcile and a replica running older code can never strip a newer grant.
 """
 
 from __future__ import annotations
-
-from typing import cast
 
 from sqlalchemy import Table, select
 from sqlalchemy.dialects import postgresql, sqlite
@@ -21,10 +20,11 @@ from app.core.auth.dashboard_access import (
     PRESET_ROLE_IDS,
     PRESET_ROLE_NAMES,
     PresetRoleSlug,
+    RoleKind,
 )
+from app.db.models import Base, DashboardRoleRecord
 
-ROLE_KIND_PRESET = "preset"
-ROLE_KIND_CUSTOM = "custom"
+_ROLES_TABLE: Table = Base.metadata.tables[DashboardRoleRecord.__tablename__]
 
 _PRESET_DESCRIPTIONS: dict[PresetRoleSlug, str] = {
     PresetRoleSlug.ADMIN: "Everything: users, security settings, credentials export, conversations, audit.",
@@ -42,7 +42,7 @@ def preset_role_rows() -> list[dict[str, object]]:
             "slug": slug.value,
             "name": PRESET_ROLE_NAMES[slug],
             "description": _PRESET_DESCRIPTIONS[slug],
-            "kind": ROLE_KIND_PRESET,
+            "kind": RoleKind.PRESET.value,
             "assignable_to_users": slug in ASSIGNABLE_PRESET_ROLES,
             "permissions_version": 1,
         }
@@ -66,16 +66,14 @@ def _insert_ignore(connection: Connection, table: Table, rows: list[dict[str, ob
         connection.execute(table.insert().values(missing))
 
 
-def _model_table() -> Table:
-    from app.db.models import DashboardRoleRecord
+def seed_preset_dashboard_roles(connection: Connection, table: Table = _ROLES_TABLE) -> None:
+    """Insert any missing preset role row using a synchronous connection.
 
-    return cast(Table, DashboardRoleRecord.__table__)
+    The migration passes its own revision-pinned table so it stays frozen
+    when the ORM model evolves; every other caller uses the current model.
+    """
 
-
-def seed_preset_dashboard_roles(connection: Connection, table: Table | None = None) -> None:
-    """Insert any missing preset role row using a synchronous connection."""
-
-    _insert_ignore(connection, table if table is not None else _model_table(), preset_role_rows())
+    _insert_ignore(connection, table, preset_role_rows())
 
 
 async def ensure_preset_dashboard_roles(connection: AsyncConnection) -> None:

--- a/app/modules/dashboard_roles/seed.py
+++ b/app/modules/dashboard_roles/seed.py
@@ -1,0 +1,82 @@
+"""Idempotent seeding of the preset ``dashboard_roles`` rows.
+
+The migration, application startup and the test schema reset all call this so
+the five preset rows exist wherever the table exists. Rows are inserted with
+"do nothing on conflict" semantics and are never updated: preset grants live
+in code (``PRESET_ROLE_GRANTS``), so there is nothing version-dependent to
+reconcile and a replica running older code can never strip a newer grant.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from sqlalchemy import Table, select
+from sqlalchemy.dialects import postgresql, sqlite
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.core.auth.dashboard_access import (
+    ASSIGNABLE_PRESET_ROLES,
+    PRESET_ROLE_IDS,
+    PRESET_ROLE_NAMES,
+    PresetRoleSlug,
+)
+
+ROLE_KIND_PRESET = "preset"
+ROLE_KIND_CUSTOM = "custom"
+
+_PRESET_DESCRIPTIONS: dict[PresetRoleSlug, str] = {
+    PresetRoleSlug.ADMIN: "Everything: users, security settings, credentials export, conversations, audit.",
+    PresetRoleSlug.OPERATOR: "Day-to-day operations: accounts, all API keys, model sources, automations.",
+    PresetRoleSlug.MEMBER: "Own API keys and own usage only.",
+    PresetRoleSlug.VIEWER: "Read-only dashboard, reports and account status.",
+    PresetRoleSlug.GUEST: "Anonymous shared read-only session; cannot be assigned to a user.",
+}
+
+
+def preset_role_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "id": PRESET_ROLE_IDS[slug],
+            "slug": slug.value,
+            "name": PRESET_ROLE_NAMES[slug],
+            "description": _PRESET_DESCRIPTIONS[slug],
+            "kind": ROLE_KIND_PRESET,
+            "assignable_to_users": slug in ASSIGNABLE_PRESET_ROLES,
+            "permissions_version": 1,
+        }
+        for slug in PresetRoleSlug
+    ]
+
+
+def _insert_ignore(connection: Connection, table: Table, rows: list[dict[str, object]]) -> None:
+    dialect = connection.dialect.name
+    if dialect == "postgresql":
+        stmt = postgresql.insert(table).values(rows).on_conflict_do_nothing(index_elements=["id"])
+        connection.execute(stmt)
+        return
+    if dialect == "sqlite":
+        stmt = sqlite.insert(table).values(rows).on_conflict_do_nothing(index_elements=["id"])
+        connection.execute(stmt)
+        return
+    existing = {row[0] for row in connection.execute(select(table.c.id)).all()}
+    missing = [row for row in rows if row["id"] not in existing]
+    if missing:
+        connection.execute(table.insert().values(missing))
+
+
+def _model_table() -> Table:
+    from app.db.models import DashboardRoleRecord
+
+    return cast(Table, DashboardRoleRecord.__table__)
+
+
+def seed_preset_dashboard_roles(connection: Connection, table: Table | None = None) -> None:
+    """Insert any missing preset role row using a synchronous connection."""
+
+    _insert_ignore(connection, table if table is not None else _model_table(), preset_role_rows())
+
+
+async def ensure_preset_dashboard_roles(connection: AsyncConnection) -> None:
+    await connection.run_sync(seed_preset_dashboard_roles)

--- a/app/modules/dashboard_roles/service.py
+++ b/app/modules/dashboard_roles/service.py
@@ -1,0 +1,53 @@
+"""Resolve a role row into the grant table the authorization layer consumes."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from types import MappingProxyType
+
+from app.core.auth.dashboard_access import (
+    PRESET_ROLE_GRANTS,
+    Grants,
+    Permission,
+    PresetRoleSlug,
+    Scope,
+)
+from app.db.models import DashboardRoleGrant, DashboardRoleRecord
+from app.modules.dashboard_roles.seed import ROLE_KIND_PRESET
+
+logger = logging.getLogger(__name__)
+
+
+def grants_from_rows(rows: Iterable[DashboardRoleGrant]) -> Grants:
+    """Build a grant table from custom-role rows.
+
+    Unknown permission or scope strings are skipped, not raised: during a
+    rolling upgrade a newer replica may have written a permission this
+    replica's vocabulary does not know yet, and that must not break every
+    request for holders of the role.
+    """
+
+    grants: dict[Permission, Scope] = {}
+    for row in rows:
+        try:
+            permission = Permission(row.permission)
+            scope = Scope(row.scope)
+        except ValueError:
+            logger.warning(
+                "dashboard_role_grant_ignored role_id=%s permission=%s scope=%s",
+                row.role_id,
+                row.permission,
+                row.scope,
+            )
+            continue
+        grants[permission] = scope
+    return MappingProxyType(grants)
+
+
+def resolve_role_grants(role: DashboardRoleRecord) -> Grants:
+    """Preset roles resolve from code; custom roles from their stored grant rows."""
+
+    if role.kind == ROLE_KIND_PRESET:
+        return PRESET_ROLE_GRANTS[PresetRoleSlug(role.slug)]
+    return grants_from_rows(role.grants)

--- a/app/modules/dashboard_roles/service.py
+++ b/app/modules/dashboard_roles/service.py
@@ -11,10 +11,10 @@ from app.core.auth.dashboard_access import (
     Grants,
     Permission,
     PresetRoleSlug,
+    RoleKind,
     Scope,
 )
 from app.db.models import DashboardRoleGrant, DashboardRoleRecord
-from app.modules.dashboard_roles.seed import ROLE_KIND_PRESET
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +46,13 @@ def grants_from_rows(rows: Iterable[DashboardRoleGrant]) -> Grants:
 
 
 def resolve_role_grants(role: DashboardRoleRecord) -> Grants:
-    """Preset roles resolve from code; custom roles from their stored grant rows."""
+    """Preset roles resolve from code; custom roles from their stored grant rows.
 
-    if role.kind == ROLE_KIND_PRESET:
+    An unknown ``kind`` or an unknown preset slug raises: preset rows are only
+    written by the migration, so such a row is a provisioning error and must
+    not fall back to a quiet default.
+    """
+
+    if RoleKind(role.kind) is RoleKind.PRESET:
         return PRESET_ROLE_GRANTS[PresetRoleSlug(role.slug)]
     return grants_from_rows(role.grants)

--- a/openspec/changes/add-dashboard-roles-schema/design.md
+++ b/openspec/changes/add-dashboard-roles-schema/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The RBAC plan (D7) fixes five preset roles and lets administrators clone them into custom roles later. Users, invites, identity mappings, key policies, and providers will all carry a `role_id`, so roles must be rows. The permission vocabulary and scope model already exist in `app/core/auth/dashboard_access.py`.
+
+## Goals / Non-Goals
+
+**Goals**
+- Give every future role reference one foreign-key target with stable ids across installs and replicas.
+- Keep preset grants out of the database so an upgrade never has to reconcile rows and mixed-version fleets cannot disagree about what `admin` means.
+- Load custom-role grants tolerantly during rolling upgrades.
+- Zero behaviour change for existing installs.
+
+**Non-Goals**
+- Any API, UI, or principal change (users arrive in the next change; the role editor in Phase 5).
+- Enforcing dependency rules on stored custom grants at read time (the editor enforces them at write time; the loader only drops unknown vocabulary).
+
+## Decisions
+
+### Preset rows, code grants
+
+`dashboard_roles` rows for presets are inserted once and never updated; `kind='preset'` rows have no `dashboard_role_grants`. `resolve_role_grants` returns `PRESET_ROLE_GRANTS[slug]` for presets and the stored rows for custom roles. A boot-time reconciler that rewrites grants was rejected: an older replica rebooting would strip newer grants, and concurrent boots race outside the migration lock.
+
+### Deterministic ids
+
+Preset ids are UUIDv5 of the slug under a fixed namespace (`PRESET_ROLE_IDS`). Migrations, fixtures, and future data (mappings, policies) can reference them without a lookup, and two databases seeded independently agree.
+
+### Seeding is shared and idempotent
+
+`seed_preset_dashboard_roles(connection)` uses dialect-specific "insert … on conflict do nothing" (PostgreSQL, SQLite) with a select-then-insert fallback. The migration calls it outside its table-existence guard (re-run safe), startup calls it right after `init_db()` (new install or a database restored without the rows), and the test schema reset calls it after `create_all` because tests do not run Alembic.
+
+### Plain string columns, application-validated
+
+`kind`, `permission`, and `scope` are `String` columns validated by `StrEnum`s in code, not `SqlEnum`, so adding a value never needs a database type migration (the same rule the plan sets for users' `status`/`role_source`).
+
+### Tolerant loader
+
+`grants_from_rows` skips rows whose permission or scope is not in this replica's vocabulary and logs them, instead of raising. During a rolling upgrade a newer replica may have written a permission this one does not know; failing every request for the role's holders would be worse than temporarily ignoring the new grant.
+
+## Risks / Trade-offs
+
+- [Risk] A future change forgets to seed presets in a new code path (e.g. a CLI that creates a database without migrations). → Seeding is one function; the startup hook covers every process that serves requests.
+- [Risk] `guest` as a row could be assigned to a user by mistake. → `assignable_to_users=false` on the row and `ASSIGNABLE_PRESET_ROLES` in code; the users change enforces it.
+- [Trade-off] Preset display names/descriptions are seeded in English and never updated by later migrations. → UI renders presets via i18n keyed by slug; the row text is a fallback for API consumers.

--- a/openspec/changes/add-dashboard-roles-schema/design.md
+++ b/openspec/changes/add-dashboard-roles-schema/design.md
@@ -11,6 +11,7 @@ The RBAC plan (D7) fixes five preset roles and lets administrators clone them in
 - Zero behaviour change for existing installs.
 
 **Non-Goals**
+- `dashboard_roles.created_by_user_id`: deferred to the first writer of custom roles (the custom-role editor), where it can carry the FK to `dashboard_users`; presets have no author.
 - Any API, UI, or principal change (users arrive in the next change; the role editor in Phase 5).
 - Enforcing dependency rules on stored custom grants at read time (the editor enforces them at write time; the loader only drops unknown vocabulary).
 
@@ -26,11 +27,11 @@ Preset ids are UUIDv5 of the slug under a fixed namespace (`PRESET_ROLE_IDS`). M
 
 ### Seeding is shared and idempotent
 
-`seed_preset_dashboard_roles(connection)` uses dialect-specific "insert … on conflict do nothing" (PostgreSQL, SQLite) with a select-then-insert fallback. The migration calls it outside its table-existence guard (re-run safe), startup calls it right after `init_db()` (new install or a database restored without the rows), and the test schema reset calls it after `create_all` because tests do not run Alembic.
+`seed_preset_dashboard_roles(connection)` uses dialect-specific "insert … on conflict do nothing" (PostgreSQL, SQLite) with a select-then-insert fallback. The migration calls it outside its table-existence guard (re-run safe) with a revision-pinned table definition, and the test schema reset calls it after `create_all` because tests do not run Alembic. There is deliberately no startup hook: it would run outside `migration_lock` and outside `init_db`'s fail-fast policy (a schema-less process with `CODEX_LB_DATABASE_MIGRATIONS_FAIL_FAST=false` would crash on the INSERT), and the migration already guarantees the rows on every supported path.
 
 ### Plain string columns, application-validated
 
-`kind`, `permission`, and `scope` are `String` columns validated by `StrEnum`s in code, not `SqlEnum`, so adding a value never needs a database type migration (the same rule the plan sets for users' `status`/`role_source`).
+`kind` (`RoleKind`), `permission`, and `scope` are `String` columns validated by `StrEnum`s in code, not `SqlEnum`, so adding a value never needs a database type migration (the same rule the plan sets for users' `status`/`role_source`).
 
 ### Tolerant loader
 
@@ -38,6 +39,6 @@ Preset ids are UUIDv5 of the slug under a fixed namespace (`PRESET_ROLE_IDS`). M
 
 ## Risks / Trade-offs
 
-- [Risk] A future change forgets to seed presets in a new code path (e.g. a CLI that creates a database without migrations). → Seeding is one function; the startup hook covers every process that serves requests.
+- [Risk] A future change creates a database without migrations (e.g. a CLI) and forgets the presets. → Seeding is one function; the only supported non-Alembic path (the test schema reset) calls it, and a missing preset surfaces as an FK error at the first user insert rather than as a quiet default.
 - [Risk] `guest` as a row could be assigned to a user by mistake. → `assignable_to_users=false` on the row and `ASSIGNABLE_PRESET_ROLES` in code; the users change enforces it.
 - [Trade-off] Preset display names/descriptions are seeded in English and never updated by later migrations. → UI renders presets via i18n keyed by slug; the row text is a fallback for API consumers.

--- a/openspec/changes/add-dashboard-roles-schema/proposal.md
+++ b/openspec/changes/add-dashboard-roles-schema/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Per-user dashboard accounts (the next change) need a role to point at, and later changes (identity mappings, invites, key policies, custom roles) all reference roles by foreign key. The permission vocabulary already exists in code (`expand-dashboard-permission-vocabulary`); what is missing is a durable role identity in the database. Storing preset grants in the database would create a second source of truth that drifts across replica versions, so the schema stores preset *rows* only and keeps preset grants in code.
+
+## What Changes
+
+- New tables `dashboard_roles` (id, slug, name, description, kind `preset|custom`, assignable_to_users, cloned_from_role_id, permissions_version, timestamps) and `dashboard_role_grants` (role_id, permission, scope) — one Alembic revision that also seeds the five preset rows (`admin`, `operator`, `member`, `viewer`, `guest`) with stable UUIDv5 ids and zero grant rows.
+- Code-defined grant tables for every preset (`PRESET_ROLE_GRANTS`; operator/member/viewer added next to the existing admin/guest), a preset registry (`PresetRoleSlug`, `PRESET_ROLE_IDS`, `ASSIGNABLE_PRESET_ROLES`), and a read-only `dashboard_roles` module (repository + `resolve_role_grants`) that resolves presets from code and custom roles from their grant rows, ignoring unknown permission strings.
+- Idempotent preset seeding shared by the migration, application startup, and the test schema reset.
+- No consumer changes: no route reads the new tables yet, the principal model is untouched, guest and admin behave exactly as before.
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-roles`: Role identity rows, preset locking (grants in code), custom-role grant storage, and the tolerant grant loader.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/db/models.py` (two models), `app/db/alembic/versions/20260909_000000_add_dashboard_roles.py`, `app/core/auth/dashboard_access.py` (preset registry + grant tables), new `app/modules/dashboard_roles/`, `app/main.py` (seed after `init_db`), `tests/conftest.py` (seed after `create_all`).
+- No setting, env var, README, nav, or API change.

--- a/openspec/changes/add-dashboard-roles-schema/proposal.md
+++ b/openspec/changes/add-dashboard-roles-schema/proposal.md
@@ -6,7 +6,7 @@ Per-user dashboard accounts (the next change) need a role to point at, and later
 
 - New tables `dashboard_roles` (id, slug, name, description, kind `preset|custom`, assignable_to_users, cloned_from_role_id, permissions_version, timestamps) and `dashboard_role_grants` (role_id, permission, scope) — one Alembic revision that also seeds the five preset rows (`admin`, `operator`, `member`, `viewer`, `guest`) with stable UUIDv5 ids and zero grant rows.
 - Code-defined grant tables for every preset (`PRESET_ROLE_GRANTS`; operator/member/viewer added next to the existing admin/guest), a preset registry (`PresetRoleSlug`, `PRESET_ROLE_IDS`, `ASSIGNABLE_PRESET_ROLES`), and a read-only `dashboard_roles` module (repository + `resolve_role_grants`) that resolves presets from code and custom roles from their grant rows, ignoring unknown permission strings.
-- Idempotent preset seeding shared by the migration, application startup, and the test schema reset.
+- Idempotent, insert-only preset seeding shared by the migration and the test schema reset (no startup reconciler).
 - No consumer changes: no route reads the new tables yet, the principal model is untouched, guest and admin behave exactly as before.
 
 ## Capabilities

--- a/openspec/changes/add-dashboard-roles-schema/specs/dashboard-roles/spec.md
+++ b/openspec/changes/add-dashboard-roles-schema/specs/dashboard-roles/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Dashboard roles are rows with stable preset identities
+
+The system SHALL store dashboard roles in a `dashboard_roles` table with columns `id`, `slug` (unique), `name`, `description`, `kind` (`preset` or `custom`), `assignable_to_users`, `cloned_from_role_id`, `permissions_version`, `created_at`, and `updated_at`. Five preset rows MUST exist with slugs `admin`, `operator`, `member`, `viewer`, and `guest`, `kind` `preset`, and ids equal to the UUIDv5 derived from the slug under the fixed preset namespace, so every install and replica uses identical identifiers. The `guest` preset MUST have `assignable_to_users` false; the other presets true. The preset rows MUST be seeded idempotently by the Alembic revision, at application startup after database initialisation, and by the test schema reset.
+
+#### Scenario: Fresh database has the five presets
+
+- **WHEN** the schema is created and seeded
+- **THEN** `dashboard_roles` contains exactly the five preset slugs with `kind` `preset` and their deterministic ids
+- **AND** repeating the seed does not add or modify rows
+
+#### Scenario: Guest cannot be assigned
+
+- **WHEN** the preset rows are read
+- **THEN** only `guest` has `assignable_to_users` false
+
+### Requirement: Preset grants live in code, custom grants in rows
+
+The system SHALL keep the grant table of every preset role in code (`PRESET_ROLE_GRANTS`) and MUST NOT store preset grants in the database; `dashboard_role_grants` rows exist only for custom roles. Resolving a preset role's grants MUST return the code table regardless of any rows attached to the preset. The preset grant tables MUST be: `admin` every permission at `all`; `operator` `dashboard:read`, `accounts:read`, `accounts:write`, `api_keys:read`, `api_keys:write`, `api_keys:assign`, `ops:write` at `all`; `member` `dashboard:read`, `api_keys:read`, `api_keys:write` at `own`; `viewer` and `guest` `dashboard:read` and `accounts:read` at `all`. Every preset table MUST satisfy the vocabulary scope and dependency rules.
+
+#### Scenario: Upgrade adds a permission to presets without a data change
+
+- **WHEN** a release adds a permission to the vocabulary and to a preset's code table
+- **THEN** the preset resolves to the new grant set with no migration or row update
+
+#### Scenario: Custom role resolves from its rows
+
+- **WHEN** a `custom` role has grant rows `dashboard:read all` and `api_keys:read own`
+- **THEN** resolving it yields exactly those grants
+
+### Requirement: Custom grant loading tolerates unknown vocabulary
+
+When loading `dashboard_role_grants` rows, the system MUST skip any row whose `permission` or `scope` is not in this process's vocabulary, log the skipped row, and return the remaining grants, rather than failing the request.
+
+#### Scenario: Newer replica wrote an unknown permission
+
+- **WHEN** a custom role has grant rows `dashboard:read all` and `future:permission all`
+- **THEN** resolving it on a replica without `future:permission` yields `dashboard:read all` only
+- **AND** a warning naming the role and permission is logged
+
+### Requirement: Dashboard roles migration
+
+The Alembic revision `20260909_000000_add_dashboard_roles` MUST create `dashboard_roles` and `dashboard_role_grants` (with `role_id` cascading on role deletion) when absent, seed the preset rows even on re-run, and drop both tables on downgrade.
+
+#### Scenario: Upgrade, downgrade, head
+
+- **GIVEN** a database at the parent revision
+- **WHEN** the revision is applied
+- **THEN** both tables exist, five preset rows are present, and no grant rows exist
+- **AND** downgrading removes both tables
+- **AND** upgrading to head passes through the revision on a single-head graph

--- a/openspec/changes/add-dashboard-roles-schema/specs/dashboard-roles/spec.md
+++ b/openspec/changes/add-dashboard-roles-schema/specs/dashboard-roles/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Dashboard roles are rows with stable preset identities
 
-The system SHALL store dashboard roles in a `dashboard_roles` table with columns `id`, `slug` (unique), `name`, `description`, `kind` (`preset` or `custom`), `assignable_to_users`, `cloned_from_role_id`, `permissions_version`, `created_at`, and `updated_at`. Five preset rows MUST exist with slugs `admin`, `operator`, `member`, `viewer`, and `guest`, `kind` `preset`, and ids equal to the UUIDv5 derived from the slug under the fixed preset namespace, so every install and replica uses identical identifiers. The `guest` preset MUST have `assignable_to_users` false; the other presets true. The preset rows MUST be seeded idempotently by the Alembic revision, at application startup after database initialisation, and by the test schema reset.
+The system SHALL store dashboard roles in a `dashboard_roles` table with columns `id`, `slug` (unique), `name`, `description`, `kind` (`preset` or `custom`), `assignable_to_users`, `cloned_from_role_id`, `permissions_version`, `created_at`, and `updated_at`. Five preset rows MUST exist with slugs `admin`, `operator`, `member`, `viewer`, and `guest`, `kind` `preset`, and ids equal to the UUIDv5 derived from the slug under the fixed preset namespace, so every install and replica uses identical identifiers. The `guest` preset MUST have `assignable_to_users` false; the other presets true. The preset rows MUST be seeded idempotently by the Alembic revision (re-run safe, insert-only) and by the test schema reset; the application MUST NOT rewrite preset rows at startup.
 
 #### Scenario: Fresh database has the five presets
 

--- a/openspec/changes/add-dashboard-roles-schema/tasks.md
+++ b/openspec/changes/add-dashboard-roles-schema/tasks.md
@@ -1,0 +1,19 @@
+## 1. Vocabulary and registry
+
+- [x] 1.1 Add `PresetRoleSlug`, `PRESET_ROLE_IDS` (UUIDv5), `PRESET_ROLE_NAMES`, `ASSIGNABLE_PRESET_ROLES`, and the operator/member/viewer grant tables; validate every preset at import.
+
+## 2. Schema
+
+- [x] 2.1 Add `DashboardRoleRecord` (`dashboard_roles`) and `DashboardRoleGrant` (`dashboard_role_grants`) models with string-typed `kind`/`permission`/`scope`.
+- [x] 2.2 Add Alembic revision `20260909_000000_add_dashboard_roles` creating both tables (guarded, downgrade drops) and seeding the preset rows outside the guard.
+- [x] 2.3 Shared idempotent seeder (`app/modules/dashboard_roles/seed.py`) used by the migration, `app/main.py` startup, and `tests/conftest.py`.
+
+## 3. Read model
+
+- [x] 3.1 `DashboardRolesRepository` (list, by id, by slug, preset lookup) and `resolve_role_grants` / `grants_from_rows` (presets from code, custom from rows, unknown vocabulary ignored with a warning).
+
+## 4. Verification
+
+- [x] 4.1 Unit: preset tables match the plan, ids stable, guest not assignable, presets resolve from code even when rows exist, unknown vocabulary ignored.
+- [x] 4.2 Integration: preset rows present after schema reset, seeding idempotent, custom grants round-trip with cascade delete, migration up/down/head.
+- [x] 4.3 `ruff`, `ty`, focused pytest, `openspec validate --strict`.

--- a/openspec/changes/add-dashboard-roles-schema/tasks.md
+++ b/openspec/changes/add-dashboard-roles-schema/tasks.md
@@ -6,7 +6,7 @@
 
 - [x] 2.1 Add `DashboardRoleRecord` (`dashboard_roles`) and `DashboardRoleGrant` (`dashboard_role_grants`) models with string-typed `kind`/`permission`/`scope`.
 - [x] 2.2 Add Alembic revision `20260909_000000_add_dashboard_roles` creating both tables (guarded, downgrade drops) and seeding the preset rows outside the guard.
-- [x] 2.3 Shared idempotent seeder (`app/modules/dashboard_roles/seed.py`) used by the migration, `app/main.py` startup, and `tests/conftest.py`.
+- [x] 2.3 Shared idempotent seeder (`app/modules/dashboard_roles/seed.py`) used by the migration and `tests/conftest.py` (no startup hook).
 
 ## 3. Read model
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ os.environ["CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS"] = "0"
 from app.db.models import Base  # noqa: E402
 from app.db.session import engine  # noqa: E402
 from app.main import create_app  # noqa: E402
+from app.modules.dashboard_roles.seed import seed_preset_dashboard_roles  # noqa: E402
 
 
 class _NoopScheduler:
@@ -129,6 +130,9 @@ def _recreate_test_schema(sync_conn) -> None:
     _drop_test_migration_tables(sync_conn)
     Base.metadata.drop_all(sync_conn)
     Base.metadata.create_all(sync_conn)
+    # Production seeds these through the migration and at startup; the test
+    # schema is built with create_all, so seed the preset role rows here too.
+    seed_preset_dashboard_roles(sync_conn)
 
 
 def _reset_test_database(sync_conn) -> None:

--- a/tests/integration/test_dashboard_roles_schema.py
+++ b/tests/integration/test_dashboard_roles_schema.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+from anyio import to_thread
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, Permission, PresetRoleSlug, Scope
+from app.core.config.settings import get_settings
+from app.db.migrate import _build_alembic_config, inspect_migration_state, run_upgrade
+from app.db.models import DashboardRoleGrant, DashboardRoleRecord
+from app.db.session import SessionLocal
+from app.modules.dashboard_roles.repository import DashboardRolesRepository
+from app.modules.dashboard_roles.seed import ROLE_KIND_CUSTOM, ROLE_KIND_PRESET, ensure_preset_dashboard_roles
+from app.modules.dashboard_roles.service import resolve_role_grants
+
+pytestmark = pytest.mark.integration
+
+_HEAD_REVISION = inspect_migration_state(get_settings().database_url).head_revision
+PARENT_REVISION = "20260908_000000_add_guest_session_generation"
+TARGET_REVISION = "20260909_000000_add_dashboard_roles"
+
+
+@pytest.mark.asyncio
+async def test_preset_rows_exist_after_schema_reset(db_setup) -> None:
+    async with SessionLocal() as session:
+        roles = await DashboardRolesRepository(session).list_roles()
+    by_slug = {role.slug: role for role in roles}
+    assert set(by_slug) == {slug.value for slug in PresetRoleSlug}
+    for slug in PresetRoleSlug:
+        role = by_slug[slug.value]
+        assert role.id == PRESET_ROLE_IDS[slug]
+        assert role.kind == ROLE_KIND_PRESET
+        assert role.grants == []
+    assert by_slug["guest"].assignable_to_users is False
+
+
+@pytest.mark.asyncio
+async def test_seeding_is_idempotent(db_setup) -> None:
+    from app.db.session import engine
+
+    async with engine.begin() as connection:
+        await ensure_preset_dashboard_roles(connection)
+        await ensure_preset_dashboard_roles(connection)
+    async with SessionLocal() as session:
+        count = (await session.execute(text("SELECT COUNT(*) FROM dashboard_roles"))).scalar_one()
+    assert count == len(PresetRoleSlug)
+
+
+@pytest.mark.asyncio
+async def test_custom_role_grants_round_trip_and_presets_resolve_from_code(db_setup) -> None:
+    async with SessionLocal() as session:
+        custom = DashboardRoleRecord(slug="ops-lite", name="Ops lite", kind=ROLE_KIND_CUSTOM, cloned_from_role_id=None)
+        custom.grants = [
+            DashboardRoleGrant(permission="dashboard:read", scope="all"),
+            DashboardRoleGrant(permission="api_keys:read", scope="own"),
+            DashboardRoleGrant(permission="not:a-permission", scope="all"),
+        ]
+        session.add(custom)
+        await session.commit()
+        custom_id = custom.id
+
+    async with SessionLocal() as session:
+        repo = DashboardRolesRepository(session)
+        loaded = await repo.get_role(custom_id)
+        assert loaded is not None
+        assert dict(resolve_role_grants(loaded)) == {
+            Permission.DASHBOARD_READ: Scope.ALL,
+            Permission.API_KEYS_READ: Scope.OWN,
+        }
+        admin = await repo.get_preset_role(PresetRoleSlug.ADMIN)
+        assert admin is not None
+        assert set(resolve_role_grants(admin)) == set(Permission)
+        # Deleting the custom role cascades its grants.
+        await session.delete(loaded)
+        await session.commit()
+        remaining = (
+            await session.execute(select(DashboardRoleGrant).where(DashboardRoleGrant.role_id == custom_id))
+        ).all()
+        assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_dashboard_roles_migration_upgrade_and_downgrade(tmp_path):
+    """Upgrade creates both tables and seeds the five preset rows (re-run safe);
+    downgrade drops them; a final walk to head proves the single-head graph."""
+    from alembic import command
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'dashboard-roles.sqlite'}"
+
+    async def _tables(engine) -> set[str]:
+        async with engine.connect() as conn:
+            rows = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
+            return {row[0] for row in rows}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, PARENT_REVISION, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        assert not {"dashboard_roles", "dashboard_role_grants"} & await _tables(engine)
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, TARGET_REVISION, bootstrap_legacy=False))
+        assert {"dashboard_roles", "dashboard_role_grants"} <= await _tables(engine)
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text("SELECT id, slug, kind, assignable_to_users FROM dashboard_roles"))).all()
+            grants = (await conn.execute(text("SELECT COUNT(*) FROM dashboard_role_grants"))).scalar_one()
+        assert {row[1] for row in rows} == {slug.value for slug in PresetRoleSlug}
+        assert {row[0] for row in rows} == set(PRESET_ROLE_IDS.values())
+        assert all(row[2] == ROLE_KIND_PRESET for row in rows)
+        assert grants == 0
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, PARENT_REVISION))
+        assert not {"dashboard_roles", "dashboard_role_grants"} & await _tables(engine)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        async with engine.connect() as conn:
+            count = (await conn.execute(text("SELECT COUNT(*) FROM dashboard_roles"))).scalar_one()
+        assert count == len(PresetRoleSlug)
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_dashboard_roles_schema.py
+++ b/tests/integration/test_dashboard_roles_schema.py
@@ -5,13 +5,13 @@ from anyio import to_thread
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from app.core.auth.dashboard_access import PRESET_ROLE_IDS, Permission, PresetRoleSlug, Scope
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, Permission, PresetRoleSlug, RoleKind, Scope
 from app.core.config.settings import get_settings
 from app.db.migrate import _build_alembic_config, inspect_migration_state, run_upgrade
 from app.db.models import DashboardRoleGrant, DashboardRoleRecord
 from app.db.session import SessionLocal
 from app.modules.dashboard_roles.repository import DashboardRolesRepository
-from app.modules.dashboard_roles.seed import ROLE_KIND_CUSTOM, ROLE_KIND_PRESET, ensure_preset_dashboard_roles
+from app.modules.dashboard_roles.seed import ensure_preset_dashboard_roles
 from app.modules.dashboard_roles.service import resolve_role_grants
 
 pytestmark = pytest.mark.integration
@@ -30,27 +30,36 @@ async def test_preset_rows_exist_after_schema_reset(db_setup) -> None:
     for slug in PresetRoleSlug:
         role = by_slug[slug.value]
         assert role.id == PRESET_ROLE_IDS[slug]
-        assert role.kind == ROLE_KIND_PRESET
+        assert role.kind == RoleKind.PRESET.value
         assert role.grants == []
     assert by_slug["guest"].assignable_to_users is False
 
 
 @pytest.mark.asyncio
-async def test_seeding_is_idempotent(db_setup) -> None:
+async def test_seeding_is_idempotent_and_never_updates_existing_rows(db_setup) -> None:
     from app.db.session import engine
 
     async with engine.begin() as connection:
+        # A missing row is re-inserted; an existing row is left untouched even
+        # when it differs from the code's definition (presets are insert-only).
+        await connection.execute(text("DELETE FROM dashboard_roles WHERE slug = 'viewer'"))
+        await connection.execute(text("UPDATE dashboard_roles SET name = 'Renamed operator' WHERE slug = 'operator'"))
         await ensure_preset_dashboard_roles(connection)
         await ensure_preset_dashboard_roles(connection)
     async with SessionLocal() as session:
-        count = (await session.execute(text("SELECT COUNT(*) FROM dashboard_roles"))).scalar_one()
-    assert count == len(PresetRoleSlug)
+        rows = (await session.execute(text("SELECT id, slug, name FROM dashboard_roles ORDER BY slug"))).all()
+    assert len(rows) == len(PresetRoleSlug)
+    by_slug = {row[1]: row for row in rows}
+    assert by_slug["viewer"][0] == PRESET_ROLE_IDS[PresetRoleSlug.VIEWER]
+    assert by_slug["operator"][2] == "Renamed operator"
 
 
 @pytest.mark.asyncio
 async def test_custom_role_grants_round_trip_and_presets_resolve_from_code(db_setup) -> None:
     async with SessionLocal() as session:
-        custom = DashboardRoleRecord(slug="ops-lite", name="Ops lite", kind=ROLE_KIND_CUSTOM, cloned_from_role_id=None)
+        custom = DashboardRoleRecord(
+            slug="ops-lite", name="Ops lite", kind=RoleKind.CUSTOM.value, cloned_from_role_id=None
+        )
         custom.grants = [
             DashboardRoleGrant(permission="dashboard:read", scope="all"),
             DashboardRoleGrant(permission="api_keys:read", scope="own"),
@@ -105,7 +114,7 @@ async def test_dashboard_roles_migration_upgrade_and_downgrade(tmp_path):
             grants = (await conn.execute(text("SELECT COUNT(*) FROM dashboard_role_grants"))).scalar_one()
         assert {row[1] for row in rows} == {slug.value for slug in PresetRoleSlug}
         assert {row[0] for row in rows} == set(PRESET_ROLE_IDS.values())
-        assert all(row[2] == ROLE_KIND_PRESET for row in rows)
+        assert all(row[2] == RoleKind.PRESET.value for row in rows)
         assert grants == 0
 
         config = _build_alembic_config(db_url)

--- a/tests/unit/test_dashboard_roles.py
+++ b/tests/unit/test_dashboard_roles.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.core.auth.dashboard_access import (
+    ADMIN_GRANTS,
+    ASSIGNABLE_PRESET_ROLES,
+    GUEST_GRANTS,
+    MEMBER_GRANTS,
+    OPERATOR_GRANTS,
+    OWN_SCOPED_PERMISSIONS,
+    PRESET_ROLE_GRANTS,
+    PRESET_ROLE_IDS,
+    PRESET_ROLE_NAMES,
+    ROLE_GRANTS,
+    VIEWER_GRANTS,
+    DashboardRole,
+    Permission,
+    PresetRoleSlug,
+    Scope,
+    legacy_permissions,
+    preset_role_id,
+    validate_grants,
+)
+from app.db.models import DashboardRoleGrant, DashboardRoleRecord
+from app.modules.dashboard_roles.seed import ROLE_KIND_CUSTOM, ROLE_KIND_PRESET, preset_role_rows
+from app.modules.dashboard_roles.service import grants_from_rows, resolve_role_grants
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_preset_has_grants_id_and_name() -> None:
+    assert set(PRESET_ROLE_GRANTS) == set(PresetRoleSlug)
+    assert set(PRESET_ROLE_IDS) == set(PresetRoleSlug)
+    assert set(PRESET_ROLE_NAMES) == set(PresetRoleSlug)
+    for grants in PRESET_ROLE_GRANTS.values():
+        validate_grants(grants)
+
+
+def test_preset_ids_are_stable_uuid5_values() -> None:
+    for slug in PresetRoleSlug:
+        parsed = uuid.UUID(PRESET_ROLE_IDS[slug])
+        assert parsed.version == 5
+        assert PRESET_ROLE_IDS[slug] == preset_role_id(slug)
+    assert len(set(PRESET_ROLE_IDS.values())) == len(PresetRoleSlug)
+    # Pin one value so a namespace change is noticed.
+    assert PRESET_ROLE_IDS[PresetRoleSlug.ADMIN] == preset_role_id(PresetRoleSlug.ADMIN)
+
+
+def test_preset_grant_tables_match_the_plan() -> None:
+    assert set(ADMIN_GRANTS) == set(Permission)
+    assert dict(OPERATOR_GRANTS) == {
+        Permission.DASHBOARD_READ: Scope.ALL,
+        Permission.ACCOUNTS_READ: Scope.ALL,
+        Permission.ACCOUNTS_WRITE: Scope.ALL,
+        Permission.API_KEYS_READ: Scope.ALL,
+        Permission.API_KEYS_WRITE: Scope.ALL,
+        Permission.API_KEYS_ASSIGN: Scope.ALL,
+        Permission.OPS_WRITE: Scope.ALL,
+    }
+    assert dict(MEMBER_GRANTS) == {
+        Permission.DASHBOARD_READ: Scope.OWN,
+        Permission.API_KEYS_READ: Scope.OWN,
+        Permission.API_KEYS_WRITE: Scope.OWN,
+    }
+    assert set(MEMBER_GRANTS) <= OWN_SCOPED_PERMISSIONS
+    assert dict(VIEWER_GRANTS) == {Permission.DASHBOARD_READ: Scope.ALL, Permission.ACCOUNTS_READ: Scope.ALL}
+    assert GUEST_GRANTS == VIEWER_GRANTS
+    # Only admin and operator hold the coarse write alias; member's own-scoped
+    # key writes must not pass the generic write gate.
+    assert legacy_permissions(OPERATOR_GRANTS) == legacy_permissions(ADMIN_GRANTS)
+    assert "write" not in {p.value for p in legacy_permissions(MEMBER_GRANTS)}
+    assert "write" not in {p.value for p in legacy_permissions(VIEWER_GRANTS)}
+
+
+def test_legacy_role_table_still_maps_to_presets() -> None:
+    assert ROLE_GRANTS[DashboardRole.ADMIN] is ADMIN_GRANTS
+    assert ROLE_GRANTS[DashboardRole.GUEST] is GUEST_GRANTS
+
+
+def test_guest_is_not_assignable() -> None:
+    assert PresetRoleSlug.GUEST not in ASSIGNABLE_PRESET_ROLES
+    assert ASSIGNABLE_PRESET_ROLES == {
+        PresetRoleSlug.ADMIN,
+        PresetRoleSlug.OPERATOR,
+        PresetRoleSlug.MEMBER,
+        PresetRoleSlug.VIEWER,
+    }
+    rows = {row["slug"]: row for row in preset_role_rows()}
+    assert rows["guest"]["assignable_to_users"] is False
+    assert all(rows[slug]["assignable_to_users"] is True for slug in ("admin", "operator", "member", "viewer"))
+    assert all(row["kind"] == ROLE_KIND_PRESET for row in rows.values())
+
+
+def test_preset_roles_resolve_from_code_not_rows() -> None:
+    role = DashboardRoleRecord(id="r0", slug="operator", name="Operator", kind=ROLE_KIND_PRESET)
+    role.grants = [DashboardRoleGrant(role_id="r0", permission="audit:read", scope="all")]
+    assert resolve_role_grants(role) is OPERATOR_GRANTS
+
+
+def test_custom_role_grants_ignore_unknown_vocabulary() -> None:
+    rows = [
+        DashboardRoleGrant(role_id="r1", permission="dashboard:read", scope="all"),
+        DashboardRoleGrant(role_id="r1", permission="api_keys:write", scope="own"),
+        DashboardRoleGrant(role_id="r1", permission="future:permission", scope="all"),
+        DashboardRoleGrant(role_id="r1", permission="accounts:read", scope="everything"),
+    ]
+    grants = grants_from_rows(rows)
+    assert dict(grants) == {Permission.DASHBOARD_READ: Scope.ALL, Permission.API_KEYS_WRITE: Scope.OWN}
+    role = DashboardRoleRecord(id="r1", slug="my-role", name="My role", kind=ROLE_KIND_CUSTOM)
+    role.grants = rows
+    assert dict(resolve_role_grants(role)) == dict(grants)

--- a/tests/unit/test_dashboard_roles.py
+++ b/tests/unit/test_dashboard_roles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 
 import pytest
@@ -19,13 +20,14 @@ from app.core.auth.dashboard_access import (
     DashboardRole,
     Permission,
     PresetRoleSlug,
+    RoleKind,
     Scope,
     legacy_permissions,
     preset_role_id,
     validate_grants,
 )
 from app.db.models import DashboardRoleGrant, DashboardRoleRecord
-from app.modules.dashboard_roles.seed import ROLE_KIND_CUSTOM, ROLE_KIND_PRESET, preset_role_rows
+from app.modules.dashboard_roles.seed import preset_role_rows
 from app.modules.dashboard_roles.service import grants_from_rows, resolve_role_grants
 
 pytestmark = pytest.mark.unit
@@ -45,8 +47,16 @@ def test_preset_ids_are_stable_uuid5_values() -> None:
         assert parsed.version == 5
         assert PRESET_ROLE_IDS[slug] == preset_role_id(slug)
     assert len(set(PRESET_ROLE_IDS.values())) == len(PresetRoleSlug)
-    # Pin one value so a namespace change is noticed.
-    assert PRESET_ROLE_IDS[PresetRoleSlug.ADMIN] == preset_role_id(PresetRoleSlug.ADMIN)
+    # Literal pins: existing installs key preset rows by these ids and `slug`
+    # is UNIQUE, so changing the namespace or name format needs a data
+    # migration, not a code edit.
+    assert dict(PRESET_ROLE_IDS) == {
+        PresetRoleSlug.ADMIN: "3fe7dc57-aabd-5b16-9850-b6d464087f07",
+        PresetRoleSlug.OPERATOR: "93bef178-3209-541e-9ab7-9a587fa0170b",
+        PresetRoleSlug.MEMBER: "3fe0d2b1-4327-5931-befc-55e04f945100",
+        PresetRoleSlug.VIEWER: "90d94023-0557-5e70-b17c-2c0f4032f535",
+        PresetRoleSlug.GUEST: "9ec22cee-91a8-5f8b-affd-bcde9400994b",
+    }
 
 
 def test_preset_grant_tables_match_the_plan() -> None:
@@ -91,24 +101,40 @@ def test_guest_is_not_assignable() -> None:
     rows = {row["slug"]: row for row in preset_role_rows()}
     assert rows["guest"]["assignable_to_users"] is False
     assert all(rows[slug]["assignable_to_users"] is True for slug in ("admin", "operator", "member", "viewer"))
-    assert all(row["kind"] == ROLE_KIND_PRESET for row in rows.values())
+    assert all(row["kind"] == RoleKind.PRESET.value for row in rows.values())
 
 
 def test_preset_roles_resolve_from_code_not_rows() -> None:
-    role = DashboardRoleRecord(id="r0", slug="operator", name="Operator", kind=ROLE_KIND_PRESET)
+    role = DashboardRoleRecord(id="r0", slug="operator", name="Operator", kind=RoleKind.PRESET.value)
     role.grants = [DashboardRoleGrant(role_id="r0", permission="audit:read", scope="all")]
     assert resolve_role_grants(role) is OPERATOR_GRANTS
 
 
-def test_custom_role_grants_ignore_unknown_vocabulary() -> None:
+def test_custom_role_grants_ignore_unknown_vocabulary(caplog: pytest.LogCaptureFixture) -> None:
     rows = [
         DashboardRoleGrant(role_id="r1", permission="dashboard:read", scope="all"),
         DashboardRoleGrant(role_id="r1", permission="api_keys:write", scope="own"),
         DashboardRoleGrant(role_id="r1", permission="future:permission", scope="all"),
         DashboardRoleGrant(role_id="r1", permission="accounts:read", scope="everything"),
     ]
-    grants = grants_from_rows(rows)
+    with caplog.at_level(logging.WARNING, logger="app.modules.dashboard_roles.service"):
+        grants = grants_from_rows(rows)
     assert dict(grants) == {Permission.DASHBOARD_READ: Scope.ALL, Permission.API_KEYS_WRITE: Scope.OWN}
-    role = DashboardRoleRecord(id="r1", slug="my-role", name="My role", kind=ROLE_KIND_CUSTOM)
+    ignored = [
+        record.getMessage() for record in caplog.records if "dashboard_role_grant_ignored" in record.getMessage()
+    ]
+    assert len(ignored) == 2
+    assert any("role_id=r1 permission=future:permission scope=all" in message for message in ignored)
+    assert any("role_id=r1 permission=accounts:read scope=everything" in message for message in ignored)
+    role = DashboardRoleRecord(id="r1", slug="my-role", name="My role", kind=RoleKind.CUSTOM.value)
     role.grants = rows
     assert dict(resolve_role_grants(role)) == dict(grants)
+
+
+def test_unknown_kind_or_preset_slug_is_a_provisioning_error() -> None:
+    bogus_kind = DashboardRoleRecord(id="r2", slug="admin", name="Admin", kind="bogus")
+    with pytest.raises(ValueError):
+        resolve_role_grants(bogus_kind)
+    unknown_preset = DashboardRoleRecord(id="r3", slug="auditor", name="Auditor", kind=RoleKind.PRESET.value)
+    with pytest.raises(ValueError):
+        resolve_role_grants(unknown_preset)


### PR DESCRIPTION
## Summary

Stacked on the CSRF/least-privilege PR (`feat/harden-dashboard-mutation-origin`, #2204). First Phase-1 PR of the dashboard RBAC plan: the **role registry** every later account feature references. Two tables, five preset rows with stable ids, grants for presets defined in code, and a tolerant loader for future custom-role grant rows. **No consumer changes** — nothing reads these tables yet, so existing installs behave identically.

## Type of change

- [x] `feat:` — new capability (schema + registry)

Linked issue: groundwork for #673 (user management); no issue closed.

## OpenSpec

- [x] This PR includes an OpenSpec change

Change directory: `openspec/changes/add-dashboard-roles-schema/` (new capability `dashboard-roles`; `openspec validate --strict` passes)

## Changes

**Vocabulary** (`app/core/auth/dashboard_access.py`): `RoleKind` (`preset|custom`), `PresetRoleSlug` (`admin|operator|member|viewer|guest`), `preset_role_id()` = UUIDv5 under a fixed namespace so every install and replica shares identical ids, `OPERATOR_GRANTS` / `MEMBER_GRANTS` (own-scoped keys) / `VIEWER_GRANTS` (= guest) next to the existing `ADMIN_GRANTS`, `PRESET_ROLE_GRANTS`, `ASSIGNABLE_PRESET_ROLES` (everything but `guest`). Import-time validation covers every preset table.

**Schema** (`app/db/models.py`, revision `20260909_000000_add_dashboard_roles`): `dashboard_roles` (`id`, `slug` unique, `name`, `description`, `kind`, `assignable_to_users`, `cloned_from_role_id` self-FK SET NULL, `permissions_version`, timestamps) and `dashboard_role_grants` (`role_id` FK CASCADE, `permission`, `scope`; PK on role+permission). The revision creates both tables behind `has_table` guards and seeds the five preset rows outside the guard with insert-ignore semantics (PostgreSQL / SQLite `ON CONFLICT DO NOTHING`, select-then-insert fallback), using its own revision-pinned table definition. Downgrade drops both tables.

**Registry module** (`app/modules/dashboard_roles/`): `seed.py` (shared idempotent seeder, also used by `tests/conftest.py` because tests build the schema with `create_all`), `repository.py` (list/get/by-slug/preset lookups), `service.py` (`resolve_role_grants`: presets resolve from code — rows never carry grants, so an older replica can never strip a newer grant; custom roles resolve from their rows, skipping unknown permission/scope strings with a warning so a rolling upgrade never breaks every request for a role).

**Design points**
- Preset grants live in code, never in the database; preset rows are insert-only (no boot-time reconciler — it would race outside the migration lock and, for a schema-less process with `CODEX_LB_DATABASE_MIGRATIONS_FAIL_FAST=false`, crash startup).
- `kind`, `permission`, `scope` are plain string columns validated by `StrEnum`s, so adding a value never needs a type migration.
- An unknown `kind` or unknown preset slug raises (provisioning error, no quiet default); unknown *grant* strings are tolerated (rolling-upgrade compatibility).
- `dashboard_roles.created_by_user_id` is deferred to the custom-role editor (presets have no author).

**Tests**: `tests/unit/test_dashboard_roles.py` (preset tables match the plan, UUIDv5 values pinned as literals, guest not assignable, presets resolve from code not rows, unknown vocabulary ignored with the warning asserted, unknown kind/slug raise), `tests/integration/test_dashboard_roles_schema.py` (rows present after schema reset, seeding idempotent and never updates existing rows, custom grants round-trip with cascade delete, migration upgrade/downgrade/head walk). The PostgreSQL migration contract test passes.

## Simplicity

- [x] Zero config; no new setting, env var, README section, or nav item.
- [x] No new required setup step (migration runs at startup as today).
- New setting(s): none
- [x] Budgets unchanged.

## Test plan

```
uv run ruff check . && uv run ruff format --check . && uv run ty check        # clean
uv run pytest tests/unit/test_dashboard_roles.py tests/unit/test_dashboard_access.py \
  tests/integration/test_dashboard_roles_schema.py tests/integration/test_dashboard_permission_gates.py -q
uv run pytest tests/unit tests/simulation -q                                    # 8591 passed
openspec validate add-dashboard-roles-schema --strict                          # valid
codex review --base feat/harden-dashboard-mutation-origin                     # findings addressed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
