### PR TITLE
feat(auth): add dashboard user tables and migrate the shared admin into a user

### DIFF
--- a/app/core/cache/invalidation.py
+++ b/app/core/cache/invalidation.py
@@ -29,6 +29,7 @@ NAMESPACE_SETTINGS = "settings"
 NAMESPACE_RESET_CREDITS = "reset_credits"
 NAMESPACE_MODEL_REGISTRY = "model_registry"
 NAMESPACE_UPSTREAM_ROUTE = "upstream_route"
+NAMESPACE_DASHBOARD_USERS = "dashboard_users"
 # Callback return values are ignored; awaitables are awaited for their side
 # effects only, so callbacks may return a status (e.g. bool) for other callers.
 type InvalidationCallback = Callable[[], object | Awaitable[object]]
@@ -47,6 +48,7 @@ _NAMESPACE_LOG_LABELS: dict[str, str] = {
     "reset_credits": "reset_credits",
     "model_registry": "model_registry",
     "upstream_route": "upstream_route",
+    "dashboard_users": "dashboard_users",
 }
 
 _BUMP_RETRY_ATTEMPTS = 3

--- a/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
+++ b/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
@@ -142,18 +142,38 @@ def upgrade() -> None:
             )
 
 
+def _user_fk_names(inspector: sa.Inspector, column: str) -> list[str]:
+    """Names of api_keys foreign keys from ``column`` to dashboard_users.
+
+    The constraint may carry this revision's explicit name or a dialect
+    default (a schema built by ``Base.metadata.create_all`` on PostgreSQL
+    names it ``api_keys_<column>_fkey``); unnamed SQLite constraints are
+    dropped together with the column by the batch table rebuild.
+    """
+
+    names: list[str] = []
+    for fk in inspector.get_foreign_keys("api_keys"):
+        name = fk.get("name")
+        if (
+            isinstance(name, str)
+            and fk.get("referred_table") == "dashboard_users"
+            and column in fk.get("constrained_columns", ())
+        ):
+            names.append(name)
+    return names
+
+
 def downgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     existing = _columns(bind, "api_keys")
     if existing & set(_API_KEY_COLUMNS):
         with op.batch_alter_table("api_keys") as batch_op:
-            if "owner_user_id" in existing:
-                batch_op.drop_constraint("fk_api_keys_owner_user_id", type_="foreignkey")
-                batch_op.drop_column("owner_user_id")
-            if "created_by_user_id" in existing:
-                batch_op.drop_constraint("fk_api_keys_created_by_user_id", type_="foreignkey")
-                batch_op.drop_column("created_by_user_id")
+            for column in ("owner_user_id", "created_by_user_id"):
+                if column in existing:
+                    for fk_name in _user_fk_names(inspector, column):
+                        batch_op.drop_constraint(fk_name, type_="foreignkey")
+                    batch_op.drop_column(column)
             if "deactivated_reason" in existing:
                 batch_op.drop_column("deactivated_reason")
     if inspector.has_table("dashboard_identities"):

--- a/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
+++ b/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
@@ -10,14 +10,18 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
-from app.modules.dashboard_roles.seed import seed_preset_dashboard_roles
-from app.modules.dashboard_users.compat import COMPAT_ADMIN_USER_ID, COMPAT_ADMIN_USERNAME
-
 revision = "20260909_010000_add_dashboard_users"
 down_revision = "20260909_000000_add_dashboard_roles"
 branch_labels = None
 depends_on = None
+
+# Frozen copies of the runtime identifiers (see
+# app.modules.dashboard_users.compat and app.core.auth.dashboard_access). A
+# migration must not import transient runtime modules; the unit test
+# tests/unit/test_dashboard_users_compat.py asserts these stay in sync.
+COMPAT_ADMIN_USER_ID = "7a4fc02d-216e-5be7-b974-bc437f23df60"
+COMPAT_ADMIN_USERNAME = "admin"
+ADMIN_ROLE_ID = "3fe7dc57-aabd-5b16-9850-b6d464087f07"
 
 _API_KEY_COLUMNS = ("owner_user_id", "created_by_user_id", "deactivated_reason")
 
@@ -101,9 +105,6 @@ def upgrade() -> None:
             if "deactivated_reason" in missing:
                 batch_op.add_column(sa.Column("deactivated_reason", sa.String(length=32), nullable=True))
 
-    # Preset rows must exist for the FK below; harmless re-seed otherwise.
-    seed_preset_dashboard_roles(bind)
-
     # Backfill: the legacy shared admin password becomes the `admin` user. Runs
     # outside the table guards so a re-run after a partial failure still
     # migrates the credential. Idempotent on the deterministic user id and on
