### PR TITLE
fix(routing): resolve soft-drain from the dashboard snapshot on background paths

### DIFF
--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -12,6 +12,7 @@ from typing import Any, AsyncIterator, Protocol, cast
 from app.core.balancer.logic import RATE_LIMITED_MIN_COOLDOWN_SECONDS
 from app.core.config.settings import get_settings
 from app.core.plan_types import normalize_account_plan_type
+from app.core.resilience.toggles import resolve_resilience_toggles
 from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.usage import capacity_for_plan
 from app.core.utils.time import naive_utc_to_epoch
@@ -26,7 +27,7 @@ from app.modules.limit_warmup.service import (
     usage_reset_confirmed,
 )
 from app.modules.proxy.account_cache import get_account_selection_cache
-from app.modules.proxy.load_balancer import background_recovery_state_from_account
+from app.modules.proxy.load_balancer import background_recovery_state_from_account, effective_routing_tunables
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.settings.repository import SettingsRepository
@@ -249,6 +250,7 @@ class UsageRefreshScheduler:
                             usage_repo=UsageRepository(session),
                             accounts=refreshed_selected_accounts,
                             monthly_reset_evidence=monthly_reset_evidence,
+                            dashboard_settings=dashboard_settings,
                         )
                     warmup_service = LimitWarmupService(
                         cast(Any, _BackgroundLimitWarmupRepository()),
@@ -340,10 +342,21 @@ async def reconcile_recoverable_account_statuses(
     usage_repo: _LatestUsageRepository,
     accounts: list[Account],
     monthly_reset_evidence: dict[str, _MonthlyResetEvidence] | None = None,
+    dashboard_settings: object | None = None,
 ) -> int:
+    """Repair recoverable account statuses from the latest usage evidence.
+
+    ``dashboard_settings`` is the dashboard-settings row the refresh cycle
+    already read; the state builds below resolve soft drain and the routing
+    tunables from it once, so the health tier they compute follows the
+    dashboard toggle exactly like a request-path state build (``None`` = the
+    environment layer, for callers without a row).
+    """
     candidates = [account for account in accounts if account.status in _RECOVERABLE_ACCOUNT_STATUSES]
     if not candidates:
         return 0
+    routing_tunables = effective_routing_tunables(dashboard_settings)
+    soft_drain_enabled = resolve_resilience_toggles(dashboard_settings).soft_drain_enabled
 
     candidate_ids = [account.id for account in candidates]
     latest_primary = await usage_repo.latest_by_account(window="primary", account_ids=candidate_ids)
@@ -370,6 +383,8 @@ async def reconcile_recoverable_account_statuses(
                     monthly_entry=monthly_entry,
                     secondary_entry=latest_secondary.get(account.id),
                 ),
+                routing_tunables=routing_tunables,
+                soft_drain_enabled=soft_drain_enabled,
             )
             if state.status != AccountStatus.ACTIVE:
                 continue

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2116,8 +2116,7 @@ def _build_states(
     soft_drain_enabled: bool | None = None,
 ) -> tuple[list[AccountState], dict[str, Account]]:
     now = REAL_CLOCK.time() if now is None else now
-    # Background callers (quota planner, usage refresh) build from an empty
-    # runtime, where these knobs scale nothing; request paths pass the snapshot.
+    # Request and background callers pass their snapshot's values; None (tests, tools) = environment layer.
     tunables = routing_tunables or effective_routing_tunables()
     states: list[AccountState] = []
     account_map: dict[str, Account] = {}
@@ -2537,11 +2536,9 @@ def _state_from_account(
         else None
     )
 
-    settings = get_settings()
     if soft_drain_enabled is None:
