### PR TITLE
feat(frontend): show provenance and reset-to-inherited on data retention settings

### DIFF
--- a/frontend/src/features/settings/components/data-retention-settings.test.tsx
+++ b/frontend/src/features/settings/components/data-retention-settings.test.tsx
@@ -106,15 +106,19 @@ describe("DataRetentionSettings", () => {
     expect(screen.getByRole("button", { name: "Save retention" })).toBeDisabled();
   });
 
-  it("shows empty inputs with the effective value as a hint while no value is stored", () => {
+  it("shows empty inputs with the shared Default badge while no value is stored", () => {
     render(
       <DataRetentionSettings
         settings={{
           ...baseSettings,
-          requestLogRetentionDays: 90,
+          requestLogRetentionDays: 0,
           usageHistoryRetentionDays: 0,
           requestLogRetentionOverrideDays: null,
           usageHistoryRetentionOverrideDays: null,
+          provenance: {
+            request_log_retention_days: { source: "default", envValue: null, default: 0 },
+            usage_history_retention_days: { source: "default", envValue: null, default: 0 },
+          },
         }}
         busy={false}
         onSave={vi.fn().mockResolvedValue(undefined)}
@@ -122,13 +126,56 @@ describe("DataRetentionSettings", () => {
     );
     expect(screen.getByLabelText("Request log retention days")).toHaveDisplayValue("");
     expect(screen.getByLabelText("Usage history retention days")).toHaveDisplayValue("");
-    expect(
-      screen.getByText("Not configured: effective 90 days (0 = disabled)"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Not configured: effective 0 days (0 = disabled)"),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("Default (0)")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Reset to inherited" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not configured/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save retention" })).toBeDisabled();
+  });
+
+  it("offers reset to inherited for a dashboard-owned window and clears only that field", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const settings = {
+      ...baseSettings,
+      requestLogRetentionDays: 90,
+      usageHistoryRetentionDays: 0,
+      requestLogRetentionOverrideDays: 90,
+      usageHistoryRetentionOverrideDays: null,
+      provenance: {
+        request_log_retention_days: { source: "dashboard" as const, envValue: null, default: 0 },
+        usage_history_retention_days: { source: "default" as const, envValue: null, default: 0 },
+      },
+    };
+
+    render(<DataRetentionSettings settings={settings} busy={false} onSave={onSave} />);
+
+    expect(screen.getByText("Default (0)")).toBeInTheDocument();
+    const reset = screen.getByRole("button", { name: "Reset to inherited" });
+    await user.click(reset);
+
+    expect(onSave).toHaveBeenCalledWith(
+      buildSettingsUpdateRequest(settings, { requestLogRetentionOverrideDays: null }),
+    );
+    expect(onSave.mock.calls[0][0]).not.toHaveProperty("usageHistoryRetentionOverrideDays");
+  });
+
+  it("renders no badge or hint against a backend that reports no provenance", () => {
+    render(
+      <DataRetentionSettings
+        settings={{
+          ...baseSettings,
+          requestLogRetentionDays: 90,
+          requestLogRetentionOverrideDays: null,
+          provenance: undefined,
+        }}
+        busy={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    expect(screen.getByLabelText("Request log retention days")).toHaveDisplayValue("");
+    expect(screen.queryByText(/Default \(/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not configured/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reset to inherited" })).not.toBeInTheDocument();
   });
 
   it("submits only the edited override field", async () => {

--- a/frontend/src/features/settings/components/data-retention-settings.tsx
+++ b/frontend/src/features/settings/components/data-retention-settings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { InheritBadge } from "@/features/settings/components/inherit-badge";
 import { buildSettingsUpdateRequest } from "@/features/settings/payload";
 import type { DashboardSettings, SettingsUpdateRequest } from "@/features/settings/schemas";
 
@@ -77,8 +78,6 @@ export function DataRetentionSettings({ settings, busy, onSave }: DataRetentionS
     void onSave(buildSettingsUpdateRequest(settings, patch));
   };
 
-  const showRequestLogInheritedHint = requestLogDays.trim() === "";
-  const showUsageHistoryInheritedHint = usageHistoryDays.trim() === "";
   const showRequestLogDisabledInfo = settings.requestLogRetentionDays === 0;
 
   return (
@@ -132,14 +131,16 @@ export function DataRetentionSettings({ settings, busy, onSave }: DataRetentionS
 
         <div className="divide-y rounded-lg border">
           <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
+            <div className="space-y-1">
               <p className="text-sm font-medium">{t("settings.retention.requestLogs.label")}</p>
               <p className="text-xs text-muted-foreground">{t("settings.retention.requestLogs.description")}</p>
-              {showRequestLogInheritedHint ? (
-                <p className="text-xs text-muted-foreground">
-                  {t("settings.retention.inheritedHint", { value: settings.requestLogRetentionDays })}
-                </p>
-              ) : null}
+              <InheritBadge
+                settings={settings}
+                name="request_log_retention_days"
+                field="requestLogRetentionOverrideDays"
+                busy={busy}
+                onSave={onSave}
+              />
             </div>
             <div className="flex items-center gap-2">
               <Input
@@ -159,14 +160,16 @@ export function DataRetentionSettings({ settings, busy, onSave }: DataRetentionS
             </div>
           </div>
           <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
+            <div className="space-y-1">
               <p className="text-sm font-medium">{t("settings.retention.usageHistory.label")}</p>
               <p className="text-xs text-muted-foreground">{t("settings.retention.usageHistory.description")}</p>
-              {showUsageHistoryInheritedHint ? (
-                <p className="text-xs text-muted-foreground">
-                  {t("settings.retention.inheritedHint", { value: settings.usageHistoryRetentionDays })}
-                </p>
-              ) : null}
+              <InheritBadge
+                settings={settings}
+                name="usage_history_retention_days"
+                field="usageHistoryRetentionOverrideDays"
+                busy={busy}
+                onSave={onSave}
+              />
             </div>
             <div className="flex items-center gap-2">
               <Input

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1337,7 +1337,6 @@
   "settings.retention.description": "Automatically prune old request logs and usage history on a background schedule.",
   "settings.retention.daysSuffix": "days",
   "settings.retention.inheritPlaceholder": "not set",
-  "settings.retention.inheritedHint": "Not configured: effective {{value}} days (0 = disabled)",
   "settings.retention.save": "Save retention",
   "settings.retention.requestLogs.label": "Request log retention",
   "settings.retention.requestLogs.description": "Delete request logs older than this many days. 0 disables deletion; non-zero values need at least 30 days. Leave empty to leave retention unconfigured (disabled).",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1101,7 +1101,6 @@
   "settings.retention.description": "백그라운드 스케줄에 따라 오래된 request log와 usage history를 자동 정리합니다.",
   "settings.retention.daysSuffix": "일",
   "settings.retention.inheritPlaceholder": "미설정",
-  "settings.retention.inheritedHint": "미설정: 적용값 {{value}}일 (0 = 비활성화)",
   "settings.retention.save": "보관 설정 저장",
   "settings.retention.requestLogs.label": "Request log 보관",
   "settings.retention.requestLogs.description": "이 일수보다 오래된 request log를 삭제합니다. 0은 삭제 비활성화이며, 0이 아닌 값은 최소 30일이어야 합니다. 비워두면 미설정 상태(비활성화)로 유지됩니다.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1337,7 +1337,6 @@
   "settings.retention.description": "按后台计划自动清理过期的请求日志和用量历史。",
   "settings.retention.daysSuffix": "天",
   "settings.retention.inheritPlaceholder": "未配置",
-  "settings.retention.inheritedHint": "未配置：生效值 {{value}} 天（0 表示禁用）",
   "settings.retention.save": "保存保留策略",
   "settings.retention.requestLogs.label": "请求日志保留",
   "settings.retention.requestLogs.description": "删除超过该天数的请求日志。0 表示禁用删除；非零值至少为 30 天。留空则保持未配置（禁用）。",

--- a/openspec/changes/retention-inherit-badge/.openspec.yaml
+++ b/openspec/changes/retention-inherit-badge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/retention-inherit-badge/proposal.md
+++ b/openspec/changes/retention-inherit-badge/proposal.md
@@ -1,0 +1,28 @@
+# Change: retention-inherit-badge
+
+## Why
+
+`settings-provenance` (#2214) gave every inheritable setting a `provenance` entry and a shared dashboard affordance (`InheritBadge` / `useInheritableSetting`) that the account-capacity caps, the resilience toggles, the upstream timeouts and the routing/overload knobs now use. The Data retention card was left on its bespoke "Not configured: effective {{value}} days" hint under a temporary allowance in `configuration-tiers` ("the two retention windows MAY keep their effective-value hint until their form is migrated"). The backend already resolves `request_log_retention_days` and `usage_history_retention_days` through the same resolver and reports `source` `default` | `dashboard` for them (no environment fallback since #2190), so the only thing missing is the form. Two different visual languages for the same concept on one page is exactly the kind of divergence `configuration-tiers` exists to remove.
+
+## What Changes
+
+- The Data retention card renders the shared `InheritBadge` under each window: `Default (0)` while the column is NULL (not configured = retention disabled) and `Reset to inherited` while the dashboard owns the value. The reset sends the existing tri-state `PUT /api/settings` with an explicit `null` for that window only.
+- The bespoke hint and its `settings.retention.inheritedHint` string are removed from `en`, `ko` and `zh-CN`. The tri-state input semantics (empty = clear to `null`, `0` = disabled, 30/45-day floors) and their validation messages are unchanged.
+- `configuration-tiers`: the temporary allowance for the retention windows is removed; every inheritable setting the dashboard exposes uses the shared affordance, and a plain hint is permitted only when the backend response carries no `provenance`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `configuration-tiers`: MODIFIED "The settings API reports value, source, environment value and default" (retention windows join the shared affordance; the migration allowance is deleted; one scenario added).
+
+## Impact
+
+- Frontend only: `frontend/src/features/settings/components/data-retention-settings.tsx`, its test, three locale files.
+- No API, schema or backend change; no new setting; no default changes.
+
+Part of the slop-removal campaign 0908 (follow-up to #2214 / #2219).

--- a/openspec/changes/retention-inherit-badge/specs/configuration-tiers/spec.md
+++ b/openspec/changes/retention-inherit-badge/specs/configuration-tiers/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: The settings API reports value, source, environment value and default
+
+For every inheritable setting — a setting whose NULL dashboard column falls back to the environment or to the code default — `GET /api/settings` and the response of `PUT /api/settings` MUST report the effective value together with its provenance, so an operator can tell whether a number is the code default, an environment variable set on this deployment, or a value saved in the dashboard. The shape is additive: the effective value stays in the existing top-level field of the setting's name (`value` is not duplicated), and `provenance`, a map keyed by setting name (the `dashboard_settings` column name, which is also the `Settings` field name for settings with an environment fallback), carries one entry per inheritable setting with `source` (`"dashboard"`, `"env"` or `"default"`), `env_value` and `default`. `source` MUST be computed by the single module-level resolver `resolve_inheritable` in `app/modules/settings/service.py` (no call site re-implements the precedence) as: `"dashboard"` when the column is non-NULL (including an explicit `0` or `false`); otherwise `"env"` when the setting has an environment fallback and the environment value differs from the code default; otherwise `"default"`. `env_value` MUST be the process environment value (the code default when the variable is unset) for a setting with an environment fallback and `null` for a database-only setting. `env_value` and `default` carry the setting's own scalar type. Adding `provenance` MUST NOT change any pre-existing response field: the flat `<name>`, `<name>_environment_value` and `<name>_override` fields remain as they are, a client that does not know `provenance` MUST keep working, and the dashboard MUST keep working against a backend that omits it. A setting promoted from the environment to the dashboard MUST be resolved through the same resolver and appear in `provenance`.
+
+`PUT /api/settings` MUST treat every inheritable setting as tri-state: a field that is omitted leaves the dashboard value unchanged, an explicit `null` clears the dashboard column so the setting returns to inheritance (`source` becomes `"env"` or `"default"`), and a concrete value is stored and wins over both. For every inheritable setting the dashboard exposes — the four account-capacity caps, the two retention windows, and every setting promoted from the environment to the dashboard — the dashboard MUST use the shared inherited affordance (`InheritBadge` / `useInheritableSetting`): a setting whose `source` is not `"dashboard"` is rendered as inherited, naming the layer and the value it inherits ("inherited from environment (12)", "default (8)"), and a setting whose `source` is `"dashboard"` offers a "reset to inherited" action that sends the existing tri-state `PUT /api/settings` with an explicit `null` for that setting and nothing else changed. No settings form renders a bespoke effective-value hint in place of the shared affordance; a form MAY fall back to a plain hint only when the backend response carries no `provenance`.
+
+#### Scenario: Provenance of an operator-set value
+
+- **GIVEN** an operator has set `proxy_account_stream_limit` to 24 through `PUT /api/settings` while the code default is 8
+- **WHEN** `GET /api/settings` is called
+- **THEN** `proxyAccountStreamLimit` is 24 and `provenance.proxy_account_stream_limit` is `{"source": "dashboard", "envValue": 8, "default": 8}`
+
+#### Scenario: Environment value differs from the default
+
+- **GIVEN** `proxy_account_stream_limit` is NULL in `dashboard_settings` and `CODEX_LB_PROXY_ACCOUNT_STREAM_LIMIT=12` while the code default is 8
+- **WHEN** `GET /api/settings` is called
+- **THEN** `proxyAccountStreamLimit` is 12 and `provenance.proxy_account_stream_limit` is `{"source": "env", "envValue": 12, "default": 8}`
+
+#### Scenario: Environment value equals the default
+
+- **GIVEN** the same column is NULL and the variable is unset or set to 8
+- **WHEN** `GET /api/settings` is called
+- **THEN** `provenance.proxy_account_stream_limit` is `{"source": "default", "envValue": 8, "default": 8}`
+
+#### Scenario: Clearing returns to inheritance
+
+- **GIVEN** an inheritable setting with an environment fallback and a non-NULL dashboard value
+- **WHEN** `PUT /api/settings` sets it to `null` and omits the other inheritable fields
+- **THEN** that column becomes NULL, the omitted settings are unchanged, and the response reports `source` as `"env"` (variable set to a non-default value) or `"default"` for the cleared setting
+
+#### Scenario: Resetting a database-only setting
+
+- **GIVEN** `request_log_retention_days` has no environment fallback and its column is NULL
+- **WHEN** `GET /api/settings` is called
+- **THEN** `provenance.request_log_retention_days` is `{"source": "default", "envValue": null, "default": 0}`; once an operator stores `0` the entry reports `source: "dashboard"`, and an explicit `null` on `PUT` returns it to `source: "default"`
+
+#### Scenario: Reset to inherited from the dashboard
+
+- **GIVEN** the routing settings show a stream limit whose `source` is `"dashboard"`
+- **WHEN** the operator activates "Reset to inherited"
+- **THEN** the dashboard sends `PUT /api/settings` with `proxyAccountStreamLimit: null` and the other fields unchanged, and the refreshed response reports `source` `"env"` or `"default"` for the stream limit
+
+
+#### Scenario: Retention windows use the shared inherited affordance
+
+- **GIVEN** `request_log_retention_days` reports `source` `"default"` and `usage_history_retention_days` reports `source` `"dashboard"`
+- **WHEN** the operator opens the Data retention card
+- **THEN** the request-log window is labelled "default (0)" with an empty input and no bespoke "not configured" hint, and the usage-history window offers "Reset to inherited", which sends `PUT /api/settings` with `usageHistoryRetentionOverrideDays: null` and no other retention field
+
+#### Scenario: Dashboard against an older backend
+
+- **GIVEN** a backend response without `provenance`
+- **WHEN** the dashboard parses it
+- **THEN** parsing succeeds and the capacity inputs fall back to the effective-value hint derived from the flat `<name>EnvironmentValue` fields

--- a/openspec/changes/retention-inherit-badge/tasks.md
+++ b/openspec/changes/retention-inherit-badge/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## 1. Dashboard
+
+- [x] 1.1 `DataRetentionSettings` renders `InheritBadge` (`request_log_retention_days` → `requestLogRetentionOverrideDays`, `usage_history_retention_days` → `usageHistoryRetentionOverrideDays`) under each window; bespoke hint removed; tri-state input, floors and validation messages unchanged.
+- [x] 1.2 `settings.retention.inheritedHint` removed from `en`, `ko`, `zh-CN` (key-parity test).
+- [x] 1.3 Tests: `Default (0)` badges with empty inputs, reset clears only the dashboard-owned window with an explicit `null`, no badge or hint against a backend without `provenance`.
+- [x] 1.4 Before/after screenshots (light and dark) in the PR.
+
+## 2. Spec
+
+- [x] 2.1 `configuration-tiers`: MODIFIED requirement removes the retention allowance and adds the "Retention windows use the shared inherited affordance" scenario.
+
+## 3. Verification
+
+- [x] 3.1 Frontend lint/typecheck/vitest, `make lint`, `uv run ty check`, `openspec validate --specs --strict`, `openspec validate retention-inherit-badge --strict`, `python3 .github/scripts/check_simplicity_budgets.py`.


### PR DESCRIPTION
## Summary

Frontend follow-up to #2214 / #2219: the Data retention card still rendered its own "Not configured: effective {{value}} days" hint while the capacity caps, Resilience, Upstream timeouts and Routing cards use the shared `InheritBadge` / `useInheritableSetting`. The backend already reports provenance for `request_log_retention_days` and `usage_history_retention_days` (`source` `default` | `dashboard`, `env_value` null since #2190), so this wires the shared affordance to both retention inputs and deletes the bespoke hint and the spec allowance that let it linger.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: follow-up to #2214 (settings provenance) and #2219 (openspec sync); slop-removal campaign 0908.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/retention-inherit-badge/` — MODIFIED `configuration-tiers` "The settings API reports value, source, environment value and default": the sentence "The two retention windows MAY keep their effective-value hint until their form is migrated to the shared component" is removed, the requirement now names the retention windows among the settings that use the shared affordance (a plain hint is permitted only when the response carries no `provenance`), and one scenario "Retention windows use the shared inherited affordance" is added. Delta is based on the current main text; `openspec validate --specs --strict` and `openspec validate retention-inherit-badge --strict` pass.

## Changes

- `frontend/src/features/settings/components/data-retention-settings.tsx`: each window renders `<InheritBadge name="request_log_retention_days" field="requestLogRetentionOverrideDays" />` / `<InheritBadge name="usage_history_retention_days" field="usageHistoryRetentionOverrideDays" />` under its description. `Default (0)` while the column is NULL (not configured = retention disabled); `Reset to inherited` while the dashboard owns the value, which sends the existing tri-state `PUT /api/settings` with an explicit `null` for that window only (the page already re-keys the card on override changes, so the draft input resets after the PUT). The bespoke hint and its `show*InheritedHint` flags are gone.
- Unchanged on purpose: the tri-state input (empty → `null`, `0` → disabled, value → override), the 30/45-day floor validation messages, the "pruning is disabled" notice + 30/90-day presets, and the "not set" placeholder.
- No `fallbackValue` is passed: against a backend that omits `provenance` (pre-#2214) the badge renders nothing rather than borrowing the capacity-cap "Inherited effective value" string, which would be misleading for a database-only setting with no environment layer. Covered by a test.
- i18n: `settings.retention.inheritedHint` removed from `en`, `ko`, `zh-CN` (key-parity test green). No new strings — the badge reuses `settings.inherit.*`.
- Tests (`data-retention-settings.test.tsx`): replaced the hint assertion with three cases — `Default (0)` badges with empty inputs and no reset button; reset on a dashboard-owned window calls `onSave` with `buildSettingsUpdateRequest(settings, { requestLogRetentionOverrideDays: null })` and no `usageHistoryRetentionOverrideDays`; no badge or hint without `provenance`.

## Simplicity

No new setting, README section, nav item or default change. Removes one bespoke UI pattern and one i18n key in favour of the shared component (P1/P2).

## Test plan

```
# frontend (worktree, shared node_modules)
bun run vitest run src/features/settings/components/data-retention-settings.test.tsx \
  src/features/settings/components/inherit-badge.test.tsx src/i18n/index.test.ts \
  src/features/settings/components/settings-page.test.tsx        # 4 files, 37 passed
bun run lint                                                      # clean
bun run typecheck                                                 # clean
# repo
make lint                                                         # ruff/format/architecture/cancellation/timing/settings-tiers ok
uv run ty check                                                   # All checks passed
python3 .github/scripts/check_simplicity_budgets.py               # ok
openspec validate --specs --strict                                # 63 passed
openspec validate retention-inherit-badge --strict                # valid
```

No Python or migration change, so no pytest / migration-check run.

Live check: backend `uv run codex-lb` on a temp `CODEX_LB_DATA_DIR` + free port, Vite dev proxied to it, password set through the bootstrap token from the log, then `PUT /api/settings {usageHistoryRetentionOverrideDays: 45}` → `provenance.request_log_retention_days = {source: default, envValue: null, default: 0}`, `provenance.usage_history_retention_days = {source: dashboard, …}`; the screenshots below are that state on `origin/main` (before) and this branch (after).

## Screenshots / output

| | Before (`origin/main` 09b48eb) | After |
|---|---|---|
| Light | ![before light](https://gist.githubusercontent.com/Soju06/04544df931ec1833e51fa7e59e067305/raw/before-retention-light.png) | ![after light](https://gist.githubusercontent.com/Soju06/04544df931ec1833e51fa7e59e067305/raw/after-retention-light.png) |
| Dark | ![before dark](https://gist.githubusercontent.com/Soju06/04544df931ec1833e51fa7e59e067305/raw/before-retention-dark.png) | ![after dark](https://gist.githubusercontent.com/Soju06/04544df931ec1833e51fa7e59e067305/raw/after-retention-dark.png) |

Before: the unconfigured request-log window shows the bespoke "Not configured: effective 0 days (0 = disabled)" line and the dashboard-owned usage-history window shows nothing. After: `Default (0)` badge on the request-log window and `Reset to inherited` on the usage-history window — the same affordance as the Resilience / Upstream timeouts / Routing cards above it. (Gist-hosted like #2214 / #2221.)

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