@@ -131,7 +132,7 @@ def upgrade() -> None:
                 {
                     "id": COMPAT_ADMIN_USER_ID,
                     "username": COMPAT_ADMIN_USERNAME,
-                    "role_id": PRESET_ROLE_IDS[PresetRoleSlug.ADMIN],
+                    "role_id": ADMIN_ROLE_ID,
                     "password_hash": settings_row[0],
                     "totp_secret": settings_row[1],
                     "totp_step": settings_row[2],

--- a/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
+++ b/app/db/alembic/versions/20260909_010000_add_dashboard_users.py
@@ -1,0 +1,161 @@
+"""Add dashboard_users, dashboard_identities, API key ownership columns, and backfill the compat admin.
+
+Revision ID: 20260909_010000_add_dashboard_users
+Revises: 20260909_000000_add_dashboard_roles
+Create Date: 2026-09-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.modules.dashboard_roles.seed import seed_preset_dashboard_roles
+from app.modules.dashboard_users.compat import COMPAT_ADMIN_USER_ID, COMPAT_ADMIN_USERNAME
+
+revision = "20260909_010000_add_dashboard_users"
+down_revision = "20260909_000000_add_dashboard_roles"
+branch_labels = None
+depends_on = None
+
+_API_KEY_COLUMNS = ("owner_user_id", "created_by_user_id", "deactivated_reason")
+
+
+def _columns(bind: sa.engine.Connection, table: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table):
+        return set()
+    return {column["name"] for column in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("dashboard_users"):
+        op.create_table(
+            "dashboard_users",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("username", sa.String(length=64), nullable=False, unique=True),
+            sa.Column("display_name", sa.String(length=128), nullable=True),
+            sa.Column("email", sa.String(length=320), nullable=True, unique=True),
+            sa.Column("role_id", sa.String(), sa.ForeignKey("dashboard_roles.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column("role_source", sa.String(length=16), server_default=sa.text("'manual'"), nullable=False),
+            sa.Column("status", sa.String(length=16), server_default=sa.text("'active'"), nullable=False),
+            sa.Column("password_hash", sa.Text(), nullable=True),
+            sa.Column("totp_secret_encrypted", sa.LargeBinary(), nullable=True),
+            sa.Column("totp_last_verified_step", sa.Integer(), nullable=True),
+            sa.Column("session_generation", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("must_change_password", sa.Boolean(), server_default=sa.false(), nullable=False),
+            sa.Column("is_break_glass", sa.Boolean(), server_default=sa.false(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column(
+                "created_by_user_id",
+                sa.String(),
+                sa.ForeignKey("dashboard_users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("last_login_at", sa.DateTime(), nullable=True),
+        )
+    if not inspector.has_table("dashboard_identities"):
+        op.create_table(
+            "dashboard_identities",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("user_id", sa.String(), sa.ForeignKey("dashboard_users.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("provider", sa.String(length=32), nullable=False),
+            sa.Column("provider_key", sa.String(length=128), nullable=False),
+            sa.Column("subject", sa.String(length=512), nullable=False),
+            sa.Column("email", sa.String(length=320), nullable=True),
+            sa.Column("display_name", sa.String(length=128), nullable=True),
+            sa.Column("groups_json", sa.Text(), nullable=True),
+            sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.UniqueConstraint("provider", "provider_key", "subject", name="uq_dashboard_identities_subject"),
+        )
+        op.create_index("idx_dashboard_identities_user_id", "dashboard_identities", ["user_id"])
+
+    existing = _columns(bind, "api_keys")
+    missing = [name for name in _API_KEY_COLUMNS if name not in existing]
+    if missing:
+        with op.batch_alter_table("api_keys") as batch_op:
+            if "owner_user_id" in missing:
+                batch_op.add_column(sa.Column("owner_user_id", sa.String(), nullable=True))
+                batch_op.create_foreign_key(
+                    "fk_api_keys_owner_user_id",
+                    "dashboard_users",
+                    ["owner_user_id"],
+                    ["id"],
+                    ondelete="SET NULL",
+                )
+            if "created_by_user_id" in missing:
+                batch_op.add_column(sa.Column("created_by_user_id", sa.String(), nullable=True))
+                batch_op.create_foreign_key(
+                    "fk_api_keys_created_by_user_id",
+                    "dashboard_users",
+                    ["created_by_user_id"],
+                    ["id"],
+                    ondelete="SET NULL",
+                )
+            if "deactivated_reason" in missing:
+                batch_op.add_column(sa.Column("deactivated_reason", sa.String(length=32), nullable=True))
+
+    # Preset rows must exist for the FK below; harmless re-seed otherwise.
+    seed_preset_dashboard_roles(bind)
+
+    # Backfill: the legacy shared admin password becomes the `admin` user. Runs
+    # outside the table guards so a re-run after a partial failure still
+    # migrates the credential. Idempotent on the deterministic user id and on
+    # the unique username.
+    settings_row = bind.execute(
+        sa.text(
+            "SELECT password_hash, totp_secret_encrypted, totp_last_verified_step FROM dashboard_settings WHERE id = 1"
+        )
+    ).first()
+    if settings_row is not None and settings_row[0] is not None:
+        existing_admin = bind.execute(
+            sa.text("SELECT id FROM dashboard_users WHERE id = :id OR username = :username"),
+            {"id": COMPAT_ADMIN_USER_ID, "username": COMPAT_ADMIN_USERNAME},
+        ).first()
+        if existing_admin is None:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO dashboard_users "
+                    "(id, username, display_name, role_id, role_source, status, password_hash, "
+                    "totp_secret_encrypted, totp_last_verified_step, session_generation, "
+                    "must_change_password, is_break_glass, created_at, updated_at) "
+                    "VALUES (:id, :username, NULL, :role_id, 'manual', 'active', :password_hash, "
+                    ":totp_secret, :totp_step, 0, :false_value, :true_value, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                {
+                    "id": COMPAT_ADMIN_USER_ID,
+                    "username": COMPAT_ADMIN_USERNAME,
+                    "role_id": PRESET_ROLE_IDS[PresetRoleSlug.ADMIN],
+                    "password_hash": settings_row[0],
+                    "totp_secret": settings_row[1],
+                    "totp_step": settings_row[2],
+                    "false_value": False,
+                    "true_value": True,
+                },
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = _columns(bind, "api_keys")
+    if existing & set(_API_KEY_COLUMNS):
+        with op.batch_alter_table("api_keys") as batch_op:
+            if "owner_user_id" in existing:
+                batch_op.drop_constraint("fk_api_keys_owner_user_id", type_="foreignkey")
+                batch_op.drop_column("owner_user_id")
+            if "created_by_user_id" in existing:
+                batch_op.drop_constraint("fk_api_keys_created_by_user_id", type_="foreignkey")
+                batch_op.drop_column("created_by_user_id")
+            if "deactivated_reason" in existing:
+                batch_op.drop_column("deactivated_reason")
+    if inspector.has_table("dashboard_identities"):
+        op.drop_table("dashboard_identities")
+    if inspector.has_table("dashboard_users"):
+        op.drop_table("dashboard_users")

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import time
 import warnings
 from contextlib import contextmanager
@@ -623,6 +624,20 @@ def _is_ignored_schema_drift(connection: Connection, diff: object) -> bool:
     return False
 
 
+_OBJECT_ADDRESS_RE = re.compile(r" object at 0x[0-9a-fA-F]+>")
+
+
+def _stable_diff_repr(diff: object) -> str:
+    """Render an autogenerate diff without CPython object addresses.
+
+    SQLAlchemy renders constraint members as ``<... object at 0x7f...>``, so the
+    repr of an otherwise identical foreign-key diff differs between two calls in
+    the same process. Drift output is compared and shown to operators, so it has
+    to be stable.
+    """
+    return _OBJECT_ADDRESS_RE.sub(" object>", repr(diff))
+
+
 def check_schema_drift(database_url: str) -> tuple[str, ...]:
     config = _build_alembic_config(database_url)
     sync_database_url = _required_sqlalchemy_url(config)
@@ -652,7 +667,7 @@ def check_schema_drift(database_url: str) -> tuple[str, ...]:
             ]
         manual_diffs = _manual_schema_drift_diffs(connection)
 
-    return tuple(repr(diff) for diff in diffs) + manual_diffs
+    return tuple(_stable_diff_repr(diff) for diff in diffs) + manual_diffs
 
 
 _NO_LEGACY_BOOTSTRAP = LegacyBootstrapResult(

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -883,6 +883,118 @@ class CapabilityLineageMarker(Base):
     )
 
 
+class DashboardUserStatus(str, Enum):
+    ACTIVE = "active"
+    DISABLED = "disabled"
+    INVITED = "invited"
+
+
+class DashboardUserRoleSource(str, Enum):
+    MANUAL = "manual"
+    MAPPING = "mapping"
+    SCIM = "scim"
+
+
+class ApiKeyDeactivatedReason(str, Enum):
+    MANUAL = "manual"
+    OWNER_DISABLED = "owner_disabled"
+    EXPIRED = "expired"
+
+
+#: Username of the account the legacy shared dashboard password is migrated
+#: into. During the expand/contract release its credentials are mirrored to the
+#: legacy ``dashboard_settings`` columns so older replicas keep working.
+COMPAT_ADMIN_USERNAME = "admin"
+
+
+class DashboardUser(Base):
+    """A person (or service) who signs in to the dashboard.
+
+    ``status``/``role_source`` are plain strings validated by the enums above
+    (no database enum type, so adding values needs no type migration). The
+    ``role_id`` foreign key is RESTRICT: a role in use cannot be deleted.
+    """
+
+    __tablename__ = "dashboard_users"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(320), unique=True, nullable=True)
+    role_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("dashboard_roles.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    role_source: Mapped[str] = mapped_column(
+        String(16),
+        default=DashboardUserRoleSource.MANUAL.value,
+        server_default=text("'manual'"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(
+        String(16),
+        default=DashboardUserStatus.ACTIVE.value,
+        server_default=text("'active'"),
+        nullable=False,
+    )
+    password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    totp_secret_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    totp_last_verified_step: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    session_generation: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"), nullable=False)
+    must_change_password: Mapped[bool] = mapped_column(Boolean, default=False, server_default=false(), nullable=False)
+    is_break_glass: Mapped[bool] = mapped_column(Boolean, default=False, server_default=false(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    created_by_user_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("dashboard_users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    role: Mapped["DashboardRoleRecord"] = relationship("DashboardRoleRecord")
+    identities: Mapped[list["DashboardIdentity"]] = relationship(
+        "DashboardIdentity",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class DashboardIdentity(Base):
+    """An external identity (reverse-proxy header, OIDC, SCIM) linked to a user.
+
+    One user may hold several identities from several providers; the
+    ``(provider, provider_key, subject)`` triple is unique.
+    """
+
+    __tablename__ = "dashboard_identities"
+    __table_args__ = (
+        UniqueConstraint("provider", "provider_key", "subject", name="uq_dashboard_identities_subject"),
+        Index("idx_dashboard_identities_user_id", "user_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("dashboard_users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    provider_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    subject: Mapped[str] = mapped_column(String(512), nullable=False)
+    email: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    display_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    groups_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+
+    user: Mapped["DashboardUser"] = relationship("DashboardUser", back_populates="identities")
+
+
 class DashboardRoleRecord(Base):
     """A dashboard role: one of the five presets or an operator-defined custom role.
 
@@ -1397,6 +1509,21 @@ class ApiKey(Base):
     )
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # Ownership (per-user accounts). NULL owner = shared/service key. Populated
+    # once principals carry a user id; declared here so the schema lands once.
+    owner_user_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("dashboard_users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_by_user_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("dashboard_users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Why an inactive key is inactive, so re-enabling a user restores only the
+    # keys that were disabled because of that user (never manual blocks).
+    deactivated_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 

--- a/app/modules/dashboard_auth/repository.py
+++ b/app/modules/dashboard_auth/repository.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import DashboardSettingsConflictError
 from app.db.models import DashboardSettings
+from app.modules.dashboard_users.compat import CompatAdminProjection
 from app.modules.settings.repository import SettingsRepository
 
 _SETTINGS_ID = 1
@@ -16,6 +17,9 @@ class DashboardAuthRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
         self._settings_repository = SettingsRepository(session)
+        # Release N: legacy credential columns are a projection of the compat
+        # `admin` user row; every credential write is mirrored before commit.
+        self._compat = CompatAdminProjection(session)
 
     async def get_settings(self) -> DashboardSettings:
         return await self._settings_repository.get_or_create()
@@ -46,6 +50,7 @@ class DashboardAuthRepository:
             if secret_encrypted is None:
                 row.totp_required_on_login = False
 
+        await self._compat.set_totp_secret(secret_encrypted)
         return await self._mutate_settings_with_retry(_mutate)
 
     async def set_password_hash(self, password_hash: str) -> DashboardSettings:
@@ -54,6 +59,7 @@ class DashboardAuthRepository:
             row.bootstrap_token_encrypted = None
             row.bootstrap_token_hash = None
 
+        await self._compat.set_password_hash(password_hash)
         return await self._mutate_settings_with_retry(_mutate)
 
     async def set_guest_password_hash(self, password_hash: str) -> DashboardSettings:
@@ -86,8 +92,12 @@ class DashboardAuthRepository:
             .values(password_hash=password_hash, bootstrap_token_encrypted=None, bootstrap_token_hash=None)
             .returning(DashboardSettings.id)
         )
