### PR TITLE
perf(dashboard): memoize weekly demand delta aggregates with a short TTL

### DIFF
--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -26,6 +27,40 @@ from app.modules.usage.repository import (
     UsageHistorySnapshot,
     UsageRepository,
 )
+
+# The weekly credit pace's trailing-demand aggregate (a LAG window over seven
+# days of usage_history per account) is re-run by every /dashboard/overview
+# and /dashboard/projections poll although the displayed pace tolerates short
+# staleness. Cache it per account->window signature for a small fixed TTL,
+# mirroring the request-log COUNT cache (app/modules/request_logs/repository.py);
+# the test suite patches the TTL to 0 so pace figures stay exact within a test.
+_TRAILING_DEMAND_TTL_SECONDS = 60.0
+_TRAILING_DEMAND_MAX_ENTRIES = 16
+# (window span in whole seconds, sorted account -> window pairs)
+_TrailingDemandKey = tuple[int, tuple[tuple[str, NormalizedUsageWindow], ...]]
+_trailing_demand_cache: dict[_TrailingDemandKey, tuple[dict[str, float], float]] = {}
+
+
+def _clear_trailing_demand_cache() -> None:
+    _trailing_demand_cache.clear()
+
+
+def _cached_trailing_demand(key: _TrailingDemandKey) -> dict[str, float] | None:
+    entry = _trailing_demand_cache.get(key)
+    if entry is None:
+        return None
+    deltas, expires_at = entry
+    if time.monotonic() >= expires_at:
+        _trailing_demand_cache.pop(key, None)
+        return None
+    return deltas
+
+
+def _store_trailing_demand(key: _TrailingDemandKey, deltas: dict[str, float], ttl_seconds: float) -> None:
+    if len(_trailing_demand_cache) >= _TRAILING_DEMAND_MAX_ENTRIES:
+        oldest = min(_trailing_demand_cache, key=lambda existing: _trailing_demand_cache[existing][1])
+        _trailing_demand_cache.pop(oldest, None)
+    _trailing_demand_cache[key] = (deltas, time.monotonic() + ttl_seconds)
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,11 +118,31 @@ class DashboardRepository:
         since: datetime,
         until: datetime,
     ) -> dict[str, float]:
-        return await self._usage_repo.positive_used_percent_deltas_by_account(
+        """Trailing positive used-percent deltas, memoized per window span and account->window signature.
+
+        The key carries the span ``until - since`` but not the bounds themselves:
+        both dashboard callers pass a trailing window anchored at ``now``, so
+        within the TTL the window drifts by at most the TTL and the figure is
+        display-only. A different span, account set or window mapping is its
+        own key.
+        """
+        ttl_seconds = _TRAILING_DEMAND_TTL_SECONDS
+        cache_key: _TrailingDemandKey = (
+            round((until - since).total_seconds()),
+            tuple(sorted(account_windows.items())),
+        )
+        if ttl_seconds > 0:
+            cached = _cached_trailing_demand(cache_key)
+            if cached is not None:
+                return dict(cached)
+        deltas = await self._usage_repo.positive_used_percent_deltas_by_account(
             account_windows,
             since=since,
             until=until,
         )
+        if ttl_seconds > 0:
+            _store_trailing_demand(cache_key, deltas, ttl_seconds)
+        return dict(deltas)
 
     async def aggregate_logs_by_bucket(
         self,

--- a/openspec/changes/memoize-weekly-demand-deltas/.openspec.yaml
+++ b/openspec/changes/memoize-weekly-demand-deltas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/memoize-weekly-demand-deltas/proposal.md
+++ b/openspec/changes/memoize-weekly-demand-deltas/proposal.md
@@ -1,0 +1,30 @@
+# Change: memoize-weekly-demand-deltas
+
+## Why
+
+The weekly credit pace card needs, per account, the sum of positive `used_percent` deltas over the trailing seven days of `usage_history` (the `weekly_demand_samples` LAG window in `UsageRepository.positive_used_percent_deltas_by_account`). Production `pg_stat_statements` shows this statement at a mean of ~1.7 s and hundreds of executions per day while a dashboard is open, because it is re-run by every poll of both dashboard endpoints.
+
+Callers (verified by grep over `app/`): only `DashboardService.get_overview` and `DashboardService.get_projections` (`app/modules/dashboard/service.py`) call `DashboardRepository.positive_used_percent_deltas_by_account`; the quota planner and the proxy hot path do not. Both callers pass the same argument shape — `_weekly_history_windows(primary_usage, secondary_usage)` (deterministic for a given latest-usage set) and a `DEMAND_WINDOW` trailing window anchored at `now` — so at the default 15 s dashboard refresh the same aggregate is computed roughly eight times per minute for a value that only moves when the usage poller appends a sample.
+
+## What Changes
+
+- `DashboardRepository.positive_used_percent_deltas_by_account` memoizes the aggregate in a process-local dict keyed by the window span (`until - since`, whole seconds) plus the sorted `account -> window` signature, for a fixed `_TRAILING_DEMAND_TTL_SECONDS = 60.0` (module constant, same precedent as `_COUNT_CACHE_TTL_SECONDS = 30.0` in `app/modules/request_logs/repository.py`; not a `CODEX_LB_*` setting, per the zero-config rule). The window bounds themselves are deliberately excluded from the key: both callers pass a window anchored at `now`, so within the TTL the window drifts by at most 60 s and the figure is display-only; keying on the span keeps a future caller with a different trailing window from being served another caller's entry. Hits return a copy so callers cannot mutate the cached value. The dict is bounded (16 entries, oldest-expiry eviction) and `_clear_trailing_demand_cache()` exists for tests.
+- Cross-replica staleness: this cache serves a display-only figure, gates no security, authorization or routing decision, and therefore does not register a cache-invalidation namespace; its documented maximum cross-replica staleness is the 60 s TTL. Account deletion or a change of the latest-usage set changes the key, so a stale entry is at worst served for the remainder of its TTL.
+- `tests/conftest.py` gains an autouse fixture that clears the dict and zeroes the TTL (mirroring `_disable_request_log_count_cache`) so existing weekly-pace tests keep exact per-request figures; cache-behaviour tests patch the TTL back to a positive value.
+- Expected effect: `weekly_demand_samples` executions drop from 2 endpoints x 4 polls/min (8/min) to about 2/min per process: the frontend polls overview and projections concurrently at the same interval and there is no in-flight dedup, so on each TTL expiry both requests miss and both run the aggregate. Per-execution cost is unchanged (out of scope). Not changed: `/api/dashboard/projections` keeps returning `weekly_credit_pace` (removing it would be an API change and is a separate follow-up now that the memo dedups it).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `query-caching`: ADDED requirement "Weekly credit pace trailing demand is memoized per process".
+
+## Impact
+
+- Code: `app/modules/dashboard/repository.py` (memo + constants), `tests/conftest.py` (autouse reset fixture), new unit and integration tests.
+- API/schema: none. Settings: none (settings-field ratchet unchanged). Docs: none (no published page renders this capability).
+- Operators: no action; the weekly pace card may lag a fresh usage sample by up to 60 s on top of the poller interval.

--- a/openspec/changes/memoize-weekly-demand-deltas/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-weekly-demand-deltas/specs/query-caching/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Weekly credit pace trailing demand is memoized per process
+
+The dashboard MUST NOT re-run the trailing positive used-percent delta aggregate over `usage_history` on every poll; `GET /api/dashboard/overview` and `GET /api/dashboard/projections` MUST reuse the result for the same trailing window span and `account -> window` signature from a process-local cache within a fixed 60-second TTL (an application constant, not an operator tunable). The window span (`until - since`) is part of the cache identity; the bounds themselves are not, because both callers anchor the window at the current time, so within the TTL the window drifts by at most the TTL. The cached figure is display-only, gates no security, authorization, or routing decision, and its documented maximum cross-replica staleness is the 60-second TTL; it therefore does not register a cache-invalidation namespace. The cache MUST be bounded and MUST return a copy so callers cannot alter the cached value.
+
+#### Scenario: Overview and projections polls share one aggregate within the TTL
+
+- **GIVEN** the latest usage rows yield the same `account -> window` signature for two dashboard requests within 60 seconds
+- **WHEN** `/api/dashboard/overview` and then `/api/dashboard/projections` are served
+- **THEN** the `weekly_demand_samples` aggregate is executed once and both responses carry the same trailing-demand figure
+
+#### Scenario: A different account signature is aggregated on its own
+
+- **GIVEN** a cached trailing-demand result for one `account -> window` signature
+- **WHEN** a request resolves a different signature (an account added or removed, or an account's weekly window remapped)
+- **THEN** its trailing demand comes from its own aggregate, not from another signature's cache entry
+
+#### Scenario: A different window span is aggregated on its own
+
+- **GIVEN** a cached trailing-demand result for a seven-day span and one `account -> window` signature
+- **WHEN** a caller requests the same signature over a different trailing span
+- **THEN** its trailing demand comes from its own aggregate, not from the seven-day entry
+
+#### Scenario: Expired entries are recomputed
+
+- **GIVEN** a cached trailing-demand result whose 60-second TTL has elapsed
+- **WHEN** a dashboard request with the same signature arrives
+- **THEN** the aggregate is executed again and the cache entry is refreshed

--- a/openspec/changes/memoize-weekly-demand-deltas/tasks.md
+++ b/openspec/changes/memoize-weekly-demand-deltas/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## 1. Implementation
+
+- [x] 1.1 Confirm callers of `DashboardRepository.positive_used_percent_deltas_by_account` (dashboard overview + projections only; quota planner unaffected) and record it in the proposal.
+- [x] 1.2 `app/modules/dashboard/repository.py`: `_TRAILING_DEMAND_TTL_SECONDS = 60.0`, bounded module dict keyed by the window span plus the sorted `account -> window` signature, `_clear_trailing_demand_cache()`, memoized wrapper returning a copy on hit; docstring states why the window bounds (not the span) are excluded from the key.
+- [x] 1.3 `tests/conftest.py`: autouse fixture clearing the dict and zeroing the TTL so weekly-pace tests stay exact.
+
+## 2. Verification
+
+- [x] 2.1 Unit tests (`tests/unit/test_dashboard_trailing_demand_cache.py`): fixture reset, zero-TTL passthrough, hit on same signature (order- and window-drift-insensitive), bounds forwarded on miss, copy on hit, miss on different signature or window span, empty signature, expiry, clear, eviction at capacity.
+- [x] 2.2 Integration test (`tests/integration/test_dashboard_trailing_demand_cache.py`): `/api/dashboard/overview` then `/api/dashboard/projections` issue exactly one `weekly_demand_samples` statement with the TTL active (identical pace payloads incl. the demand-derived `addProAccounts`) and two with the TTL zeroed.
+- [x] 2.3 Existing `tests/integration/test_dashboard_overview.py` and `tests/unit/test_dashboard_*.py` stay green; `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, architecture/cancellation/timing/settings-tier guards, `openspec validate memoize-weekly-demand-deltas --strict`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,6 +215,17 @@ def _disable_account_usage_summary_cache(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _disable_dashboard_trailing_demand_cache(monkeypatch):
+    """Zero the weekly-pace trailing-demand cache TTL so dashboard pace
+    figures stay exact within a test. The TTL is a fixed constant in
+    production; cache-behavior tests patch it back to a positive value."""
+    import app.modules.dashboard.repository as dashboard_repository_module
+
+    dashboard_repository_module._clear_trailing_demand_cache()
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 0.0)
+
+
+@pytest.fixture(autouse=True)
 def _disable_background_loop_schedulers(monkeypatch) -> tuple[str, ...]:
     """Replace every ambient app-lifespan background loop with a no-op.
 

--- a/tests/integration/test_dashboard_trailing_demand_cache.py
+++ b/tests/integration/test_dashboard_trailing_demand_cache.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import event
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import naive_utc_to_epoch
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal, engine
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.dashboard import repository as dashboard_repository_module
+from app.modules.usage.repository import UsageRepository
+
+pytestmark = pytest.mark.integration
+
+_FIXED_NOW = datetime(2026, 8, 17, 12, 0, 0)
+
+
+async def _seed_weekly_account(account_id: str) -> None:
+    encryptor = TokenEncryptor()
+    reset_at = int(naive_utc_to_epoch(_FIXED_NOW + timedelta(hours=4)))
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            Account(
+                id=account_id,
+                email=f"{account_id}@example.com",
+                plan_type="pro",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=_FIXED_NOW,
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+        usage_repo = UsageRepository(session)
+        # Two climbs (5 -> 95, 5 -> 100) give 185% of trailing positive demand
+        # against 100% of fleet capacity, and the saturated latest sample lets
+        # the pace card surface that surplus as ``addProAccounts`` — the only
+        # response field derived from the memoized aggregate.
+        for minutes_ago, used_percent in ((170, 5.0), (120, 95.0), (70, 5.0), (1, 100.0)):
+            await usage_repo.add_entry(
+                account_id,
+                used_percent,
+                window="secondary",
+                window_minutes=10_080,
+                reset_at=reset_at,
+                recorded_at=_FIXED_NOW - timedelta(minutes=minutes_ago),
+            )
+
+
+async def _weekly_demand_statements(async_client, paths: list[str]) -> tuple[list[str], list[dict]]:
+    statements: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    payloads: list[dict] = []
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        for path in paths:
+            response = await async_client.get(path)
+            assert response.status_code == 200
+            payloads.append(response.json())
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+    return [statement for statement in statements if "weekly_demand_samples" in statement], payloads
+
+
+@pytest.mark.asyncio
+async def test_overview_and_projections_share_one_trailing_demand_query(async_client, db_setup, monkeypatch):
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: _FIXED_NOW)
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    await _seed_weekly_account("acc-memo")
+
+    demand_statements, payloads = await _weekly_demand_statements(
+        async_client,
+        ["/api/dashboard/overview", "/api/dashboard/projections", "/api/dashboard/overview"],
+    )
+
+    assert len(demand_statements) == 1
+    cached_entries = list(dashboard_repository_module._trailing_demand_cache.values())
+    assert len(cached_entries) == 1
+    assert cached_entries[0][0] == {"acc-memo": pytest.approx(185.0)}
+    paces = [payload["weeklyCreditPace"] for payload in payloads]
+    assert all(pace is not None for pace in paces)
+    assert paces[0]["addProAccounts"] == 1
+    assert paces[0] == paces[1] == paces[2]
+
+
+@pytest.mark.asyncio
+async def test_trailing_demand_query_reruns_when_ttl_is_zero(async_client, db_setup, monkeypatch):
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: _FIXED_NOW)
+    await _seed_weekly_account("acc-exact")
+
+    demand_statements, _ = await _weekly_demand_statements(
+        async_client,
+        ["/api/dashboard/overview", "/api/dashboard/projections"],
+    )
+
+    assert len(demand_statements) == 2
+    assert dashboard_repository_module._trailing_demand_cache == {}

--- a/tests/unit/test_dashboard_trailing_demand_cache.py
+++ b/tests/unit/test_dashboard_trailing_demand_cache.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.dashboard import repository as dashboard_repository_module
+from app.modules.dashboard.repository import DashboardRepository
+
+
+class _RecordingUsageRepo:
+    def __init__(self, deltas: dict[str, float]) -> None:
+        self.calls: list[tuple[tuple[tuple[str, str], ...], datetime, datetime]] = []
+        self._deltas = deltas
+
+    async def positive_used_percent_deltas_by_account(self, account_windows, *, since, until):
+        self.calls.append((tuple(account_windows.items()), since, until))
+        return dict(self._deltas) if account_windows else {}
+
+
+def _repo(deltas: dict[str, float] | None = None) -> tuple[DashboardRepository, _RecordingUsageRepo]:
+    repo = DashboardRepository(MagicMock())
+    usage_repo = _RecordingUsageRepo(deltas or {"acc_a": 12.5})
+    cast(Any, repo)._usage_repo = usage_repo
+    return repo, usage_repo
+
+
+_NOW = datetime(2026, 9, 9, 12, 0, 0)
+_WINDOW = {"since": _NOW - timedelta(days=7), "until": _NOW}
+_WEEK_SECONDS = 7 * 24 * 3600
+
+
+def test_autouse_fixture_zeroes_ttl_and_clears_cache() -> None:
+    assert dashboard_repository_module._TRAILING_DEMAND_TTL_SECONDS == 0.0
+    assert dashboard_repository_module._trailing_demand_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_zero_ttl_disables_memoization() -> None:
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+
+    assert len(usage_repo.calls) == 2
+    assert dashboard_repository_module._trailing_demand_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_same_signature_within_ttl_queries_once(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    first = await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary", "acc_b": "primary"}, **_WINDOW)
+    # Insertion order and the drifting window must not defeat the memo.
+    drifted = {"since": _WINDOW["since"] + timedelta(seconds=15), "until": _WINDOW["until"] + timedelta(seconds=15)}
+    second = await repo.positive_used_percent_deltas_by_account({"acc_b": "primary", "acc_a": "secondary"}, **drifted)
+
+    assert len(usage_repo.calls) == 1
+    assert first == second == {"acc_a": 12.5}
+
+
+@pytest.mark.asyncio
+async def test_miss_forwards_signature_and_window_bounds(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+
+    assert usage_repo.calls == [((("acc_a", "secondary"),), _WINDOW["since"], _WINDOW["until"])]
+
+
+@pytest.mark.asyncio
+async def test_different_window_span_is_its_own_entry(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    await repo.positive_used_percent_deltas_by_account(
+        {"acc_a": "secondary"}, since=_NOW - timedelta(hours=3), until=_NOW
+    )
+
+    assert len(usage_repo.calls) == 2
+    assert set(dashboard_repository_module._trailing_demand_cache) == {
+        (_WEEK_SECONDS, (("acc_a", "secondary"),)),
+        (3 * 3600, (("acc_a", "secondary"),)),
+    }
+
+
+@pytest.mark.asyncio
+async def test_empty_signature_is_memoized_as_empty(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    first = await repo.positive_used_percent_deltas_by_account({}, **_WINDOW)
+    second = await repo.positive_used_percent_deltas_by_account({}, **_WINDOW)
+
+    assert first == second == {}
+    assert len(usage_repo.calls) == 1
+    assert (_WEEK_SECONDS, ()) in dashboard_repository_module._trailing_demand_cache
+
+
+@pytest.mark.asyncio
+async def test_hit_returns_a_copy(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, _ = _repo()
+
+    first = await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    first["acc_a"] = -1.0
+    second = await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+
+    assert second == {"acc_a": 12.5}
+
+
+@pytest.mark.asyncio
+async def test_different_signature_queries_independently(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "primary"}, **_WINDOW)
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary", "acc_b": "secondary"}, **_WINDOW)
+
+    assert len(usage_repo.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_expired_entry_is_recomputed(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    key = (_WEEK_SECONDS, (("acc_a", "secondary"),))
+    deltas, _expires_at = dashboard_repository_module._trailing_demand_cache[key]
+    dashboard_repository_module._trailing_demand_cache[key] = (deltas, time.monotonic() - 1.0)
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+
+    assert len(usage_repo.calls) == 2
+    _deltas, refreshed_expires_at = dashboard_repository_module._trailing_demand_cache[key]
+    assert refreshed_expires_at > time.monotonic()
+
+
+@pytest.mark.asyncio
+async def test_clear_forces_recompute(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+    dashboard_repository_module._clear_trailing_demand_cache()
+    await repo.positive_used_percent_deltas_by_account({"acc_a": "secondary"}, **_WINDOW)
+
+    assert len(usage_repo.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_evicts_oldest_entry_at_capacity(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard_repository_module, "_TRAILING_DEMAND_TTL_SECONDS", 60.0)
+    repo, usage_repo = _repo()
+    capacity = dashboard_repository_module._TRAILING_DEMAND_MAX_ENTRIES
+
+    for index in range(capacity + 1):
+        await repo.positive_used_percent_deltas_by_account({f"acc_{index}": "secondary"}, **_WINDOW)
+    await repo.positive_used_percent_deltas_by_account({"acc_0": "secondary"}, **_WINDOW)
+
+    assert len(dashboard_repository_module._trailing_demand_cache) == capacity
+    assert len(usage_repo.calls) == capacity + 2


### PR DESCRIPTION
## Why

The weekly credit pace card needs, per account, the sum of positive `used_percent` deltas over the trailing 7 days of `usage_history` (`weekly_demand_samples` LAG window in `positive_used_percent_deltas_by_account`). Production `pg_stat_statements` (2026-09-09) shows this statement at mean 1.73s and hundreds of executions while a dashboard is open, because both `GET /api/dashboard/overview` and `GET /api/dashboard/projections` re-run it on every poll (default 15s refresh → ~8 executions/min for a value that only moves when the usage poller appends a sample). Callers verified by grep: only `DashboardService.get_overview` / `get_projections`; the quota planner and proxy hot path do not use it.

## What changes

- `DashboardRepository.positive_used_percent_deltas_by_account` memoizes the aggregate in a process-local dict keyed by window span + sorted account→window signature, fixed `_TRAILING_DEMAND_TTL_SECONDS = 60.0` (module constant; same precedent as `_COUNT_CACHE_TTL_SECONDS` in `request_logs/repository.py`; not a `CODEX_LB_*` setting). Bounded (16 entries, oldest-expiry eviction), hits return a copy, `_clear_trailing_demand_cache()` for tests.
- Display-only figure; gates no security/authorization/routing decision → no cache-invalidation namespace; documented max cross-replica staleness = 60s TTL.
- `tests/conftest.py`: autouse fixture zeroes the TTL and clears the dict (mirrors `_disable_request_log_count_cache`) so existing tests stay exact.
- Expected effect: executions drop from ~8/min to ~2/min per process while a dashboard is open. Per-execution cost unchanged (out of scope).

## OpenSpec

`openspec/changes/memoize-weekly-demand-deltas/` — ADDED requirement "Weekly credit pace trailing demand is memoized per process" under `query-caching`. Validates `--strict`.

## Tests

- `tests/unit/test_dashboard_trailing_demand_cache.py` (new): hit/miss/expiry/eviction/copy semantics/key isolation by span.
- `tests/integration/test_dashboard_trailing_demand_cache.py` (new): both endpoints share one execution within TTL; fixture reset keeps exactness.
- 114 dashboard tests green; gates (ruff, architecture, cancellation, timing-seams, settings-tiers, ty) green. Local `codex review --base c38e4de15`: no actionable regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)