### PR TITLE
docs(openspec): replace archive-generated Purpose stubs with real purpose statements

### DIFF
--- a/openspec/specs/account-auth-export/spec.md
+++ b/openspec/specs/account-auth-export/spec.md
@@ -1,7 +1,7 @@
 # account-auth-export Specification
 
 ## Purpose
-TBD - created by manual sync from archived OpenSpec changes. Update Purpose after archive.
+Governs the OpenCode-format account credential export. Operators who onboard accounts through codex-lb should not have to repeat the OpenAI OAuth flow inside OpenCode, so a selected account can be exported as an OpenCode-compatible `auth.json` holding only that account's OAuth entry. The payload is delivered through the unified export endpoint, must exclude codex-lb-only metadata, and must never leak token material into audit records.
 ## Requirements
 ### Requirement: Per-account OpenCode auth export
 The system SHALL let an authenticated dashboard user export one selected account as an OpenCode-compatible `auth.json` payload. The payload SHALL be delivered as the `opencodeAuthJson` member of the unified `POST /api/accounts/{id}/export/auth` response; the system SHALL NOT expose a dedicated OpenCode export route.

--- a/openspec/specs/account-identity/spec.md
+++ b/openspec/specs/account-identity/spec.md
@@ -1,7 +1,7 @@
 # account-identity Specification
 
 ## Purpose
-TBD - created by archiving change fix-shared-workspace-account-slots. Update Purpose after archive.
+Defines how codex-lb identifies a stored account when upstream identifiers are not unique. Several workspace members can share one upstream `chatgpt_account_id`, so keying account slots on that identifier alone let one member's login or reauthorization overwrite another member's tokens. This capability keeps each login email on its own slot, makes duplicate consolidation preserve a recoverable canonical identity, and keeps dashboard OAuth polls from acting on stale generations.
 ## Requirements
 ### Requirement: Shared upstream workspace identities preserve account slots
 

--- a/openspec/specs/account-pool-usage-v1-usage/spec.md
+++ b/openspec/specs/account-pool-usage-v1-usage/spec.md
@@ -1,7 +1,7 @@
 # account-pool-usage-v1-usage Specification
 
 ## Purpose
-TBD - created by archiving change add-account-pool-usage-to-v1-usage. Update Purpose after archive.
+Governs what pooled-account capacity an API-key client can learn from `GET /v1/usage`. Key-level limits and aggregate upstream windows alone do not tell a client how much of the primary and secondary account pool remains, and administrators previously had no way to limit which usage detail sections a key exposes. This capability adds `account_pool_usage` to the response and lets each key's `usage_sections` setting decide which sections are returned.
 ## Requirements
 ### Requirement: /v1/usage response includes account_pool_usage
 

--- a/openspec/specs/account-quota-presentation/spec.md
+++ b/openspec/specs/account-quota-presentation/spec.md
@@ -1,7 +1,7 @@
 # account-quota-presentation Specification
 
 ## Purpose
-TBD - created by archiving change free-account-monthly-window. Update Purpose after archive.
+Governs how account quota windows are presented across the dashboard when an account does not fit the paid 5h/7d shape. Free accounts report a single monthly window, and rendering it as weekly produced wrong bars, trends, donut totals, and assigned-account badges. This capability keeps monthly-only accounts labelled as such, omits zero-credit accounts from window totals they cannot contribute to, and keeps quota refreshes visually stable.
 ## Requirements
 ### Requirement: Free-account quota surfaces are monthly-only
 

--- a/openspec/specs/account-routing/spec.md
+++ b/openspec/specs/account-routing/spec.md
@@ -1,7 +1,7 @@
 # account-routing Specification
 
 ## Purpose
-TBD - created by archiving change add-relative-availability-routing. Update Purpose after archive.
+Defines how the proxy chooses which account serves a request and how upstream feedback changes that choice. It covers the selection strategies operators can pick (relative availability, sequential and reset drain, single-account, manual and additional-quota policies, reset-window preference), how rate-limit, overload, and error signals scope penalties to the responsible account, and which of those signals must be shared across replicas versus kept replica-local. The goal is to spend pooled quota deliberately while never leaving a request routed to an account that cannot serve it.
 ## Requirements
 ### Requirement: Relative availability routing
 