+        configured = result.scalar_one_or_none() is not None
+        if configured:
+            # First-run setup creates the `admin` account the credential belongs to.
+            await self._compat.ensure_exists(password_hash=password_hash)
         await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        return configured
 
     async def get_password_hash(self) -> str | None:
         row = await self._settings_repository.get_or_create()
@@ -102,6 +112,8 @@ class DashboardAuthRepository:
             row.totp_secret_encrypted = None
             row.totp_last_verified_step = None
 
+        await self._compat.set_password_hash(None)
+        await self._compat.set_totp_secret(None)
         return await self._mutate_settings_with_retry(_mutate)
 
     async def store_bootstrap_token_if_absent(self, token_encrypted: bytes, token_hash: bytes) -> bool:
@@ -143,5 +155,13 @@ class DashboardAuthRepository:
             .values(totp_last_verified_step=step)
             .returning(DashboardSettings.id)
         )
+        advanced = result.scalar_one_or_none() is not None
+        # The replay counter must advance in both places or in neither: a code
+        # accepted by the legacy column but already used on the user row (or
+        # vice versa) is a replay.
+        mirrored = await self._compat.try_advance_totp_step(step)
+        if not advanced or mirrored is False:
+            await self._session.rollback()
+            return False
         await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        return True

--- a/app/modules/dashboard_auth/repository.py
+++ b/app/modules/dashboard_auth/repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from sqlalchemy import or_, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,22 +24,36 @@ class DashboardAuthRepository:
     async def get_settings(self) -> DashboardSettings:
         return await self._settings_repository.get_or_create()
 
-    async def _mutate_settings_with_retry(self, mutate: Callable[[DashboardSettings], None]) -> DashboardSettings:
+    async def _mutate_settings_with_retry(
+        self,
+        mutate: Callable[[DashboardSettings], None],
+        *,
+        mirror: Callable[[DashboardSettings], Awaitable[None]] | None = None,
+    ) -> DashboardSettings:
         """Apply a single-purpose settings mutation, retrying once on a version conflict.
 
         These mutations are idempotent absolute writes (set/clear a credential
         field), so losing the optimistic version race to a concurrent settings
         update is benign: re-read the fresh row, re-apply the same mutation,
         and commit again instead of surfacing a 500.
+
+        ``mirror`` re-applies the compat-admin projection of the same write
+        (it receives the mutated legacy row). It runs before every commit
+        attempt because the conflict rollback discards the flushed user-row
+        update together with the legacy one.
         """
         row = await self._settings_repository.get_or_create()
         mutate(row)
+        if mirror is not None:
+            await mirror(row)
         try:
             await self._settings_repository.commit_refresh(row)
         except DashboardSettingsConflictError:
             row = await self._settings_repository.get_or_create()
             await self._session.refresh(row)
             mutate(row)
+            if mirror is not None:
+                await mirror(row)
             await self._settings_repository.commit_refresh(row)
         return row
 
@@ -50,8 +64,10 @@ class DashboardAuthRepository:
             if secret_encrypted is None:
                 row.totp_required_on_login = False
 
-        await self._compat.set_totp_secret(secret_encrypted)
-        return await self._mutate_settings_with_retry(_mutate)
+        return await self._mutate_settings_with_retry(
+            _mutate,
+            mirror=lambda row: self._compat.set_totp_secret(secret_encrypted, legacy_password_hash=row.password_hash),
+        )
 
     async def set_password_hash(self, password_hash: str) -> DashboardSettings:
         def _mutate(row: DashboardSettings) -> None:
@@ -59,8 +75,9 @@ class DashboardAuthRepository:
             row.bootstrap_token_encrypted = None
             row.bootstrap_token_hash = None
 
-        await self._compat.set_password_hash(password_hash)
-        return await self._mutate_settings_with_retry(_mutate)
+        return await self._mutate_settings_with_retry(
+            _mutate, mirror=lambda _row: self._compat.set_password_hash(password_hash)
+        )
 
     async def set_guest_password_hash(self, password_hash: str) -> DashboardSettings:
         def _mutate(row: DashboardSettings) -> None:
@@ -112,9 +129,11 @@ class DashboardAuthRepository:
             row.totp_secret_encrypted = None
             row.totp_last_verified_step = None
 
-        await self._compat.set_password_hash(None)
-        await self._compat.set_totp_secret(None)
-        return await self._mutate_settings_with_retry(_mutate)
+        async def _mirror(_row: DashboardSettings) -> None:
+            await self._compat.set_password_hash(None)
+            await self._compat.set_totp_secret(None, legacy_password_hash=None)
+
+        return await self._mutate_settings_with_retry(_mutate, mirror=_mirror)
 
     async def store_bootstrap_token_if_absent(self, token_encrypted: bytes, token_hash: bytes) -> bool:
         await self._settings_repository.get_or_create()

--- a/app/modules/dashboard_users/compat.py
+++ b/app/modules/dashboard_users/compat.py
@@ -45,6 +45,11 @@ class CompatAdminProjection:
     ) -> DashboardUser:
         user = await self.get()
         if user is not None:
