### PR TITLE
test: make http-bridge file-affinity tests provision their own schema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -605,3 +605,61 @@ def _stop_leaked_live_usage_ingestor():
             "test leaked a live-usage ingestor whose task(s) already failed: " + "; ".join(failures),
             pytrace=False,
         )
+
+
+def _pending_audit_log_tasks() -> list[asyncio.Task[None]]:
+    from app.core.audit import service as audit_service
+
+    return [task for task in audit_service._AUDIT_LOG_TASKS if not task.done()]
+
+
+async def _reap_leaked_audit_log_tasks() -> None:
+    """Cancel audit-log tasks a test left behind and drop them from the registry.
+
+    Only tasks bound to the loop this coroutine runs on are cancelled and
+    awaited; a task that belongs to another (already closed) loop cannot be
+    reaped from here and is inert, so it is only removed from the registry.
+    Awaiting a cancelled task raises ``CancelledError`` in this coroutine
+    without cancelling it — the exception is the task's outcome, not ours.
+    """
+    from app.core.audit import service as audit_service
+
+    loop = asyncio.get_running_loop()
+    leaked = _pending_audit_log_tasks()
+    reapable = [task for task in leaked if task.get_loop() is loop]
+    for task in reapable:
+        task.cancel()
+    for task in reapable:
+        try:
+            await task
+        except (Exception, asyncio.CancelledError):
+            continue
+    for task in leaked:
+        audit_service._AUDIT_LOG_TASKS.discard(task)
+
+
+@pytest.fixture(autouse=True)
+def _reap_leaked_audit_log_tasks_fence():
+    """Fence the process-global audit-log task registry per test (issue #2209).
+
+    ``AuditService.log_async`` is fire-and-forget: it schedules the database
+    write as a task on the running loop and tracks it only in the module-global
+    ``_AUDIT_LOG_TASKS`` set. A test that drives a login or mutation path and
+    returns before that write is stepped (or without a provisioned schema for
+    it to ever complete against) leaves the task pending on the shared session
+    loop, where it survives into every later test. test_otel's lifespan drain
+    test asserts the registry is empty before it starts and then fails on a
+    leak it did not cause. Cancel and settle any leaked task after every test
+    so none crosses a test boundary.
+
+    Same shape as ``_stop_leaked_live_usage_ingestor`` above: a sync fixture
+    that only enters the event loop when a leak is actually present, because
+    spinning the loop after every test would call the loop clock while some
+    tests still hold finite ``time.monotonic`` fakes during teardown.
+    """
+    yield
+    if not _pending_audit_log_tasks():
+        return
+    loop = _session_loop
+    if loop is not None and not loop.is_closed() and not loop.is_running():
+        loop.run_until_complete(_reap_leaked_audit_log_tasks())

--- a/tests/unit/test_dashboard_auth_password_service.py
+++ b/tests/unit/test_dashboard_auth_password_service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from unittest.mock import Mock
 
 import bcrypt
 import pytest
 