--- a/openspec/specs/api-firewall/spec.md
+++ b/openspec/specs/api-firewall/spec.md
@@ -1,7 +1,7 @@
 # api-firewall Specification
 
 ## Purpose
-TBD - created by archiving change port-firewall-to-react. Update Purpose after archive.
+Governs the IP allowlist that gates the proxy surfaces (`/backend-api/codex/*`, `/v1/*`) and the dashboard API for managing it. Operators who expose codex-lb beyond a private network need to restrict which client addresses may reach the proxy, including deployments behind a reverse proxy where the client IP must be derived from trusted forwarding headers. This capability defines allowlist management, enforcement on protected paths, trusted-proxy header handling, and the safety defaults around header trust and cache TTL.
 ## Requirements
 ### Requirement: Firewall allowlist management API
 Dashboard API MUST expose firewall allowlist management endpoints at `/api/firewall/ips` for listing, creating, and deleting allowed client IP addresses.

--- a/openspec/specs/api-response-metadata/spec.md
+++ b/openspec/specs/api-response-metadata/spec.md
@@ -1,7 +1,7 @@
 # api-response-metadata Specification
 
 ## Purpose
-TBD - created by archiving change add-app-version-response-header. Update Purpose after archive.
+Governs the HTTP response headers codex-lb adds globally across route families, currently the `X-App-Version` header. Operators and client integrations need a stable way to identify which build produced a response when debugging or verifying a rollout, without changing any response body contract. The header is limited to responses the server completed (2xx-4xx) and omitted from 5xx and WebSocket traffic.
 ## Requirements
 ### Requirement: HTTP 2xx-4xx responses include the running app version header
 The system MUST attach `X-App-Version` to HTTP responses whose final status code is in the `200-499` range. The header value MUST equal the running codex-lb package version. This requirement applies across dashboard, health, proxy, and static-file HTTP routes, including handled framework or domain `4xx` responses. If a response already sets `X-App-Version`, the system MUST preserve the explicit value rather than overwrite it.

--- a/openspec/specs/audio-transcriptions-compat/spec.md
+++ b/openspec/specs/audio-transcriptions-compat/spec.md
@@ -1,7 +1,7 @@
 # audio-transcriptions-compat Specification
 
 ## Purpose
-TBD - created by archiving change add-transcription-proxy-compat. Update Purpose after archive.
+Governs the transcription proxy routes: the native Codex `POST /backend-api/transcribe` and the OpenAI-compatible `POST /v1/audio/transcriptions`. Codex voice input and OpenAI-style clients both send audio through these paths, so they must reuse the proxy's authentication, model restriction, rate-limit, account-selection, and retry behaviour with a fixed effective model, while keeping multipart uploads authorized and bounded.
 ## Requirements
 ### Requirement: Native transcription proxy endpoint
 The system SHALL expose `POST /backend-api/transcribe` for multipart audio transcription requests. The endpoint MUST accept a multipart `file` part and MAY accept a `prompt` part, and MUST forward requests to upstream `/transcribe` using selected account credentials. While forwarding multipart form data, the service MUST strip inbound `Content-Type` header values case-insensitively so the upstream client can generate a correct boundary. For a non-native Codex client, the upstream request MUST use canonical `codex_cli_rs` `User-Agent`, `originator`, and `version` values and MUST NOT forward OpenAI SDK fingerprint headers including `x-stainless-*`. A native Codex client MUST forward its inbound `User-Agent` unchanged and MUST NOT add canonical `originator` or `version` headers.

--- a/openspec/specs/automations/spec.md
+++ b/openspec/specs/automations/spec.md
@@ -1,7 +1,7 @@
 # automations Specification
 
 ## Purpose
-TBD - created by archiving change add-automations-scheduled-pings. Update Purpose after archive.
+Governs operator-defined automation jobs that send scheduled ping traffic from selected accounts and models for readiness checks and warm-up. It defines the dashboard API for managing jobs, daily schedules with timezone and weekday semantics, safe execution in multi-replica deployments, account failover within a run, and queryable run history. Automation traffic must never alter durable user continuity such as sticky sessions.
 ## Requirements
 ### Requirement: Automation jobs are manageable via dashboard APIs
 