+            # Re-arming after a password removal: the row survives with NULL
+            # credentials and must pick up the new ones.
+            user.password_hash = password_hash
+            user.totp_secret_encrypted = totp_secret_encrypted
+            user.totp_last_verified_step = totp_last_verified_step
             return user
         user = DashboardUser(
             id=COMPAT_ADMIN_USER_ID,
@@ -65,12 +70,18 @@ class CompatAdminProjection:
         user = await self.get()
         if user is not None:
             user.password_hash = password_hash
+        elif password_hash is not None:
+            # A replica of the previous release set the legacy password without
+            # a user row; the first mirrored write self-heals the projection.
+            await self.ensure_exists(password_hash=password_hash)
 
-    async def set_totp_secret(self, secret_encrypted: bytes | None) -> None:
+    async def set_totp_secret(self, secret_encrypted: bytes | None, *, legacy_password_hash: str | None) -> None:
         user = await self.get()
         if user is not None:
             user.totp_secret_encrypted = secret_encrypted
             user.totp_last_verified_step = None
+        elif secret_encrypted is not None and legacy_password_hash is not None:
+            await self.ensure_exists(password_hash=legacy_password_hash, totp_secret_encrypted=secret_encrypted)
 
     async def try_advance_totp_step(self, step: int) -> bool | None:
         """Advance the replay counter; ``None`` when there is no compat user to mirror."""

--- a/app/modules/dashboard_users/compat.py
+++ b/app/modules/dashboard_users/compat.py
@@ -1,0 +1,94 @@
+"""Expand/contract bridge between the legacy shared admin password and ``dashboard_users``.
+
+Release N stores the credential in both places: the ``admin`` user row (the new
+source of truth from the next change on) and the legacy ``dashboard_settings``
+columns that replicas still running the previous release read. Every write to
+the legacy credential goes through :class:`CompatAdminProjection` so the two
+never drift; release N+1 removes the projection and the legacy columns.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.db.models import COMPAT_ADMIN_USERNAME, DashboardUser, DashboardUserRoleSource, DashboardUserStatus
+
+__all__ = ["COMPAT_ADMIN_USERNAME", "COMPAT_ADMIN_USER_ID", "CompatAdminProjection"]
+
+#: Deterministic id of the migrated admin so the migration and the runtime
+#: bootstrap path create the same row and re-runs stay idempotent.
+COMPAT_ADMIN_USER_ID = str(
+    uuid.uuid5(uuid.UUID("6f1c0e4e-2b4a-4c1e-9c3b-7a5d2e8f0a11"), "codex-lb:dashboard-user:compat-admin")
+)
+
+
+class CompatAdminProjection:
+    """Mirror legacy-credential writes onto the ``admin`` user row (no commit)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self) -> DashboardUser | None:
+        stmt = select(DashboardUser).where(DashboardUser.username == COMPAT_ADMIN_USERNAME)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def ensure_exists(
+        self,
+        *,
+        password_hash: str,
+        totp_secret_encrypted: bytes | None = None,
+        totp_last_verified_step: int | None = None,
+    ) -> DashboardUser:
+        user = await self.get()
+        if user is not None:
+            return user
+        user = DashboardUser(
+            id=COMPAT_ADMIN_USER_ID,
+            username=COMPAT_ADMIN_USERNAME,
+            role_id=PRESET_ROLE_IDS[PresetRoleSlug.ADMIN],
+            role_source=DashboardUserRoleSource.MANUAL.value,
+            status=DashboardUserStatus.ACTIVE.value,
+            password_hash=password_hash,
+            totp_secret_encrypted=totp_secret_encrypted,
+            totp_last_verified_step=totp_last_verified_step,
+            is_break_glass=True,
+        )
+        self._session.add(user)
+        await self._session.flush()
+        return user
+
+    async def set_password_hash(self, password_hash: str | None) -> None:
+        user = await self.get()
+        if user is not None:
+            user.password_hash = password_hash
+
+    async def set_totp_secret(self, secret_encrypted: bytes | None) -> None:
+        user = await self.get()
+        if user is not None:
+            user.totp_secret_encrypted = secret_encrypted
+            user.totp_last_verified_step = None
+
+    async def try_advance_totp_step(self, step: int) -> bool | None:
+        """Advance the replay counter; ``None`` when there is no compat user to mirror."""
+
+        result = await self._session.execute(
+            update(DashboardUser)
+            .where(DashboardUser.username == COMPAT_ADMIN_USERNAME)
+            .where(
+                or_(
+                    DashboardUser.totp_last_verified_step.is_(None),
+                    DashboardUser.totp_last_verified_step < step,
+                )
+            )
+            .values(totp_last_verified_step=step)
+            .returning(DashboardUser.id)
+        )
+        advanced = result.scalar_one_or_none() is not None
+        if advanced:
+            return True
+        exists = (await self.get()) is not None
+        return False if exists else None

--- a/openspec/changes/add-dashboard-users-schema/design.md
+++ b/openspec/changes/add-dashboard-users-schema/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The RBAC plan turns the shared password into an `admin` user without a visible migration step (D11): same password, same TOTP, no banner. Replicas of the previous release must keep working during a rolling upgrade, and they read only the legacy `dashboard_settings` columns. The role rows this schema references were added by `add-dashboard-roles-schema`.
+
+## Goals / Non-Goals
+
+**Goals**
+- Land every account-related column once (users, identities, key ownership) so later changes never re-migrate.
+- Migrate the existing credential into the `admin` user automatically and idempotently.
+- Keep old and new replicas consistent for one release by mirroring writes, never by dual reads.
+
+**Non-Goals**
+- Reading users for authentication, per-user TOTP enrolment, invites, or any API (next changes).
+- Stamping `created_by_user_id` on new API keys (principals carry no user id yet).
+- Removing the legacy columns (release N+1).
+
+## Decisions
+
+### Backfill in the migration, create at runtime for fresh installs
+
+The revision inserts the `admin` row only when a legacy password exists; a passwordless install creates it at first `POST /password/setup` through `CompatAdminProjection.ensure_exists`. Both use the same deterministic id and the unique username, so re-running the migration or racing the bootstrap cannot produce two admins.
+
+### Write-side projection, read-side untouched
+
+`DashboardAuthRepository` mirrors password/TOTP writes to the user row **before** the legacy write inside the same session and commits once; the retry-on-version-conflict path re-applies the legacy mutation only (the user mirror is not versioned). New code does not read the user row: introducing `users OR legacy` reads now would create a second truth to unwind in N+1, so the switch happens atomically in the next change.
+
+### Replay counter advances on both rows or neither
+
+`try_advance_totp_last_verified_step` runs both conditional updates and rolls back unless both advanced (a missing compat user simply means there is nothing to mirror). A code accepted by the legacy column but already consumed on the user row — possible when a newer replica verified it — is therefore rejected as a replay on both, closing T16.
+
+### Plain string status/role_source columns
+
+As with roles, `status` and `role_source` are `String` columns validated by `str`/`Enum` classes in code, so `invited`, `mapping`, `scim` and future values need no type migration.
+
+### Ownership columns now, semantics later
+
+`owner_user_id`, `created_by_user_id`, and `deactivated_reason` are nullable and unused; adding them here avoids a second `api_keys` ALTER (SQLite table rebuild) when self-service keys arrive.
+
+## Risks / Trade-offs
+
+- [Risk] Migration backfill and runtime creation race on a fresh install during rolling upgrade. → Deterministic id + unique username make the second insert fail idempotently; the runtime path checks existence first.
+- [Risk] A future refactor writes the legacy column without going through the repository. → All legacy credential writes already funnel through `DashboardAuthRepository`; the mirror lives there.
+- [Trade-off] The compat user's `password_hash` mirror is not covered by the optimistic version of `dashboard_settings`. → Acceptable for one release: both writes happen in one transaction from one request, and the next change makes the user row authoritative.

--- a/openspec/changes/add-dashboard-users-schema/design.md
+++ b/openspec/changes/add-dashboard-users-schema/design.md
@@ -18,11 +18,11 @@ The RBAC plan turns the shared password into an `admin` user without a visible m
 
 ### Backfill in the migration, create at runtime for fresh installs
 
-The revision inserts the `admin` row only when a legacy password exists; a passwordless install creates it at first `POST /password/setup` through `CompatAdminProjection.ensure_exists`. Both use the same deterministic id and the unique username, so re-running the migration or racing the bootstrap cannot produce two admins.
+The revision inserts the `admin` row only when a legacy password exists (its identifiers are frozen literals in the revision, checked against the runtime constants by a unit test, so deleting the compat module later cannot break `alembic upgrade`); a passwordless install creates it at first `POST /password/setup` through `CompatAdminProjection.ensure_exists`, which also re-arms a row left credential-less by a password removal. Mirrored writes that find a legacy password but no row create it, covering a password configured by an old replica during the rolling window. Both use the same deterministic id and the unique username, so re-running the migration or racing the bootstrap cannot produce two admins.
 
 ### Write-side projection, read-side untouched
 
-`DashboardAuthRepository` mirrors password/TOTP writes to the user row **before** the legacy write inside the same session and commits once; the retry-on-version-conflict path re-applies the legacy mutation only (the user mirror is not versioned). New code does not read the user row: introducing `users OR legacy` reads now would create a second truth to unwind in N+1, so the switch happens atomically in the next change.
+`DashboardAuthRepository` mirrors password/TOTP writes to the user row inside the same session as the legacy write and commits once. The retry-on-version-conflict path re-applies **both** mutations: the conflict rollback discards the flushed user-row update along with the legacy one, so a mirror applied only before the first attempt would be lost silently. New code does not read the user row: introducing `users OR legacy` reads now would create a second truth to unwind in N+1, so the switch happens atomically in the next change.
 
 ### Replay counter advances on both rows or neither
 