-        # C2-3 resilience toggles: callers on the request path pass the
-        # dashboard value; anything else inherits the env alias / default.
-        soft_drain_enabled = resolve_resilience_toggles(None, startup_settings=settings).soft_drain_enabled
+        # C2-3 resilience toggles: callers pass the dashboard value; None (tests, tools) = env alias / default.
+        soft_drain_enabled = resolve_resilience_toggles(None, startup_settings=get_settings()).soft_drain_enabled
     new_tier = _sync_runtime_health_tier(
         account_id=account.id,
         status=status,
@@ -2734,11 +2731,14 @@ def background_recovery_state_from_account(
     account: Account,
     primary_entry: UsageHistory | None,
     secondary_entry: UsageHistory | None,
+    routing_tunables: RoutingTunables | None = None,
+    soft_drain_enabled: bool | None = None,
 ) -> AccountState:
     """Evaluate recovery without live runtime state.
 
     Seed a throwaway runtime from the persisted block marker so post-block usage
-    can clear stale reset guards after a balancer restart.
+    can clear stale reset guards after a balancer restart. ``routing_tunables`` and
+    ``soft_drain_enabled`` are the caller's dashboard-snapshot values (health tier follows the dashboard).
     """
 
     runtime = RuntimeState()
@@ -2758,6 +2758,8 @@ def background_recovery_state_from_account(
         secondary_entry=secondary_entry,
         runtime=runtime,
         now=now,
+        routing_tunables=routing_tunables,
+        soft_drain_enabled=soft_drain_enabled,
     )
     if account.status == AccountStatus.RATE_LIMITED:
         freshness_entry = _rate_limited_freshness_entry(

--- a/app/modules/quota_planner/api.py
+++ b/app/modules/quota_planner/api.py
@@ -208,6 +208,11 @@ async def get_quota_planner_forecast(
     horizon_hours: int = Query(default=36, ge=1, le=168, alias="horizonHours"),
     context: QuotaPlannerContext = Depends(get_quota_planner_context),
 ) -> QuotaPlannerForecastResponse:
+    # One dashboard-settings snapshot per request, taken before the first
+    # repository query: a cache refresh opens its own session, so it must not
+    # run while the request session already holds a pooled connection. No
+    # runtime lock is held here either.
+    dashboard_settings = await get_settings_cache().get()
     settings = await context.repository.get_settings()
     demand_slots = await context.repository.aggregate_demand_slot_units()
     forecast = build_demand_forecast(settings=settings, slot_units=demand_slots, horizon_hours=horizon_hours)
@@ -216,9 +221,6 @@ async def get_quota_planner_forecast(
     latest_primary = await usage_repo.latest_by_account()
     latest_secondary = await usage_repo.latest_by_account(window="secondary")
     latest_monthly = await usage_repo.latest_by_account(window="monthly")
-    # One dashboard-settings snapshot per request (no runtime lock is held
-    # here): the states follow the dashboard soft-drain toggle and tunables.
-    dashboard_settings = await get_settings_cache().get()
     states, _ = _build_states(
         accounts=accounts,
         latest_primary=latest_primary,

--- a/app/modules/quota_planner/api.py
+++ b/app/modules/quota_planner/api.py
@@ -10,11 +10,13 @@ from app.core.auth.dependencies import (
     set_dashboard_error_format,
     validate_dashboard_session,
 )
+from app.core.config.settings_cache import get_settings_cache
 from app.core.exceptions import DashboardBadRequestError
+from app.core.resilience.toggles import resolve_resilience_toggles
 from app.dependencies import QuotaPlannerContext, get_quota_planner_context
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache
-from app.modules.proxy.load_balancer import _build_states
+from app.modules.proxy.load_balancer import _build_states, effective_routing_tunables
 from app.modules.quota_planner.logic import PlannerSettings, build_demand_forecast, simulate_pool
 from app.modules.quota_planner.schemas import (
     QuotaPlannerDecisionResponse,
@@ -214,12 +216,17 @@ async def get_quota_planner_forecast(
     latest_primary = await usage_repo.latest_by_account()
     latest_secondary = await usage_repo.latest_by_account(window="secondary")
     latest_monthly = await usage_repo.latest_by_account(window="monthly")
+    # One dashboard-settings snapshot per request (no runtime lock is held
+    # here): the states follow the dashboard soft-drain toggle and tunables.
+    dashboard_settings = await get_settings_cache().get()
     states, _ = _build_states(
         accounts=accounts,
         latest_primary=latest_primary,
         latest_secondary=latest_secondary,
         latest_monthly=latest_monthly,
         runtime={},
+        routing_tunables=effective_routing_tunables(dashboard_settings),
+        soft_drain_enabled=resolve_resilience_toggles(dashboard_settings).soft_drain_enabled,
     )
     simulation = simulate_pool(settings=settings, states=states, demand_forecast=forecast)
     return _forecast_response(forecast, simulation)

--- a/app/modules/quota_planner/scheduler.py
+++ b/app/modules/quota_planner/scheduler.py
@@ -7,11 +7,13 @@ import time
 from datetime import datetime, timezone
 
 from app.core.config.settings import get_settings
+from app.core.config.settings_cache import get_settings_cache
+from app.core.resilience.toggles import resolve_resilience_toggles
 from app.core.scheduling.leader_election_handle import get_leader_election as _get_leader_election
 from app.core.utils.time import to_utc_naive
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
-from app.modules.proxy.load_balancer import _build_states
+from app.modules.proxy.load_balancer import _build_states, effective_routing_tunables
 from app.modules.quota_planner.logic import build_demand_forecast, plan_shadow_actions, simulate_pool
 from app.modules.quota_planner.repository import QuotaPlannerRepository
 from app.modules.quota_planner.warmup import QuotaWarmupService
@@ -72,6 +74,10 @@ class QuotaPlannerScheduler:
             )
 
     async def _run_once_as_leader(self) -> bool:
+        # One dashboard-settings snapshot per tick, taken before the session and
+        # outside any runtime lock: the account states below resolve soft drain
+        # and the routing tunables from it, not from the environment layer.
+        dashboard_settings = await get_settings_cache().get()
         async with get_background_session() as session:
             planner_repo = QuotaPlannerRepository(session)
             settings = await planner_repo.get_settings()
@@ -91,6 +97,8 @@ class QuotaPlannerScheduler:
                 latest_secondary=latest_secondary,
                 latest_monthly=latest_monthly,
                 runtime={},
+                routing_tunables=effective_routing_tunables(dashboard_settings),
+                soft_drain_enabled=resolve_resilience_toggles(dashboard_settings).soft_drain_enabled,
             )
             now = datetime.now(timezone.utc)
             demand_slots = await planner_repo.aggregate_demand_slot_units()

--- a/openspec/changes/background-paths-read-dashboard-snapshot/.openspec.yaml
+++ b/openspec/changes/background-paths-read-dashboard-snapshot/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/background-paths-read-dashboard-snapshot/proposal.md
+++ b/openspec/changes/background-paths-read-dashboard-snapshot/proposal.md
@@ -6,7 +6,7 @@
 
 ## What Changes
 
-- The quota planner tick takes one dashboard-settings snapshot per tick (`await get_settings_cache().get()`, before its session, outside any runtime lock) and the forecast endpoint takes one per request; both pass `effective_routing_tunables(snapshot)` and `resolve_resilience_toggles(snapshot).soft_drain_enabled` into `_build_states`.
+- The quota planner tick takes one dashboard-settings snapshot per tick (`await get_settings_cache().get()`, before its session, outside any runtime lock) and the forecast endpoint takes one per request (before its first repository query, so a cache refresh never opens a second session while the request session holds a pooled connection); both pass `effective_routing_tunables(snapshot)` and `resolve_resilience_toggles(snapshot).soft_drain_enabled` into `_build_states`.
 - `reconcile_recoverable_account_statuses` accepts the `dashboard_settings` row the usage-refresh cycle already read for the warmup service, resolves the toggle and the tunables once and passes them into `background_recovery_state_from_account`, which forwards them to `_state_from_account`. Callers without a row (tests) keep the environment layer.
 - No new setting, column, endpoint or dashboard surface; no runtime lock reads settings.
 

--- a/openspec/changes/background-paths-read-dashboard-snapshot/proposal.md
+++ b/openspec/changes/background-paths-read-dashboard-snapshot/proposal.md
@@ -1,0 +1,27 @@
+# Change: background-paths-read-dashboard-snapshot
+
+## Why
+
+`dashboard-managed-resilience-toggles` (#2220) and `dashboard-managed-routing-overload` (#2224) moved soft drain and the five routing/overload knobs into `dashboard_settings`, and every request path resolves them from the `SettingsCache` snapshot it already holds. Both changes deferred the background state builds: the quota planner tick (`QuotaPlannerScheduler._run_once_as_leader`), the quota planner forecast endpoint (`GET /api/quota-planner/forecast`) and the usage-refresh recovery reconciliation (`reconcile_recoverable_account_statuses` → `background_recovery_state_from_account`) passed no snapshot into `_build_states` / `_state_from_account`, so the health tier they computed inherited `CODEX_LB_SOFT_DRAIN_ENABLED` and the pressure knobs came from the environment. The configuration-tiers policy (P-F / P-F') is that every consumer of a dashboard-managed T3 setting reads the dashboard snapshot; an operator turning soft drain off in the dashboard must not see planner states that still drain. This is the follow-up both PRs recorded.
+
+## What Changes
+
+- The quota planner tick takes one dashboard-settings snapshot per tick (`await get_settings_cache().get()`, before its session, outside any runtime lock) and the forecast endpoint takes one per request; both pass `effective_routing_tunables(snapshot)` and `resolve_resilience_toggles(snapshot).soft_drain_enabled` into `_build_states`.
+- `reconcile_recoverable_account_statuses` accepts the `dashboard_settings` row the usage-refresh cycle already read for the warmup service, resolves the toggle and the tunables once and passes them into `background_recovery_state_from_account`, which forwards them to `_state_from_account`. Callers without a row (tests) keep the environment layer.
+- No new setting, column, endpoint or dashboard surface; no runtime lock reads settings.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `account-routing`: the requirements "Resilience toggles follow the dashboard value" and "Routing weights and overload isolation are dashboard settings" (both added by the two unarchived sibling changes above; this change builds on their text) no longer allow the background state builds to resolve the environment layer — they take one snapshot per tick or request — and gain a scenario each. This change MUST be archived after `dashboard-managed-resilience-toggles` and `dashboard-managed-routing-overload`.
+
+## Impact
+
+- Code: `app/modules/quota_planner/scheduler.py`, `app/modules/quota_planner/api.py`, `app/core/usage/refresh_scheduler.py`, `app/modules/proxy/load_balancer.py` (`background_recovery_state_from_account` signature; comments).
+- Behaviour: the planner's simulated account states and the recovery state build follow the dashboard soft-drain toggle and routing tunables within the settings cache TTL. Neither path routes traffic on the health tier, so account selection is unchanged.
+- No migration, no API change, no new environment variable.

--- a/openspec/changes/background-paths-read-dashboard-snapshot/specs/account-routing/spec.md
+++ b/openspec/changes/background-paths-read-dashboard-snapshot/specs/account-routing/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Resilience toggles follow the dashboard value
+
+Soft drain (the draining/probing health tiers), the deterministic failover decision and the circuit-breaker selection gate MUST be controlled by the `dashboard_settings` columns `soft_drain_enabled`, `deterministic_failover_enabled` and `circuit_breaker_enabled`. A NULL column MUST inherit the process environment value (the deprecated `CODEX_LB_*` alias) and then the code default, and a non-NULL column MUST win over both; the effective value MUST come from the single `configuration-tiers` resolver, and the settings API MUST report each toggle's effective value and provenance. Account selection MUST resolve the three toggles once from the dashboard-settings snapshot its caller obtained before entering runtime locks — the same snapshot that produced the concurrency caps — MUST apply that resolution to every reload of its selection inputs (sticky and non-sticky retries, exclusion- and security-filtered pools) and to opportunistic admission, and MUST NOT read the database, await the settings cache or read `get_settings().<toggle>` for them while holding a runtime lock or inside the retry loop. Force Probe settlement MUST take one snapshot before acquiring the account lock. The background state builds — the quota planner tick, the quota planner forecast endpoint and the usage-refresh recovery reconciliation — MUST resolve soft drain from one dashboard-settings snapshot taken per tick or per request outside any runtime lock (the settings cache, or the dashboard-settings row the usage-refresh cycle already read) and pass it into the state build, so the health tier they compute follows the dashboard toggle; they MUST NOT resolve the environment layer while a snapshot is available. Only a caller with no snapshot at all (tests, tools) resolves the environment layer, which is the pre-dashboard behaviour. Changing a toggle in the dashboard MUST take effect on the next selection on every replica without a restart.
+
+#### Scenario: Dashboard turns soft drain off
+
+- **GIVEN** `CODEX_LB_SOFT_DRAIN_ENABLED` is unset (default on) and an operator sets soft drain off in the dashboard
+- **WHEN** the next selection evaluates an account whose primary usage is above the fixed drain threshold
+- **THEN** the account stays in the healthy tier instead of entering the draining tier
+- **AND** no database read or settings-cache await happened under the runtime lock
+
+#### Scenario: Background state builds follow the dashboard soft-drain value
+
+- **GIVEN** `CODEX_LB_SOFT_DRAIN_ENABLED` is unset (default on) and the dashboard stores `soft_drain_enabled = false`
+- **WHEN** the quota planner tick or forecast endpoint builds its account states, or the usage-refresh recovery evaluates a recoverable account
+- **THEN** the states are built with soft drain off, so an account above the fixed drain threshold stays in the healthy tier
+- **AND** the snapshot was taken once for that tick or request, outside any runtime lock
+
+#### Scenario: Dashboard turns deterministic failover off
+
+- **GIVEN** an operator has set deterministic failover off in the dashboard
+- **WHEN** a stream, compact or WebSocket attempt fails before the first event with a failover-eligible classification
+- **THEN** the proxy surfaces the failure instead of retrying on the next account
+
+#### Scenario: Dashboard enables the circuit-breaker gate the environment left off
+
+- **GIVEN** `CODEX_LB_CIRCUIT_BREAKER_ENABLED=false` and an operator turns the circuit breaker on in the dashboard
+- **AND** every account's breaker is open
+- **WHEN** a selection runs
+- **THEN** the balancer reports the upstream as degraded because the breakers are open, without a restart
+
+#### Scenario: Inherited toggle follows a later environment change
+
+- **GIVEN** a toggle's dashboard column is NULL
+- **WHEN** the process environment value changes and the process restarts
+- **THEN** the new environment value applies and the settings API reports `source: "env"` (or `"default"` when it equals the code default)
+
+### Requirement: Routing weights and overload isolation are dashboard settings
+
+The in-flight pressure penalty (`proxy_account_inflight_penalty_pct`), the leased-token weight (`proxy_account_lease_token_weight`), the account lease TTL (`proxy_account_lease_ttl_seconds`), the overload isolation window (`proxy_overload_isolation_seconds`) and the error-rate weighting switch (`proxy_account_error_rate_weighting_enabled`) MUST be `dashboard_settings` columns of the same name, resolved as code default < environment < dashboard: a NULL column inherits the process environment value (or the code default), and a non-NULL column wins over the environment. The first-boot seed and the migration MUST leave the columns NULL. The settings API MUST expose each effective value with a `provenance` entry and accept the tri-state update (omitted = unchanged, `null` = inherit, value = store) with the bounds of the corresponding `Settings` field; the in-flight penalty MUST additionally be bounded at 100 on write (an inherited environment value above 100 MUST still be readable), and a dashboard lease TTL MUST satisfy the same `account-lease-ttl-covers-*` timeout invariants that startup validation applies to the environment value, evaluated against the effective request budgets. The load balancer MUST NOT read the process settings for these values on the request path: the proxy service MUST resolve them once per selection or lease operation from the cached dashboard snapshot it already holds for that operation (the snapshot the concurrency caps are derived from) and pass them into account selection, opportunistic admission and lease acquisition, and the balancer MUST thread that snapshot through every runtime-lock section of the operation without reading settings. A path that carries no request snapshot (the stream error funnel recording an overload rejection, an unkeyed bridge session reacquiring its lease) MUST reuse the balancer's most recent request snapshot rather than read settings; the environment applies only before the first request has been served. The background state builds (the quota planner tick and forecast endpoint, the usage-refresh recovery reconciliation) MUST resolve the knobs from the dashboard-settings snapshot they take once per tick or per request and pass them into the state build; only a caller with no snapshot at all (tests, tools) resolves the environment alone. A changed value takes effect within the settings cache TTL without a restart, with these runtime semantics: a new isolation window applies to trips recorded after the change only — an account already isolated keeps its existing deadline, and storing `0` does not lift an active isolation; a new lease TTL applies at the next stale-lease reclaim pass to every existing lease (judged by its acquisition time). The environment variables remain as deprecated fallbacks for one release and are removed in the next minor.
+
+#### Scenario: Dashboard value overrides startup environment
+
+- **GIVEN** the process environment sets `CODEX_LB_PROXY_ACCOUNT_INFLIGHT_PENALTY_PCT=2.5` and the dashboard stores `proxy_account_inflight_penalty_pct = 10`
+- **WHEN** account states are built for a selection
+- **THEN** each in-flight request adds 10 percentage points of pressure, not 2.5
+
+#### Scenario: Background state builds resolve the knobs from the dashboard snapshot
+
+- **GIVEN** the process environment leaves `proxy_account_inflight_penalty_pct` at 2.5 and the dashboard stores `proxy_account_inflight_penalty_pct = 37.5`
+- **WHEN** the quota planner tick or forecast endpoint builds its account states, or the usage-refresh recovery evaluates a recoverable account
+- **THEN** the state build receives the routing tunables resolved from the dashboard snapshot (in-flight penalty 37.5), not the environment value
+- **AND** no settings read happens under a runtime lock
+
+#### Scenario: Cleared dashboard value returns to the environment
+
+- **GIVEN** the dashboard stores `proxy_account_lease_ttl_seconds = 1200` while the environment sets `CODEX_LB_PROXY_ACCOUNT_LEASE_TTL_SECONDS=1800`
+- **WHEN** `PUT /api/settings` sends `proxyAccountLeaseTtlSeconds: null`
+- **THEN** the response reports the effective TTL 1800 with `provenance.proxy_account_lease_ttl_seconds.source` `"env"`
+- **AND** the next request snapshot judges stale leases against 1800 seconds
+
+#### Scenario: Isolation window change applies to future trips only
+
+- **GIVEN** an account isolated for 1800 seconds with 1000 seconds remaining
+- **WHEN** the dashboard stores `proxy_overload_isolation_seconds = 0` (or 240)
+- **THEN** the account stays isolated until its existing deadline
+- **AND** the next account whose window trips at the isolation level receives the soft backoff only (or 240 seconds)
+
+#### Scenario: Lease TTL change applies at the next reclaim pass
+
+- **GIVEN** a response-create lease acquired 700 seconds ago while the effective lease TTL was 900
+- **WHEN** the dashboard stores `proxy_account_lease_ttl_seconds = 600` and the next selection or lease acquisition runs its stale-lease reclaim
+- **THEN** that lease is reclaimed as stale in that pass
+
+#### Scenario: Selection never reads settings under the runtime lock
+
+- **GIVEN** a request whose selection acquires the balancer's runtime lock
+- **WHEN** the balancer builds states, reclaims stale leases and evaluates draw weights
+- **THEN** every knob comes from the `RoutingTunables` snapshot passed in for that operation and no settings or database read happens inside the lock section
+
+#### Scenario: Out-of-bounds value is rejected
+
+- **WHEN** `PUT /api/settings` sends `proxyAccountInflightPenaltyPct: 150`, `proxyAccountLeaseTtlSeconds: 0`, or a lease TTL below the proxy or compact request budget (for example 120 with the default 600 s budget)
+- **THEN** the request is rejected with a validation error naming the violated invariant and the stored values are unchanged

--- a/openspec/changes/background-paths-read-dashboard-snapshot/tasks.md
+++ b/openspec/changes/background-paths-read-dashboard-snapshot/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## 1. Backend
+
+- [x] 1.1 Quota planner tick: one `SettingsCache` snapshot per tick before the session; `_build_states` receives `routing_tunables` and `soft_drain_enabled` resolved from it.
+- [x] 1.2 Quota planner forecast endpoint: one snapshot per request, same two arguments.
+- [x] 1.3 Usage-refresh recovery: `reconcile_recoverable_account_statuses(dashboard_settings=...)` receives the row the cycle already read; `background_recovery_state_from_account` forwards `routing_tunables` / `soft_drain_enabled` to `_state_from_account`.
+- [x] 1.4 `_build_states` / `_state_from_account` comments no longer document the background env fallback.
+
+## 2. Verification
+
+- [x] 2.1 Unit: `background_recovery_state_from_account` health tier follows the passed dashboard value (above-threshold account stays healthy with soft drain off) and forwards the tunables; `reconcile_recoverable_account_statuses` resolves both from a fake dashboard row and falls back to the environment without one.
+- [x] 2.2 Integration: after `PUT /api/settings` stores values that differ from the environment, the forecast endpoint and the scheduler tick build states with the dashboard soft-drain value and in-flight penalty.
+- [x] 2.3 `make lint`, `uv run ty check`, touched test files, `openspec validate background-paths-read-dashboard-snapshot --strict`, `openspec validate --specs --strict`.

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -5,12 +5,14 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
+from app.core.resilience.toggles import resolve_resilience_toggles
 from app.core.utils.time import utcnow
 from app.db.models import (
     Account,
@@ -23,6 +25,8 @@ from app.db.models import (
 )
 from app.db.session import SessionLocal
 from app.modules.api_keys.service import ApiKeyInvalidError, ApiKeyNotFoundError, ApiKeyRateLimitExceededError
+from app.modules.quota_planner import api as quota_planner_api
+from app.modules.quota_planner import scheduler as quota_planner_scheduler
 from app.modules.quota_planner.logic import PlannerAction, PlannerSettings
 from app.modules.quota_planner.repository import QuotaPlannerRepository
 from app.modules.quota_planner.scheduler import QuotaPlannerScheduler
@@ -233,6 +237,58 @@ async def test_quota_planner_forecast_api_returns_simulation(async_client, db_se
     assert payload["slotSeconds"] == 900
     assert "simulation" in payload
     assert payload["simulation"]["forecastUnits"] == payload["totalDemandUnits"]
+
+
+def _record_build_states(monkeypatch, module) -> list[dict[str, Any]]:
+    captured: list[dict[str, Any]] = []
+    original_build_states = module._build_states
+
+    def recording_build_states(**kwargs):
+        captured.append(kwargs)
+        return original_build_states(**kwargs)
+
+    monkeypatch.setattr(module, "_build_states", recording_build_states)
+    return captured
+
+
+async def _store_dashboard_values_differing_from_environment(async_client) -> tuple[bool, float]:
+    soft_drain_enabled = not resolve_resilience_toggles(None).soft_drain_enabled
+    inflight_penalty_pct = 37.5
+    response = await async_client.put(
+        "/api/settings",
+        json={"softDrainEnabled": soft_drain_enabled, "proxyAccountInflightPenaltyPct": inflight_penalty_pct},
+    )
+    assert response.status_code == 200
+    return soft_drain_enabled, inflight_penalty_pct
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_forecast_builds_states_from_the_dashboard_snapshot(monkeypatch, async_client, db_setup):
+    del db_setup
+    captured = _record_build_states(monkeypatch, quota_planner_api)
+    soft_drain_enabled, inflight_penalty_pct = await _store_dashboard_values_differing_from_environment(async_client)
+
+    response = await async_client.get("/api/quota-planner/forecast?horizonHours=6")
+
+    assert response.status_code == 200
+    assert len(captured) == 1
+    assert captured[0]["soft_drain_enabled"] is soft_drain_enabled
+    assert captured[0]["routing_tunables"].inflight_penalty_pct == inflight_penalty_pct
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_scheduler_tick_builds_states_from_the_dashboard_snapshot(
+    monkeypatch, async_client, db_setup
+):
+    del db_setup
+    captured = _record_build_states(monkeypatch, quota_planner_scheduler)
+    soft_drain_enabled, inflight_penalty_pct = await _store_dashboard_values_differing_from_environment(async_client)
+
+    assert await QuotaPlannerScheduler()._run_once_as_leader() is True
+
+    assert len(captured) == 1
+    assert captured[0]["soft_drain_enabled"] is soft_drain_enabled
+    assert captured[0]["routing_tunables"].inflight_penalty_pct == inflight_penalty_pct
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -267,6 +267,24 @@ async def test_quota_planner_forecast_builds_states_from_the_dashboard_snapshot(
     del db_setup
     captured = _record_build_states(monkeypatch, quota_planner_api)
     soft_drain_enabled, inflight_penalty_pct = await _store_dashboard_values_differing_from_environment(async_client)
+    # The snapshot read may refresh the cache through its own session, so it
+    # must complete before the request session issues its first query and
+    # pins a pooled connection.
+    order: list[str] = []
+    settings_cache = quota_planner_api.get_settings_cache()
+    original_cache_get = settings_cache.get
+    original_planner_get_settings = QuotaPlannerRepository.get_settings
+
+    async def recording_cache_get(*args, **kwargs):
+        order.append("dashboard_snapshot")
+        return await original_cache_get(*args, **kwargs)
+
+    async def recording_planner_get_settings(self, *args, **kwargs):
+        order.append("first_repository_query")
+        return await original_planner_get_settings(self, *args, **kwargs)
+
+    monkeypatch.setattr(settings_cache, "get", recording_cache_get)
+    monkeypatch.setattr(QuotaPlannerRepository, "get_settings", recording_planner_get_settings)
 
     response = await async_client.get("/api/quota-planner/forecast?horizonHours=6")
 
@@ -274,6 +292,7 @@ async def test_quota_planner_forecast_builds_states_from_the_dashboard_snapshot(
     assert len(captured) == 1
     assert captured[0]["soft_drain_enabled"] is soft_drain_enabled
     assert captured[0]["routing_tunables"].inflight_penalty_pct == inflight_penalty_pct
+    assert order.index("dashboard_snapshot") < order.index("first_repository_query")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -28,6 +28,7 @@ from app.core.balancer import (
 from app.core.balancer.logic import DRAIN_PRIMARY_THRESHOLD_PCT, PROBE_QUIET_SECONDS
 from app.core.usage.quota import apply_usage_quota
 from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.proxy._load_balancer.tunables import RoutingTunables
 from app.modules.proxy.load_balancer import (
     RuntimeState,
     _additional_quota_applies_to_plan,
@@ -6290,3 +6291,52 @@ def test_select_account_fill_first_primary_dominates_over_secondary():
     assert result.account is not None
     # Primary still wins -- only ties break on secondary.
     assert result.account.account_id == "high-secondary"
+
+
+def test_background_recovery_state_from_account_follows_the_dashboard_soft_drain_and_tunables(monkeypatch):
+    """Usage-refresh recovery builds its state from the values the caller resolved from its dashboard row."""
+    import app.modules.proxy.load_balancer as load_balancer_module
+
+    now = 1_700_000_000.0
+    monkeypatch.setattr("time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    account = _make_test_account(status=AccountStatus.ACTIVE)
+    draining_primary = _make_test_usage(
+        window="primary",
+        used_percent=DRAIN_PRIMARY_THRESHOLD_PCT + 5.0,
+        reset_at=int(now + 3600),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+        window_minutes=300,
+    )
+    captured: list[dict[str, object]] = []
+    original_state_from_account = load_balancer_module._state_from_account
+
+    def recording_state_from_account(**kwargs):
+        captured.append(kwargs)
+        return original_state_from_account(**kwargs)
+
+    monkeypatch.setattr(load_balancer_module, "_state_from_account", recording_state_from_account)
+    dashboard_tunables = RoutingTunables(inflight_penalty_pct=37.5)
+
+    # Environment layer (soft drain defaults on): the account above the fixed threshold drains.
+    assert (
+        background_recovery_state_from_account(
+            account=account,
+            primary_entry=draining_primary,
+            secondary_entry=None,
+        ).health_tier
+        == 1
+    )
+    # The dashboard value the caller resolved wins: soft drain off keeps the account healthy.
+    state = background_recovery_state_from_account(
+        account=account,
+        primary_entry=draining_primary,
+        secondary_entry=None,
+        routing_tunables=dashboard_tunables,
+        soft_drain_enabled=False,
+    )
+    assert state.health_tier == 0
+    assert captured[-1]["soft_drain_enabled"] is False
+    assert captured[-1]["routing_tunables"] is dashboard_tunables
+    assert captured[0]["soft_drain_enabled"] is None
+    assert captured[0]["routing_tunables"] is None

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -4,12 +4,15 @@ import asyncio
 from collections.abc import Awaitable, Callable, Collection
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
+from app.core.resilience.toggles import resolve_resilience_toggles
 from app.core.usage import refresh_scheduler as refresh_scheduler_module
 from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.proxy.load_balancer import effective_routing_tunables
 
 pytestmark = pytest.mark.unit
 
@@ -1582,3 +1585,53 @@ async def test_refresh_slices_scope_queries_and_followups_to_selected_account(
     assert set(cast("dict[str, UsageHistory]", warmup_calls[0]["after_primary"])) == {"acc_b"}
     assert invalidations == 1
     assert open_sessions == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_builds_states_from_the_dashboard_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recovery state build resolves soft drain and the routing tunables from the cycle's dashboard row."""
+    now = 1_700_000_000.0
+    monkeypatch.setattr("time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+    candidate = _make_account(
+        "acc_rate_limited",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=int(now + 3600),
+        blocked_at=int(now - 30),
+    )
+    captured: list[dict[str, Any]] = []
+    original_state_from_account = refresh_scheduler_module.background_recovery_state_from_account
+
+    def recording_state_from_account(**kwargs: Any):
+        captured.append(kwargs)
+        return original_state_from_account(**kwargs)
+
+    monkeypatch.setattr(
+        refresh_scheduler_module, "background_recovery_state_from_account", recording_state_from_account
+    )
+    environment_soft_drain = resolve_resilience_toggles(None).soft_drain_enabled
+    environment_penalty = effective_routing_tunables(None).inflight_penalty_pct
+    dashboard_row = SimpleNamespace(
+        soft_drain_enabled=not environment_soft_drain,
+        proxy_account_inflight_penalty_pct=environment_penalty + 35.0,
+    )
+
+    async def reconcile(dashboard_settings: object | None) -> int:
+        return await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+            accounts_repo=StubAccountsRepository([candidate]),
+            usage_repo=StubUsageRepository(),
+            accounts=[candidate],
+            dashboard_settings=dashboard_settings,
+        )
+
+    assert await reconcile(dashboard_row) == 0
+    assert captured[-1]["soft_drain_enabled"] is (not environment_soft_drain)
+    assert captured[-1]["routing_tunables"].inflight_penalty_pct == environment_penalty + 35.0
+
+    # Without a row (callers outside the refresh cycle) the environment layer still applies.
+    assert await reconcile(None) == 0
+    assert captured[-1]["soft_drain_enabled"] is environment_soft_drain
+    assert captured[-1]["routing_tunables"].inflight_penalty_pct == environment_penalty


### PR DESCRIPTION
## Summary

Follow-up to #2220 (C2-3) and #2224 (C2-2): the three background state builds — the quota planner tick, the quota planner forecast endpoint and the usage-refresh recovery reconciliation — passed no dashboard-settings snapshot into `_build_states` / `_state_from_account`, so the health tier they computed inherited `CODEX_LB_SOFT_DRAIN_ENABLED` and the routing tunables came from the environment even when the dashboard stored a different value. They now read the dashboard snapshot like every other consumer of a T3 setting (configuration-tiers P-F / P-F').

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: follow-up recorded in the "Deferred" notes of #2220 and #2224 (no separate issue). Part of the slop-removal campaign 0908.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/background-paths-read-dashboard-snapshot/`

The delta MODIFIES the two `account-routing` requirements added by the (merged, not yet archived) sibling changes `dashboard-managed-resilience-toggles` and `dashboard-managed-routing-overload` — "Resilience toggles follow the dashboard value" and "Routing weights and overload isolation are dashboard settings" — replacing the sentence that allowed background callers to resolve the environment layer, and adds one scenario to each. Based on the current delta text; this change must be archived after those two. `openspec validate background-paths-read-dashboard-snapshot --strict` and `openspec validate --specs --strict` pass.

## Changes

- `app/modules/quota_planner/scheduler.py`: `_run_once_as_leader` takes one `await get_settings_cache().get()` per tick, before opening its session and outside any runtime lock, and passes `routing_tunables=effective_routing_tunables(snapshot)` / `soft_drain_enabled=resolve_resilience_toggles(snapshot).soft_drain_enabled` into `_build_states`.
- `app/modules/quota_planner/api.py`: `GET /api/quota-planner/forecast` does the same once per request, before its first repository query (a cache refresh opens its own session, so it must not run while the request session already holds a pooled connection; local `codex review` reproduced a bounded-pool checkout timeout with the snapshot taken after the queries).
- `app/core/usage/refresh_scheduler.py`: `reconcile_recoverable_account_statuses(..., dashboard_settings=)` receives the `dashboard_settings` row the refresh cycle already read for the warmup service (no extra read), resolves the toggle and the tunables once per call and passes them into `background_recovery_state_from_account`. Callers without a row (tests) keep the environment layer.
- `app/modules/proxy/load_balancer.py`: `background_recovery_state_from_account` gains `routing_tunables` / `soft_drain_enabled` and forwards them to `_state_from_account`; the comments that documented the background env fallback are rewritten (file stays at the 3021-line architecture ceiling; `settings = get_settings()` inlined into its only use).
- C2-2 tunables: with an empty runtime the pressure knobs scale nothing, but the snapshot is threaded anyway so the same rule (every consumer reads the snapshot) holds for both toggle and tunables; no behaviour change in selection.

No new setting, column, endpoint, dashboard surface or migration. No settings read under a runtime lock (neither path holds one).

## Simplicity

No new setting, README section, dashboard nav item or default change — section not applicable.

## Test plan

New tests (one per path, dashboard value ≠ environment):

- `tests/unit/test_load_balancer.py::test_background_recovery_state_from_account_follows_the_dashboard_soft_drain_and_tunables` — an account above the fixed drain threshold drains on the environment layer (tier 1) and stays healthy (tier 0) with `soft_drain_enabled=False`; the tunables object is forwarded to `_state_from_account`.
- `tests/unit/test_usage_refresh_scheduler_recovery.py::test_reconcile_recoverable_account_statuses_builds_states_from_the_dashboard_row` — fake row (`soft_drain_enabled` inverted, in-flight penalty env+35) reaches `background_recovery_state_from_account`; without a row the environment applies.
- `tests/integration/test_quota_planner_api.py::test_quota_planner_forecast_builds_states_from_the_dashboard_snapshot` and `::test_quota_planner_scheduler_tick_builds_states_from_the_dashboard_snapshot` — after `PUT /api/settings` stores `softDrainEnabled` (inverted) and `proxyAccountInflightPenaltyPct: 37.5`, both `_build_states` calls receive the dashboard values; the forecast test additionally asserts the snapshot read precedes the first repository query.

```
uv run pytest -q tests/unit/test_load_balancer.py tests/unit/test_usage_refresh_scheduler_recovery.py tests/unit/test_quota_planner.py tests/unit/test_routing_tunables.py tests/unit/test_resilience_toggles.py tests/unit/test_proxy_load_balancer_refresh.py
# 448 passed, 3 skipped
uv run pytest -q tests/integration/test_quota_planner_api.py tests/integration/test_resilience_toggles_runtime.py tests/integration/test_usage_refresh_scheduler_scope.py tests/integration/test_atomic_quota_warmup_claims.py
# 47 passed
make lint            # ruff + architecture (load_balancer.py 3021/3021) + cancellation-safety + timing seams + settings tiers: ok
uv run ty check      # All checks passed!
python3 .github/scripts/check_simplicity_budgets.py   # OK
openspec validate background-paths-read-dashboard-snapshot --strict && openspec validate --specs --strict   # 63 passed
```

## Screenshots / output

No user-visible surface (background state builds; the settings API and dashboard are unchanged).

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally (`make lint`, `uv run ty check`, the unit/integration files above).
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean (`openspec validate --specs --strict` 63/63; `openspec validate background-paths-read-dashboard-snapshot --strict` valid).
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