--- a/openspec/specs/bridge-ring-membership/spec.md
+++ b/openspec/specs/bridge-ring-membership/spec.md
@@ -1,7 +1,7 @@
 # bridge-ring-membership Specification
 
 ## Purpose
-TBD - created by archiving change harden-bridge-ring-lifecycle. Update Purpose after archive.
+Governs how replicas join, stay in, and leave the shared bridge ring that routes hard-affinity HTTP bridge requests to the owning replica. Sibling replicas must converge on the same view of which instances are alive, so a replica registers before serving bridge traffic, heartbeats on a fixed cadence, ages its row on shutdown rather than deleting it, and dead rows are eventually purged.
 ## Requirements
 ### Requirement: Replicas register in the bridge ring before serving bridge traffic
 Each replica MUST register its instance id (and advertised endpoint when configured) in the shared `bridge_ring_members` table before hard-affinity HTTP bridge requests are admitted. While registration is incomplete in a multi-replica deployment, hard-affinity bridge requests MUST wait for registration up to the configured connect timeout and fail with a retryable `bridge_owner_unreachable` error when the wait expires.

--- a/openspec/specs/clipboard-copy-fallback/spec.md
+++ b/openspec/specs/clipboard-copy-fallback/spec.md
@@ -1,7 +1,7 @@
 # clipboard-copy-fallback Specification
 
 ## Purpose
-TBD - created by archiving change add-clipboard-fallback. Update Purpose after archive.
+Governs the shared dashboard clipboard utility. The Clipboard API is unavailable in non-secure contexts and can fail inside focus-trapped dialogs, which made copy controls fail silently in real flows. This capability defines the secure path, the fallback path, and explicit container scoping so copying keeps working inside dialogs.
 ## Requirements
 ### Requirement: Clipboard copy utility supports secure and fallback paths
 The frontend clipboard utility SHALL use `navigator.clipboard.writeText` when available in secure contexts and SHALL fall back to `document.execCommand("copy")` when the Clipboard API is unavailable or blocked.

--- a/openspec/specs/files-upload-protocol/spec.md
+++ b/openspec/specs/files-upload-protocol/spec.md
@@ -1,7 +1,7 @@
 # files-upload-protocol Specification
 
 ## Purpose
-TBD - created by archiving change add-backend-api-files-protocol. Update Purpose after archive.
+Governs the native Codex file upload protocol (`POST /backend-api/files` and the finalize/status endpoint) that lets clients upload a large attachment once and reference it by `file_id` in later turns instead of hitting the responses message-size ceiling. File routes must share the proxy's account selection, authentication, and request-log plumbing, and finalize ownership must be durable across replicas so follow-up calls reach the account that registered the upload.
 ## Requirements
 ### Requirement: Native file upload registration endpoint
 

--- a/openspec/specs/fleet-summary/spec.md
+++ b/openspec/specs/fleet-summary/spec.md
@@ -1,7 +1,7 @@
 # fleet-summary Specification
 
 ## Purpose
-TBD - created by archiving change add-fleet-observability-endpoint. Update Purpose after archive.
+Governs the API-key-authenticated fleet surface (`/api/fleet/*`) that external monitors read: the fleet summary, the observability feed of request pressure windows and sticky-session continuity, and fleet-triggered usage refreshes. These endpoints must follow the fleet usage-visibility policy, exclude sensitive identifiers and raw error payloads, and participate in graceful shutdown.
 ## Requirements
 ### Requirement: Fleet observability requires API key authentication
 

--- a/openspec/specs/live-usage-ingestion/spec.md
+++ b/openspec/specs/live-usage-ingestion/spec.md
@@ -1,7 +1,7 @@
 # live-usage-ingestion Specification
 
 ## Purpose
-TBD - created by archiving change live-rate-limit-ingestion. Update Purpose after archive.
+Governs the passive usage source that reads rate-limit headers and `codex.rate_limits` stream events from proxied traffic. Polling upstream usage alone leaves selection state up to a refresh interval behind real usage, so bursty traffic could exhaust a window before the poller noticed. This capability turns every proxied turn into a usage snapshot while guaranteeing that ingestion never impairs the serving path, is throttled per account, can be switched off, and has an instance-scoped lifecycle.
 ## Requirements
 ### Requirement: Proxied responses feed passive usage snapshots
 

