### PR TITLE
docs(helm): document the pre-1.13 StatefulSet migration shim and its deprecation

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -649,12 +649,19 @@ section covers the upgrade paths that need operator attention.
 ### From chart versions older than 1.13.0
 
 Chart 1.13.0 (codex-lb v1.13.0, April 2026, #363) moved the application from a
-`Deployment` named `<release>-codex-lb` to a `StatefulSet` named
-`<release>-codex-lb-workload` so `/responses` owner handoff can address pods by
-stable name. Helm cannot change a resource's kind in place, so the chart carries
-a three-piece shim that cuts the public Service over without dropping traffic:
+`Deployment` named `<fullname>` to a `StatefulSet` named `<fullname>-workload`
+so `/responses` owner handoff can address pods by stable name. Helm cannot
+change a resource's kind in place, so the chart carries a three-piece shim that
+keeps the public Service pointed at the legacy pods while the StatefulSet
+starts and then cuts it over:
 
-1. **`pre-upgrade` hook `<release>-codex-lb-legacy-prepare`**
+`<fullname>` below is the chart fullname (`codex-lb.fullname`): the release
+name itself when it contains `codex-lb` (release `codex-lb` -> `codex-lb`,
+the name used by the install commands in this README), otherwise
+`<release>-codex-lb`; `fullnameOverride` replaces both. The hook Job names
+truncate the fullname to fit the 63-character limit.
+
+1. **`pre-upgrade` hook `<fullname>-legacy-prepare`**
    (`templates/legacy-deployment-prepare-hook.yaml`): a Job that patches the
    legacy Deployment's pod template with the traffic-lane label
    `codex-lb.soju.dev/traffic: legacy` and waits (up to 10 minutes) for that
@@ -666,7 +673,7 @@ a three-piece shim that cuts the public Service over without dropping traffic:
    release) or still says `legacy`, the Service is rendered with the legacy
    selector so the old pods keep serving while the StatefulSet starts. Once the
    lane is `workload`, it stays `workload`.
-3. **`post-upgrade` hook `<release>-codex-lb-legacy-cleanup`**
+3. **`post-upgrade` hook `<fullname>-legacy-cleanup`**
    (`templates/legacy-deployment-cleanup-hook.yaml`): a Job that waits for the
    StatefulSet to reach its desired ready replicas, patches the Service
    selector to `codex-lb.soju.dev/traffic: workload`, then deletes the legacy
@@ -682,27 +689,41 @@ failed hook leaves its Job and logs behind for inspection.
 | Value | Effect |
 | --- | --- |
 | `auto` (default) | Lookup-based behaviour described above. |
-| `legacy` | Always select the legacy Deployment pods. Only useful to hold traffic on the old Deployment while debugging a stalled cutover. |
+| `legacy` | Render the legacy selector unconditionally. This only controls what the chart renders: the cleanup hook still patches the live Service to `workload` once the StatefulSet is ready, so `legacy` does not suspend the cutover. It only keeps the rendered selector on the legacy pods for as long as the StatefulSet is not ready (a stalled cutover), which `auto` does as well. |
 | `workload` | Always select the StatefulSet pods and skip the lookup. Safe once the cutover has completed. |
 
 Verify after the first upgrade from a pre-1.13 release:
 
 ```bash
 # the Service selects the StatefulSet pods
-kubectl get svc <release>-codex-lb -n <namespace> -o jsonpath='{.spec.selector}'
+kubectl get svc <fullname> -n <namespace> -o jsonpath='{.spec.selector}'
 # expected to contain "codex-lb.soju.dev/traffic":"workload"
 
 # the legacy Deployment is gone and the StatefulSet is ready
-kubectl get deploy <release>-codex-lb -n <namespace>   # NotFound
-kubectl get sts <release>-codex-lb-workload -n <namespace>
+kubectl get deploy <fullname> -n <namespace>   # NotFound
+kubectl get sts <fullname>-workload -n <namespace>
 
 # a failed hook keeps its Job for inspection
-kubectl logs job/<release>-codex-lb-legacy-prepare -n <namespace>
-kubectl logs job/<release>-codex-lb-legacy-cleanup -n <namespace>
+kubectl logs job/<fullname>-legacy-prepare -n <namespace>
+kubectl logs job/<fullname>-legacy-cleanup -n <namespace>
 ```