@@ -36,8 +36,13 @@ As with roles, `status` and `role_source` are `String` columns validated by `str
 
 `owner_user_id`, `created_by_user_id`, and `deactivated_reason` are nullable and unused; adding them here avoids a second `api_keys` ALTER (SQLite table rebuild) when self-service keys arrive.
 
+### Legacy columns stay authoritative through release N
+
+Every replica of release N still authenticates against `dashboard_settings`. A replica of the previous release that is still running during the rolling upgrade writes password/TOTP changes to the legacy columns only, so the `admin` user row can lag behind them. That is harmless while nothing reads the user row, and the change that switches authority (`user-login-and-session-v2`) re-projects the legacy columns onto the `admin` row in its migration before the first read, then reverses the mirror direction. The user row is therefore never the source of truth for a credential that an old writer could still change.
+
 ## Risks / Trade-offs
 
 - [Risk] Migration backfill and runtime creation race on a fresh install during rolling upgrade. → Deterministic id + unique username make the second insert fail idempotently; the runtime path checks existence first.
 - [Risk] A future refactor writes the legacy column without going through the repository. → All legacy credential writes already funnel through `DashboardAuthRepository`; the mirror lives there.
-- [Trade-off] The compat user's `password_hash` mirror is not covered by the optimistic version of `dashboard_settings`. → Acceptable for one release: both writes happen in one transaction from one request, and the next change makes the user row authoritative.
+- [Trade-off] The compat user's `password_hash` mirror is not covered by the optimistic version of `dashboard_settings`. → Both writes happen in one transaction from one request and the mirror is re-applied on the conflict retry; the next change re-projects legacy → user once more before making the user row authoritative.
+- [Risk] Old-release replicas write only the legacy columns during the rolling window. → Legacy stays authoritative for this release (see above); the authority switch re-projects first.

--- a/openspec/changes/add-dashboard-users-schema/proposal.md
+++ b/openspec/changes/add-dashboard-users-schema/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The dashboard has no notion of a person: the shared admin password is two columns on the settings row, TOTP is one secret for the whole install, and API keys have no owner. Per-user accounts need their tables before any login, invite, or audit change can use them. This change lands the schema and the migration bridge for the existing shared password, with no visible behaviour change.
+
+## What Changes
+
+- New tables `dashboard_users` (username, display name, e-mail, `role_id` → `dashboard_roles` RESTRICT, `role_source`, `status`, per-user password hash and TOTP secret/step, `session_generation`, `must_change_password`, `is_break_glass`, audit timestamps, `created_by_user_id`) and `dashboard_identities` (external identities, unique on provider/provider_key/subject, cascade on user deletion).
+- `api_keys` gains `owner_user_id` and `created_by_user_id` (both SET NULL on user deletion) and `deactivated_reason`; existing keys are unowned "service keys".
+- Alembic revision `20260909_010000_add_dashboard_users` creates the above and **backfills the legacy admin**: if `dashboard_settings.password_hash` is set, an `admin` user (deterministic id, admin preset, `is_break_glass=true`) is created with the same password hash, TOTP secret, and replay counter. Installs without a password get no user; first-run password setup creates the `admin` row at runtime.
+- **Expand/contract release N**: the legacy `dashboard_settings` credential columns stay as a projection of the `admin` user. Every legacy credential write (first-run setup, password change/removal, TOTP secret set/clear, TOTP replay-counter advance) is mirrored onto the user row in the same transaction; the replay counter must advance on both rows or the code is rejected as a replay. No code path reads the user row yet, so admin/guest behaviour is identical; the next change switches reads to the users table.
+- `dashboard_users` cache-invalidation namespace registered (consumer arrives with the users cache).
+
+## Capabilities
+
+### New Capabilities
+
+- `dashboard-users`: account and identity schema, API key ownership columns, legacy-admin backfill, and the release-N compat projection.
+
+### Modified Capabilities
+
+None (the `admin-auth` login/session contract is unchanged in this change).
+
+## Impact
+
+- `app/db/models.py`, one Alembic revision, `app/modules/dashboard_users/compat.py`, `app/modules/dashboard_auth/repository.py` (mirroring), `app/core/cache/invalidation.py` (namespace).
+- No route, setting, env var, README, nav, or frontend change. Existing tests unchanged; new integration tests cover backfill, mirroring, replay refusal, uniqueness, and ownership columns.

--- a/openspec/changes/add-dashboard-users-schema/specs/dashboard-users/spec.md
+++ b/openspec/changes/add-dashboard-users-schema/specs/dashboard-users/spec.md
@@ -33,7 +33,7 @@ The Alembic revision `20260909_010000_add_dashboard_users` MUST create the table
 
 ### Requirement: Legacy credential columns are a projection of the admin user
 
-During the expand/contract release, every write to the legacy dashboard credential MUST be mirrored onto the `admin` user row within the same transaction: first-run password setup MUST create the `admin` user (deterministic id, admin preset, break-glass designation); password change and removal MUST update or clear the user's `password_hash`; TOTP secret set and clear MUST update the user's secret and reset its replay step; password removal MUST also clear the user's TOTP fields. Advancing the TOTP replay counter MUST succeed only if both the legacy column and the user row advance; otherwise nothing is written and the code is rejected as a replay. Authentication and session reads MUST continue to use the legacy columns in this release.
+During the expand/contract release, every write to the legacy dashboard credential MUST be mirrored onto the `admin` user row within the same transaction: first-run password setup MUST create the `admin` user (deterministic id, admin preset, break-glass designation); password change and removal MUST update or clear the user's `password_hash`; TOTP secret set and clear MUST update the user's secret and reset its replay step; password removal MUST also clear the user's TOTP fields. Advancing the TOTP replay counter MUST succeed only if both the legacy column and the user row advance; otherwise nothing is written and the code is rejected as a replay. When the legacy write is retried after an optimistic version conflict, the mirror MUST be re-applied so both rows are committed together. Setting a password again after removal MUST re-arm the existing `admin` row rather than create a second user, and a mirrored write that finds a legacy password without an `admin` row MUST create the row from the legacy credential. Authentication and session reads MUST continue to use the legacy columns in this release, and the release that makes the user row authoritative MUST re-project the legacy columns onto the `admin` user before its first read.
 
 #### Scenario: First-run setup creates the admin account
 
@@ -45,6 +45,24 @@ During the expand/contract release, every write to the legacy dashboard credenti
 
 - **WHEN** the dashboard password is changed
 - **THEN** the `admin` user's `password_hash` equals the legacy column
+
+#### Scenario: Setup after removal re-arms the admin row
+
+- **GIVEN** the password was removed and the `admin` row remains with no credentials
+- **WHEN** `POST /api/dashboard-auth/password/setup` succeeds again
+- **THEN** the same `admin` row holds the new password hash and exactly one user exists
+
+#### Scenario: Legacy password without an admin row is projected on the next write
+
+- **GIVEN** a legacy password hash set by a replica of the previous release and no `admin` row
+- **WHEN** a TOTP secret or a new password is written through the repository
+- **THEN** the `admin` row is created carrying the legacy password hash and the new value
+
+#### Scenario: Mirror survives a settings version conflict
+
+- **GIVEN** a concurrent settings update commits between the credential read and its commit
+- **WHEN** the password change is retried on the fresh row
+- **THEN** the `admin` user's `password_hash` equals the new legacy column value
 
 #### Scenario: One-sided replay counter advance is refused
 

--- a/openspec/changes/add-dashboard-users-schema/specs/dashboard-users/spec.md
+++ b/openspec/changes/add-dashboard-users-schema/specs/dashboard-users/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Dashboard user and identity tables
+
+The system SHALL store dashboard accounts in `dashboard_users` with `id`, unique `username`, `display_name`, unique nullable `email`, `role_id` referencing `dashboard_roles` with RESTRICT deletion, string `role_source` (`manual`, `mapping`, `scim`; default `manual`), string `status` (`active`, `disabled`, `invited`; default `active`), nullable `password_hash`, nullable `totp_secret_encrypted` and `totp_last_verified_step`, `session_generation` (default 0), `must_change_password` and `is_break_glass` (default false), `created_at`, nullable self-referencing `created_by_user_id` (SET NULL), `updated_at`, and nullable `last_login_at`. External identities SHALL be stored in `dashboard_identities` with `user_id` cascading on user deletion and a unique `(provider, provider_key, subject)` triple. `api_keys` SHALL carry nullable `owner_user_id` and `created_by_user_id` (SET NULL on user deletion) and a nullable string `deactivated_reason`.
+
+#### Scenario: Duplicate identity is rejected
+
+- **WHEN** a second identity row with the same provider, provider key, and subject is inserted
+- **THEN** the insert fails with a uniqueness violation
+
+#### Scenario: Deleting a user detaches keys and removes identities
+
+- **WHEN** a user who owns an API key and has an identity is deleted
+- **THEN** the key remains with `owner_user_id` null
+- **AND** the identity row is removed
+
+### Requirement: Legacy shared admin is migrated into the admin user
+
+The Alembic revision `20260909_010000_add_dashboard_users` MUST create the tables and columns above and, when `dashboard_settings.password_hash` is set, MUST insert a user with the deterministic compat id, username `admin`, the admin preset role, `status` `active`, `role_source` `manual`, `is_break_glass` true, and the same `password_hash`, `totp_secret_encrypted`, and `totp_last_verified_step`. When no legacy password is set the revision MUST create no user. The backfill MUST be idempotent on re-run and the downgrade MUST drop the new tables and columns.
+
+#### Scenario: Install with a password gets one admin user
+
+- **GIVEN** a database at the parent revision whose settings row has a password hash, TOTP secret, and replay step
+- **WHEN** the revision is applied
+- **THEN** exactly one `dashboard_users` row exists with username `admin`, the admin preset, break-glass designation, and the copied credential fields
+
+#### Scenario: Install without a password gets no user
+
+- **GIVEN** a settings row without a password hash
+- **WHEN** the revision is applied
+- **THEN** `dashboard_users` is empty
+
+### Requirement: Legacy credential columns are a projection of the admin user
+
+During the expand/contract release, every write to the legacy dashboard credential MUST be mirrored onto the `admin` user row within the same transaction: first-run password setup MUST create the `admin` user (deterministic id, admin preset, break-glass designation); password change and removal MUST update or clear the user's `password_hash`; TOTP secret set and clear MUST update the user's secret and reset its replay step; password removal MUST also clear the user's TOTP fields. Advancing the TOTP replay counter MUST succeed only if both the legacy column and the user row advance; otherwise nothing is written and the code is rejected as a replay. Authentication and session reads MUST continue to use the legacy columns in this release.
+
+#### Scenario: First-run setup creates the admin account
+
+- **WHEN** `POST /api/dashboard-auth/password/setup` succeeds on an install with no users
+- **THEN** a `dashboard_users` row `admin` exists with the same password hash as the legacy column
+- **AND** a second setup attempt is refused and no second user is created
+
+#### Scenario: Password change is mirrored
+
+- **WHEN** the dashboard password is changed
+- **THEN** the `admin` user's `password_hash` equals the legacy column
+
+#### Scenario: One-sided replay counter advance is refused
+
+- **GIVEN** the `admin` user's replay step is already at the submitted step while the legacy column is behind
+- **WHEN** the replay counter is advanced with that step
+- **THEN** the call reports a replay and neither row changes

--- a/openspec/changes/add-dashboard-users-schema/tasks.md
+++ b/openspec/changes/add-dashboard-users-schema/tasks.md
@@ -1,0 +1,17 @@
+## 1. Schema
+
+- [x] 1.1 Add `DashboardUser` and `DashboardIdentity` models (string status/role_source, RESTRICT role FK, self FK for creator, unique identity triple, cascade identities).
+- [x] 1.2 Add `api_keys.owner_user_id`, `created_by_user_id` (SET NULL) and `deactivated_reason`.
+- [x] 1.3 Alembic revision `20260909_010000_add_dashboard_users` (guarded creates, batch-mode column adds with named FKs, downgrade).
+
+## 2. Legacy admin bridge
+
+- [x] 2.1 Backfill the `admin` user from `dashboard_settings` credentials in the migration (deterministic id, admin preset, break-glass designation, idempotent).
+- [x] 2.2 `CompatAdminProjection` + `DashboardAuthRepository` mirroring for first-run setup, password set/clear, TOTP secret set/clear, and the replay counter (both-or-neither).
+- [x] 2.3 Register the `dashboard_users` cache-invalidation namespace and log label.
+
+## 3. Verification
+
+- [x] 3.1 Integration: first-run setup creates the admin row; change/remove password mirrored; TOTP secret and counter mirrored; one-sided counter advance refused; identity uniqueness; API key ownership columns and SET NULL on owner deletion.
+- [x] 3.2 Migration test with and without a legacy password: tables/columns created, backfill correct, downgrade clean, head reachable.
+- [x] 3.3 `ruff`, `ty`, focused pytest, PostgreSQL drift contract, `openspec validate --strict`.

--- a/tests/integration/test_cache_invalidation_bus.py
+++ b/tests/integration/test_cache_invalidation_bus.py
@@ -25,6 +25,7 @@ from app.core.cache.invalidation import (
     NAMESPACE_ACCOUNT_ROUTING,
     NAMESPACE_ACCOUNT_SELECTION,
     NAMESPACE_API_KEY,
+    NAMESPACE_DASHBOARD_USERS,
     NAMESPACE_FIREWALL,
     NAMESPACE_MODEL_REGISTRY,
     NAMESPACE_RESET_CREDITS,
@@ -385,6 +386,7 @@ def test_namespace_log_labels_cover_all_namespaces() -> None:
             NAMESPACE_RESET_CREDITS,
             NAMESPACE_MODEL_REGISTRY,
             NAMESPACE_UPSTREAM_ROUTE,
+            NAMESPACE_DASHBOARD_USERS,
         )
     }
 

--- a/tests/integration/test_dashboard_users_schema.py
+++ b/tests/integration/test_dashboard_users_schema.py
@@ -1,0 +1,254 @@
+"""Schema, backfill, and compat-projection tests for the per-user account tables.
+
+Release N keeps the legacy shared-admin columns on ``dashboard_settings`` as a
+projection of the ``admin`` user row. These tests prove (a) the migration
+creates the tables and backfills the existing credential, (b) every legacy
+credential write reaches the user row, and (c) the TOTP replay counter cannot
+be advanced on one side only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from anyio import to_thread
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.core.config.settings import get_settings
+from app.db.migrate import _build_alembic_config, inspect_migration_state, run_upgrade
+from app.db.models import ApiKey, DashboardIdentity, DashboardSettings, DashboardUser
+from app.db.session import SessionLocal
+from app.modules.dashboard_auth.repository import DashboardAuthRepository
+from app.modules.dashboard_users.compat import COMPAT_ADMIN_USER_ID, COMPAT_ADMIN_USERNAME
+
+pytestmark = pytest.mark.integration
+
+_HEAD_REVISION = inspect_migration_state(get_settings().database_url).head_revision
+PARENT_REVISION = "20260909_000000_add_dashboard_roles"
+TARGET_REVISION = "20260909_010000_add_dashboard_users"
+
+
+async def _compat_user() -> DashboardUser | None:
+    async with SessionLocal() as session:
+        return (
+            await session.execute(select(DashboardUser).where(DashboardUser.username == COMPAT_ADMIN_USERNAME))
+        ).scalar_one_or_none()
+
+
+async def _legacy_settings() -> DashboardSettings:
+    async with SessionLocal() as session:
+        return (await session.execute(select(DashboardSettings))).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_first_run_password_setup_creates_the_admin_user(async_client) -> None:
+    assert await _compat_user() is None
+    setup = await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password123"})
+    assert setup.status_code == 200, setup.text
+
+    user = await _compat_user()
+    assert user is not None
+    assert user.id == COMPAT_ADMIN_USER_ID
+    assert user.role_id == PRESET_ROLE_IDS[PresetRoleSlug.ADMIN]
+    assert user.status == "active"
+    assert user.role_source == "manual"
+    assert user.is_break_glass is True
+    assert user.password_hash == (await _legacy_settings()).password_hash
+
+    # A second setup attempt is refused and leaves exactly one admin row.
+    again = await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password456"})
+    assert again.status_code == 409
+    async with SessionLocal() as session:
+        count = (await session.execute(text("SELECT COUNT(*) FROM dashboard_users"))).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_password_change_and_removal_are_mirrored(async_client) -> None:
+    assert (
+        await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password123"})
+    ).status_code == 200
+    login = await async_client.post("/api/dashboard-auth/password/login", json={"password": "password123"})
+    assert login.status_code == 200
+
+    changed = await async_client.post(
+        "/api/dashboard-auth/password/change",
+        json={"currentPassword": "password123", "newPassword": "password456"},
+    )
+    assert changed.status_code == 200, changed.text
+    user = await _compat_user()
+    legacy = await _legacy_settings()
+    assert user is not None and user.password_hash == legacy.password_hash
+
+    removed = await async_client.request("DELETE", "/api/dashboard-auth/password", json={"password": "password456"})
+    assert removed.status_code == 200, removed.text
+    user = await _compat_user()
+    assert user is not None
+    assert user.password_hash is None
+    assert user.totp_secret_encrypted is None
+    assert (await _legacy_settings()).password_hash is None
+
+
+@pytest.mark.asyncio
+async def test_totp_secret_and_replay_counter_are_mirrored(async_client) -> None:
+    assert (
+        await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password123"})
+    ).status_code == 200
+    assert (
+        await async_client.post("/api/dashboard-auth/password/login", json={"password": "password123"})
+    ).status_code == 200
+
+    async with SessionLocal() as session:
+        repository = DashboardAuthRepository(session)
+        await repository.set_totp_secret(b"encrypted-secret")
+    user = await _compat_user()
+    legacy = await _legacy_settings()
+    assert user is not None
+    assert user.totp_secret_encrypted == b"encrypted-secret" == legacy.totp_secret_encrypted
+    assert user.totp_last_verified_step is None
+
+    async with SessionLocal() as session:
+        repository = DashboardAuthRepository(session)
+        assert await repository.try_advance_totp_last_verified_step(100) is True
+        assert await repository.try_advance_totp_last_verified_step(100) is False  # replay
+        assert await repository.try_advance_totp_last_verified_step(101) is True
+    user = await _compat_user()
+    legacy = await _legacy_settings()
+    assert user is not None and user.totp_last_verified_step == 101 == legacy.totp_last_verified_step
+
+
+@pytest.mark.asyncio
+async def test_replay_counter_refuses_when_only_one_side_would_advance(async_client) -> None:
+    assert (
+        await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password123"})
+    ).status_code == 200
+    # Simulate a peer that already consumed step 200 on the user row only.
+    async with SessionLocal() as session:
+        user = (await session.execute(select(DashboardUser))).scalar_one()
+        user.totp_last_verified_step = 200
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repository = DashboardAuthRepository(session)
+        assert await repository.try_advance_totp_last_verified_step(200) is False
+    legacy = await _legacy_settings()
+    user = await _compat_user()
+    assert legacy.totp_last_verified_step is None  # rolled back, not advanced on one side
+    assert user is not None and user.totp_last_verified_step == 200
+
+
+@pytest.mark.asyncio
+async def test_identity_uniqueness_and_api_key_ownership_columns(db_setup) -> None:
+    async with SessionLocal() as session:
+        user = DashboardUser(username="alice", role_id=PRESET_ROLE_IDS[PresetRoleSlug.OPERATOR])
+        session.add(user)
+        await session.flush()
+        session.add(
+            DashboardIdentity(user_id=user.id, provider="trusted_header", provider_key="default", subject="alice")
+        )
+        key = ApiKey(
+            id=str(uuid.uuid4()),
+            name="alice-key",
+            key_hash="hash-1",
+            key_prefix="sk-clb-alice",
+            owner_user_id=user.id,
+            created_by_user_id=user.id,
+        )
+        session.add(key)
+        await session.commit()
+        user_id, key_id = user.id, key.id
+
+    async with SessionLocal() as session:
+        session.add(
+            DashboardIdentity(user_id=user_id, provider="trusted_header", provider_key="default", subject="alice")
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    async with SessionLocal() as session:
+        stored = (await session.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
+        assert stored.owner_user_id == user_id
+        assert stored.deactivated_reason is None
+        # Deleting the owner detaches the key (SET NULL) and cascades identities.
+        owner = (await session.execute(select(DashboardUser).where(DashboardUser.id == user_id))).scalar_one()
+        await session.delete(owner)
+        await session.commit()
+    async with SessionLocal() as session:
+        stored = (await session.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
+        assert stored.owner_user_id is None
+        identities = (await session.execute(select(DashboardIdentity))).scalars().all()
+        assert identities == []
+
+
+@pytest.mark.parametrize("legacy_password_configured", [True, False])
+@pytest.mark.asyncio
+async def test_dashboard_users_migration_backfills_the_compat_admin(tmp_path, legacy_password_configured: bool):
+    from alembic import command
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'dashboard-users.sqlite'}"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, PARENT_REVISION, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            existing = (await conn.execute(text("SELECT id FROM dashboard_settings"))).first()
+            if existing is None:
+                await conn.execute(text("INSERT INTO dashboard_settings (id) VALUES (1)"))
+            if legacy_password_configured:
+                await conn.execute(
+                    text(
+                        "UPDATE dashboard_settings SET password_hash = :h, totp_secret_encrypted = :s, "
+                        "totp_last_verified_step = :st WHERE id = 1"
+                    ),
+                    {"h": "$2b$legacy", "s": b"legacy-secret", "st": 42},
+                )
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, TARGET_REVISION, bootstrap_legacy=False))
+        # Re-run the same revision's upgrade body by walking down and up: rows stay unique.
+        async with engine.connect() as conn:
+            tables = {row[0] for row in await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))}
+            assert {"dashboard_users", "dashboard_identities"} <= tables
+            api_key_columns = {row[1] for row in await conn.execute(text("PRAGMA table_info('api_keys')"))}
+            assert {"owner_user_id", "created_by_user_id", "deactivated_reason"} <= api_key_columns
+            users = (
+                await conn.execute(
+                    text(
+                        "SELECT id, username, role_id, status, is_break_glass, password_hash, "
+                        "totp_secret_encrypted, totp_last_verified_step FROM dashboard_users"
+                    )
+                )
+            ).all()
+        if legacy_password_configured:
+            assert len(users) == 1
+            (row,) = users
+            assert row[0] == COMPAT_ADMIN_USER_ID
+            assert row[1] == COMPAT_ADMIN_USERNAME
+            assert row[2] == PRESET_ROLE_IDS[PresetRoleSlug.ADMIN]
+            assert row[3] == "active"
+            assert bool(row[4]) is True
+            assert row[5] == "$2b$legacy"
+            assert row[6] == b"legacy-secret"
+            assert row[7] == 42
+        else:
+            assert users == []
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, PARENT_REVISION))
+        async with engine.connect() as conn:
+            tables = {row[0] for row in await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))}
+            api_key_columns = {row[1] for row in await conn.execute(text("PRAGMA table_info('api_keys')"))}
+        assert not {"dashboard_users", "dashboard_identities"} & tables
+        assert not {"owner_user_id", "created_by_user_id", "deactivated_reason"} & api_key_columns
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        async with engine.connect() as conn:
+            count = (await conn.execute(text("SELECT COUNT(*) FROM dashboard_users"))).scalar_one()
+        assert count == (1 if legacy_password_configured else 0)
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_dashboard_users_schema.py
+++ b/tests/integration/test_dashboard_users_schema.py
@@ -19,11 +19,13 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
 from app.core.config.settings import get_settings
+from app.core.exceptions import DashboardSettingsConflictError
 from app.db.migrate import _build_alembic_config, inspect_migration_state, run_upgrade
 from app.db.models import ApiKey, DashboardIdentity, DashboardSettings, DashboardUser
 from app.db.session import SessionLocal
 from app.modules.dashboard_auth.repository import DashboardAuthRepository
 from app.modules.dashboard_users.compat import COMPAT_ADMIN_USER_ID, COMPAT_ADMIN_USERNAME
+from app.modules.settings.repository import SettingsRepository
 
 pytestmark = pytest.mark.integration
 
@@ -91,6 +93,76 @@ async def test_password_change_and_removal_are_mirrored(async_client) -> None:
     assert user.password_hash is None
     assert user.totp_secret_encrypted is None
     assert (await _legacy_settings()).password_hash is None
+
+    # Setting a password again re-arms the surviving admin row instead of
+    # leaving it credential-less next to a populated legacy column.
+    again = await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password789"})
+    assert again.status_code == 200, again.text
+    user = await _compat_user()
+    legacy = await _legacy_settings()
+    assert user is not None and user.id == COMPAT_ADMIN_USER_ID
+    assert user.password_hash is not None and user.password_hash == legacy.password_hash
+    async with SessionLocal() as session:
+        count = (await session.execute(text("SELECT COUNT(*) FROM dashboard_users"))).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_mirrored_writes_create_the_admin_row_when_an_old_replica_left_only_the_legacy_column(db_setup) -> None:
+    # A replica of the previous release configured the password: legacy column
+    # set, no user row. The next mirrored write must self-heal the projection.
+    async with SessionLocal() as session:
+        repository = DashboardAuthRepository(session)
+        await repository.get_settings()
+        await session.execute(text("UPDATE dashboard_settings SET password_hash = '$2b$old-replica' WHERE id = 1"))
+        await session.commit()
+    assert await _compat_user() is None
+
+    async with SessionLocal() as session:
+        await DashboardAuthRepository(session).set_totp_secret(b"secret-from-new-replica")
+    user = await _compat_user()
+    assert user is not None and user.id == COMPAT_ADMIN_USER_ID
+    assert user.password_hash == "$2b$old-replica"
+    assert user.totp_secret_encrypted == b"secret-from-new-replica"
+
+    async with SessionLocal() as session:
+        user_row = (await session.execute(select(DashboardUser))).scalar_one()
+        await session.delete(user_row)
+        await session.commit()
+    async with SessionLocal() as session:
+        await DashboardAuthRepository(session).set_password_hash("$2b$new-replica")
+    user = await _compat_user()
+    assert user is not None and user.password_hash == "$2b$new-replica"
+
+
+@pytest.mark.asyncio
+async def test_mirror_is_reapplied_when_the_settings_commit_conflicts(async_client, monkeypatch) -> None:
+    assert (
+        await async_client.post("/api/dashboard-auth/password/setup", json={"password": "password123"})
+    ).status_code == 200
+
+    original_commit_refresh = SettingsRepository.commit_refresh
+    attempts = {"count": 0}
+
+    async def _conflict_once(self, settings, *, on_committed=None):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            # A concurrent settings writer won the optimistic version race:
+            # commit_refresh rolls the whole transaction back, including the
+            # flushed compat-admin mirror.
+            await self._session.rollback()
+            raise DashboardSettingsConflictError()
+        await original_commit_refresh(self, settings, on_committed=on_committed)
+
+    monkeypatch.setattr(SettingsRepository, "commit_refresh", _conflict_once)
+    async with SessionLocal() as session:
+        await DashboardAuthRepository(session).set_password_hash("$2b$retried")
+    assert attempts["count"] == 2
+
+    user = await _compat_user()
+    legacy = await _legacy_settings()
+    assert legacy.password_hash == "$2b$retried"
+    assert user is not None and user.password_hash == "$2b$retried"
 
 
 @pytest.mark.asyncio
@@ -209,12 +281,18 @@ async def test_dashboard_users_migration_backfills_the_compat_admin(tmp_path, le
                 )
 
         await to_thread.run_sync(lambda: run_upgrade(db_url, TARGET_REVISION, bootstrap_legacy=False))
-        # Re-run the same revision's upgrade body by walking down and up: rows stay unique.
+        # Idempotency on pre-existing state: stamp back (no downgrade) and
+        # re-run the same upgrade body over the already-created tables/rows.
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.stamp(config, PARENT_REVISION))
+        await to_thread.run_sync(lambda: run_upgrade(db_url, TARGET_REVISION, bootstrap_legacy=False))
         async with engine.connect() as conn:
             tables = {row[0] for row in await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))}
             assert {"dashboard_users", "dashboard_identities"} <= tables
-            api_key_columns = {row[1] for row in await conn.execute(text("PRAGMA table_info('api_keys')"))}
+            api_key_column_names = [row[1] for row in await conn.execute(text("PRAGMA table_info('api_keys')"))]
+            api_key_columns = set(api_key_column_names)
             assert {"owner_user_id", "created_by_user_id", "deactivated_reason"} <= api_key_columns
+            assert len(api_key_column_names) == len(api_key_columns)
             users = (
                 await conn.execute(
                     text(
@@ -237,7 +315,7 @@ async def test_dashboard_users_migration_backfills_the_compat_admin(tmp_path, le
         else:
             assert users == []
 
-        config = _build_alembic_config(db_url)
+        # The down/up walk validates the downgrade and a fresh re-apply.
         await to_thread.run_sync(lambda: command.downgrade(config, PARENT_REVISION))
         async with engine.connect() as conn:
             tables = {row[0] for row in await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))}

--- a/tests/unit/test_dashboard_users_compat.py
+++ b/tests/unit/test_dashboard_users_compat.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.modules.dashboard_users.compat import COMPAT_ADMIN_USER_ID, COMPAT_ADMIN_USERNAME
+
+pytestmark = pytest.mark.unit
+
+_MIGRATION = Path("app/db/alembic/versions/20260909_010000_add_dashboard_users.py")
+
+
+def test_migration_literals_match_the_runtime_identifiers() -> None:
+    """The revision freezes the ids instead of importing the transient compat module."""
+
+    spec = importlib.util.spec_from_file_location("add_dashboard_users_revision", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.COMPAT_ADMIN_USER_ID == COMPAT_ADMIN_USER_ID
+    assert module.COMPAT_ADMIN_USERNAME == COMPAT_ADMIN_USERNAME
+    assert module.ADMIN_ROLE_ID == PRESET_ROLE_IDS[PresetRoleSlug.ADMIN]


### PR DESCRIPTION
## Summary

Stacked on the roles-schema PR (`feat/dashboard-roles-schema`, #2217). Second Phase-1 PR of the dashboard RBAC plan: the **per-user account tables**, plus the expand/contract bridge that turns today's shared admin password into an `admin` user without any visible migration step — same password, same TOTP, no banner. **Authentication still reads the legacy `dashboard_settings` columns in this release**; every credential write is mirrored onto the user row so the next PR can switch authority atomically.

## Type of change

- [x] `feat:` — new capability (schema + compat projection)

Linked issue: groundwork for #673 (user management); no issue closed.

## OpenSpec

- [x] This PR includes an OpenSpec change

Change directory: `openspec/changes/add-dashboard-users-schema/` (new capability `dashboard-users`; `openspec validate --strict` passes)

## Changes

**Schema** (`app/db/models.py`, revision `20260909_010000_add_dashboard_users`):
- `dashboard_users`: `id`, `username` (unique), `display_name`, `email` (unique, nullable), `role_id` FK → `dashboard_roles` RESTRICT, `role_source` (`manual|mapping|scim`), `status` (`active|disabled|invited`), `password_hash`, `totp_secret_encrypted`, `totp_last_verified_step`, `session_generation`, `must_change_password`, `is_break_glass`, `created_by_user_id` self-FK SET NULL, `last_login_at`, timestamps.
- `dashboard_identities`: external identities (`provider`, `provider_key`, `subject` unique together, `groups_json`, `last_seen_at`) FK → users CASCADE. Column-only; no login path yet.
- `api_keys` gains `owner_user_id` / `created_by_user_id` (FK SET NULL) and `deactivated_reason`, all nullable and unused for now (existing keys stay "service keys"). Added here so the later self-service change needs no second SQLite table rebuild.
- Backfill: when a legacy password exists, the revision inserts the `admin` user (deterministic UUIDv5 id, admin preset, `is_break_glass=true`, TOTP secret and replay step copied). Identifiers are frozen literals in the revision (a unit test keeps them in sync with the runtime constants). Idempotent; downgrade drops the tables and columns.

**Compat projection** (`app/modules/dashboard_users/compat.py`, `app/modules/dashboard_auth/repository.py`): first-run `POST /password/setup` creates the `admin` row; password change/removal, TOTP secret set/clear are mirrored in the same transaction, and the mirror is re-applied on the optimistic-conflict retry. The TOTP replay counter advances on both rows or neither. Setting a password again after removal re-arms the surviving row; a mirrored write that finds a legacy password without a row creates it (old replica configured it during the rolling window). `NAMESPACE_DASHBOARD_USERS` is registered on the invalidation bus for the next PR.

**Design points**
- Legacy columns stay authoritative through this release; the authority switch (next PR) re-projects legacy → user once in its migration before the first read.
- Plain string `status` / `role_source` columns validated by `StrEnum`s in code.
- No consumer changes: no new API, no dashboard change, principals unchanged.

**Tests**: `tests/integration/test_dashboard_users_schema.py` (setup creates the admin row and refuses a second setup, change/remove/re-setup mirrored, conflict retry keeps both rows in sync, self-healing projection, TOTP secret and replay counter mirrored, one-sided advance refused, identity uniqueness and key-ownership SET NULL, migration with/without legacy password incl. stamp-back idempotency and downgrade), `tests/unit/test_dashboard_users_compat.py` (frozen migration literals), cache namespace label test updated.

## Simplicity

- [x] Zero config; no new setting, env var, README section, or nav item.
- [x] No new required setup step.
- New setting(s): none
- [x] Budgets unchanged.

## Test plan

```
uv run ruff check . && uv run ruff format --check . && uv run ty check        # clean
uv run pytest tests/integration/test_dashboard_users_schema.py tests/integration/test_dashboard_password_auth.py \
  tests/integration/test_dashboard_totp_auth.py tests/integration/test_dashboard_bootstrap.py \
  tests/integration/test_replica_guardrails.py tests/unit/test_dashboard_users_compat.py -q
uv run pytest tests/integration -q                                              # 115 passed, 5 skipped (pg-only)
openspec validate add-dashboard-users-schema --strict                          # valid
codex review --base feat/dashboard-roles-schema                                # 2 P1 findings fixed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