--- a/openspec/specs/model-catalog-compat/spec.md
+++ b/openspec/specs/model-catalog-compat/spec.md
@@ -1,7 +1,7 @@
 # model-catalog-compat Specification
 
 ## Purpose
-TBD - created by archiving change populate-bootstrap-model-metadata. Update Purpose after archive.
+Governs the model catalogs codex-lb serves to Codex-native and OpenAI-compatible clients, and how those catalogs feed routing. Fresh instances need a usable bootstrap catalog before the first upstream refresh, refreshed upstream data must then stay authoritative and replica-coherent, and catalog metadata (context windows, speed tiers, reasoning efforts, model-source identity) must be preserved exactly so clients can parse it. It also fixes how per-account catalog knowledge constrains or degrades pooled routing without falsely excluding accounts.
 ## Requirements
 ### Requirement: Bootstrap model catalog is available before refresh
 

--- a/openspec/specs/proxy-warmup/spec.md
+++ b/openspec/specs/proxy-warmup/spec.md
@@ -1,7 +1,7 @@
 # proxy-warmup Specification
 
 ## Purpose
-TBD - created by archiving change add-v1-warmup-endpoint. Update Purpose after archive.
+Governs `POST /v1/warmup`, which lets API-key clients warm the accounts in their pool before real traffic so first-request latency and upstream cold starts do not reach users. It defines target-pool derivation from key scope, deterministic `normal`/`strict`/`force` mode semantics, the minimal upstream request, and the rule that warmup traffic is visible in request logs but excluded from aggregate and API-key usage accounting.
 ## Requirements
 ### Requirement: Warmup endpoint is exposed on the v1 proxy surface
 The system SHALL expose `POST /v1/warmup` on the same authenticated proxy surface as other `/v1/*` routes. The endpoint SHALL accept a JSON body with `mode` and SHALL return HTTP 200 with a structured JSON summary of submitted, skipped, and failed account warmups for every valid execution. Per-account `ProxyAuthError` and `ProxyRateLimitError` failures SHALL be represented in the `failed` summary regardless of the number of target accounts.

--- a/openspec/specs/rate-limit-reset-credits/spec.md
+++ b/openspec/specs/rate-limit-reset-credits/spec.md
@@ -1,7 +1,7 @@
 # rate-limit-reset-credits Specification
 
 ## Purpose
-TBD - created by archiving change add-rate-limit-reset-credits. Update Purpose after archive.
+Governs visibility and redemption of upstream banked rate-limit reset credits per account. Upstream exposes the redeem affordance only in selected editors, so operators managing many accounts had no way to see how many credits an account holds, when they expire, or to redeem one from the dashboard. This capability defines the per-account polling cadence and in-memory cache, operator redemption of the soonest-expiring credit, isolation of polling failures from account status, and cross-replica serialization of redemption and cache invalidation.
 ## Requirements
 ### Requirement: Reset credits are polled per account on a fixed cadence
 

--- a/openspec/specs/release-automation/spec.md
+++ b/openspec/specs/release-automation/spec.md
@@ -1,7 +1,7 @@
 # release-automation Specification
 
 ## Purpose
-TBD - created by archiving change cleanup-superseded-beta-release-prs. Update Purpose after archive.
+Governs the GitHub workflow that keeps the beta release PR in sync with the release-please train. When the train moves before a beta PR merges, older automation-created beta PRs must be closed and their branches removed so a stale PR cannot be merged, while manual, protected, and current beta PRs are preserved and newly created beta PRs carry a changelog consistent with the stable release PR.
 ## Requirements
 ### Requirement: Superseded beta release PR cleanup
 

--- a/openspec/specs/release-management/spec.md
+++ b/openspec/specs/release-management/spec.md
@@ -1,7 +1,7 @@
 # release-management Specification
 
 ## Purpose
