### PR TITLE
feat(audit): record the acting account, target and severity on audit rows

### DIFF
--- a/app/core/audit/service.py
+++ b/app/core/audit/service.py
@@ -3,12 +3,41 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Protocol
 
+from app.core.audit.types import (
+    AuditActor,
+    AuditAuthMethod,
+    AuditDetails,
+    AuditDetailScalar,
+    AuditDetailValue,
+    AuditEvent,
+    AuditSeverity,
+    AuditTarget,
+)
 from app.core.shutdown import is_control_plane_task_admission_open, wait_for_tasks_to_drain
 from app.core.utils.request_id import get_request_id
 from app.db.models import AuditLog
 from app.db.session import get_session
+
+__all__ = [
+    "AuditActor",
+    "AuditAuthMethod",
+    "AuditDetailScalar",
+    "AuditDetailValue",
+    "AuditDetails",
+    "AuditEvent",
+    "AuditService",
+    "AuditSeverity",
+    "AuditSink",
+    "AuditTarget",
+    "DatabaseAuditSink",
+    "drain_audit_log_tasks",
+    "get_audit_sinks",
+    "register_audit_sink",
+    "reset_audit_sinks",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +55,6 @@ _REDACTED_DETAIL_KEYS = frozenset(
     }
 )
 
-type AuditDetailScalar = str | int | float | bool | None
-type AuditDetailValue = AuditDetailScalar | Sequence[AuditDetailScalar]
-type AuditDetails = Mapping[str, AuditDetailValue]
-
 _AUDIT_LOG_TASKS: set[asyncio.Task[None]] = set()
 
 