+
+For the `codex-lb` release from the install commands above, `<fullname>` is
+`codex-lb`: `kubectl get sts codex-lb-workload`, `job/codex-lb-legacy-cleanup`.
+A `NotFound` for the Deployment is only meaningful when the StatefulSet exists
+and the Service selector already says `workload`.
 
 Notes and opt-out:
 
+- **Plan the first upgrade from a pre-1.13 release as a maintenance window,
+  not a zero-downtime rollout.** The chart no longer renders the legacy
+  Deployment and nothing marks it `helm.sh/resource-policy: keep`, so Helm
+  itself removes it from the release during the upgrade's resource sync, which
+  runs before the `post-upgrade` cleanup hook. Its pods can therefore start
+  terminating while the Service still selects them and before the StatefulSet
+  is ready. The shim bounds the gap (the Service is never pointed at an
+  unready StatefulSet, and the cleanup hook waits for readiness before it
+  flips the selector); it does not eliminate it.
 - The hooks render on every `helm upgrade`, including releases first
   installed on 1.13.0 or later. There they are no-ops (the prepare Job finds no
   Deployment and exits 0; the cleanup Job re-applies the `workload` selector
@@ -743,11 +764,12 @@ the dashboard (PRINCIPLES.md P2 / P6). Visible to Helm users:
 
 **Removed environment variables.** `templates/configmap.yaml` no longer
 templates these; the application ignores them and logs one
-`removed setting(s) ignored` WARN at startup for one release.
+`removed setting(s) ignored` WARN at startup for at least one release (the
+names are pruned from the warning list afterwards and stay inert).
 
 | Removed variable | Former chart value | Replacement |
 | --- | --- | --- |
-| `CODEX_LB_UPSTREAM_STREAM_TRANSPORT` (#2192) | `config.upstreamStreamTransport` | Settings -> Routing -> Upstream stream transport (`auto` / `http` / `websocket`). Operators who pinned `http` or `websocket` must pin it again in the dashboard after upgrading; persisted `default` rows are migrated to `auto`. |
+| `CODEX_LB_UPSTREAM_STREAM_TRANSPORT` (#2192) | `config.upstreamStreamTransport` | Settings -> Advanced -> Routing -> Upstream stream transport (`auto` / `http` / `websocket`). Operators who pinned `http` or `websocket` must pin it again in the dashboard after upgrading; persisted `default` rows are migrated to `auto`. |
 | `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` (#2190) | `config.cacheAffinityMaxAgeSeconds` | The dashboard cache-affinity TTL, which was already the effective source: the env value only seeded the first-created settings row. |
 | `CODEX_LB_REQUEST_LOG_RETENTION_DAYS`, `CODEX_LB_USAGE_HISTORY_RETENTION_DAYS` (#2190) | `extraEnv` only | Settings -> Advanced -> Data retention. An empty dashboard value means retention is disabled; set the window once after upgrading. |
 | `CODEX_LB_HTTP_DOWNSTREAM_TRANSPORT_POLICY`, `CODEX_LB_WARMUP_MODEL`, `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_GATEWAY_SAFE_MODE` (#2190) | `extraEnv` only | Dashboard settings of the same name (first-boot seeds or never read). |
@@ -769,15 +791,23 @@ references them). Drop them at your convenience, and drop the raw names from
 Precedence is code default < environment < dashboard: the chart value is the
 effective value only while the dashboard field is left empty (shown as
 inherited). Once an operator saves a dashboard value, changing the chart value
-and rolling the pods has no effect until the dashboard field is cleared, and
-startup logs one `environment value(s) ignored because the dashboard owns the
-setting` WARN naming the shadowed variables. The same applies to every setting
-marked `T3 (dashboard)` in the
+and rolling the pods has no effect until the dashboard field is cleared. The
+same precedence applies to every setting marked `T3 (dashboard)` in the
 [settings reference](https://soju06.github.io/codex-lb/reference/settings/) when
 it is passed through `extraEnv` (request budgets, stream idle timeout, SSE
 keepalive, soft drain, deterministic failover, routing weights, overload
-isolation, per-account caps). These aliases are slated for removal in a later
-minor; move persistent overrides into the dashboard.
+isolation, per-account caps).
+
+Whether the shadowing is announced depends on the setting. For
+`config.upstreamConnectTimeout` and the other timeout/budget, per-account cap,
+routing-weight and overload-isolation aliases, startup logs one
+`environment value(s) ignored because the dashboard owns the setting` WARN
+naming the shadowed variables. The three resilience toggles
+(`config.circuitBreakerEnabled` / `CODEX_LB_CIRCUIT_BREAKER_ENABLED`, soft
+drain, deterministic failover) are overridden by a saved dashboard value
+without a startup WARN; check the toggle's provenance in Settings -> Advanced
+-> Resilience instead. These aliases are slated for removal in a later minor;
+move persistent overrides into the dashboard.
 
 ## Validation
 

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -639,7 +639,145 @@ overrides should retain additional helper-launch headroom.
 - External secrets installs keep the dedicated migration Job and fail closed behind the schema gate.
 - Bundled installs stay easy to bootstrap and keep the migration hook for upgrades.
 - StatefulSet pod-template checksums force rollouts when chart-managed ConfigMaps or Secrets change.
-- The workload resource name is intentionally different from the legacy Deployment name to avoid Helm kind-migration conflicts during upgrade.
+- The workload resource name is intentionally different from the legacy Deployment name to avoid Helm kind-migration conflicts during upgrade. Releases first installed before chart 1.13.0 go through the cutover described in [Upgrading](#upgrading).
+
+## Upgrading
+
+`helm upgrade` follows the [Upgrade Contract](#upgrade-contract) above. This
+section covers the upgrade paths that need operator attention.
+
+### From chart versions older than 1.13.0
+
+Chart 1.13.0 (codex-lb v1.13.0, April 2026, #363) moved the application from a
+`Deployment` named `<release>-codex-lb` to a `StatefulSet` named
+`<release>-codex-lb-workload` so `/responses` owner handoff can address pods by
+stable name. Helm cannot change a resource's kind in place, so the chart carries
+a three-piece shim that cuts the public Service over without dropping traffic:
+
+1. **`pre-upgrade` hook `<release>-codex-lb-legacy-prepare`**
+   (`templates/legacy-deployment-prepare-hook.yaml`): a Job that patches the
+   legacy Deployment's pod template with the traffic-lane label
+   `codex-lb.soju.dev/traffic: legacy` and waits (up to 10 minutes) for that
+   rollout to become ready. When no legacy Deployment exists the Job exits
+   immediately.
+2. **Service selector `auto` mode** (`templates/service.yaml`,
+   `migration.serviceSelectorMode`): during an upgrade the chart looks up the
+   existing Service. If its selector has no traffic-lane label yet (a pre-1.13
+   release) or still says `legacy`, the Service is rendered with the legacy
+   selector so the old pods keep serving while the StatefulSet starts. Once the
+   lane is `workload`, it stays `workload`.
+3. **`post-upgrade` hook `<release>-codex-lb-legacy-cleanup`**
+   (`templates/legacy-deployment-cleanup-hook.yaml`): a Job that waits for the
+   StatefulSet to reach its desired ready replicas, patches the Service
+   selector to `codex-lb.soju.dev/traffic: workload`, then deletes the legacy
+   Deployment.
+
+Each hook creates its own ServiceAccount, Role and RoleBinding. Helm deletes
+them together with the Job on success
+(`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`), so a
+failed hook leaves its Job and logs behind for inspection.
+
+`migration.serviceSelectorMode`:
+
+| Value | Effect |
+| --- | --- |
+| `auto` (default) | Lookup-based behaviour described above. |
+| `legacy` | Always select the legacy Deployment pods. Only useful to hold traffic on the old Deployment while debugging a stalled cutover. |
+| `workload` | Always select the StatefulSet pods and skip the lookup. Safe once the cutover has completed. |
+
+Verify after the first upgrade from a pre-1.13 release:
+
+```bash
+# the Service selects the StatefulSet pods
+kubectl get svc <release>-codex-lb -n <namespace> -o jsonpath='{.spec.selector}'
+# expected to contain "codex-lb.soju.dev/traffic":"workload"
+
+# the legacy Deployment is gone and the StatefulSet is ready
+kubectl get deploy <release>-codex-lb -n <namespace>   # NotFound
+kubectl get sts <release>-codex-lb-workload -n <namespace>
+
+# a failed hook keeps its Job for inspection
+kubectl logs job/<release>-codex-lb-legacy-prepare -n <namespace>
+kubectl logs job/<release>-codex-lb-legacy-cleanup -n <namespace>
+```
+
+Notes and opt-out:
+
+- The hooks render on every `helm upgrade`, including releases first
+  installed on 1.13.0 or later. There they are no-ops (the prepare Job finds no
+  Deployment and exits 0; the cleanup Job re-applies the `workload` selector
+  and ignores the missing Deployment), but they still create a short-lived Job
+  plus RBAC objects and wait for the StatefulSet to be ready. No values switch
+  disables them; the planned removal below is the opt-out.
+- Do not set `migration.serviceSelectorMode: workload` for the first upgrade
+  from a pre-1.13 release: the Service would switch to StatefulSet pods before
+  any are ready.
+- Client-side rendering cannot perform the `lookup`. `helm template` renders
+  the `workload` selector (it is not an upgrade); `helm upgrade --dry-run`
+  renders the `legacy` selector because the lookup comes back empty. Use
+  `helm upgrade --dry-run=server` to preview what the real upgrade renders, or
+  set `migration.serviceSelectorMode: workload` on releases that have completed
+  the cutover.
+
+### Deprecation: pre-1.13 migration shim
+
+Planned removal, announced here: the shim above (both legacy-deployment hooks,
+the lookup-based `auto` selector mode, the `codex-lb.legacySelectorLabels`
+helper and the `migration.serviceSelectorMode` value) is scheduled for removal
+in the first minor release after 1.26. After that release:
+
+- the public Service always renders the `workload` selector and
+  `migration.serviceSelectorMode` is no longer read;
+- `helm upgrade` no longer creates the two hook Jobs and their RBAC objects;
+- upgrading a release that is still on a chart older than 1.13.0 requires an
+  intermediate upgrade to any 1.13.0 - 1.26.x chart (so the cutover runs)
+  before moving to the current chart.
+
+Releases first installed on 1.13.0 or later, and releases that have already
+completed the cutover, are not affected.
+
+### Upgrading across 1.24 -> 1.25
+
+codex-lb 1.25 kept moving behaviour tunables out of the environment and into
+the dashboard (PRINCIPLES.md P2 / P6). Visible to Helm users:
+
+**Removed environment variables.** `templates/configmap.yaml` no longer
+templates these; the application ignores them and logs one
+`removed setting(s) ignored` WARN at startup for one release.
+
+| Removed variable | Former chart value | Replacement |
+| --- | --- | --- |
+| `CODEX_LB_UPSTREAM_STREAM_TRANSPORT` (#2192) | `config.upstreamStreamTransport` | Settings -> Routing -> Upstream stream transport (`auto` / `http` / `websocket`). Operators who pinned `http` or `websocket` must pin it again in the dashboard after upgrading; persisted `default` rows are migrated to `auto`. |
+| `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` (#2190) | `config.cacheAffinityMaxAgeSeconds` | The dashboard cache-affinity TTL, which was already the effective source: the env value only seeded the first-created settings row. |
+| `CODEX_LB_REQUEST_LOG_RETENTION_DAYS`, `CODEX_LB_USAGE_HISTORY_RETENTION_DAYS` (#2190) | `extraEnv` only | Settings -> Advanced -> Data retention. An empty dashboard value means retention is disabled; set the window once after upgrading. |
+| `CODEX_LB_HTTP_DOWNSTREAM_TRANSPORT_POLICY`, `CODEX_LB_WARMUP_MODEL`, `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_GATEWAY_SAFE_MODE` (#2190) | `extraEnv` only | Dashboard settings of the same name (first-boot seeds or never read). |
+
+`values.schema.json` does not reject unknown `config.*` keys, so values files or
+`--reuse-values` state that still carry `config.upstreamStreamTransport` or
+`config.cacheAffinityMaxAgeSeconds` render fine and are ignored (nothing
+references them). Drop them at your convenience, and drop the raw names from
+`extraEnv` to silence the startup WARN.
+
+**Environment variables that became deprecated aliases** (#2220, #2221,
+#2224). Two chart values still template settings the dashboard now owns:
+
+| Chart value | Environment variable | Dashboard home |
+| --- | --- | --- |
+| `config.upstreamConnectTimeout` | `CODEX_LB_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | Settings -> Advanced -> Upstream timeouts |
+| `config.circuitBreakerEnabled` | `CODEX_LB_CIRCUIT_BREAKER_ENABLED` | Settings -> Advanced -> Resilience |
+
+Precedence is code default < environment < dashboard: the chart value is the
+effective value only while the dashboard field is left empty (shown as
+inherited). Once an operator saves a dashboard value, changing the chart value
+and rolling the pods has no effect until the dashboard field is cleared, and
+startup logs one `environment value(s) ignored because the dashboard owns the
+setting` WARN naming the shadowed variables. The same applies to every setting
+marked `T3 (dashboard)` in the
+[settings reference](https://soju06.github.io/codex-lb/reference/settings/) when
+it is passed through `extraEnv` (request budgets, stream idle timeout, SSE
+keepalive, soft drain, deterministic failover, routing weights, overload
+isolation, per-account caps). These aliases are slated for removal in a later
+minor; move persistent overrides into the dashboard.
 
 ## Validation
 

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -134,6 +134,7 @@ config:
   # @param config.upstreamBaseUrl Override OpenAI upstream base URL (empty = default)
   upstreamBaseUrl: ""
   # @param config.upstreamConnectTimeout Upstream connection timeout seconds
+  # (deprecated env alias since 1.25: a value saved in Settings -> Advanced -> Upstream timeouts wins)
   upstreamConnectTimeout: 10
   # @param config.logFormat Log output format (json|text)
   logFormat: json
@@ -142,7 +143,8 @@ config:
   # @param config.leaderElectionTtlSeconds Leader election TTL in seconds
   leaderElectionTtlSeconds: 30
   # @param config.circuitBreakerEnabled Enable circuit breaker for upstream requests
-  # (failure threshold and recovery timeout are fixed application constants)
+  # (failure threshold and recovery timeout are fixed application constants;
+  # deprecated env alias since 1.25: a value saved in Settings -> Advanced -> Resilience wins)
   circuitBreakerEnabled: true
   # @param config.backpressureMaxConcurrentRequests Max concurrent in-flight requests
   backpressureMaxConcurrentRequests: 0
@@ -490,6 +492,9 @@ migration:
   # @param migration.enabled Run database migration Job on install/upgrade
   enabled: true
   # @param migration.serviceSelectorMode Public Service selector mode during controller migration (auto keeps legacy during first upgrade/cutover and workload after cutover)
+  # DEPRECATED: part of the pre-1.13 Deployment -> StatefulSet migration shim (with the
+  # legacy-deployment-*-hook.yaml Jobs). Planned removal in the first minor release after
+  # 1.26; the Service will then always select the StatefulSet pods. See README "Upgrading".
   serviceSelectorMode: auto
   # @param migration.backoffLimit Maximum retries before marking Job failed
   backoffLimit: 3

--- a/openspec/changes/document-helm-pre-1-13-shim-deprecation/proposal.md
+++ b/openspec/changes/document-helm-pre-1-13-shim-deprecation/proposal.md
@@ -1,0 +1,30 @@
+# Change: document-helm-pre-1-13-shim-deprecation
+
+## Why
+
+Chart 1.13.0 (#363) moved the application from a `Deployment` to a `StatefulSet` and added a three-piece migration shim (`legacy-deployment-prepare-hook.yaml`, `legacy-deployment-cleanup-hook.yaml`, the lookup-based `auto` Service selector mode behind `migration.serviceSelectorMode`). #2211 kept the shim because releases installed before 1.13.0 still depend on it, but the chart README never described the upgrade path, the shim's limits, or when the shim goes away. Announcing the removal is a compatibility commitment to Helm operators (AGENTS.md: operator-contract and compatibility changes are OpenSpec-gated), so the commitment is recorded here rather than only in the README.
+
+## What Changes
+
+- The chart README gains an `Upgrading` section: what the hooks do, the `migration.serviceSelectorMode` knob and what it does and does not control, verification commands keyed on the chart fullname, the caveat that the first upgrade from a pre-1.13 release is not zero-downtime (Helm removes the legacy Deployment during the resource sync, before the post-upgrade hook), and a `1.24 -> 1.25` note about the settings that left the environment.
+- Deprecation announced: the shim is planned for removal in the first minor release after 1.26. Until then the chart keeps rendering it; the removal itself is a separate OpenSpec change.
+- `values.yaml` marks `migration.serviceSelectorMode` as deprecated with a pointer to the README.
+
+No template or default changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: ADDED requirement — the pre-1.13 controller-migration shim is retained through the 1.26 minor, its upgrade path and limits are documented in the chart README, and its removal is announced there ahead of time.
+
+## Impact
+
+- Docs: `deploy/helm/codex-lb/README.md`, `deploy/helm/codex-lb/values.yaml` comments.
+- Operators: releases first installed on 1.13.0 or later are unaffected. Releases still on a pre-1.13 chart must upgrade to any 1.13.0 - 1.26.x chart before the shim is removed.
+
+Part of the slop-removal campaign 0908 (follow-up to #2211).

--- a/openspec/changes/document-helm-pre-1-13-shim-deprecation/specs/deployment-installation/spec.md
+++ b/openspec/changes/document-helm-pre-1-13-shim-deprecation/specs/deployment-installation/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Helm pre-1.13 controller-migration shim is retained through 1.26 and its removal is announced
+
+The Helm chart MUST keep rendering the pre-1.13 controller-migration shim (the `pre-upgrade` legacy-prepare hook, the `post-upgrade` legacy-cleanup hook, the lookup-based `auto` Service selector mode and the `migration.serviceSelectorMode` value) on every chart release up to and including the 1.26 minor. The chart README MUST document the upgrade path from chart versions older than 1.13.0: what each hook does, what `migration.serviceSelectorMode` controls (the rendered selector only; the cleanup hook cuts the live Service over regardless), how to verify the cutover using the chart fullname, and that the first upgrade from a pre-1.13 release is not zero-downtime because Helm removes the legacy Deployment during the resource sync before the post-upgrade hook runs. The README MUST state the planned removal (the first minor release after 1.26) and the intermediate-upgrade path for releases still on a pre-1.13 chart before the removal ships. Removing the shim MUST be its own OpenSpec change that supersedes this requirement.
+
+#### Scenario: Operator upgrades a release installed before chart 1.13.0
+
+- **GIVEN** a release installed from a chart older than 1.13.0 and any chart up to the 1.26 minor
+- **WHEN** the operator runs `helm upgrade`
+- **THEN** the chart renders the legacy-prepare and legacy-cleanup hooks and the `auto` selector mode
+- **AND** the chart README tells the operator to plan a maintenance window, how to verify the cutover, and what `migration.serviceSelectorMode` does and does not control
+
+#### Scenario: Operator reads the deprecation notice
+
+- **WHEN** an operator reads the chart README's `Upgrading` section
+- **THEN** it states that the shim is planned for removal in the first minor release after 1.26
+- **AND** it states that a release still on a pre-1.13 chart must first upgrade to a 1.13.0 - 1.26.x chart

--- a/openspec/changes/document-helm-pre-1-13-shim-deprecation/tasks.md
+++ b/openspec/changes/document-helm-pre-1-13-shim-deprecation/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## 1. Documentation
+
+- [x] 1.1 `deploy/helm/codex-lb/README.md`: `## Upgrading` with the pre-1.13 shim (hooks, `migration.serviceSelectorMode`, fullname-keyed verification, maintenance-window caveat, no-op-on-newer-releases note, dry-run limits), the deprecation statement, and the `1.24 -> 1.25` settings note (removed variables, deprecated aliases, which of them log the shadowing WARN).
+- [x] 1.2 `deploy/helm/codex-lb/values.yaml`: `DEPRECATED` comment on `migration.serviceSelectorMode`; alias notes on `config.upstreamConnectTimeout` and `config.circuitBreakerEnabled`.
+
+## 2. Verification
+
+- [x] 2.1 `helm lint deploy/helm/codex-lb`, `make helm-lint helm-template`, `uv run pytest tests/unit/test_helm_replica_artifacts.py`, `python3 .github/scripts/check_simplicity_budgets.py`.
+- [x] 2.2 `openspec validate document-helm-pre-1-13-shim-deprecation --strict` and `openspec validate --specs --strict`.


### PR DESCRIPTION
## Summary

Follow-up to #2211 (Helm legacy-deployment hooks kept): document the pre-1.13 Deployment -> StatefulSet migration shim the chart still carries, announce its planned removal, and add a 1.24 -> 1.25 upgrade note covering the settings changes visible to Helm users. Docs, values comments and a small OpenSpec change recording the deprecation commitment; no template or default changes.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [x] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: follow-up to #2211; context #363 (chart 1.13.0), #2190, #2192, #2220, #2221, #2224

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/document-helm-pre-1-13-shim-deprecation/` — ADDED `deployment-installation` requirement "Helm pre-1.13 controller-migration shim is retained through 1.26 and its removal is announced" (shim kept on every chart up to 1.26.x, README documents the path / knob scope / fullname-keyed verification / non-zero-downtime caveat, removal is its own change). No existing requirement covered the chart's controller-migration path; the deprecation is a compatibility commitment (AGENTS.md OpenSpec gate), hence the delta. The Helm README is not part of the mkdocs `docs_dir`, so no docs-site delta.

## Changes

- `deploy/helm/codex-lb/README.md`: new `## Upgrading` section after `## Upgrade Contract`:
  - **From chart versions older than 1.13.0** — what `legacy-deployment-prepare-hook.yaml` (pre-upgrade: labels the legacy Deployment pods `codex-lb.soju.dev/traffic: legacy`, waits for rollout) and `legacy-deployment-cleanup-hook.yaml` (post-upgrade: waits for the StatefulSet, patches the Service selector to `workload`, deletes the Deployment) do; the `migration.serviceSelectorMode` table (`auto` / `legacy` / `workload`); `kubectl` verification keyed on the chart fullname (release `codex-lb` renders `codex-lb`, not `codex-lb-codex-lb`); caveats: the first upgrade from a pre-1.13 release is **not zero-downtime** (Helm removes the legacy Deployment during the resource sync, before the post-upgrade hook; the shim bounds the gap, it does not remove it), `legacy` mode only controls the rendered selector (the cleanup hook patches the live Service regardless), the hooks render as no-ops on every upgrade and have no disable switch, do not force `workload` before cutover, `helm template` / `helm upgrade --dry-run` cannot `lookup` the Service (use `--dry-run=server`).
  - **Deprecation: pre-1.13 migration shim** — planned removal, announced here: first minor release after 1.26; what changes afterwards and the intermediate-upgrade path for releases still on a pre-1.13 chart.
  - **Upgrading across 1.24 -> 1.25** — table of removed env vars the chart no longer templates (`CODEX_LB_UPSTREAM_STREAM_TRANSPORT` / `config.upstreamStreamTransport` from #2192; `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` / `config.cacheAffinityMaxAgeSeconds`, retention aliases, transport policy, warmup model, gateway safe mode from #2190) with their dashboard replacements and the one-release startup WARN; table of the two chart values whose env vars became deprecated dashboard aliases (`config.upstreamConnectTimeout` -> Settings -> Advanced -> Upstream timeouts, `config.circuitBreakerEnabled` -> Settings -> Advanced -> Resilience) with the code default < env < dashboard precedence; the `environment value(s) ignored because the dashboard owns the setting` WARN is scoped to the settings that actually emit it (`_ENVIRONMENT_INHERITABLE_SETTINGS`: timeouts/budgets, per-account caps, routing weights, overload isolation) — the three resilience toggles (`RESILIENCE_TOGGLE_SETTINGS`) are overridden without a WARN, and the README says so.
  - The existing "workload resource name" bullet in Upgrade Contract now links to the new section.
- `openspec/changes/document-helm-pre-1-13-shim-deprecation/`: proposal, tasks, ADDED `deployment-installation` requirement (see OpenSpec above).
- `deploy/helm/codex-lb/values.yaml`: `DEPRECATED` comment on `migration.serviceSelectorMode` (planned removal, pointer to README) and one-line alias notes on `config.upstreamConnectTimeout` and `config.circuitBreakerEnabled`.

## Simplicity

No new setting, no default change, no root README section (the budgeted README is the repository root `README.md`; this PR touches the chart README only). `check_simplicity_budgets.py`: all within budget.

## Test plan

```
make helm-lint helm-template                                  # all 7 value overlays lint (--strict) and render
uv run pytest tests/unit/test_helm_replica_artifacts.py -q    # 28 passed (chart README bridge examples)
python3 .github/scripts/check_simplicity_budgets.py           # OK
helm lint deploy/helm/codex-lb                                # 0 failed
openspec validate document-helm-pre-1-13-shim-deprecation --strict && openspec validate --specs --strict   # valid; 63 passed
codex review --base origin/main                               # round 1: 4 P2 on the shim text (all confirmed against the templates, fixed); round 2: clean
helm template ... --set migration.serviceSelectorMode={auto,legacy,workload} -s templates/service.yaml
  # auto (template, not an upgrade) -> workload; legacy -> legacy; workload -> workload — matches the README text
helm template ... -s templates/configmap.yaml | grep -cE 'UPSTREAM_STREAM_TRANSPORT|CACHE_AFFINITY_MAX_AGE|RETENTION_DAYS|WARMUP_MODEL|DOWNSTREAM_TRANSPORT_POLICY|GATEWAY_SAFE_MODE'
  # 0 — the removed vars are no longer templated; UPSTREAM_CONNECT_TIMEOUT / CIRCUIT_BREAKER_ENABLED still are
```

Not run: `mkdocs build --strict` — the chart README is outside `docs_dir` and not in the mkdocs nav (`docs/deployment/kubernetes.md` links to it on GitHub). Not run: a live `helm upgrade` from a pre-1.13 release; the hook behaviour is described from the template sources.

## Screenshots / output

No user-visible surface beyond the README text.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change. (docs-only; existing `test_helm_replica_artifacts.py` still passes against the edited README)
- [x] Ran the relevant `make <target>` subset locally (`make helm-lint helm-template`).
- [x] If touching specs: `openspec validate document-helm-pre-1-13-shim-deprecation --strict` and `openspec validate --specs --strict` pass.
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