-TBD - created by archiving change add-beta-release-channel. Update Purpose after archive.
+Governs the release channels of codex-lb: the stable path owned by release-please and the PR-driven beta channel layered on it. Beta releases must be prepared through release PRs, publish as GitHub prereleases on merge, never advance stable aliases or the stable manifest, and withdraw public release metadata when publishing fails, so stable promotion stays release-please owned and every release-managed version field is guarded.
 ## Requirements
 ### Requirement: Beta releases are prepared through release PRs
 

--- a/openspec/specs/report-aggregation/spec.md
+++ b/openspec/specs/report-aggregation/spec.md
@@ -1,7 +1,7 @@
 # report-aggregation Specification
 
 ## Purpose
-TBD - created by archiving change harden-reports-performance. Update Purpose after archive.
+Governs how dashboard reports are assembled from permanent time-bucketed aggregates plus the not-yet-folded raw complement, so historical totals, filter dimensions, and distinct conversation counts survive raw request-log retention and stay correct for any requested timezone. Long report windows previously scanned raw rows until they timed out and every filter change re-ran the full report; this capability bounds that work by preferring folded history, keeping filter options and report caching lightweight, and limiting exact speed metrics to short windows with explicit disclosure.
 ## Requirements
 ### Requirement: Permanent report aggregates
 The system SHALL preserve request counts, error and cancellation counts, token totals, cost, first activity, active accounts and distinct normalized conversations in permanent time buckets, including account, API key, model and User-Agent filter dimensions. Report days SHALL respect the requested timezone. Folded history and raw complement SHALL be read in one snapshot without overlap. Partial storage buckets SHALL use raw data; retained history at sub-hour boundaries has the same bounded edge limitation as existing hourly statistics.

--- a/openspec/specs/scheduler-coordination/spec.md
+++ b/openspec/specs/scheduler-coordination/spec.md
@@ -1,7 +1,7 @@
 # scheduler-coordination Specification
 
 ## Purpose
-TBD - created by archiving change harden-scheduler-leader-election. Update Purpose after archive.
+Governs the shared leader lease that gates singleton background schedulers in multi-replica deployments. Without a sound lease every replica runs the same token refreshes, warmups, and usage fetches, marking healthy accounts as needing re-authentication and double-spending quota. This capability requires atomic lease acquisition on both database backends, expiry evaluated in a single clock domain, renewal while gated work runs with demotion on loss, and release on graceful shutdown.
 ## Requirements
 ### Requirement: Singleton schedulers gate on the shared leader lease
 

--- a/openspec/specs/unified-auth-export/spec.md
+++ b/openspec/specs/unified-auth-export/spec.md
@@ -1,7 +1,7 @@
 # unified-auth-export Specification
 
 ## Purpose
-TBD - created by archiving change unify-auth-export. Update Purpose after archive.
+Governs the single account credential export surface: one `POST /api/accounts/{id}/export/auth` endpoint returning structured tokens plus both Codex and OpenCode `auth.json` payloads, and the dashboard modal that switches between formats. Two divergent export buttons forced users to know the target format up front and gave inconsistent security UX; this capability replaces them, requires an explicit security warning, and retires the predecessor routes.
 ## Requirements
 ### Requirement: Combined auth export endpoint
 

--- a/openspec/specs/upstream-proxy-routing/spec.md
+++ b/openspec/specs/upstream-proxy-routing/spec.md
@@ -1,7 +1,7 @@
 # upstream-proxy-routing Specification
 
 ## Purpose
-TBD - created by archiving change add-codex-proxy-pool-egress. Update Purpose after archive.
+Governs how account-scoped upstream traffic to ChatGPT/OpenAI/Codex leaves the process. Every upstream call for an account bound to a proxy pool must use that pool and fail closed before any network open when the route is unavailable, because a partial per-request proxy setting would let other surfaces leak through the default pool or direct egress. It also fixes the TLS fingerprint contract, the route metadata recorded in request logs, pool membership validation, and how proxy credentials are carried and validated.
 ## Requirements
 ### Requirement: Account-bound upstream traffic must use the bound proxy pool
 When an account has an explicit upstream proxy pool binding, every ChatGPT/OpenAI/Codex upstream operation using that account's credentials MUST resolve a route from the bound pool before opening a network connection.


### PR DESCRIPTION
## Summary