@@ -41,6 +66,80 @@ def _sanitize_details(details: AuditDetails | None) -> dict[str, AuditDetailValu
     return sanitized or None
 
 
+class AuditSink(Protocol):
+    """A destination for audit events. Sinks must not raise to callers; failures are logged."""
+
+    async def emit(self, event: AuditEvent) -> None: ...
+
+
+class DatabaseAuditSink:
+    """The authoritative sink: one ``audit_logs`` row per event."""
+
+    async def emit(self, event: AuditEvent) -> None:
+        actor = event.actor
+        target = event.target
+        async for session in get_session():
+            session.add(
+                AuditLog(
+                    timestamp=event.timestamp,
+                    action=event.action,
+                    actor_ip=event.actor_ip,
+                    details=json.dumps(event.details) if event.details else None,
+                    request_id=event.request_id,
+                    actor_user_id=actor.user_id if actor else None,
+                    actor_username=actor.username if actor else None,
+                    actor_role_slug=actor.role_slug if actor else None,
+                    auth_method=actor.auth_method if actor else None,
+                    target_type=target.type if target else None,
+                    target_id=target.id if target else None,
+                    severity=event.severity.value,
+                )
+            )
+            await session.commit()
+
+
+_DEFAULT_SINKS: tuple[AuditSink, ...] = (DatabaseAuditSink(),)
+_AUDIT_SINKS: tuple[AuditSink, ...] = _DEFAULT_SINKS
+
+
+def get_audit_sinks() -> tuple[AuditSink, ...]:
+    """Registered sinks in emit order; the database sink is always first."""
+
+    return _AUDIT_SINKS
+
+
+def register_audit_sink(sink: AuditSink) -> None:
+    global _AUDIT_SINKS
+    _AUDIT_SINKS = (*_AUDIT_SINKS, sink)
+
+
+def reset_audit_sinks() -> None:
+    global _AUDIT_SINKS
+    _AUDIT_SINKS = _DEFAULT_SINKS
+
+
+def _build_event(
+    action: str,
+    actor_ip: str | None,
+    details: AuditDetails | None,
+    request_id: str | None,
+    *,
+    actor: AuditActor | None,
+    target: AuditTarget | None,
+    severity: AuditSeverity,
+) -> AuditEvent:
+    return AuditEvent(
+        action=action,
+        timestamp=datetime.now(UTC),
+        actor=actor,
+        actor_ip=actor_ip,
+        target=target,
+        severity=severity,
+        details=_sanitize_details(details),
+        request_id=request_id,
+    )
+
+
 class AuditService:
     @staticmethod
     async def log(
@@ -48,8 +147,14 @@ class AuditService:
         actor_ip: str | None = None,
         details: AuditDetails | None = None,
         request_id: str | None = None,
+        *,
+        actor: AuditActor | None = None,
+        target: AuditTarget | None = None,
+        severity: AuditSeverity = AuditSeverity.INFO,
     ) -> None:
-        await _write_audit_log(action, actor_ip, details, request_id)
+        await _write_audit_log(
+            _build_event(action, actor_ip, details, request_id, actor=actor, target=target, severity=severity)
+        )
 
     @staticmethod
     def log_async(
@@ -57,14 +162,24 @@ class AuditService:
         actor_ip: str | None = None,
         details: AuditDetails | None = None,
         request_id: str | None = None,
+        *,
+        actor: AuditActor | None = None,
+        target: AuditTarget | None = None,
+        severity: AuditSeverity = AuditSeverity.INFO,
     ) -> None:
         if not is_control_plane_task_admission_open():
             logger.warning("Audit log task rejected after shutdown admission closed: %s", action)
             return
-        task = asyncio.create_task(
-            _write_audit_log(action, actor_ip, details, request_id or get_request_id()),
-            name=f"audit-log-{action}",
+        event = _build_event(
+            action,
+            actor_ip,
+            details,
+            request_id or get_request_id(),
+            actor=actor,
+            target=target,
+            severity=severity,
         )
+        task = asyncio.create_task(_write_audit_log(event), name=f"audit-log-{action}")
         _AUDIT_LOG_TASKS.add(task)
         task.add_done_callback(_handle_audit_log_task_done)
 
@@ -91,22 +206,11 @@ def _handle_audit_log_task_done(task: asyncio.Task[None]) -> None:
         _AUDIT_LOG_TASKS.discard(task)
 
 
-async def _write_audit_log(
-    action: str,
-    actor_ip: str | None,
-    details: AuditDetails | None,
-    request_id: str | None,
-) -> None:
-    try:
-        sanitized_details = _sanitize_details(details)
-        async for session in get_session():
-            log_entry = AuditLog(
-                action=action,
-                actor_ip=actor_ip,
-                details=json.dumps(sanitized_details) if sanitized_details else None,
-                request_id=request_id,
-            )
-            session.add(log_entry)
-            await session.commit()
-    except Exception:
-        logger.warning("Failed to write audit log", exc_info=True)
+async def _write_audit_log(event: AuditEvent) -> None:
+    """Fan the event out to every sink; one failing sink never starves the others."""
+
+    for sink in get_audit_sinks():
+        try:
+            await sink.emit(event)
+        except Exception:
+            logger.warning("Audit sink %s failed for action %s", type(sink).__name__, event.action, exc_info=True)

--- a/app/core/audit/types.py
+++ b/app/core/audit/types.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from app.core.auth.dashboard_access import DashboardPrincipal, DashboardRole, PresetRoleSlug
+
+type AuditDetailScalar = str | int | float | bool | None
+type AuditDetailValue = AuditDetailScalar | Sequence[AuditDetailScalar]
+type AuditDetails = Mapping[str, AuditDetailValue]
+
+
+class AuditSeverity(StrEnum):
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+class AuditAuthMethod(StrEnum):
+    """How the acting party authenticated. Stored as the plain string."""
+
+    PASSWORD = "password"
+    TOTP = "totp"
+    GUEST = "guest"
+    TRUSTED_HEADER = "trusted_header"
+    DISABLED = "disabled"
+    LOCAL_BOOTSTRAP = "local_bootstrap"
+    API_KEY = "api_key"
+    OIDC = "oidc"
+    SCIM = "scim"
+    CLI = "cli"
+
+
+@dataclass(frozen=True, slots=True)
+class AuditActor:
+    """Snapshot of who acted, taken at write time.
+
+    The user id is a plain string, not a foreign key: an audit row must outlive
+    the account it names. ``user_id`` is ``None`` for principals without an
+    account row (implicit local admin, trusted header, disabled auth, guest);
+    a trusted-header admin still records the proxy-asserted username.
+    """
+
+    user_id: str | None
+    username: str | None
+    role_slug: str | None
+    auth_method: str | None
+
+    @classmethod
+    def from_principal(cls, principal: DashboardPrincipal) -> AuditActor:
+        if principal.user_id is not None:
+            return cls(
+                user_id=principal.user_id,
+                username=principal.username,
+                role_slug=principal.role_slug,
+                auth_method=principal.auth_method,
+            )
+        if principal.role is DashboardRole.GUEST:
+            return cls(
+                user_id=None,
+                username=None,
+                role_slug=PresetRoleSlug.GUEST.value,
+                auth_method=AuditAuthMethod.GUEST.value,
+            )
+        return cls(
+            user_id=None,
+            username=principal.actor,
+            role_slug=PresetRoleSlug.ADMIN.value,
+            auth_method=principal.auth_method,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AuditTarget:
+    """What was acted on: a stable type name plus the object's identifier."""
+
+    type: str
+    id: str
+
+
+@dataclass(frozen=True, slots=True)
+class AuditEvent:
+    """One audit record as handed to every sink. ``details`` is already sanitised."""
+
+    action: str
+    timestamp: datetime
+    actor: AuditActor | None
+    actor_ip: str | None
+    target: AuditTarget | None
+    severity: AuditSeverity
+    details: dict[str, AuditDetailValue] | None
+    request_id: str | None

--- a/app/db/alembic/versions/20260909_030000_add_audit_actor_columns.py
+++ b/app/db/alembic/versions/20260909_030000_add_audit_actor_columns.py
@@ -1,0 +1,103 @@
+"""Add actor, target and severity columns to audit_logs.
+
+Revision ID: 20260909_030000_add_audit_actor_columns
+Revises: 20260909_020000_reproject_compat_admin_credentials
+Create Date: 2026-09-09
+
+The actor columns are a snapshot (no foreign key) so an audit row outlives the
+account it names. Existing rows keep NULL actor/target columns and receive
+``severity='info'`` through the server default.
+
+On SQLite the ``timestamp`` text of rows written through the database default
+(``CURRENT_TIMESTAMP``, second granularity) is padded once to the
+microsecond form the ORM writes and binds, so time-window predicates and
+same-second ordering compare consistently. Representation only; the instant
+does not change.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260909_030000_add_audit_actor_columns"
+down_revision = "20260909_020000_reproject_compat_admin_credentials"
+branch_labels = None
+depends_on = None
+
+_TABLE = "audit_logs"
+_COLUMN_NAMES: tuple[str, ...] = (
+    "actor_user_id",
+    "actor_username",
+    "actor_role_slug",
+    "auth_method",
+    "target_type",
+    "target_id",
+    "severity",
+)
+_INDEXES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("idx_audit_logs_actor_user_id", ("actor_user_id",)),
+    ("idx_audit_logs_target", ("target_type", "target_id")),
+)
+
+
+def _new_columns() -> tuple[sa.Column, ...]:
+    """Fresh Column objects per call: a Column may be bound to one table only."""
+
+    return (
+        sa.Column("actor_user_id", sa.String(length=36), nullable=True),
+        sa.Column("actor_username", sa.String(length=64), nullable=True),
+        sa.Column("actor_role_slug", sa.String(length=32), nullable=True),
+        sa.Column("auth_method", sa.String(length=32), nullable=True),
+        sa.Column("target_type", sa.String(length=32), nullable=True),
+        sa.Column("target_id", sa.String(length=128), nullable=True),
+        sa.Column("severity", sa.String(length=16), nullable=False, server_default=sa.text("'info'")),
+    )
+
+
+def _columns(inspector: sa.Inspector) -> set[str]:
+    if not inspector.has_table(_TABLE):
+        return set()
+    return {column["name"] for column in inspector.get_columns(_TABLE)}
+
+
+def _indexes(inspector: sa.Inspector) -> set[str]:
+    if not inspector.has_table(_TABLE):
+        return set()
+    return {name for index in inspector.get_indexes(_TABLE) if isinstance(name := index.get("name"), str)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return
+    existing_columns = _columns(inspector)
+    missing = [column for column in _new_columns() if column.name not in existing_columns]
+    if missing:
+        with op.batch_alter_table(_TABLE) as batch_op:
+            for column in missing:
+                batch_op.add_column(column)
+    existing_indexes = _indexes(sa.inspect(bind))
+    for name, columns in _INDEXES:
+        if name not in existing_indexes:
+            op.create_index(name, _TABLE, list(columns))
+    if bind.dialect.name == "sqlite":
+        op.execute(sa.text("UPDATE audit_logs SET timestamp = timestamp || '.000000' WHERE timestamp NOT LIKE '%.%'"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE):
+        return
+    existing_indexes = _indexes(inspector)
+    for name, _ in _INDEXES:
+        if name in existing_indexes:
+            op.drop_index(name, table_name=_TABLE)
+    existing_columns = _columns(inspector)
+    present = [name for name in _COLUMN_NAMES if name in existing_columns]
+    if present:
+        with op.batch_alter_table(_TABLE) as batch_op:
+            for name in present:
+                batch_op.drop_column(name)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -718,7 +718,19 @@ class AccountLimitWarmup(Base):
 
 
 class AuditLog(Base):
+    """Append-only record of dashboard actions.
+
+    The ``actor_*`` columns are a snapshot of the acting account, not foreign
+    keys: a row must survive the deletion of the account it names. They are all
+    NULL for rows written before attribution existed and for principals without
+    an account row (implicit local admin, trusted header, guest).
+    """
+
     __tablename__ = "audit_logs"
+    __table_args__ = (
+        Index("idx_audit_logs_actor_user_id", "actor_user_id"),
+        Index("idx_audit_logs_target", "target_type", "target_id"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=func.now(), nullable=False, index=True)
@@ -726,6 +738,13 @@ class AuditLog(Base):
     actor_ip: Mapped[str | None] = mapped_column(String(50), nullable=True)
     details: Mapped[str | None] = mapped_column(Text, nullable=True)
     request_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    actor_user_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    actor_username: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    actor_role_slug: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    auth_method: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    target_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    target_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False, server_default=text("'info'"))
 
 
 class SchedulerLeader(Base):

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -4,7 +4,7 @@ import logging
 
 from fastapi import APIRouter, Depends, Request, Response
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
 from app.core.auth.dashboard_access import DashboardPrincipal, Permission
 from app.core.auth.dependencies import (
     require_dashboard_permission,
@@ -148,7 +148,7 @@ async def consume_account_usage_reset_credit(
     request: Request,
     account_id: str,
     payload: AccountUsageResetConsumeRequest | None = None,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountUsageResetConsumeResponse:
     try:
@@ -173,6 +173,8 @@ async def consume_account_usage_reset_credit(
     AuditService.log_async(
         "account_usage_reset_consumed",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", result.account_id),
         details={
             "account_id": result.account_id,
             "code": result.code,
@@ -188,7 +190,7 @@ async def export_account_auth(
     request: Request,
     response: Response,
     account_id: str,
-    _export_access=Depends(require_dashboard_permission(Permission.ACCOUNTS_EXPORT)),
+    principal: DashboardPrincipal = Depends(require_dashboard_permission(Permission.ACCOUNTS_EXPORT)),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountAuthExportResponse:
     result = await context.service.export_auth(account_id)
@@ -200,6 +202,8 @@ async def export_account_auth(
     AuditService.log_async(
         "account_auth_exported",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", account_id),
         details={"account_id": account_id},
     )
     return result
@@ -212,7 +216,7 @@ async def export_account_auth(
 )
 async def import_account(
     request: Request,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountImportResponse:
     raise_for_unsupported_multipart_content_encoding(request)
@@ -232,6 +236,8 @@ async def import_account(
         AuditService.log_async(
             "account_created",
             actor_ip=request.client.host if request.client else None,
+            actor=AuditActor.from_principal(principal),
+            target=AuditTarget("account", response.account_id),
             details={"account_id": response.account_id},
         )
         return response
@@ -261,7 +267,7 @@ async def update_account(
     account_id: str,
     payload: AccountUpdateRequest,
     request: Request,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountUpdateResponse:
     changed_fields = [field for field, value in payload.model_dump(exclude_unset=True).items() if value is not None]
@@ -276,6 +282,8 @@ async def update_account(
     AuditService.log_async(
         "account_updated",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", account_id),
         details={
             "account_id": account_id,
             "changed_fields": changed_fields,
@@ -289,7 +297,7 @@ async def probe_account(
     request: Request,
     account_id: str,
     body: AccountProbeRequest | None = None,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountProbeResponse:
     requested_model = body.model if body is not None else None
@@ -327,6 +335,8 @@ async def probe_account(
     AuditService.log_async(
         "account_probed",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", result.account_id),
         details={
             "account_id": result.account_id,
             "probe_status_code": result.probe_status_code,
@@ -401,7 +411,7 @@ async def delete_account(
     request: Request,
     account_id: str,
     delete_history: bool = False,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountDeleteResponse:
     success = await context.service.delete_account(account_id, delete_history=delete_history)
@@ -410,6 +420,8 @@ async def delete_account(
     AuditService.log_async(
         "account_deleted",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", account_id),
         details={"account_id": account_id, "delete_history": delete_history},
     )
     return AccountDeleteResponse(status="deleted")

--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, Request, Response
 
-from app.core.audit.service import AuditService
-from app.core.auth.dashboard_access import Permission
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
+from app.core.auth.dashboard_access import DashboardPrincipal, Permission
 from app.core.auth.dependencies import (
     require_dashboard_permission,
     require_dashboard_write_access,
@@ -133,7 +133,7 @@ async def create_api_key(
     request: Request,
     response: Response,
     payload: ApiKeyCreateRequest = Body(...),
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ApiKeysContext = Depends(get_api_keys_context),
 ) -> ApiKeyCreateResponse:
     limit_inputs = _build_limit_inputs(payload)
@@ -167,6 +167,8 @@ async def create_api_key(
     AuditService.log_async(
         "api_key_created",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("api_key", created.id),
         details={"key_id": created.id},
     )
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
@@ -192,7 +194,7 @@ async def update_api_key(
     request: Request,
     key_id: str,
     payload: ApiKeyUpdateRequest = Body(...),
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ApiKeysContext = Depends(get_api_keys_context),
 ) -> ApiKeyResponse:
     fields = payload.model_fields_set
@@ -243,6 +245,8 @@ async def update_api_key(
         AuditService.log_async(
             "api_key_revoked",
             actor_ip=request.client.host if request.client else None,
+            actor=AuditActor.from_principal(principal),
+            target=AuditTarget("api_key", key_id),
             details={"key_id": row.id},
         )
     return _to_response(row)
@@ -252,7 +256,7 @@ async def update_api_key(
 async def delete_api_key(
     request: Request,
     key_id: str,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ApiKeysContext = Depends(get_api_keys_context),
 ) -> Response:
     try:
@@ -262,6 +266,8 @@ async def delete_api_key(
     AuditService.log_async(
         "api_key_revoked",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("api_key", key_id),
         details={"key_id": key_id},
     )
     return Response(status_code=204)

--- a/app/modules/audit/api.py
+++ b/app/modules/audit/api.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, Query
 
+from app.core.audit.types import AuditSeverity
 from app.core.auth.dashboard_access import Permission
 from app.core.auth.dependencies import require_dashboard_permission, set_dashboard_error_format
 from app.dependencies import AuditContext, get_audit_context
-from app.modules.audit.schemas import AuditLogResponse
+from app.modules.audit.repository import AuditLogFilters
+from app.modules.audit.schemas import AuditActorResponse, AuditLogResponse, AuditTargetResponse
+from app.modules.audit.service import AuditLogData
 
 router = APIRouter(
     prefix="/api/audit-logs",
@@ -13,23 +18,71 @@ router = APIRouter(
     dependencies=[Depends(require_dashboard_permission(Permission.AUDIT_READ)), Depends(set_dashboard_error_format)],
 )
 
+#: ``details.reason`` values are lower-case identifiers; the filter is matched
+#: textually inside the JSON column, so anything else is refused up front.
+_REASON_PATTERN = r"^[a-z_]{1,32}$"
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Normalise a query datetime to UTC; a naive value is taken as UTC.
+
+    Rows are stored with UTC wall-clock components, so comparing against the
+    caller's own offset would silently shift the window on SQLite.
+    """
+
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _to_response(row: AuditLogData) -> AuditLogResponse:
+    return AuditLogResponse(
+        id=row.id,
+        timestamp=row.timestamp,
+        action=row.action,
+        actor_ip=row.actor_ip,
+        details=row.details,
+        request_id=row.request_id,
+        actor=(
+            AuditActorResponse(
+                user_id=row.actor.user_id,
+                username=row.actor.username,
+                role_slug=row.actor.role_slug,
+                auth_method=row.actor.auth_method,
+            )
+            if row.actor is not None
+            else None
+        ),
+        target=AuditTargetResponse(type=row.target.type, id=row.target.id) if row.target is not None else None,
+        severity=row.severity,
+    )
+
 
 @router.get("", response_model=list[AuditLogResponse])
 async def list_audit_logs(
     action: str | None = Query(default=None),
+    actor_user_id: str | None = Query(default=None, max_length=36),
+    target_type: str | None = Query(default=None, max_length=32),
+    target_id: str | None = Query(default=None, max_length=128),
+    severity: AuditSeverity | None = Query(default=None),
+    reason: str | None = Query(default=None, pattern=_REASON_PATTERN),
+    since: datetime | None = Query(default=None, description="Inclusive lower bound (ISO 8601)"),
+    until: datetime | None = Query(default=None, description="Exclusive upper bound (ISO 8601)"),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     context: AuditContext = Depends(get_audit_context),
 ) -> list[AuditLogResponse]:
-    rows = await context.service.list_logs(action=action, limit=limit, offset=offset)
-    return [
-        AuditLogResponse(
-            id=row.id,
-            timestamp=row.timestamp,
-            action=row.action,
-            actor_ip=row.actor_ip,
-            details=row.details,
-            request_id=row.request_id,
-        )
-        for row in rows
-    ]
+    filters = AuditLogFilters(
+        action=action,
+        actor_user_id=actor_user_id,
+        target_type=target_type,
+        target_id=target_id,
+        severity=severity.value if severity is not None else None,
+        reason=reason,
+        since=_as_utc(since),
+        until=_as_utc(until),
+    )
+    rows = await context.service.list_logs(filters, limit=limit, offset=offset)
+    return [_to_response(row) for row in rows]

--- a/app/modules/audit/repository.py
+++ b/app/modules/audit/repository.py
@@ -1,9 +1,41 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import AuditLog
+
+_LIKE_ESCAPE = "\\"
+
+
+@dataclass(frozen=True, slots=True)
+class AuditLogFilters:
+    """Predicates for listing audit rows. Every field is optional; ``None`` means "no filter"."""
+
+    action: str | None = None
+    actor_user_id: str | None = None
+    target_type: str | None = None
+    target_id: str | None = None
+    severity: str | None = None
+    reason: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+
+
+def _reason_like_pattern(reason: str) -> str:
+    """Match ``"reason": "<value>"`` inside the JSON text of ``details``.
+
+    ``details`` is written by ``json.dumps`` with default separators, so the
+    key/value pair has exactly this spelling. The caller validates ``reason``
+    against ``[a-z_]+``; the underscore is escaped because it is a LIKE
+    single-character wildcard.
+    """
+
+    escaped = reason.replace("_", f"{_LIKE_ESCAPE}_")
+    return f'%"reason": "{escaped}"%'
 
 
 class AuditRepository:
@@ -12,14 +44,28 @@ class AuditRepository:
 
     async def list_logs(
         self,
+        filters: AuditLogFilters,
         *,
-        action: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[AuditLog]:
         stmt = select(AuditLog).order_by(AuditLog.timestamp.desc(), AuditLog.id.desc())
-        if action:
-            stmt = stmt.where(AuditLog.action == action)
+        if filters.action:
+            stmt = stmt.where(AuditLog.action == filters.action)
+        if filters.actor_user_id:
+            stmt = stmt.where(AuditLog.actor_user_id == filters.actor_user_id)
+        if filters.target_type:
+            stmt = stmt.where(AuditLog.target_type == filters.target_type)
+        if filters.target_id:
+            stmt = stmt.where(AuditLog.target_id == filters.target_id)
+        if filters.severity:
+            stmt = stmt.where(AuditLog.severity == filters.severity)
+        if filters.reason:
+            stmt = stmt.where(AuditLog.details.like(_reason_like_pattern(filters.reason), escape=_LIKE_ESCAPE))
+        if filters.since is not None:
+            stmt = stmt.where(AuditLog.timestamp >= filters.since)
+        if filters.until is not None:
+            stmt = stmt.where(AuditLog.timestamp < filters.until)
         if offset:
             stmt = stmt.offset(offset)
         if limit:

--- a/app/modules/audit/schemas.py
+++ b/app/modules/audit/schemas.py
@@ -9,6 +9,18 @@ type AuditDetailScalar = str | int | float | bool | None
 type AuditDetailValue = AuditDetailScalar | Sequence[AuditDetailScalar]
 
 
+class AuditActorResponse(DashboardModel):
+    user_id: str | None = None
+    username: str | None = None
+    role_slug: str | None = None
+    auth_method: str | None = None
+
+
+class AuditTargetResponse(DashboardModel):
+    type: str
+    id: str
+
+
 class AuditLogResponse(DashboardModel):
     id: int
     timestamp: datetime
@@ -16,3 +28,6 @@ class AuditLogResponse(DashboardModel):
     actor_ip: str | None = None
     details: dict[str, AuditDetailValue] | None = None
     request_id: str | None = None
+    actor: AuditActorResponse | None = None
+    target: AuditTargetResponse | None = None
+    severity: str = "info"

--- a/app/modules/audit/service.py
+++ b/app/modules/audit/service.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 
+from app.core.audit.types import AuditActor, AuditDetailValue, AuditTarget
 from app.db.models import AuditLog
-from app.modules.audit.repository import AuditRepository
+from app.modules.audit.repository import AuditLogFilters, AuditRepository
 
-type AuditDetailScalar = str | int | float | bool | None
-type AuditDetailValue = AuditDetailScalar | Sequence[AuditDetailScalar]
 type AuditDetails = dict[str, AuditDetailValue]
 
 
@@ -22,6 +20,9 @@ class AuditLogData:
     actor_ip: str | None
     details: AuditDetails | None
     request_id: str | None
+    actor: AuditActor | None
+    target: AuditTarget | None
+    severity: str
 
 
 class AuditLogsService:
@@ -30,12 +31,12 @@ class AuditLogsService:
 
     async def list_logs(
         self,
+        filters: AuditLogFilters,
         *,
-        action: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[AuditLogData]:
-        rows = await self._repository.list_logs(action=action, limit=limit, offset=offset)
+        rows = await self._repository.list_logs(filters, limit=limit, offset=offset)
         return [_to_audit_log_data(row) for row in rows]
 
 
@@ -45,6 +46,18 @@ def _to_audit_log_data(row: AuditLog) -> AuditLogData:
         parsed = json.loads(row.details)
         if isinstance(parsed, dict):
             details = cast(AuditDetails, parsed)
+    actor: AuditActor | None = None
+    actor_columns = (row.actor_user_id, row.actor_username, row.actor_role_slug, row.auth_method)
+    if any(value is not None for value in actor_columns):
+        actor = AuditActor(
+            user_id=row.actor_user_id,
+            username=row.actor_username,
+            role_slug=row.actor_role_slug,
+            auth_method=row.auth_method,
+        )
+    target: AuditTarget | None = None
+    if row.target_type is not None and row.target_id is not None:
+        target = AuditTarget(type=row.target_type, id=row.target_id)
     return AuditLogData(
         id=row.id,
         timestamp=row.timestamp,
@@ -52,4 +65,7 @@ def _to_audit_log_data(row: AuditLog) -> AuditLogData:
         actor_ip=row.actor_ip,
         details=details,
         request_id=row.request_id,
+        actor=actor,
+        target=target,
+        severity=row.severity,
     )

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -6,7 +6,7 @@ from time import time
 from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import JSONResponse
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
 from app.core.auth.dashboard_access import (
     ADMIN_GRANTS,
     GUEST_GRANTS,
@@ -79,8 +79,10 @@ from app.modules.dashboard_auth.service import (
     assignable_role_ids,
     get_dashboard_session_store,
     get_guest_password_rate_limiter,
+    get_login_failed_audit_rate_limiter,
     get_password_rate_limiter,
     get_totp_rate_limiter,
+    log_login_failed,
 )
 
 router = APIRouter(
@@ -466,6 +468,7 @@ async def login_password(
     except PasswordNotConfiguredError as exc:
         raise DashboardBadRequestError(str(exc), code="password_not_configured") from exc
     except UsernameRequiredError as exc:
+        await _audit_username_required(request, context)
         raise DashboardValidationError(str(exc), code="username_required") from exc
 
     limiter = get_password_rate_limiter()
@@ -487,6 +490,25 @@ async def login_password(
     return await _issue_user_session_response(request, context, user, totp_verified=False, auth_method="password")
 
 
+async def _audit_username_required(request: Request, context: DashboardAuthContext) -> None:
+    """Audit a ``username_required`` refusal without letting it become an unbounded row source.
+
+    The refusal itself never spends password budget, so a client that is
+    already at the password limit gets no row, and a dedicated per-client
+    budget (same 8/60 s shape, own counter) bounds the rows a client can add
+    without ever touching the password limiter's counter.
+    """
+
+    try:
+        await get_password_rate_limiter().check(_session_client_key(request, prefix="password_login"), context.session)
+        await get_login_failed_audit_rate_limiter().check_and_increment(
+            _session_client_key(request, prefix="login_failed_audit"), context.session
+        )
+    except DashboardRateLimitError:
+        return
+    log_login_failed(_client_host(request), "password", "username_required")
+
+
 @router.post("/password/change")
 async def change_password(
     request: Request,
@@ -500,7 +522,11 @@ async def change_password(
 
     try:
         await context.service.change_password(
-            resolved.user, payload.current_password, new_password, actor_ip=_client_host(request)
+            resolved.user,
+            payload.current_password,
+            new_password,
+            actor_ip=_client_host(request),
+            auth_method=resolved.state.auth_method,
         )
     except PasswordNotConfiguredError as exc:
         raise DashboardBadRequestError(str(exc), code="password_not_configured") from exc
@@ -553,13 +579,18 @@ async def remove_guest_password(
 async def revoke_guest_sessions(
     request: Request,
     context: DashboardAuthContext = Depends(get_dashboard_auth_context),
-    _principal: DashboardPrincipal = Depends(require_dashboard_permission(Permission.SECURITY_WRITE)),
+    principal: DashboardPrincipal = Depends(require_dashboard_permission(Permission.SECURITY_WRITE)),
 ) -> JSONResponse:
     """Invalidate every outstanding guest session without touching guest settings."""
 
     await context.service.revoke_guest_sessions()
     await get_settings_cache().invalidate()
-    AuditService.log_async("guest_sessions_revoked", actor_ip=_client_host(request))
+    AuditService.log_async(
+        "guest_sessions_revoked",
+        actor_ip=_client_host(request),
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("settings", "guest_access"),
+    )
     return JSONResponse(status_code=200, content={"status": "ok"})
 
 
@@ -572,7 +603,12 @@ async def remove_password(
     resolved = await _require_management_session(request, context)
 
     try:
-        await context.service.remove_password(resolved.user, payload.password, actor_ip=_client_host(request))
+        await context.service.remove_password(
+            resolved.user,
+            payload.password,
+            actor_ip=_client_host(request),
+            auth_method=resolved.state.auth_method,
+        )
     except PasswordNotConfiguredError as exc:
         raise DashboardBadRequestError(str(exc), code="password_not_configured") from exc
     except InvalidCredentialsError as exc:
@@ -597,7 +633,9 @@ async def logout_everywhere(
     """Revoke every session of the signed-in account, including this one."""
 
     resolved = await _require_password_session(request, context)
-    await context.service.revoke_user_sessions(resolved.user, actor_ip=_client_host(request))
+    await context.service.revoke_user_sessions(
+        resolved.user, actor_ip=_client_host(request), auth_method=resolved.state.auth_method
+    )
     await get_dashboard_users_cache().invalidate()
     response = JSONResponse(status_code=200, content={"status": "ok"})
     response.delete_cookie(key=DASHBOARD_SESSION_COOKIE, path="/")

--- a/app/modules/dashboard_auth/service.py
+++ b/app/modules/dashboard_auth/service.py
@@ -13,7 +13,7 @@ from typing import Literal, Protocol
 import bcrypt
 import segno
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditAuthMethod, AuditService, AuditSeverity, AuditTarget
 from app.core.auth.dashboard_access import (
     ADMIN_GRANTS,
     ASSIGNABLE_PRESET_ROLES,
@@ -22,6 +22,7 @@ from app.core.auth.dashboard_access import (
     DashboardRole,
     Grants,
     Permission,
+    PresetRoleSlug,
     permission_strings,
 )
 from app.core.auth.dashboard_mode import DashboardAuthMode
@@ -346,10 +347,39 @@ class LoginTarget:
 
     username: str | None
     user: DashboardUser | None
+    #: Why no account was resolved (audit ``login_failed.reason``); ``None`` when ``user`` is set.
+    refusal_reason: str | None = None
 
 
 def _user_is_active(user: DashboardUser | None) -> bool:
     return user is not None and user.status == DashboardUserStatus.ACTIVE.value
+
+
+def _user_actor(user: DashboardUser, auth_method: str) -> AuditActor:
+    return AuditActor(user_id=user.id, username=user.username, role_slug=user.role.slug, auth_method=auth_method)
+
+
+def _user_target(user: DashboardUser) -> AuditTarget:
+    return AuditTarget("user", user.id)
+
+
+_GUEST_ACTOR = AuditActor(
+    user_id=None,
+    username=None,
+    role_slug=PresetRoleSlug.GUEST.value,
+    auth_method=AuditAuthMethod.GUEST.value,
+)
+
+
+def log_login_failed(actor_ip: str | None, method: str, reason: str, *, username: str | None = None) -> None:
+    """Audit a refused sign-in: no actor (nobody authenticated), warning severity, a fixed reason."""
+
+    AuditService.log_async(
+        "login_failed",
+        actor_ip=actor_ip,
+        details={"method": method, "username": username, "reason": reason},
+        severity=AuditSeverity.WARNING,
+    )
 
 
 def role_summary(user: DashboardUser) -> DashboardUserRoleSummary:
@@ -572,8 +602,10 @@ class DashboardAuthService:
 
         A single-user install accepts a login without a username. With more
         than one active local password user the username is mandatory
-        (``UsernameRequiredError``), and that refusal must not spend any
-        rate-limit budget.
+        (``UsernameRequiredError``); that refusal must not spend any rate-limit
+        budget, and the route decides whether to audit it. Why a username did
+        not resolve is kept on the target for the audit row only; the client
+        never learns it.
         """
 
         auth_state = await self._repository.get_local_auth_state()
@@ -586,9 +618,13 @@ class DashboardAuthService:
             return LoginTarget(username=user.username if user is not None else None, user=user)
         normalized = normalize_username(username)
         if not is_valid_username(normalized):
-            return LoginTarget(username=normalized, user=None)
+            return LoginTarget(username=normalized, user=None, refusal_reason="invalid_username")
         user = await self._repository.get_user_by_username(normalized)
-        return LoginTarget(username=normalized, user=user if _user_is_active(user) else None)
+        if user is None:
+            return LoginTarget(username=normalized, user=None, refusal_reason="unknown_identity")
+        if not _user_is_active(user):
+            return LoginTarget(username=normalized, user=None, refusal_reason="disabled_user")
+        return LoginTarget(username=normalized, user=user)
 
     async def verify_user_password(
         self,
@@ -610,14 +646,11 @@ class DashboardAuthService:
         matched = _check_password(password, stored_hash if stored_hash is not None else _dummy_password_hash())
         if user is None or stored_hash is None or not matched:
             username_is_valid = target.username is not None and is_valid_username(target.username)
-            AuditService.log_async(
-                "login_failed",
-                actor_ip=actor_ip,
-                details={
-                    "method": AUTH_METHOD_PASSWORD,
-                    "username": target.username if username_is_valid else None,
-                    "reason": "bad_password" if target.username is None or username_is_valid else "invalid_username",
-                },
+            log_login_failed(
+                actor_ip,
+                AUTH_METHOD_PASSWORD,
+                target.refusal_reason or "bad_password",
+                username=target.username if username_is_valid else None,
             )
             raise InvalidCredentialsError("Invalid credentials")
         await self._repository.touch_last_login(user.id)
@@ -627,6 +660,8 @@ class DashboardAuthService:
                 "login_success",
                 actor_ip=actor_ip,
                 details={"method": AUTH_METHOD_PASSWORD, "username": user.username},
+                actor=_user_actor(user, AUTH_METHOD_PASSWORD),
+                target=_user_target(user),
             )
         return user
 
@@ -648,12 +683,12 @@ class DashboardAuthService:
         generation = settings.guest_session_generation
         current = settings.guest_password_hash
         if current is None:
-            AuditService.log_async("login_success", actor_ip=actor_ip, details={"method": "guest"})
+            AuditService.log_async("login_success", actor_ip=actor_ip, details={"method": "guest"}, actor=_GUEST_ACTOR)
             return GuestVerification(password_verified=False, guest_session_generation=generation)
         if password is None or not _check_password(password, current):
-            AuditService.log_async("login_failed", actor_ip=actor_ip, details={"method": "guest"})
+            log_login_failed(actor_ip, AuditAuthMethod.GUEST.value, "bad_password")
             raise InvalidCredentialsError("Invalid credentials")
-        AuditService.log_async("login_success", actor_ip=actor_ip, details={"method": "guest"})
+        AuditService.log_async("login_success", actor_ip=actor_ip, details={"method": "guest"}, actor=_GUEST_ACTOR)
         return GuestVerification(password_verified=True, guest_session_generation=generation)
 
     async def change_password(
@@ -663,18 +698,35 @@ class DashboardAuthService:
         new_password: str,
         *,
         actor_ip: str | None = None,
+        auth_method: str | None = None,
     ) -> int:
-        """Rotate the password and revoke every other session; returns the new generation."""
+        """Rotate the password and revoke every other session; returns the new generation.
+
+        ``auth_method`` is how the calling session authenticated (audit actor).
+        """
 
         if user.password_hash is None:
             raise PasswordNotConfiguredError("Password is not configured")
         if not _check_password(current_password, user.password_hash):
             raise InvalidCredentialsError("Invalid credentials")
         rotated = await self._repository.rotate_user_password(user.id, _hash_password(new_password))
-        AuditService.log_async("password_changed", actor_ip=actor_ip, details={"username": user.username})
+        AuditService.log_async(
+            "password_changed",
+            actor_ip=actor_ip,
+            details={"username": user.username},
+            actor=_user_actor(user, auth_method or AUTH_METHOD_PASSWORD),
+            target=_user_target(user),
+        )
         return rotated.session_generation
 
-    async def remove_password(self, user: DashboardUser, password: str, *, actor_ip: str | None = None) -> None:
+    async def remove_password(
+        self,
+        user: DashboardUser,
+        password: str,
+        *,
+        actor_ip: str | None = None,
+        auth_method: str | None = None,
+    ) -> None:
         """Solo-install only: drop the user's credentials so the install is passwordless again."""
 
         if user.password_hash is None:
@@ -684,14 +736,28 @@ class DashboardAuthService:
         if await self._repository.count_active_users() != 1 or await self._repository.count_user_identities(user.id):
             raise OtherUsersExistError("Other users exist; log out everywhere instead of removing the password")
         await self._repository.clear_user_credentials(user.id)
-        AuditService.log_async("password_removed", actor_ip=actor_ip, details={"username": user.username})
+        AuditService.log_async(
+            "password_removed",
+            actor_ip=actor_ip,
+            details={"username": user.username},
+            actor=_user_actor(user, auth_method or AUTH_METHOD_PASSWORD),
+            target=_user_target(user),
+        )
 
-    async def revoke_user_sessions(self, user: DashboardUser, *, actor_ip: str | None = None) -> int:
+    async def revoke_user_sessions(
+        self,
+        user: DashboardUser,
+        *,
+        actor_ip: str | None = None,
+        auth_method: str | None = None,
+    ) -> int:
         generation = await self._repository.bump_session_generation(user.id)
         AuditService.log_async(
             "user_sessions_revoked",
             actor_ip=actor_ip,
             details={"username": user.username, "scope": "self"},
+            actor=_user_actor(user, auth_method or AUTH_METHOD_PASSWORD),
+            target=_user_target(user),
         )
         return generation
 
@@ -738,7 +804,13 @@ class DashboardAuthService:
         if not verification.is_valid:
             raise TotpInvalidCodeError("Invalid TOTP code")
         await self._repository.set_user_totp_secret(resolved.user.id, self._encryptor.encrypt(secret))
-        AuditService.log_async("totp_enabled", actor_ip=actor_ip, details={"username": resolved.user.username})
+        AuditService.log_async(
+            "totp_enabled",
+            actor_ip=actor_ip,
+            details={"username": resolved.user.username},
+            actor=_user_actor(resolved.user, resolved.state.auth_method or AUTH_METHOD_PASSWORD),
+            target=_user_target(resolved.user),
+        )
 
     async def verify_totp(
         self,
@@ -760,15 +832,25 @@ class DashboardAuthService:
             window=1,
             last_verified_step=user.totp_last_verified_step,
         )
+        # Snapshot the attribution before the counter write: a refused replay
+        # rolls the session back, which expires ``user`` and would turn a later
+        # attribute read into a lazy load outside the async context.
+        username = user.username
+        actor = _user_actor(user, AuditAuthMethod.TOTP.value)
+        target = _user_target(user)
         if not verification.is_valid or verification.matched_step is None:
-            AuditService.log_async("login_failed", actor_ip=actor_ip, details={"method": "totp"})
+            log_login_failed(actor_ip, AuditAuthMethod.TOTP.value, "bad_totp", username=username)
             raise TotpInvalidCodeError("Invalid TOTP code")
         updated = await self._repository.try_advance_user_totp_step(user.id, verification.matched_step)
         if not updated:
-            AuditService.log_async("login_failed", actor_ip=actor_ip, details={"method": "totp"})
+            log_login_failed(actor_ip, AuditAuthMethod.TOTP.value, "bad_totp", username=username)
             raise TotpInvalidCodeError("Invalid TOTP code")
         AuditService.log_async(
-            "login_success", actor_ip=actor_ip, details={"method": "totp", "username": user.username}
+            "login_success",
+            actor_ip=actor_ip,
+            details={"method": "totp", "username": username},
+            actor=actor,
+            target=target,
         )
         # Honor the existing password-session expiry so that a TTL change
         # mid-flow (between password login and TOTP submission) cannot extend
@@ -808,7 +890,13 @@ class DashboardAuthService:
         if not updated:
             raise TotpInvalidCodeError("Invalid TOTP code")
         await self._repository.set_user_totp_secret(user.id, None)
-        AuditService.log_async("totp_disabled", actor_ip=actor_ip, details={"username": user.username})
+        AuditService.log_async(
+            "totp_disabled",
+            actor_ip=actor_ip,
+            details={"username": user.username},
+            actor=_user_actor(user, resolved.state.auth_method or AUTH_METHOD_PASSWORD),
+            target=_user_target(user),
+        )
 
     def logout(self, session_id: str | None) -> None:
         self._session_store.delete(session_id)
@@ -826,6 +914,9 @@ _dashboard_session_store = DashboardSessionStore()
 _totp_rate_limiter = DatabaseRateLimiter(max_attempts=8, window_seconds=60, type="totp")
 _password_rate_limiter = DatabaseRateLimiter(max_attempts=8, window_seconds=60, type="password")
 _guest_password_rate_limiter = DatabaseRateLimiter(max_attempts=8, window_seconds=60, type="guest_password")
+#: Bounds the anonymous ``login_failed`` rows a client can append from refusals
+#: that by design spend no password budget (``username_required``).
+_login_failed_audit_rate_limiter = DatabaseRateLimiter(max_attempts=8, window_seconds=60, type="login_failed_audit")
 
 
 def get_dashboard_session_store() -> DashboardSessionStore:
@@ -842,6 +933,10 @@ def get_password_rate_limiter() -> DatabaseRateLimiter:
 
 def get_guest_password_rate_limiter() -> DatabaseRateLimiter:
     return _guest_password_rate_limiter
+
+
+def get_login_failed_audit_rate_limiter() -> DatabaseRateLimiter:
+    return _login_failed_audit_rate_limiter
 
 
 def _qr_svg_data_uri(payload: str) -> str:

--- a/app/modules/model_sources/api.py
+++ b/app/modules/model_sources/api.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter, Body, Depends, Request, Response
 from sqlalchemy.orm.exc import StaleDataError
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
+from app.core.auth.dashboard_access import DashboardPrincipal
 from app.core.auth.dependencies import (
     require_dashboard_write_access,
     set_dashboard_error_format,
@@ -41,7 +42,7 @@ async def list_model_sources(
 async def create_model_source(
     request: Request,
     payload: ModelSourceCreateRequest = Body(...),
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ModelSourcesContext = Depends(get_model_sources_context),
 ) -> ModelSourceResponse:
     try:
@@ -51,6 +52,8 @@ async def create_model_source(
     AuditService.log_async(
         "model_source_created",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("model_source", created.id),
         details={"source_id": created.id},
     )
     return created
@@ -61,7 +64,7 @@ async def update_model_source(
     request: Request,
     source_id: str,
     payload: ModelSourceUpdateRequest = Body(...),
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ModelSourcesContext = Depends(get_model_sources_context),
 ) -> ModelSourceResponse:
     try:
@@ -73,6 +76,8 @@ async def update_model_source(
     AuditService.log_async(
         "model_source_updated",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("model_source", updated.id),
         details={"source_id": updated.id},
     )
     return updated
@@ -82,7 +87,7 @@ async def update_model_source(
 async def delete_model_source(
     request: Request,
     source_id: str,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: ModelSourcesContext = Depends(get_model_sources_context),
 ) -> Response:
     # Deleting the designated subscription-overflow source is a kill switch
@@ -114,6 +119,8 @@ async def delete_model_source(
     AuditService.log_async(
         "model_source_deleted",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("model_source", source_id),
         details={"source_id": source_id, "subscription_overflow_cleared": overflow_cleared},
     )
     return Response(status_code=204)

--- a/app/modules/quota_planner/api.py
+++ b/app/modules/quota_planner/api.py
@@ -4,7 +4,8 @@ import json
 
 from fastapi import APIRouter, Body, Depends, Query, Request
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
+from app.core.auth.dashboard_access import DashboardPrincipal
 from app.core.auth.dependencies import (
     require_dashboard_write_access,
     set_dashboard_error_format,
@@ -148,7 +149,7 @@ async def update_quota_planner_settings(
     request: Request,
     payload: QuotaPlannerSettingsUpdateRequest = Body(...),
     context: QuotaPlannerContext = Depends(get_quota_planner_context),
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
 ) -> QuotaPlannerSettingsResponse:
     current = await context.repository.get_settings()
     updated = PlannerSettings(
@@ -190,6 +191,8 @@ async def update_quota_planner_settings(
     AuditService.log_async(
         "quota_planner_settings_changed",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("settings", "quota_planner"),
         details={"mode": saved.mode},
     )
     return _settings_response(saved)

--- a/app/modules/rate_limit_reset_credits/api.py
+++ b/app/modules/rate_limit_reset_credits/api.py
@@ -13,7 +13,8 @@ from pydantic import Field
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
+from app.core.auth.dashboard_access import DashboardPrincipal
 from app.core.auth.dependencies import (
     require_dashboard_write_access,
     set_dashboard_error_format,
@@ -156,7 +157,7 @@ async def consume_rate_limit_reset_credit(
     request: Request,
     account_id: str,
     payload: AccountUsageResetConsumeRequest | None = None,
-    _write_access=Depends(require_dashboard_write_access),
+    principal: DashboardPrincipal = Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> ConsumeResetCreditResponseSchema:
     account = await context.repository.get_by_id(account_id)
@@ -194,6 +195,8 @@ async def consume_rate_limit_reset_credit(
     AuditService.log_async(
         "account_rate_limit_reset_credit_consumed",
         actor_ip=request.client.host if request.client else None,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("account", account_id),
         details={
             "account_id": account_id,
             "consume_code": outcome.response.code,

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -14,7 +14,7 @@ from python_socks import ProxyType
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from app.core.audit.service import AuditService
+from app.core.audit.service import AuditActor, AuditService, AuditTarget
 from app.core.auth.dashboard_access import DashboardPrincipal, DashboardRole, Permission
 from app.core.auth.dependencies import (
     ensure_dashboard_permission,
@@ -1661,6 +1661,8 @@ async def update_settings(
     AuditService.log_async(
         "settings_changed",
         actor_ip=actor_ip,
+        actor=AuditActor.from_principal(principal),
+        target=AuditTarget("settings", "dashboard"),
         details={"changed_fields": changed_fields},
     )
     # M5 conversation archive: enabling turns the proxy into a full

--- a/openspec/changes/attribute-audit-actor/design.md
+++ b/openspec/changes/attribute-audit-actor/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`AuditService.log_async()` is called from about 30 dashboard routes and service methods. Since `user-login-and-session-v2` every request principal carries the account behind it, but the audit row only ever stored `action`, `actor_ip`, `details`, `request_id`. This change adds attribution without changing the fire-and-forget write model (owned tasks, shutdown drain) that `audit-logging` already specifies.
+
+## Goals / Non-Goals
+
+**Goals**
+- Every audit row written from a dashboard request names the acting account (or the kind of implicit principal), how it authenticated, and where possible the object it acted on.
+- Failed sign-ins are searchable by reason.
+- The write path has a seam for a second destination that call sites never see.
+
+**Non-Goals**
+- A webhook/SIEM sink (Phase 5a), audit UI, retention/purge, editing or deleting rows, new settings.
+
+## Decisions
+
+### Actor is a snapshot, not a foreign key
+
+`actor_user_id` is a plain `String(36)` with an index, and `actor_username` / `actor_role_slug` are copied at write time. A foreign key with `ON DELETE SET NULL` would erase the one thing an investigator needs after an account is removed, and `CASCADE` would delete evidence. The snapshot also keeps the row honest about *which* role the person held at the time, which a join to a later-edited role could not.
+
+### Three principal kinds, one mapping
+
+`AuditActor.from_principal` is the only place that knows how a `DashboardPrincipal` becomes an actor: an account session copies `user_id/username/role_slug/auth_method`; the implicit admin (local bootstrap, trusted header, disabled auth) has no account, so it records `role_slug=admin` and its `auth_method` (`local_bootstrap|trusted_header|disabled`) with NULL id and username; a guest records `role_slug=guest`, `auth_method=guest`. Service methods that receive a `DashboardUser` instead of a principal (password change/removal, session revocation, TOTP) build the actor from the user row with the method that authenticated the session; the TOTP path snapshots it before the counter write because a refused replay rolls the session back and expires the instance.
+
+The `AuditAuthMethod` vocabulary already lists `cli` for a future command-line writer; no constructor exists for it until a caller does.
+
+### `login_failed` has no actor but always a reason
+
+The party that failed to sign in is by definition unauthenticated, so the actor columns stay NULL and the identifying data lives in `details` (`method`, `username`, `reason`). `resolve_login_target` keeps the refusal reason (`unknown_identity`, `disabled_user`, `invalid_username`) on the target so `verify_user_password` can record it while the client still receives one indistinguishable `401 invalid_credentials` after exactly one bcrypt check. `username_required` (422, no rate-limit budget) is now audited too, but from the route, not the service: because the refusal happens before the password limiter by design, an anonymous client on a multi-user install could otherwise append audit rows without bound. The route writes the row only if the client is not already at the password limit (the limiter's non-incrementing `check`) and a dedicated `login_failed_audit` limiter (same 8/60 s shape, its own counter) still admits it; the password limiter's counter is never touched by these requests. Severity `warning` makes the failures filterable without a reason list.
+
+`AuditActor.from_principal` records the proxy-asserted username (`DashboardRequestAuth.actor`) for the trusted-header admin, so those rows are not anonymous even though no account row exists.
+
+### Sinks: build once, fan out, database first
+
+`_write_audit_log` receives a fully built `AuditEvent` (sanitised details, UTC timestamp, resolved request id) and awaits each registered sink in order inside its own `try`. The database sink is registered first and is the authoritative record; a failing sink is logged with its class name and the action and the loop continues. The registry is a module-level tuple (`get_audit_sinks` / `register_audit_sink` / `reset_audit_sinks`) rather than a setting: the only consumer today is tests, and the webhook change will decide how a sink is configured. `_AUDIT_LOG_TASKS`, `drain_audit_log_tasks` and the admission cutoff are untouched.
+
+The event timestamp moves from the database default (`func.now()`) to the process clock (`datetime.now(UTC)`) so every sink sees the same instant; the row is written with that value.
+
+### `reason` filter is a text match on the JSON column
+
+`details` is `Text`, written by `json.dumps` with default separators, so a `reason` filter is `details LIKE '%"reason": "<value>"%'` with `_` escaped. This is portable across SQLite and PostgreSQL and needs no JSON operator or generated column, at the cost of a table scan bounded by the other predicates (`action`, `severity`, time window) and of relying on the writer's spelling. The value is validated against `^[a-z_]{1,32}$` before it reaches SQL. If the audit log grows into a hot query path this becomes a real column; today the listing is admin-only and paged.
+
+### Time window
+
+`since` is inclusive, `until` exclusive. Both are normalised to UTC (naive input is taken as UTC) because rows are stored with UTC wall-clock components and SQLite compares the text form.
+
+On SQLite that text form differs between rows written through the database default (`CURRENT_TIMESTAMP`, `YYYY-MM-DD HH:MM:SS`) and rows the ORM writes or binds (`.ffffff` suffix), so an inclusive `since` on an exact legacy second would skip legacy rows and same-second ordering would interleave wrongly. The migration pads legacy SQLite rows once (`timestamp || '.000000'` where no fraction is present). This changes the representation only, never the instant; PostgreSQL stores a real `timestamptz` and is untouched. The model keeps its `func.now()` default.
+
+### Severity vocabulary
+
+`info` (default), `warning` (failed sign-ins), `critical` (reserved for break-glass and destructive identity events in later changes). Stored as a string with a `StrEnum` in code, like every other vocabulary column in this schema.
+
+## Size
+
+The change lands at roughly +560 net lines of application code against the ~450 planned; the overrun is the new `app/core/audit/types.py` module (the actor/target/event vocabulary the sink interface needs) and the migration with its guards, not the call-site threading.
+
+## Risks / Trade-offs
+
+- Every audited route now reads its principal by name (`principal: DashboardPrincipal = Depends(...)`) instead of an ignored `_write_access` parameter; tests that call route functions directly must pass a principal.
+- The `reason` LIKE filter is only as good as the writers' spelling; the vocabulary is fixed in the spec and tested end to end.
+- Actor snapshots go stale on username change by design; the id stays stable.

--- a/openspec/changes/attribute-audit-actor/proposal.md
+++ b/openspec/changes/attribute-audit-actor/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Audit rows today say *what* happened (`action`), from *where* (`actor_ip`) and a free-form `details` blob. They do not say *who* did it: the previous change (`user-login-and-session-v2`) made `dashboard_users` the source of truth for sign-in, so every dashboard request now carries an account (`user_id`, `username`, `role_slug`, `auth_method`) on its principal, but none of that reaches the audit table. Once several people share an install, "settings changed from 10.0.0.5" is not an answer. The listing also cannot be filtered by anything but `action`, and every write goes straight to the database, so a future external sink (webhook / SIEM, PLAN §4.7) would have to touch every call site.
+
+## What Changes
+
+- **Attribution columns on `audit_logs`** (revision `20260909_030000_add_audit_actor_columns`): `actor_user_id`, `actor_username`, `actor_role_slug`, `auth_method`, `target_type`, `target_id` (all nullable) and `severity` (`info|warning|critical`, NOT NULL, default `info`). The actor columns are a snapshot, deliberately without a foreign key, so an audit row outlives the account it names. Existing rows keep NULL actor/target columns and get `severity='info'`.
+- **`AuditActor` / `AuditTarget` / `AuditSeverity`** in `app/core/audit/types.py`; `AuditActor.from_principal(principal)` maps the three principal kinds (account, implicit admin — keeping the trusted-header asserted username — and guest). `AuditService.log_async()` / `log()` gain keyword-only `actor`, `target`, `severity`; the positional parameters are unchanged so existing callers compile.
+- **Every dashboard call site passes its actor** (accounts, API keys, settings, model sources, quota planner, reset credits, guest revocation, password/TOTP self-service). `login_success` names the account that signed in; `login_failed` stays actor-less, becomes `severity=warning`, and always records `details.reason` from `{bad_password, bad_totp, unknown_identity, disabled_user, invalid_username, username_required}` — including the `422 username_required` refusal, which was not audited before.
+- **Sink interface.** `AuditSink` protocol, `DatabaseAuditSink` (the current row write), and a module-level registry (`get_audit_sinks` / `register_audit_sink` / `reset_audit_sinks`) defaulting to the database sink. The write task builds one `AuditEvent` and fans it out; a failing sink is logged and never blocks the others. Task ownership and shutdown drain are unchanged. No webhook sink in this change.
+- **Listing filters** on `GET /api/audit-logs` (`audit:read`): `actor_user_id`, `target_type`, `target_id`, `severity`, `reason`, `since`, `until` next to the existing `action`/`limit`/`offset`. Each row gains `actor {userId, username, roleSlug, authMethod} | null`, `target {type, id} | null`, `severity`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `audit-logging`: rows record actor, auth method, target and severity; writes fan out to registered sinks with the database sink authoritative; listing supports actor/target/severity/reason/time filters; failed sign-ins record a reason.
+
+## Impact
+
+- `app/core/audit/{types,service}.py`, `app/db/models.py` (`AuditLog`), one Alembic revision, `app/modules/audit/{api,repository,service,schemas}.py`, and the audit call sites in `app/modules/{accounts,api_keys,settings,model_sources,quota_planner,rate_limit_reset_credits,dashboard_auth}`.
+- Wire: additive response fields and query parameters only; `audit_logs` stays append-only (no UPDATE/DELETE path). No new setting, env var, README section, nav item or frontend change (the dashboard has no audit view yet).

--- a/openspec/changes/attribute-audit-actor/specs/audit-logging/spec.md
+++ b/openspec/changes/attribute-audit-actor/specs/audit-logging/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Audit rows record the acting account, auth method, target and severity
+
+Every `audit_logs` row MUST carry nullable `actor_user_id`, `actor_username`, `actor_role_slug`, `auth_method`, `target_type`, `target_id` columns and a NOT NULL `severity` column (`info`, `warning`, or `critical`; default `info`). The actor columns MUST be a snapshot taken at write time with no foreign key to `dashboard_users`, so a row survives the deletion of the account it names. An audit write initiated by a dashboard request MUST record the request principal: an account session records the account's id, username, role slug and authentication method; the implicit admin (local bootstrap, trusted header, disabled auth) records `actor_role_slug` `admin`, its `auth_method` (`local_bootstrap`, `trusted_header`, or `disabled`), a NULL id, and as `actor_username` the proxy-asserted username when the request carried one (trusted header) and NULL otherwise; a guest records `actor_role_slug` `guest` and `auth_method` `guest`. Where the acted-on object is known the write MUST record `target_type` and `target_id` (for example `account`, `api_key`, `model_source`, `user`, or `settings` with the settings group as id). Rows written before this requirement existed MUST keep NULL actor and target columns and MUST read as `severity` `info`. `AuditService.log_async()` and `AuditService.log()` MUST keep accepting their existing positional parameters unchanged and accept the actor, target and severity as keyword-only parameters.
+
+#### Scenario: Signed-in account changes settings
+
+- **GIVEN** an `admin` account signed in with a password
+- **WHEN** it calls `PUT /api/settings`
+- **THEN** the `settings_changed` row records that account's id, username `admin`, role slug `admin`, `auth_method` `password`
+- **AND** `target_type` `settings` with `target_id` `dashboard`
+- **AND** `severity` `info`
+
+#### Scenario: Implicit local admin is recorded without an account
+
+- **GIVEN** a passwordless install serving a local request as the implicit admin
+- **WHEN** the request performs an audited mutation
+- **THEN** the row records `auth_method` `local_bootstrap` and `actor_role_slug` `admin`
+- **AND** `actor_user_id` and `actor_username` are NULL
+
+#### Scenario: Trusted-header admin records the asserted username
+
+- **GIVEN** `dashboard_auth_mode` `trusted_header` and a request whose trusted header names `ops`
+- **WHEN** the request performs an audited mutation
+- **THEN** the row records `auth_method` `trusted_header`, `actor_role_slug` `admin`, `actor_username` `ops`
+- **AND** `actor_user_id` is NULL
+
+#### Scenario: Pre-existing rows are unchanged by the migration
+
+- **GIVEN** an `audit_logs` row written before revision `20260909_030000_add_audit_actor_columns`
+- **WHEN** the revision is applied
+- **THEN** the row's actor and target columns are NULL and its `severity` is `info`
+- **AND** downgrading the revision removes the new columns and indexes while keeping the row
+
+### Requirement: Audit writes fan out to registered sinks; the database sink is authoritative
+
+The system MUST build one `AuditEvent` per `AuditService.log_async()` / `log()` call, containing the action, a UTC timestamp, the actor, actor IP, target, severity, sanitised details and request id, and MUST deliver it to every registered `AuditSink` in registration order. The database sink MUST be registered first and MUST remain the authoritative record. A sink that raises MUST be reported with the sink's class name and the action, and MUST NOT prevent delivery to the remaining sinks or fail the audit task. With no sink registered by the operator the registry MUST contain exactly the database sink. Sink fan-out MUST NOT change the task-ownership or shutdown-drain guarantees of the asynchronous write path.
+
+#### Scenario: Failing sink does not lose the database row
+
+- **GIVEN** a registered sink that raises on every `emit`
+- **WHEN** an audit write runs
+- **THEN** the `audit_logs` row is written
+- **AND** every other registered sink receives the same event
+- **AND** the failure is reported with the sink class and the action
+
+#### Scenario: Details are sanitised before any sink sees them
+
+- **WHEN** an audit write carries details containing a redacted key such as `password`
+- **THEN** the event delivered to every sink omits that key
+- **AND** the stored row omits it as well
+
+### Requirement: Audit log listing supports actor, target, severity, reason and time filters
+
+`GET /api/audit-logs` (permission `audit:read`) MUST accept, in addition to `action`, `limit` and `offset`, the optional query parameters `actor_user_id`, `target_type`, `target_id`, `severity` (one of `info`, `warning`, `critical`), `reason` (matching `^[a-z_]{1,32}$`, matched against `details.reason`), `since` (inclusive) and `until` (exclusive) as ISO 8601 datetimes normalised to UTC. A value outside these constraints MUST be refused with `422`. Filters combine with AND. Each returned row MUST include `actor` (`{userId, username, roleSlug, authMethod}`, or `null` when every actor column is NULL), `target` (`{type, id}` or `null`) and `severity`. The listing MUST remain read-only: no endpoint updates or deletes audit rows.
+
+#### Scenario: Filter by actor and target
+
+- **GIVEN** rows attributed to account `u-1` acting on `account` `acc-1` and rows without attribution
+- **WHEN** `GET /api/audit-logs?actor_user_id=u-1` or `GET /api/audit-logs?target_type=account&target_id=acc-1` is called
+- **THEN** only the attributed rows are returned
+- **AND** each carries `actor.userId` `u-1` and `target` `{type: account, id: acc-1}`
+
+#### Scenario: Filter by reason and time window
+
+- **GIVEN** `login_failed` rows with `details.reason` `bad_password` and `bad_totp` at different times
+- **WHEN** `GET /api/audit-logs?reason=bad_totp` is called
+- **THEN** only the `bad_totp` row is returned
+- **AND** `since` / `until` restrict the result to rows with `since <= timestamp < until`
+
+#### Scenario: Legacy row shape
+
+- **GIVEN** a row whose actor and target columns are NULL
+- **WHEN** it is listed
+- **THEN** its `actor` and `target` are `null` and its `severity` is `info`
+
+#### Scenario: Invalid filter values are refused
+
+- **WHEN** `reason` contains characters outside `[a-z_]`, `severity` is not in the vocabulary, or `since` is not a datetime
+- **THEN** the response is `422`
+
+### Requirement: Failed sign-ins record a reason
+
+Every `login_failed` row MUST have NULL actor columns, `severity` `warning`, and `details` containing `method`, `username` (the normalised username when it is well formed, otherwise `null`) and `reason`, where `reason` is one of `bad_password`, `bad_totp`, `unknown_identity`, `disabled_user`, `invalid_username`, `username_required`. A password login refused with `422 username_required` MUST write a `login_failed` row with that reason unless the client is already at the password rate limit or has exhausted a per-client budget of 8 such rows per 60 seconds; the refusal MUST NOT increment the password rate-limit counter. Recording the reason MUST NOT change what the client receives: unknown, disabled and wrong-password failures keep the identical `401 invalid_credentials` body and single password check. A successful sign-in (`login_success`) MUST record the signed-in account as the actor with the method that completed the sign-in (`password` or `totp`) and the account as `target` (`user`, account id).
+
+#### Scenario: Unknown and disabled accounts are distinguishable in the audit log only
+
+- **GIVEN** an active account `admin`, a disabled account `ghost`, and no account `nobody`
+- **WHEN** logins are attempted with a wrong password for `admin`, and any password for `nobody` and `ghost`
+- **THEN** each response is `401 invalid_credentials`
+- **AND** the `login_failed` rows record reasons `bad_password`, `unknown_identity`, `disabled_user` respectively with `severity` `warning` and NULL actor columns
+
+#### Scenario: Missing username on a multi-account install is audited
+
+- **GIVEN** two active accounts hold passwords
+- **WHEN** `POST /api/dashboard-auth/password/login` is called without a username
+- **THEN** the response is `422 username_required`
+- **AND** a `login_failed` row with `reason` `username_required` and `severity` `warning` is written
+
+#### Scenario: Anonymous refusals cannot flood the audit log
+
+- **GIVEN** two active accounts hold passwords
+- **WHEN** one client sends more than 8 username-less login requests within 60 seconds
+- **THEN** every response is `422 username_required`
+- **AND** at most 8 `login_failed` rows with `reason` `username_required` are written
+- **AND** the password rate-limit counter for that client stays at zero
+
+#### Scenario: Successful sign-in names the account
+
+- **WHEN** an account signs in with a password (no TOTP step pending)
+- **THEN** the `login_success` row records the account's id, username, role slug and `auth_method` `password`
+- **AND** `target_type` `user` with the account id

--- a/openspec/changes/attribute-audit-actor/tasks.md
+++ b/openspec/changes/attribute-audit-actor/tasks.md
@@ -1,0 +1,28 @@
+## 1. Schema
+
+- [x] 1.1 `AuditLog` gains `actor_user_id`, `actor_username`, `actor_role_slug`, `auth_method`, `target_type`, `target_id`, `severity` plus indexes `idx_audit_logs_actor_user_id` and `idx_audit_logs_target`.
+- [x] 1.2 Revision `20260909_030000_add_audit_actor_columns`: guarded column adds in SQLite batch mode, index creation, inspector-based downgrade; existing rows keep NULL actor columns and `severity='info'`; SQLite legacy `timestamp` text padded to the microsecond form.
+
+## 2. Core types and sinks
+
+- [x] 2.1 `app/core/audit/types.py`: `AuditSeverity`, `AuditAuthMethod`, `AuditActor` (`from_principal`), `AuditTarget`, `AuditEvent`.
+- [x] 2.2 `AuditService.log_async` / `log` accept keyword-only `actor`, `target`, `severity`; positional parameters unchanged.
+- [x] 2.3 `AuditSink` protocol, `DatabaseAuditSink`, registry (`get_audit_sinks`, `register_audit_sink`, `reset_audit_sinks`); `_write_audit_log` builds one event and fans out with per-sink error isolation; task ownership and drain unchanged.
+
+## 3. Call sites
+
+- [x] 3.1 Accounts, API keys, settings, model sources, quota planner, reset credits and guest revocation routes pass `actor=AuditActor.from_principal(principal)` and a target.
+- [x] 3.2 Dashboard-auth service: `login_success` carries the account actor; `password_changed`, `password_removed`, `user_sessions_revoked`, `totp_enabled`, `totp_disabled` carry the account actor and `("user", id)` target; guest `login_success` carries the guest actor.
+- [x] 3.3 `login_failed`: actor NULL, `severity=warning`, `details.reason` from the fixed vocabulary; `resolve_login_target` keeps the refusal reason; the login route audits `username_required` behind the password limiter's read-only check and a dedicated per-client audit budget.
+- [x] 3.4 Self-service routes pass the session's `auth_method` to `change_password`, `remove_password`, `revoke_user_sessions`.
+
+## 4. API
+
+- [x] 4.1 `GET /api/audit-logs` filters `actor_user_id`, `target_type`, `target_id`, `severity`, `reason` (`^[a-z_]{1,32}$`, LIKE on the JSON text), `since` / `until` (UTC-normalised, inclusive / exclusive).
+- [x] 4.2 `AuditLogResponse` gains `actor`, `target`, `severity`.
+
+## 5. Verification
+
+- [x] 5.1 Unit: actor mapping for the three principal kinds and `system`; event built once with sanitised details; failing sink does not block the database sink and is logged; existing task-ownership/drain tests updated to the event-based write signature.
+- [x] 5.2 Integration: signed-in admin mutation attributed with target; implicit local admin recorded as `local_bootstrap`; failed sign-ins carry reason and warning without an actor (including `username_required`); listing filters and response shape; migration upgrade/downgrade on SQLite with a pre-existing row.
+- [x] 5.3 `ruff`, `ty`, focused pytest, `openspec validate attribute-audit-actor --strict`.

--- a/tests/integration/test_audit_actor_attribution.py
+++ b/tests/integration/test_audit_actor_attribution.py
@@ -1,0 +1,396 @@
+"""Audit rows name who acted, how they authenticated and what they touched.
+
+Product-path coverage for the ``attribute-audit-actor`` change: signed-in
+accounts, the implicit local admin, failed sign-ins, the listing filters, and
+the schema migration.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import bcrypt
+import pytest
+from anyio import to_thread
+from httpx import AsyncClient
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.core.audit.service import drain_audit_log_tasks
+from app.core.auth import generate_unique_account_id
+from app.core.auth.dashboard_access import PRESET_ROLE_IDS, PresetRoleSlug
+from app.core.auth.dashboard_users_cache import get_dashboard_users_cache
+from app.core.config.settings import get_settings
+from app.db.migrate import _build_alembic_config, inspect_migration_state, run_upgrade
+from app.db.models import AuditLog, DashboardUser, RateLimitAttempt
+from app.db.session import SessionLocal
+from app.modules.audit.repository import AuditLogFilters, AuditRepository
+
+pytestmark = pytest.mark.integration
+
+_HEAD_REVISION = inspect_migration_state(get_settings().database_url).head_revision
+_PARENT_REVISION = "20260909_020000_reproject_compat_admin_credentials"
+_TARGET_REVISION = "20260909_030000_add_audit_actor_columns"
+_ACTOR_COLUMNS = (
+    "actor_user_id",
+    "actor_username",
+    "actor_role_slug",
+    "auth_method",
+    "target_type",
+    "target_id",
+    "severity",
+)
+_INDEXES = ("idx_audit_logs_actor_user_id", "idx_audit_logs_target")
+
+
+async def _rows(action: str) -> list[AuditLog]:
+    assert await drain_audit_log_tasks(5.0)
+    async with SessionLocal() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.action == action).order_by(AuditLog.id))
+        return list(result.scalars().all())
+
+
+async def _setup_admin(client: AsyncClient, password: str = "password123") -> dict[str, Any]:
+    response = await client.post("/api/dashboard-auth/password/setup", json={"password": password})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _auth_json(account_id: str, email: str) -> str:
+    claims = {
+        "email": email,
+        "chatgpt_account_id": account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    body = base64.urlsafe_b64encode(json.dumps(claims, separators=(",", ":")).encode()).rstrip(b"=").decode("ascii")
+    return json.dumps(
+        {
+            "tokens": {
+                "idToken": f"header.{body}.sig",
+                "accessToken": "access-token",
+                "refreshToken": "refresh-token",
+                "accountId": account_id,
+            }
+        }
+    )
+
+
+async def _insert_user(username: str, *, password: str = "second-password-1", status: str = "active") -> DashboardUser:
+    async with SessionLocal() as session:
+        user = DashboardUser(
+            id=str(uuid.uuid4()),
+            username=username,
+            role_id=PRESET_ROLE_IDS[PresetRoleSlug.OPERATOR],
+            status=status,
+            password_hash=bcrypt.hashpw(password.encode(), bcrypt.gensalt(4)).decode(),
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+    await get_dashboard_users_cache().invalidate()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_signed_in_admin_mutation_records_actor_and_target(async_client: AsyncClient) -> None:
+    user_id = (await _setup_admin(async_client))["user"]["id"]
+    assert (await async_client.post("/api/dashboard-auth/logout", json={})).status_code == 200
+    login = await async_client.post("/api/dashboard-auth/password/login", json={"password": "password123"})
+    assert login.status_code == 200, login.text
+
+    assert (await async_client.put("/api/settings", json={"stickyThreadsEnabled": False})).status_code == 200
+    (row,) = await _rows("settings_changed")
+    assert (row.actor_user_id, row.actor_username, row.actor_role_slug, row.auth_method) == (
+        user_id,
+        "admin",
+        "admin",
+        "password",
+    )
+    assert (row.target_type, row.target_id, row.severity) == ("settings", "dashboard", "info")
+
+    assert (await async_client.post("/api/dashboard-auth/guest/logout-all")).status_code == 200
+    (revoked,) = await _rows("guest_sessions_revoked")
+    assert revoked.actor_user_id == user_id
+    assert (revoked.target_type, revoked.target_id) == ("settings", "guest_access")
+
+    (signed_in,) = await _rows("login_success")
+    assert signed_in.actor_user_id == user_id
+    assert signed_in.auth_method == "password"
+    assert (signed_in.target_type, signed_in.target_id) == ("user", user_id)
+
+
+@pytest.mark.asyncio
+async def test_account_and_api_key_routes_record_their_targets(async_client: AsyncClient) -> None:
+    email, raw_account_id = "audit-actor@example.com", "acc_audit_actor"
+    imported = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", _auth_json(raw_account_id, email), "application/json")},
+    )
+    assert imported.status_code == 200, imported.text
+    account_id = generate_unique_account_id(raw_account_id, email)
+    (created,) = await _rows("account_created")
+    assert (created.target_type, created.target_id) == ("account", account_id)
+    assert (created.actor_role_slug, created.auth_method, created.actor_user_id) == ("admin", "local_bootstrap", None)
+
+    key = await async_client.post("/api/api-keys/", json={"name": "audit-actor-key"})
+    assert key.status_code == 200, key.text
+    key_id = key.json()["id"]
+    (key_row,) = await _rows("api_key_created")
+    assert (key_row.target_type, key_row.target_id) == ("api_key", key_id)
+    assert key_row.actor_role_slug == "admin"
+
+    listed = await async_client.get("/api/audit-logs", params={"target_type": "api_key", "target_id": key_id})
+    assert listed.status_code == 200, listed.text
+    (entry,) = listed.json()
+    assert entry["action"] == "api_key_created"
+    assert entry["target"] == {"type": "api_key", "id": key_id}
+    assert entry["actor"] == {"userId": None, "username": None, "roleSlug": "admin", "authMethod": "local_bootstrap"}
+
+
+@pytest.mark.asyncio
+async def test_guest_login_records_the_guest_actor(async_client: AsyncClient) -> None:
+    assert (await async_client.put("/api/settings", json={"guestAccessEnabled": True})).status_code == 200
+
+    assert (await async_client.post("/api/dashboard-auth/guest/login")).status_code == 200
+    (row,) = await _rows("login_success")
+    assert json.loads(row.details or "{}") == {"method": "guest"}
+    assert (row.actor_user_id, row.actor_username, row.actor_role_slug, row.auth_method) == (
+        None,
+        None,
+        "guest",
+        "guest",
+    )
+    assert row.severity == "info"
+
+
+@pytest.mark.asyncio
+async def test_username_required_refusals_are_audited_within_a_budget(async_client: AsyncClient) -> None:
+    await _setup_admin(async_client)
+    await _insert_user("ops")
+    assert (await async_client.post("/api/dashboard-auth/logout", json={})).status_code == 200
+
+    for _ in range(12):
+        response = await async_client.post("/api/dashboard-auth/password/login", json={"password": "password123"})
+        assert response.status_code == 422, response.text
+        assert response.json()["error"]["code"] == "username_required"
+
+    rows = await _rows("login_failed")
+    assert len(rows) == 8
+    assert all(json.loads(row.details or "{}")["reason"] == "username_required" for row in rows)
+    async with SessionLocal() as session:
+        password_attempts = await session.scalar(
+            select(func.count()).select_from(RateLimitAttempt).where(RateLimitAttempt.type == "password")
+        )
+    assert password_attempts == 0
+
+    # The refusals spent no password budget: a real attempt is still admitted.
+    still_admitted = await async_client.post(
+        "/api/dashboard-auth/password/login", json={"username": "admin", "password": "password123"}
+    )
+    assert still_admitted.status_code == 200, still_admitted.text
+
+
+@pytest.mark.asyncio
+async def test_implicit_local_admin_records_bootstrap_auth_method(async_client: AsyncClient) -> None:
+    assert (await async_client.put("/api/settings", json={"stickyThreadsEnabled": False})).status_code == 200
+
+    (row,) = await _rows("settings_changed")
+    assert row.actor_user_id is None
+    assert row.actor_username is None
+    assert row.actor_role_slug == "admin"
+    assert row.auth_method == "local_bootstrap"
+    assert (row.target_type, row.target_id, row.severity) == ("settings", "dashboard", "info")
+
+
+@pytest.mark.asyncio
+async def test_failed_sign_ins_record_reason_without_an_actor(async_client: AsyncClient) -> None:
+    await _setup_admin(async_client)
+    await _insert_user("ghost", status="disabled")
+    assert (await async_client.post("/api/dashboard-auth/logout", json={})).status_code == 200
+
+    attempts = [
+        ({"password": "wrong-password"}, 401, "bad_password", "admin"),
+        ({"username": "nobody", "password": "wrong-password"}, 401, "unknown_identity", "nobody"),
+        ({"username": "ghost", "password": "second-password-1"}, 401, "disabled_user", "ghost"),
+        ({"username": "has space", "password": "wrong-password"}, 401, "invalid_username", None),
+    ]
+    for payload, status, _, _ in attempts:
+        response = await async_client.post("/api/dashboard-auth/password/login", json=payload)
+        assert response.status_code == status, response.text
+        assert response.json()["error"]["code"] == "invalid_credentials"
+
+    await _insert_user("ops")  # a second password holder makes the username mandatory
+    ambiguous = await async_client.post("/api/dashboard-auth/password/login", json={"password": "password123"})
+    assert ambiguous.status_code == 422
+    assert ambiguous.json()["error"]["code"] == "username_required"
+
+    rows = await _rows("login_failed")
+    assert [json.loads(row.details or "{}")["reason"] for row in rows] == [
+        *(reason for _, _, reason, _ in attempts),
+        "username_required",
+    ]
+    assert [json.loads(row.details or "{}")["username"] for row in rows] == [
+        *(username for _, _, _, username in attempts),
+        None,
+    ]
+    for row in rows:
+        assert row.severity == "warning"
+        assert row.actor_user_id is None
+        assert row.actor_username is None
+        assert row.actor_role_slug is None
+        assert row.auth_method is None
+        assert json.loads(row.details or "{}")["method"] == "password"
+
+
+@pytest.mark.asyncio
+async def test_audit_log_listing_filters_and_response_shape(async_client: AsyncClient) -> None:
+    base = datetime(2026, 9, 9, 12, 0, tzinfo=UTC)
+    async with SessionLocal() as session:
+        session.add_all(
+            [
+                AuditLog(
+                    action="login_failed",
+                    actor_ip="203.0.113.1",
+                    details=json.dumps({"method": "password", "username": None, "reason": "bad_password"}),
+                    severity="warning",
+                    timestamp=base,
+                ),
+                AuditLog(
+                    action="login_failed",
+                    actor_ip="203.0.113.2",
+                    details=json.dumps({"method": "totp", "username": "alice", "reason": "bad_totp"}),
+                    severity="warning",
+                    timestamp=base + timedelta(hours=1),
+                ),
+                AuditLog(
+                    action="account_updated",
+                    actor_ip="203.0.113.3",
+                    details=json.dumps({"account_id": "acc-1", "changed_fields": ["alias"]}),
+                    actor_user_id="u-1",
+                    actor_username="alice",
+                    actor_role_slug="operator",
+                    auth_method="password",
+                    target_type="account",
+                    target_id="acc-1",
+                    severity="info",
+                    timestamp=base + timedelta(hours=2),
+                ),
+                # A row written before attribution existed: every new column NULL,
+                # severity from the server default.
+                AuditLog(action="settings_changed", actor_ip="127.0.0.1", timestamp=base + timedelta(hours=3)),
+            ]
+        )
+        await session.commit()
+
+    async def _list(**params: str) -> list[dict[str, Any]]:
+        response = await async_client.get("/api/audit-logs", params=params)
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    everything = await _list()
+    assert [entry["action"] for entry in everything] == [
+        "settings_changed",
+        "account_updated",
+        "login_failed",
+        "login_failed",
+    ]
+    legacy, attributed, totp_failure, password_failure = everything
+    assert legacy["actor"] is None
+    assert legacy["target"] is None
+    assert legacy["severity"] == "info"
+    assert attributed["actor"] == {
+        "userId": "u-1",
+        "username": "alice",
+        "roleSlug": "operator",
+        "authMethod": "password",
+    }
+    assert attributed["target"] == {"type": "account", "id": "acc-1"}
+    assert attributed["severity"] == "info"
+    assert password_failure["severity"] == "warning"
+
+    assert [entry["id"] for entry in await _list(actor_user_id="u-1")] == [attributed["id"]]
+    assert [entry["id"] for entry in await _list(target_type="account", target_id="acc-1")] == [attributed["id"]]
+    assert [entry["id"] for entry in await _list(severity="warning")] == [totp_failure["id"], password_failure["id"]]
+    assert [entry["id"] for entry in await _list(reason="bad_totp")] == [totp_failure["id"]]
+    assert [entry["id"] for entry in await _list(reason="bad_password")] == [password_failure["id"]]
+    assert [entry["id"] for entry in await _list(action="login_failed", reason="bad_password")] == [
+        password_failure["id"]
+    ]
+    window = await _list(
+        since=(base + timedelta(hours=1)).isoformat(),
+        until=(base + timedelta(hours=3)).isoformat(),
+    )
+    assert [entry["id"] for entry in window] == [attributed["id"], totp_failure["id"]]
+
+    for bad in ({"reason": "Bad-Password"}, {"severity": "loud"}, {"since": "yesterday"}):
+        response = await async_client.get("/api/audit-logs", params=bad)
+        assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_audit_actor_columns_migration_upgrade_and_downgrade(tmp_path) -> None:
+    from alembic import command
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'audit-actor.sqlite'}"
+
+    async def _columns(engine) -> set[str]:
+        async with engine.connect() as conn:
+            return {row[1] for row in await conn.execute(text("PRAGMA table_info('audit_logs')"))}
+
+    async def _indexes(engine) -> set[str]:
+        async with engine.connect() as conn:
+            return {row[1] for row in await conn.execute(text("PRAGMA index_list('audit_logs')"))}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, _PARENT_REVISION, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        assert not set(_ACTOR_COLUMNS) & await _columns(engine)
+        async with engine.begin() as conn:
+            # The database default writes second-granular text on SQLite.
+            await conn.execute(
+                text("INSERT INTO audit_logs (timestamp, action) VALUES ('2026-09-09 12:00:00', 'legacy')")
+            )
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, _TARGET_REVISION, bootstrap_legacy=False))
+        assert set(_ACTOR_COLUMNS) <= await _columns(engine)
+        assert set(_INDEXES) <= await _indexes(engine)
+        async with engine.connect() as conn:
+            legacy = (
+                await conn.execute(text("SELECT severity, actor_user_id, target_type, timestamp FROM audit_logs"))
+            ).one()
+        assert legacy == ("info", None, None, "2026-09-09 12:00:00.000000")
+
+        # Same second in the microsecond form the ORM writes: an inclusive
+        # `since` on that exact second must return both rows.
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO audit_logs (timestamp, action, severity) "
+                    "VALUES ('2026-09-09 12:00:00.250000', 'fresh', 'info')"
+                )
+            )
+        async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+            since = datetime(2026, 9, 9, 12, 0, tzinfo=UTC)
+            rows = await AuditRepository(session).list_logs(AuditLogFilters(since=since))
+            assert [row.action for row in rows] == ["fresh", "legacy"]
+            later = AuditLogFilters(since=since + timedelta(seconds=1))
+            assert await AuditRepository(session).list_logs(later) == []
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, _PARENT_REVISION))
+        assert not set(_ACTOR_COLUMNS) & await _columns(engine)
+        assert not set(_INDEXES) & await _indexes(engine)
+        async with engine.connect() as conn:
+            surviving = await conn.execute(text("SELECT action FROM audit_logs ORDER BY id"))
+            assert surviving.all() == [("legacy",), ("fresh",)]
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert set(_ACTOR_COLUMNS) <= await _columns(engine)
+        assert set(_INDEXES) <= await _indexes(engine)
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_dashboard_users_schema.py
+++ b/tests/integration/test_dashboard_users_schema.py
@@ -322,8 +322,12 @@ async def test_dashboard_users_migration_backfills_the_compat_admin(tmp_path, le
 REPROJECT_REVISION = "20260909_020000_reproject_compat_admin_credentials"
 
 
-def test_reproject_revision_is_the_head() -> None:
-    assert _HEAD_REVISION == REPROJECT_REVISION
+def test_reproject_revision_is_on_the_single_head_path() -> None:
+    from alembic.script import ScriptDirectory
+
+    script = ScriptDirectory.from_config(_build_alembic_config(get_settings().database_url))
+    assert script.get_heads() == [_HEAD_REVISION]
+    assert REPROJECT_REVISION in {revision.revision for revision in script.iterate_revisions(_HEAD_REVISION, "base")}
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_multi_replica.py
+++ b/tests/integration/test_multi_replica.py
@@ -296,15 +296,15 @@ async def test_automations_scheduler_tick_body_runs_once_across_two_replicas(db_
 
 @pytest.mark.asyncio
 async def test_audit_log_records_from_different_modules(db_session):
-    from app.core.audit.service import _write_audit_log
+    from app.core.audit.service import AuditService
 
-    await _write_audit_log(
+    await AuditService.log(
         "account_created",
         actor_ip="1.2.3.4",
         details={"name": "test"},
         request_id="req-1",
     )
-    await _write_audit_log(
+    await AuditService.log(
         "api_key_created",
         actor_ip="1.2.3.5",
         details={"name": "key1"},

--- a/tests/unit/test_audit_actor.py
+++ b/tests/unit/test_audit_actor.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+import app.core.audit.service as audit_service_module
+from app.core.audit.service import (
+    AuditActor,
+    AuditEvent,
+    AuditService,
+    AuditSeverity,
+    AuditTarget,
+    DatabaseAuditSink,
+    get_audit_sinks,
+    register_audit_sink,
+    reset_audit_sinks,
+)
+from app.core.auth.dashboard_access import (
+    OPERATOR_GRANTS,
+    PRESET_ROLE_IDS,
+    DashboardAuthMode,
+    PresetRoleSlug,
+    admin_principal,
+    guest_principal,
+    user_principal,
+)
+from app.db.models import AuditLog, DashboardRoleRecord, DashboardUser
+from app.db.session import SessionLocal
+
+pytestmark = pytest.mark.unit
+
+
+def _operator_user() -> DashboardUser:
+    role = DashboardRoleRecord(
+        id=PRESET_ROLE_IDS[PresetRoleSlug.OPERATOR],
+        slug=PresetRoleSlug.OPERATOR.value,
+        name="Operator",
+        kind="preset",
+    )
+    user = DashboardUser(id=str(uuid.uuid4()), username="alice", role_id=role.id, status="active")
+    user.role = role
+    return user
+
+
+def test_actor_from_user_principal_snapshots_the_account() -> None:
+    user = _operator_user()
+    principal = user_principal(user, OPERATOR_GRANTS, auth_method="password")
+
+    actor = AuditActor.from_principal(principal)
+
+    assert actor == AuditActor(user_id=user.id, username="alice", role_slug="operator", auth_method="password")
+
+
+@pytest.mark.parametrize(
+    ("auth_mode", "auth_method", "asserted_actor"),
+    [
+        (DashboardAuthMode.STANDARD, "local_bootstrap", None),
+        (DashboardAuthMode.TRUSTED_HEADER, "trusted_header", "ops"),
+        (DashboardAuthMode.DISABLED, "disabled", None),
+    ],
+)
+def test_actor_from_implicit_admin_has_no_account(
+    auth_mode: DashboardAuthMode, auth_method: str, asserted_actor: str | None
+) -> None:
+    principal = admin_principal(auth_mode=auth_mode, actor=asserted_actor, auth_method=auth_method)
+
+    actor = AuditActor.from_principal(principal)
+
+    # The trusted-header admin has no account row but the proxy asserted a name; keep it.
+    assert actor == AuditActor(user_id=None, username=asserted_actor, role_slug="admin", auth_method=auth_method)
+
+
+def test_actor_from_guest_principal() -> None:
+    assert AuditActor.from_principal(guest_principal()) == AuditActor(
+        user_id=None, username=None, role_slug="guest", auth_method="guest"
+    )
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def emit(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+class _FailingSink:
+    async def emit(self, event: AuditEvent) -> None:
+        raise RuntimeError("webhook down")
+
+
+@pytest.fixture
+def _sink_registry():
+    reset_audit_sinks()
+    try:
+        yield
+    finally:
+        reset_audit_sinks()
+
+
+def test_default_registry_is_the_database_sink(_sink_registry) -> None:
+    sinks = get_audit_sinks()
+    assert len(sinks) == 1
+    assert isinstance(sinks[0], DatabaseAuditSink)
+
+
+@pytest.mark.asyncio
+async def test_event_is_built_once_with_sanitised_details_and_attribution(db_setup, _sink_registry) -> None:
+    recording = _RecordingSink()
+    register_audit_sink(recording)
+    actor = AuditActor(user_id="u-1", username="alice", role_slug="operator", auth_method="password")
+    target = AuditTarget("api_key", "k-1")
+
+    await AuditService.log(
+        "api_key_created",
+        actor_ip="203.0.113.9",
+        details={"key_id": "k-1", "key": "sk-clb-secret", "password": "nope"},
+        request_id="req-1",
+        actor=actor,
+        target=target,
+        severity=AuditSeverity.WARNING,
+    )
+
+    assert len(recording.events) == 1
+    event = recording.events[0]
+    assert event.action == "api_key_created"
+    assert event.details == {"key_id": "k-1"}
+    assert event.actor == actor
+    assert event.target == target
+    assert event.severity is AuditSeverity.WARNING
+    assert event.timestamp.tzinfo is not None
+
+    async with SessionLocal() as session:
+        row = (await session.execute(select(AuditLog).where(AuditLog.request_id == "req-1"))).scalar_one()
+    assert json.loads(row.details or "{}") == {"key_id": "k-1"}
+    assert (row.actor_user_id, row.actor_username, row.actor_role_slug, row.auth_method) == (
+        "u-1",
+        "alice",
+        "operator",
+        "password",
+    )
+    assert (row.target_type, row.target_id, row.severity) == ("api_key", "k-1", "warning")
+
+
+@pytest.mark.asyncio
+async def test_failing_sink_does_not_block_other_sinks(
+    db_setup, _sink_registry, caplog: pytest.LogCaptureFixture
+) -> None:
+    register_audit_sink(_FailingSink())
+    recording = _RecordingSink()
+    register_audit_sink(recording)
+
+    with caplog.at_level(logging.WARNING, logger=audit_service_module.__name__):
+        AuditService.log_async("sink_fanout_test", actor_ip="127.0.0.1")
+        assert await audit_service_module.drain_audit_log_tasks(timeout_seconds=5) is True
+
+    async with SessionLocal() as session:
+        rows = (await session.execute(select(AuditLog).where(AuditLog.action == "sink_fanout_test"))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].severity == "info"
+    assert rows[0].actor_user_id is None
+    assert [event.action for event in recording.events] == ["sink_fanout_test"]
+    assert "Audit sink _FailingSink failed for action sink_fanout_test" in caplog.text
+    assert audit_service_module._AUDIT_LOG_TASKS == set()

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -105,8 +105,8 @@ async def test_audit_log_async_is_fire_and_forget(monkeypatch: pytest.MonkeyPatc
     started = asyncio.Event()
     allow_write_finish = asyncio.Event()
 
-    async def slow_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
-        _ = (action, actor_ip, details, request_id)
+    async def slow_write(event: audit_service_module.AuditEvent) -> None:
+        _ = event
         started.set()
         await allow_write_finish.wait()
 
@@ -166,8 +166,8 @@ async def test_audit_log_task_failure_is_consumed_and_cleaned_up(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    async def fail_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
-        _ = (action, actor_ip, details, request_id)
+    async def fail_write(event: audit_service_module.AuditEvent) -> None:
+        _ = event
         raise RuntimeError("unexpected audit failure")
 
     monkeypatch.setattr(audit_service_module, "_write_audit_log", fail_write)
@@ -188,8 +188,8 @@ async def test_audit_log_drain_reports_overdue_task(
     started = asyncio.Event()
     allow_write_finish = asyncio.Event()
 
-    async def blocked_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
-        _ = (action, actor_ip, details, request_id)
+    async def blocked_write(event: audit_service_module.AuditEvent) -> None:
+        _ = event
         started.set()
         await allow_write_finish.wait()
 

--- a/tests/unit/test_dashboard_auth_api.py
+++ b/tests/unit/test_dashboard_auth_api.py
@@ -128,7 +128,7 @@ def _login_context(user: DashboardUser | None, *, target: LoginTarget | None = N
 
 
 def _limiter() -> SimpleNamespace:
-    return SimpleNamespace(check_and_increment=AsyncMock(), clear_for_key=AsyncMock())
+    return SimpleNamespace(check=AsyncMock(), check_and_increment=AsyncMock(), clear_for_key=AsyncMock())
 
 
 def _store() -> SimpleNamespace:
@@ -312,7 +312,12 @@ async def test_login_password_username_required_does_not_spend_budget():
         ),
     )
     ip_limiter = _limiter()
-    with patch("app.modules.dashboard_auth.api.get_password_rate_limiter", return_value=ip_limiter):
+    audit_limiter = _limiter()
+    with (
+        patch("app.modules.dashboard_auth.api.get_password_rate_limiter", return_value=ip_limiter),
+        patch("app.modules.dashboard_auth.api.get_login_failed_audit_rate_limiter", return_value=audit_limiter),
+        patch("app.modules.dashboard_auth.api.log_login_failed") as log_login_failed,
+    ):
         with pytest.raises(DashboardValidationError) as exc_info:
             await login_password(
                 _build_login_request("/api/dashboard-auth/password/login"),
@@ -321,7 +326,12 @@ async def test_login_password_username_required_does_not_spend_budget():
             )
 
     assert exc_info.value.code == "username_required"
+    # Audited, but only through the read-only password check plus the audit budget.
+    ip_limiter.check.assert_awaited_once()
     ip_limiter.check_and_increment.assert_not_awaited()
+    audit_limiter.check_and_increment.assert_awaited_once()
+    log_login_failed.assert_called_once()
+    assert log_login_failed.call_args.args[1:] == ("password", "username_required")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_dashboard_auth_password_service.py
+++ b/tests/unit/test_dashboard_auth_password_service.py
@@ -8,6 +8,7 @@ from typing import Any
 import bcrypt
 import pytest
 
+from app.core.audit.service import AuditActor, AuditSeverity, AuditTarget
 from app.core.auth.dashboard_access import PRESET_ROLE_IDS, DashboardPermission, DashboardRole, PresetRoleSlug
 from app.core.auth.dashboard_mode import DashboardAuthMode
 from app.db.models import COMPAT_ADMIN_USERNAME, DashboardRoleRecord, DashboardUser
@@ -25,19 +26,45 @@ from app.modules.dashboard_users.repository import DashboardUserCounts, LocalAut
 pytestmark = pytest.mark.unit
 
 
+@dataclass(slots=True, frozen=True)
+class _AuditCall:
+    action: str
+    details: dict[str, Any]
+    actor: AuditActor | None
+    target: AuditTarget | None
+    severity: AuditSeverity
+
+
 @pytest.fixture(autouse=True)
-def audit_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any]]]:
+def audit_events(monkeypatch: pytest.MonkeyPatch) -> list[_AuditCall]:
     """Record audit calls instead of scheduling background tasks that would outlive the test loop."""
 
     import app.modules.dashboard_auth.service as service_module
 
-    events: list[tuple[str, dict[str, Any]]] = []
+    events: list[_AuditCall] = []
 
-    def _record(action: str, actor_ip: str | None = None, details: Any = None, request_id: str | None = None) -> None:
-        events.append((action, dict(details or {})))
+    def _record(
+        action: str,
+        actor_ip: str | None = None,
+        details: Any = None,
+        request_id: str | None = None,
+        *,
+        actor: AuditActor | None = None,
+        target: AuditTarget | None = None,
+        severity: AuditSeverity = AuditSeverity.INFO,
+    ) -> None:
+        events.append(_AuditCall(action, dict(details or {}), actor, target, severity))
 
     monkeypatch.setattr(service_module.AuditService, "log_async", staticmethod(_record))
     return events
+
+
+def _user_actor(user: DashboardUser, auth_method: str) -> AuditActor:
+    return AuditActor(user_id=user.id, username=user.username, role_slug=user.role.slug, auth_method=auth_method)
+
+
+def _calls(events: list[_AuditCall], action: str) -> list[_AuditCall]:
+    return [call for call in events if call.action == action]
 
 
 @dataclass(slots=True)
@@ -319,9 +346,7 @@ async def test_failed_logins_always_cost_exactly_one_password_check(monkeypatch:
 
 
 @pytest.mark.asyncio
-async def test_failed_login_audit_keeps_only_well_formed_usernames(
-    audit_events: list[tuple[str, dict[str, Any]]],
-) -> None:
+async def test_failed_login_audit_keeps_only_well_formed_usernames(audit_events: list[_AuditCall]) -> None:
     repository = _FakeRepository()
     service = _service(repository)
     await service.setup_password("password123")
@@ -332,10 +357,93 @@ async def test_failed_login_audit_keeps_only_well_formed_usernames(
     with pytest.raises(InvalidCredentialsError):
         await service.verify_user_password(await service.resolve_login_target("nobody"), "wrong")
 
-    failures = [details for action, details in audit_events if action == "login_failed"]
+    failures = _calls(audit_events, "login_failed")
     assert len(failures) == 4
-    assert [details["username"] for details in failures] == [None, None, None, "nobody"]
-    assert [details["reason"] for details in failures] == ["invalid_username"] * 3 + ["bad_password"]
+    assert [call.details["username"] for call in failures] == [None, None, None, "nobody"]
+    assert [call.details["reason"] for call in failures] == ["invalid_username"] * 3 + ["unknown_identity"]
+    assert all(call.actor is None and call.severity is AuditSeverity.WARNING for call in failures)
+
+
+@pytest.mark.asyncio
+async def test_self_service_audit_names_the_account_and_session_method(audit_events: list[_AuditCall]) -> None:
+    repository = _FakeRepository()
+    service = _service(repository)
+    admin = await service.setup_password("password123")
+    expected_target = AuditTarget("user", admin.id)
+
+    await service.verify_password("password123")
+    (signed_in,) = _calls(audit_events, "login_success")
+    assert signed_in.actor == _user_actor(admin, "password")
+    assert signed_in.target == expected_target
+
+    await service.change_password(admin, "password123", "new-password-456", auth_method="password")
+    (changed,) = _calls(audit_events, "password_changed")
+    assert changed.actor == _user_actor(admin, "password")
+    assert changed.target == expected_target
+    assert changed.severity is AuditSeverity.INFO
+
+    # The session's own method is threaded through; the default is the password method.
+    await service.revoke_user_sessions(admin, auth_method="trusted_header")
+    await service.revoke_user_sessions(admin)
+    threaded, defaulted = _calls(audit_events, "user_sessions_revoked")
+    assert threaded.actor == _user_actor(admin, "trusted_header")
+    assert defaulted.actor == _user_actor(admin, "password")
+    assert threaded.target == defaulted.target == expected_target
+
+    await service.remove_password(admin, "new-password-456", auth_method="password")
+    (removed,) = _calls(audit_events, "password_removed")
+    assert removed.actor == _user_actor(admin, "password")
+    assert removed.target == expected_target
+    assert removed.severity is AuditSeverity.INFO
+
+
+@pytest.mark.asyncio
+async def test_totp_audit_attribution(monkeypatch: pytest.MonkeyPatch, audit_events: list[_AuditCall]) -> None:
+    import pyotp
+
+    import app.core.auth.totp as totp_module
+    import app.modules.dashboard_auth.service as service_module
+    from app.modules.dashboard_auth.service import TotpInvalidCodeError
+
+    current = {"value": 1_700_000_000}
+    monkeypatch.setattr(service_module, "time", lambda: current["value"])
+    monkeypatch.setattr(totp_module, "time", lambda: current["value"])
+
+    repository = _FakeRepository()
+    store = DashboardSessionStore()
+    service = _service(repository, store)
+    admin = await service.setup_password("password123")
+    expected_target = AuditTarget("user", admin.id)
+    secret = pyotp.random_base32()
+    totp = pyotp.TOTP(secret)
+
+    await service.confirm_totp_setup(
+        session_id=_session_for(store, admin), secret=secret, code=totp.at(current["value"])
+    )
+    (enabled,) = _calls(audit_events, "totp_enabled")
+    assert enabled.actor == _user_actor(admin, "password")  # the password session's method
+    assert enabled.target == expected_target
+
+    code = totp.at(current["value"])
+    verified, _ = await service.verify_totp(session_id=_session_for(store, admin), code=code, ttl_seconds=3600)
+    (signed_in,) = _calls(audit_events, "login_success")
+    assert signed_in.actor == _user_actor(admin, "totp")
+    assert signed_in.target == expected_target
+    assert signed_in.details == {"method": "totp", "username": admin.username}
+
+    with pytest.raises(TotpInvalidCodeError):
+        await service.verify_totp(session_id=_session_for(store, admin), code=code, ttl_seconds=3600)
+    (replayed,) = _calls(audit_events, "login_failed")
+    assert replayed.actor is None
+    assert replayed.target is None
+    assert replayed.severity is AuditSeverity.WARNING
+    assert replayed.details == {"method": "totp", "username": admin.username, "reason": "bad_totp"}
+
+    current["value"] += 60
+    await service.disable_totp(session_id=verified, code=totp.at(current["value"]))
+    (disabled,) = _calls(audit_events, "totp_disabled")
+    assert disabled.actor == _user_actor(admin, "password")
+    assert disabled.target == expected_target
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -23,6 +23,7 @@ from yarl import URL
 import app.core.tracing.otel as otel
 import app.modules.proxy.service as proxy_module
 from app.core.audit import service as audit_service_module
+from app.core.auth.dashboard_access import DashboardAuthMode, DashboardPrincipal, admin_principal
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy_websocket import UpstreamWebSocket
 from app.core.config.settings import Settings
@@ -634,14 +635,8 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
     def _init_background_db() -> None:
         call_order.append("init_background_db")
 
-    async def _blocked_audit_write(
-        action: str,
-        actor_ip: str | None,
-        details: audit_service_module.AuditDetails | None,
-        request_id: str | None,
-    ) -> None:
-        _ = (action, actor_ip, details, request_id)
-        audit_write_actions.append(action)
+    async def _blocked_audit_write(event: audit_service_module.AuditEvent) -> None:
+        audit_write_actions.append(event.action)
         audit_write_started.set()
         await allow_audit_write.wait()
 
@@ -697,8 +692,8 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
         last_used_at=None,
     )
 
-    async def _allow_dashboard_access() -> None:
-        return None
+    async def _allow_dashboard_access() -> DashboardPrincipal:
+        return admin_principal(auth_mode=DashboardAuthMode.STANDARD, auth_method="local_bootstrap")
 
     async def _accounts_context_override() -> SimpleNamespace:
         return SimpleNamespace(service=_BlockedAccountsService())

--- a/tests/unit/test_rate_limit_reset_credits_api.py
+++ b/tests/unit/test_rate_limit_reset_credits_api.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import pytest
 from fastapi import Request
 
+from app.core.auth.dashboard_access import DashboardAuthMode, admin_principal
 from app.core.auth.dependencies import require_dashboard_write_access
 from app.core.auth.refresh import RefreshError
 from app.core.clients.rate_limit_reset_credits import (
@@ -45,6 +46,7 @@ from app.modules.rate_limit_reset_credits.api import (
 from app.modules.rate_limit_reset_credits.store import RateLimitResetCreditsStore
 
 pytestmark = pytest.mark.unit
+_ADMIN_PRINCIPAL = admin_principal(auth_mode=DashboardAuthMode.STANDARD, auth_method="local_bootstrap")
 
 
 class StubEncryptor(TokenEncryptor):
@@ -1380,7 +1382,7 @@ async def test_consume_handler_returns_404_when_account_missing() -> None:
         await consume_rate_limit_reset_credit(
             _fake_request(),
             account_id="missing",
-            _write_access=None,
+            principal=_ADMIN_PRINCIPAL,
             context=cast(Any, fake_context),
         )
 
@@ -1419,7 +1421,7 @@ async def test_consume_handler_audits_live_available_count_before_when_cache_mis
     response = await consume_rate_limit_reset_credit(
         _fake_request(),
         account_id="acc_1",
-        _write_access=None,
+        principal=_ADMIN_PRINCIPAL,
         context=cast(Any, fake_context),
     )
 
@@ -1459,7 +1461,7 @@ async def test_consume_handler_invalidates_selection_cache_on_permanent_refresh_
         await consume_rate_limit_reset_credit(
             _fake_request(),
             account_id="acc_1",
-            _write_access=None,
+            principal=_ADMIN_PRINCIPAL,
             context=cast(Any, fake_context),
         )
 
@@ -1497,7 +1499,7 @@ async def test_consume_handler_keeps_selection_cache_on_transient_refresh_error(
         await consume_rate_limit_reset_credit(
             _fake_request(),
             account_id="acc_1",
-            _write_access=None,
+            principal=_ADMIN_PRINCIPAL,
             context=cast(Any, fake_context),
         )
 


### PR DESCRIPTION
## Summary

Stacked on the login/session PR (`feat/user-login-and-session-v2`, #2223). Fourth Phase-1 PR of the dashboard RBAC plan: audit rows now record **who** acted (the dashboard account), **how** they authenticated, **what** they acted on, and a severity, and the audit write path fans out through a small sink interface so an external (webhook) sink can be added later without touching call sites. `GET /api/audit-logs` gains the matching filters. No behaviour change for callers that do not use the new fields.

## Type of change

- [x] `feat:` — new capability (audit attribution + sink registry)

Linked issue: groundwork for #673 (user management); no issue closed.

## OpenSpec

- [x] This PR includes an OpenSpec change

Change directory: `openspec/changes/attribute-audit-actor/` (`audit-logging` ADDED ×4; `openspec validate --strict` passes)

## Changes

**Schema** (revision `20260909_030000_add_audit_actor_columns`): `audit_logs` gains nullable `actor_user_id` (snapshot, deliberately no foreign key so rows survive account deletion), `actor_username`, `actor_role_slug`, `auth_method`, `target_type`, `target_id`, and `severity` (`info|warning|critical`, NOT NULL, default `info` backfilled). Indexes on `actor_user_id` and `(target_type, target_id)`. Guarded adds, SQLite batch mode, inspector-based downgrade. On SQLite, legacy second-granular timestamps are normalised once to the fractional text form so range filters compare consistently.

**Core** (`app/core/audit/types.py`, `app/core/audit/service.py`): `AuditActor.from_principal(principal)` maps account sessions to their id/username/role slug/auth method, implicit admins to `auth_method` `local_bootstrap|trusted_header|disabled` (trusted-header principals keep the proxy-asserted username), guests to `guest`. `AuditTarget(type, id)`, `AuditSeverity`, `AuditEvent`. `AuditService.log/log_async` keep their positional parameters and gain keyword-only `actor`, `target`, `severity`. Writes build one event and fan out to registered sinks; the database sink is first and authoritative, a failing sink is logged and never blocks the others, and task ownership / shutdown drain are unchanged.

**Call sites**: every audited mutation (accounts, API keys, model sources, settings, quota planner, reset credits, guest access, self-service auth) now passes the acting principal and, where obvious, the target. Routes that audit bind the principal instead of the ignored access-marker dependency. `login_failed` rows carry `severity=warning`, actor `null`, and `details.reason ∈ {bad_password, bad_totp, unknown_identity, disabled_user, invalid_username, username_required}`; the `username_required` (422) case is audited only while the client is below the password rate limit so an anonymous client cannot flood the table.

**API** (`GET /api/audit-logs`, still `audit:read`): rows gain `actor {userId, username, roleSlug, authMethod} | null`, `target {type, id} | null`, `severity`. New filters `actor_user_id`, `target_type`, `target_id`, `severity`, `reason` (validated `^[a-z_]{1,32}$`, matched against the details JSON), `since` (inclusive) / `until` (exclusive). Append-only: no update or delete path.

**Tests**: unit (actor mapping for every principal kind, event sanitisation, sink isolation, self-service attribution), integration (signed-in admin attribution with target, implicit local admin, guest login actor, failed sign-in reasons incl. throttled `username_required`, filter matrix and 422s, account/API-key targets, migration up/down with pre-existing rows), existing audit/otel/multi-replica tests updated.

## Simplicity

- [x] Zero config; no new setting, env var, README section, or nav item.
- [x] No new required setup step.
- New setting(s): none
- [x] Budgets unchanged. Frontend untouched (the audit UI ignores unknown fields).

App code is ≈ +560 net lines against the ~450 planned; the overrun is the new types module and the migration.

## Test plan

```
uv run ruff check . && uv run ruff format --check . && uv run ty check        # clean
uv run pytest tests/unit/test_audit_actor.py tests/unit/test_audit_trail.py tests/unit/test_otel.py \
  tests/unit/test_dashboard_auth_*.py tests/integration/test_audit_actor_attribution.py \
  tests/integration/test_audit_logs_api.py tests/integration/test_settings_audit_changed_fields.py \
  tests/integration/test_dashboard_password_auth.py tests/integration/test_dashboard_totp_auth.py \
  tests/integration/test_accounts_api.py tests/integration/test_api_keys_api.py \
  tests/integration/test_dashboard_route_permission_matrix.py tests/integration/test_multi_replica.py \
  tests/e2e/test_auth_flow.py -q
openspec validate attribute-audit-actor --strict                              # valid
codex review --base feat/user-login-and-session-v2                           # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