+from app.core.audit.service import AuditService
 from app.core.auth.dashboard_access import DashboardPermission, DashboardRole
 from app.core.auth.dashboard_mode import DashboardAuthMode
 from app.modules.dashboard_auth.service import (
@@ -16,6 +18,23 @@ from app.modules.dashboard_auth.service import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _stub_audit_log(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Keep the login paths from scheduling real audit-log writes.
+
+    ``verify_password`` / ``verify_guest_password`` / ``verify_totp`` call
+    ``AuditService.log_async``, which is fire-and-forget: it spawns an
+    ``audit-log-login_*`` task that writes through the real database session.
+    These tests run against in-memory fakes with no provisioned schema, so the
+    task can never complete; left alone it outlives the test on the shared
+    session loop and trips later suites that assert the audit registry is
+    empty (tests/unit/test_otel.py lifespan drain test, issue #2209).
+    """
+    log_async = Mock()
+    monkeypatch.setattr(AuditService, "log_async", log_async)
+    return log_async
 
 
 @dataclass(slots=True)

--- a/tests/unit/test_dashboard_auth_password_service.py
+++ b/tests/unit/test_dashboard_auth_password_service.py
@@ -27,10 +27,10 @@ def _stub_audit_log(monkeypatch: pytest.MonkeyPatch) -> Mock:
     ``verify_password`` / ``verify_guest_password`` / ``verify_totp`` call
     ``AuditService.log_async``, which is fire-and-forget: it spawns an
     ``audit-log-login_*`` task that writes through the real database session.
-    These tests run against in-memory fakes with no provisioned schema, so the
-    task can never complete; left alone it outlives the test on the shared
-    session loop and trips later suites that assert the audit registry is
-    empty (tests/unit/test_otel.py lifespan drain test, issue #2209).
+    These tests return synchronously right after the call, before the loop
+    ever steps that task, so it stays pending on the shared session loop and
+    trips later suites that assert the audit registry is empty
+    (tests/unit/test_otel.py lifespan drain test, issue #2209).
     """
     log_async = Mock()
     monkeypatch.setattr(AuditService, "log_async", log_async)

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -23233,6 +23233,11 @@ async def test_get_or_create_http_bridge_session_waiter_propagates_terminal_infl
 
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    # The registration gate consults ring membership through the real database;
+    # this test only exercises the in-memory inflight waiter, so pin the gate
+    # closed like the sibling inflight tests instead of depending on schema
+    # some earlier module happened to provision.
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
     monkeypatch.setattr(
         proxy_service,
@@ -28488,7 +28493,12 @@ async def test_create_http_bridge_session_does_not_classify_post_selection_failu
 @pytest.mark.asyncio
 async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses(
     monkeypatch: pytest.MonkeyPatch,
+    db_setup: bool,
 ) -> None:
+    # ``_pin_file_account`` writes through the real ``SessionLocal`` into
+    # ``file_account_pins``; ``db_setup`` provisions that schema instead of
+    # relying on an earlier module having reset the shared test database.
+    del db_setup
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     await service._pin_file_account("file_from_other_account", "acc-file")
     payload = proxy_service.ResponsesRequest.model_validate(


### PR DESCRIPTION
## Summary

Two `tests/unit/test_proxy_http_bridge.py` tests only passed when an earlier module had already reset the shared test database (`sqlite3.OperationalError: no such table: file_account_pins` when the file or a subset runs alone); they now provision or bypass what they need themselves. Also fences the leaked `audit-log-login_*` tasks that made `test_otel`'s lifespan drain test fail depending on which tests ran before it (surfaced in #2213's verification).

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #2209

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only (test-only: no behavior, contract, or schema change; no `app/` file touched)
- [ ] This PR touches a codex-faithful path

Change directory: n/a

## Changes

**Root cause (#2209).** The test database is the shared `app.db.session.engine` (file SQLite under `CODEX_LB_DATABASE_URL`), and the only thing that creates its schema is `_reset_db_state` in `tests/conftest.py` (reached via `db_setup` / `app_instance` / `async_client`). Nothing in `test_proxy_http_bridge.py` requests any of those, so the two tests below depended on an alphabetically earlier module having run one of them.

- `tests/unit/test_proxy_http_bridge.py`
  - `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses`: `_pin_file_account` writes through the real `SessionLocal` into `file_account_pins`, so the test now requests the existing `db_setup` fixture (same `del db_setup` idiom as `test_api_key_last_used_coalescer.py`).
  - `test_get_or_create_http_bridge_session_waiter_propagates_terminal_inflight_proxy_error`: the unpatched registration gate ran `RingMembershipService.list_active()` against the unprovisioned database and blew the test's `wait_for(..., timeout=0.1)` (traceback ends in `ring_membership.py:193 list_active -> CancelledError -> TimeoutError`). The test only exercises the in-memory inflight waiter, so it now pins `_http_bridge_should_wait_for_registration` to `False` exactly like the four sibling inflight tests already do (lines ~22194-22412). In full-suite order the gate returned `False` anyway (empty ring), so the exercised path is unchanged.
- `tests/unit/test_dashboard_auth_password_service.py` (leak origin for the `test_otel` failure): `verify_password` / `verify_guest_password` / `verify_totp` call the real `AuditService.log_async`, which spawns an `audit-log-login_*` task that writes via `get_session()`. These tests are synchronous and return right after the call, before the session-scoped loop ever steps that task, so it stays pending (`<Task pending name='audit-log-login_failed' ... running at app/core/audit/service.py:79>`, i.e. never entered rather than blocked on the missing schema) and outlives the test; `test_otel::test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_resource_close` then fails its `assert _AUDIT_LOG_TASKS == set()` precondition. A module autouse fixture now stubs `AuditService.log_async` with a `Mock`. A per-test census of the whole unit suite (probe fixture printing pending audit tasks after each test) showed these 7 tests are the only origin; every other hit was a later test inheriting the same pending tasks.
- `tests/conftest.py`: new sync autouse fence `_reap_leaked_audit_log_tasks_fence`, same shape as the existing `_stop_leaked_live_usage_ingestor` (#1755): loop-passive check of `_AUDIT_LOG_TASKS`, and only when a leak is present it enters the session loop to cancel + settle the tasks bound to that loop and drop them from the registry (foreign-loop tasks are inert and only dropped). This keeps the otel precondition true even if a future test spawns an audit task without draining it.

No `pytest-randomly` / `pytest-random-order` in `pyproject.toml`; per the harness rules no dependency was added, so order independence is proven with explicit node ids in both orders (below).

## Test plan

```
# reproduce (before, on origin/main 09b48eb27)
uv run pytest tests/unit/test_proxy_http_bridge.py -q -k "file_affinity or terminal_inflight"      # 1 failed (file_affinity: no such table: file_account_pins), 1 passed
uv run pytest -q "tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_waiter_propagates_terminal_inflight_proxy_error"
                                                                                                  # 1 failed (TimeoutError via ring_membership.list_active)
uv run pytest tests/unit/test_proxy_http_bridge.py -q -x                                          # 1 failed, 604 passed (file alone)
uv run pytest tests/unit -q -k "dashboard_auth or audit"                                          # 1 failed = test_otel lifespan drain (assert _AUDIT_LOG_TASKS == set()), 27 passed

# after
A=tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_waiter_propagates_terminal_inflight_proxy_error
B=tests/unit/test_proxy_http_bridge.py::test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses
uv run pytest -q "$A"            # 1 passed
uv run pytest -q "$B"            # 1 passed
uv run pytest -q "$A" "$B"       # 2 passed
uv run pytest -q "$B" "$A"       # 2 passed (reverse order)
uv run pytest tests/unit/test_proxy_http_bridge.py -q -k "file_affinity or terminal_inflight"   # 2 passed
uv run pytest tests/unit/test_proxy_http_bridge.py -q                                           # 1058 passed (file alone)
uv run pytest tests/unit/test_dashboard_auth_password_service.py -q                             # 9 passed
uv run pytest tests/unit -q -k "dashboard_auth or audit"                                        # 28 passed
uv run pytest tests/unit/test_otel.py tests/unit/test_audit_trail.py -q                         # 56 passed
# fence proof: throwaway test that calls AuditService.log_async() and returns, then the otel drain test
uv run pytest -q tests/unit/test_zz_tmp_audit_leaker.py "tests/unit/test_otel.py::test_lifespan_drains_..."   # 2 passed (file removed, not committed)
uv run pytest tests/unit -q                                                                     # 9015 passed, 3 skipped in 16:19 (full unit suite)
make lint                        # ruff + architecture + cancellation-safety + timing seams + settings tiers: pass
uv run ty check                  # All checks passed!
python3 .github/scripts/check_simplicity_budgets.py   # OK

# verifier round 2 (after docstring-wording commit c8d69cde4)
uv run pytest -q "$B"; uv run pytest -q "$A"; uv run pytest -q "$A" "$B"                          # 1 / 1 / 2 passed
uv run pytest tests/unit/test_proxy_http_bridge.py -q -k "file_affinity or terminal_inflight"   # 2 passed, 1056 deselected
uv run pytest tests/unit/test_proxy_http_bridge.py -q -x                                        # 1058 passed
uv run pytest tests/unit/test_dashboard_auth_password_service.py "tests/unit/test_otel.py::test_lifespan_drains_..."   # 10 passed (leak repro order)
uv run pytest tests/unit/test_dashboard_auth_password_service.py tests/unit/test_otel.py tests/unit/test_audit_trail.py -q   # 65 passed
uv run ruff check / ruff format --check on the 3 touched files                                   # clean
codex review --base origin/main                                                                 # "No actionable regressions were found" (1,216 tests passed in its run)
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. (no specs touched)
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