Twenty-three capability specs under `openspec/specs/` still opened with the archive tool's placeholder `TBD - created by archiving change <name>. Update Purpose after archive.` (plus one `manual sync` variant). This includes `report-aggregation`, created by the `harden-reports-performance` archive in #2227 after this branch was first cut; the branch is rebased onto that main. Each `## Purpose` is now a 2–4 sentence statement of what the capability governs and why it exists, written from the originating archived change proposal and the spec's current requirement set. Requirement, scenario, and behaviour text is untouched.

## Type of change

- [x] `docs:` — documentation only

Linked issue: none — the slop-removal campaign has no tracking issue; the `slop-removal` label is the campaign marker.

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Only `## Purpose` prose changes; no requirement or scenario deltas, so no change folder is needed. `openspec validate --specs --strict` passes (64/64).

## Changes

Spec → originating archived change used as the source for the Purpose text:

| spec | source change (`openspec/changes/archive/`) |
|---|---|
| `account-auth-export` | `2026-06-02-add-opencode-auth-export` (+ `2026-09-09-retire-uncalled-dashboard-routes` for the unified-endpoint delivery) |
| `account-identity` | `2026-07-12-fix-shared-workspace-account-slots` |
| `account-pool-usage-v1-usage` | `2026-07-12-add-account-pool-usage-to-v1-usage` |
| `account-quota-presentation` | `2026-07-12-free-account-monthly-window` |
| `account-routing` | `2026-06-02-add-relative-availability-routing` (Purpose written to cover the full current requirement set, which spans many later changes) |
| `api-firewall` | `2026-03-03-port-firewall-to-react` |
| `api-response-metadata` | `2026-06-02-add-app-version-response-header` |
| `audio-transcriptions-compat` | `2026-03-03-add-transcription-proxy-compat` |
| `automations` | `2026-07-12-add-automations-scheduled-pings` |
| `bridge-ring-membership` | `2026-07-15-harden-bridge-ring-lifecycle` |
| `clipboard-copy-fallback` | `2026-06-02-add-clipboard-fallback` |
| `files-upload-protocol` | `2026-05-17-add-backend-api-files-protocol` |
| `fleet-summary` | `2026-07-12-add-fleet-observability-endpoint` |
| `live-usage-ingestion` | `2026-07-14-live-rate-limit-ingestion` |
| `model-catalog-compat` | `2026-06-02-populate-bootstrap-model-metadata` (Purpose covers the full current catalog/routing requirement set) |
| `proxy-warmup` | `2026-07-12-add-v1-warmup-endpoint` |
| `rate-limit-reset-credits` | `2026-07-12-add-rate-limit-reset-credits` |
| `release-automation` | `2026-06-02-cleanup-superseded-beta-release-prs` |
| `release-management` | `2026-06-02-add-beta-release-channel` |
| `report-aggregation` | `2026-09-09-harden-reports-performance` (archived by #2227) |
| `scheduler-coordination` | `2026-07-15-harden-scheduler-leader-election` |
| `unified-auth-export` | `2026-07-12-unify-auth-export` |
| `upstream-proxy-routing` | `2026-07-12-add-codex-proxy-pool-egress` |

Also verified: the five specs created by the 2026-09-09 archive batch (`account-deletion`, `configuration-tiers`, `deterministic-proxy-simulation`, `oauth-callback-privacy`, `reports`) already carry real Purposes; no change there. `grep -rl "TBD - created by" openspec/specs` now returns nothing.

## Test plan

```
openspec validate --specs --strict            # Totals: 64 passed, 0 failed
uv sync --frozen --group docs && uv run mkdocs build --strict   # Documentation built
make lint                                     # ruff / architecture / cancellation / timing / settings tiers all pass
python3 .github/scripts/check_simplicity_budgets.py            # all budgets OK
grep -rl "TBD - created by" openspec/specs    # empty
```

No Python, frontend, or migration files are touched, so no pytest / vitest targets apply.

## Screenshots / output

Not applicable — no user-visible surface.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above. (N/A — no tracking issue; campaign label applied.)
- [x] Added or updated tests covering the change. (N/A — prose-only spec edit; validated with `openspec validate --specs --strict`.)
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

