### PR TITLE
fix(automations): pin the stale-claim reclaim window to the budget captured at run start

### DIFF
--- a/app/db/alembic/versions/20260909_060000_automation_run_claim_budget.py
+++ b/app/db/alembic/versions/20260909_060000_automation_run_claim_budget.py
@@ -1,0 +1,50 @@
+"""pin the automation stale-claim reclaim window to the budget captured at claim time
+
+Revision ID: 20260909_060000_automation_run_claim_budget
+Revises: 20260909_050000_dashboard_routing_overload_settings
+Create Date: 2026-09-09
+
+Adds the nullable ``automation_runs.claim_budget_seconds`` column. Every
+claim (fresh or stale reclaim) stores the compact request budget in effect
+at that moment, and the stale-claim reclaim window is derived from the
+stored value instead of the current dashboard budget, so lowering the
+budget in the dashboard no longer reclaims an in-flight run early. Rows
+claimed before this revision stay NULL and keep using the current budget.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260909_060000_automation_run_claim_budget"
+down_revision = "20260909_050000_dashboard_routing_overload_settings"
+branch_labels = None
+depends_on = None
+
+_TABLE = "automation_runs"
+_COLUMN = "claim_budget_seconds"
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    existing = _columns(op.get_bind(), _TABLE)
+    if not existing or _COLUMN in existing:
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(sa.Column(_COLUMN, sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    existing = _columns(op.get_bind(), _TABLE)
+    if _COLUMN not in existing:
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column(_COLUMN)

--- a/app/db/alembic/versions/20260909_070000_automation_run_claim_budget.py
+++ b/app/db/alembic/versions/20260909_070000_automation_run_claim_budget.py
@@ -1,7 +1,7 @@
 """pin the automation stale-claim reclaim window to the budget captured at claim time
 
-Revision ID: 20260909_060000_automation_run_claim_budget
-Revises: 20260909_050000_dashboard_routing_overload_settings
+Revision ID: 20260909_070000_automation_run_claim_budget
+Revises: 20260909_060000_add_report_rollup
 Create Date: 2026-09-09
 
 Adds the nullable ``automation_runs.claim_budget_seconds`` column. Every
@@ -18,8 +18,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine import Connection
 
-revision = "20260909_060000_automation_run_claim_budget"
-down_revision = "20260909_050000_dashboard_routing_overload_settings"
+revision = "20260909_070000_automation_run_claim_budget"
+down_revision = "20260909_060000_add_report_rollup"
 branch_labels = None
 depends_on = None
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1669,6 +1669,11 @@ class AutomationRun(Base):
     error_code: Mapped[str | None] = mapped_column(String(100), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    # Compact request budget (seconds) in effect when this row was last
+    # claimed; the stale-claim reclaim window is derived from it so a later
+    # dashboard change cannot reclaim an in-flight run early. NULL on rows
+    # claimed before the column existed (they use the current budget).
+    claim_budget_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
 
     job: Mapped[AutomationJob] = relationship("AutomationJob", back_populates="runs")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1670,9 +1670,10 @@ class AutomationRun(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
     # Compact request budget (seconds) in effect when this row was last
-    # claimed; the stale-claim reclaim window is derived from it so a later
-    # dashboard change cannot reclaim an in-flight run early. NULL on rows
-    # claimed before the column existed (they use the current budget).
+    # claimed; the stale-claim reclaim window covers the larger of this value
+    # and the current budget so a later dashboard change cannot reclaim an
+    # in-flight run early. NULL on rows claimed before the column existed
+    # (they use the current budget).
     claim_budget_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
 

--- a/app/modules/automations/repository.py
+++ b/app/modules/automations/repository.py
@@ -27,6 +27,38 @@ from app.db.models import (
 
 DEFAULT_AUTOMATION_SCHEDULE_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
+# A running claim is reclaimable once it has been held for the compact request
+# budget it was claimed under plus this grace, never sooner than the floor.
+RUN_CLAIM_GRACE_SECONDS = 30.0
+RUN_CLAIM_MIN_TIMEOUT_SECONDS = 30.0
+
+
+def effective_compact_request_budget_seconds() -> float:
+    """The compact request budget currently in effect (dashboard value when bound)."""
+    return with_dashboard_overrides(get_settings()).compact_request_budget_seconds
+
+
+def run_claim_timeout_seconds(claim_budget_seconds: float | None, *, fallback_budget_seconds: float) -> float:
+    """Reclaim window for a claim made under ``claim_budget_seconds``.
+
+    ``None`` marks a row claimed before the budget was stored on it; such rows
+    use ``fallback_budget_seconds`` (the current effective budget).
+    """
+    budget = fallback_budget_seconds if claim_budget_seconds is None else claim_budget_seconds
+    return max(RUN_CLAIM_MIN_TIMEOUT_SECONDS, budget + RUN_CLAIM_GRACE_SECONDS)
+
+
+def run_stale_started_before(
+    *,
+    now_utc: datetime,
+    claim_budget_seconds: float | None,
+    fallback_budget_seconds: float,
+) -> datetime:
+    """Latest ``started_at`` at which a claim under ``claim_budget_seconds`` counts as stale at ``now_utc``."""
+    return now_utc - timedelta(
+        seconds=run_claim_timeout_seconds(claim_budget_seconds, fallback_budget_seconds=fallback_budget_seconds)
+    )
+
 
 @dataclass(frozen=True, slots=True)
 class AutomationRunRecord:
@@ -49,6 +81,7 @@ class AutomationRunRecord:
     error_code: str | None
     error_message: str | None
     attempt_count: int
+    claim_budget_seconds: float | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -419,6 +452,7 @@ class AutomationsRepository:
             status="running",
             account_id=account_id,
             attempt_count=0,
+            claim_budget_seconds=effective_compact_request_budget_seconds(),
         )
         self._session.add(run)
         try:
@@ -463,6 +497,7 @@ class AutomationsRepository:
                     "status",
                     "account_id",
                     "attempt_count",
+                    "claim_budget_seconds",
                 ],
                 select(
                     literal(run_id),
@@ -480,6 +515,7 @@ class AutomationsRepository:
                     literal("running"),
                     literal(account_id),
                     literal(0),
+                    literal(effective_compact_request_budget_seconds()),
                 ).where(
                     exists(
                         select(AutomationRunCycleAccount.account_id)
@@ -569,24 +605,32 @@ class AutomationsRepository:
         if not candidates:
             return []
         cycle_keys = [cycle.cycle_key for cycle in candidates]
-        stale_started_before = _automation_run_execution_claim_stale_started_before(now_utc)
+        fallback_budget_seconds = effective_compact_request_budget_seconds()
         result = await self._session.execute(
             select(
                 AutomationRun.cycle_key,
-                AutomationRun.account_id,
                 AutomationRun.slot_key,
                 AutomationRun.status,
                 AutomationRun.finished_at,
                 AutomationRun.started_at,
                 AutomationRun.scheduled_for,
+                AutomationRun.claim_budget_seconds,
             ).where(AutomationRun.cycle_key.in_(cycle_keys))
         )
         occupied_slot_keys_by_cycle_key: dict[str, set[str]] = {}
-        for cycle_key, _account_id, slot_key, status, finished_at, started_at, scheduled_for in result.all():
+        for cycle_key, slot_key, status, finished_at, started_at, scheduled_for, claim_budget_seconds in result.all():
             is_stale_running = (
                 status == "running"
                 and finished_at is None
-                and (started_at <= scheduled_for or started_at < stale_started_before)
+                and (
+                    started_at <= scheduled_for
+                    or started_at
+                    < run_stale_started_before(
+                        now_utc=now_utc,
+                        claim_budget_seconds=claim_budget_seconds,
+                        fallback_budget_seconds=fallback_budget_seconds,
+                    )
+                )
             )
             if is_stale_running:
                 continue
@@ -703,6 +747,7 @@ class AutomationsRepository:
             )
             for index, (account_id, scheduled_for) in enumerate(accounts)
         ]
+        claim_budget_seconds = effective_compact_request_budget_seconds()
         claimed_runs = [
             AutomationRun(
                 id=f"run_{uuid4().hex}",
@@ -720,6 +765,7 @@ class AutomationsRepository:
                 status="running",
                 account_id=account_id,
                 attempt_count=0,
+                claim_budget_seconds=claim_budget_seconds,
             )
             for slot_key, scheduled_for, account_id in runs
         ]
@@ -812,10 +858,14 @@ class AutomationsRepository:
         self,
         *,
         now_utc: datetime,
-        stale_started_before: datetime,
         cycle_key: str | None = None,
         limit: int = 500,
     ) -> list[AutomationRunRecord]:
+        # The SQL bound is the shortest reclaim window any row can have; the
+        # exact per-row window (pinned at claim time, current budget for
+        # legacy NULL rows) is applied below.
+        earliest_stale_started_before = now_utc - timedelta(seconds=RUN_CLAIM_MIN_TIMEOUT_SECONDS)
+        fallback_budget_seconds = effective_compact_request_budget_seconds()
         stmt = (
             select(AutomationRun, AutomationJob.name, AutomationJob.model, AutomationJob.reasoning_effort)
             .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
@@ -833,7 +883,7 @@ class AutomationsRepository:
             .where(
                 or_(
                     AutomationRun.started_at <= AutomationRun.scheduled_for,
-                    AutomationRun.started_at < stale_started_before,
+                    AutomationRun.started_at < earliest_stale_started_before,
                 )
             )
             .order_by(
@@ -847,9 +897,20 @@ class AutomationsRepository:
         if cycle_key is not None:
             stmt = stmt.where(AutomationRun.cycle_key == cycle_key)
         result = await self._session.execute(stmt)
-        return [
+        due_runs = [
             self._run_from_model(run, job_name=job_name, model=model, reasoning_effort=reasoning_effort)
             for run, job_name, model, reasoning_effort in result.all()
+        ]
+        return [
+            run
+            for run in due_runs
+            if run.started_at <= run.scheduled_for
+            or run.started_at
+            < run_stale_started_before(
+                now_utc=now_utc,
+                claim_budget_seconds=run.claim_budget_seconds,
+                fallback_budget_seconds=fallback_budget_seconds,
+            )
         ]
 
     async def claim_manual_run_execution(
@@ -874,7 +935,10 @@ class AutomationsRepository:
                     AutomationRun.started_at < stale_started_before,
                 )
             )
-            .values(started_at=claimed_started_at)
+            .values(
+                started_at=claimed_started_at,
+                claim_budget_seconds=effective_compact_request_budget_seconds(),
+            )
             .returning(AutomationRun)
         )
         run = result.scalar_one_or_none()
@@ -904,7 +968,10 @@ class AutomationsRepository:
                     AutomationRun.started_at < stale_started_before,
                 )
             )
-            .values(started_at=claimed_started_at)
+            .values(
+                started_at=claimed_started_at,
+                claim_budget_seconds=effective_compact_request_budget_seconds(),
+            )
             .returning(AutomationRun)
         )
         run = result.scalar_one_or_none()
@@ -1630,6 +1697,7 @@ class AutomationsRepository:
             error_code=run.error_code,
             error_message=run.error_message,
             attempt_count=run.attempt_count,
+            claim_budget_seconds=run.claim_budget_seconds,
         )
 
     @staticmethod
@@ -1785,12 +1853,6 @@ def _serialize_schedule_days(days: Sequence[str]) -> str:
     if not normalized:
         return ",".join(DEFAULT_AUTOMATION_SCHEDULE_DAYS)
     return ",".join(normalized)
-
-
-def _automation_run_execution_claim_stale_started_before(now_utc: datetime) -> datetime:
-    settings = with_dashboard_overrides(get_settings())
-    timeout_seconds = max(30.0, settings.compact_request_budget_seconds + 30.0)
-    return now_utc - timedelta(seconds=timeout_seconds)
 
 
 def _scheduled_slot_key(job_id: str, *, account_id: str, due_slot: datetime) -> str:

--- a/app/modules/automations/repository.py
+++ b/app/modules/automations/repository.py
@@ -27,8 +27,10 @@ from app.db.models import (
 
 DEFAULT_AUTOMATION_SCHEDULE_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
-# A running claim is reclaimable once it has been held for the compact request
-# budget it was claimed under plus this grace, never sooner than the floor.
+# A running claim is reclaimable once it has been held for the larger of the
+# compact request budget it was claimed under and the current budget, plus this
+# grace, never sooner than the floor. A dashboard change can therefore only
+# widen a live claim's window, never narrow it.
 RUN_CLAIM_GRACE_SECONDS = 30.0
 RUN_CLAIM_MIN_TIMEOUT_SECONDS = 30.0
 
@@ -41,10 +43,17 @@ def effective_compact_request_budget_seconds() -> float:
 def run_claim_timeout_seconds(claim_budget_seconds: float | None, *, fallback_budget_seconds: float) -> float:
     """Reclaim window for a claim made under ``claim_budget_seconds``.
 
-    ``None`` marks a row claimed before the budget was stored on it; such rows
-    use ``fallback_budget_seconds`` (the current effective budget).
+    The window covers the larger of the pinned budget and
+    ``fallback_budget_seconds`` (the current effective budget): lowering the
+    dashboard budget cannot shrink the window under an in-flight run, and a
+    raised budget still covers an attempt started by a writer that advanced
+    ``started_at`` without refreshing the pin (pre-pin replica during a rolling
+    deploy). ``None`` marks a row that never had a pin; it uses the current
+    budget alone.
     """
-    budget = fallback_budget_seconds if claim_budget_seconds is None else claim_budget_seconds
+    budget = (
+        fallback_budget_seconds if claim_budget_seconds is None else max(claim_budget_seconds, fallback_budget_seconds)
+    )
     return max(RUN_CLAIM_MIN_TIMEOUT_SECONDS, budget + RUN_CLAIM_GRACE_SECONDS)
 
 
@@ -863,7 +872,7 @@ class AutomationsRepository:
     ) -> list[AutomationRunRecord]:
         # The SQL bound is the shortest reclaim window any row can have; the
         # exact per-row window (pinned at claim time, current budget for
-        # legacy NULL rows) is applied below.
+        # legacy NULL rows) is applied to the fetched candidates below.
         earliest_stale_started_before = now_utc - timedelta(seconds=RUN_CLAIM_MIN_TIMEOUT_SECONDS)
         fallback_budget_seconds = effective_compact_request_budget_seconds()
         stmt = (
@@ -892,26 +901,34 @@ class AutomationsRepository:
                 AutomationRun.started_at.asc(),
                 AutomationRun.id.asc(),
             )
-            .limit(limit)
         )
         if cycle_key is not None:
             stmt = stmt.where(AutomationRun.cycle_key == cycle_key)
-        result = await self._session.execute(stmt)
-        due_runs = [
-            self._run_from_model(run, job_name=job_name, model=model, reasoning_effort=reasoning_effort)
-            for run, job_name, model, reasoning_effort in result.all()
-        ]
-        return [
-            run
-            for run in due_runs
-            if run.started_at <= run.scheduled_for
-            or run.started_at
-            < run_stale_started_before(
-                now_utc=now_utc,
-                claim_budget_seconds=run.claim_budget_seconds,
-                fallback_budget_seconds=fallback_budget_seconds,
+        # Page through the candidates so claims still inside their own window
+        # never consume ``limit`` slots owed to eligible rows behind them.
+        due_runs: list[AutomationRunRecord] = []
+        offset = 0
+        while len(due_runs) < limit:
+            result = await self._session.execute(stmt.offset(offset).limit(limit))
+            rows = result.all()
+            due_runs.extend(
+                run
+                for run in (
+                    self._run_from_model(run, job_name=job_name, model=model, reasoning_effort=reasoning_effort)
+                    for run, job_name, model, reasoning_effort in rows
+                )
+                if run.started_at <= run.scheduled_for
+                or run.started_at
+                < run_stale_started_before(
+                    now_utc=now_utc,
+                    claim_budget_seconds=run.claim_budget_seconds,
+                    fallback_budget_seconds=fallback_budget_seconds,
+                )
             )
-        ]
+            if len(rows) < limit:
+                break
+            offset += limit
+        return due_runs[:limit]
 
     async def claim_manual_run_execution(
         self,

--- a/app/modules/automations/service.py
+++ b/app/modules/automations/service.py
@@ -17,8 +17,7 @@ from app.core.auth.refresh import RefreshError
 from app.core.balancer import PERMANENT_FAILURE_CODES, account_status_for_permanent_failure
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy import compact_responses as core_compact_responses
-from app.core.config.dashboard_overrides import dashboard_overrides_bound, with_dashboard_overrides
-from app.core.config.settings import get_settings
+from app.core.config.dashboard_overrides import dashboard_overrides_bound
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.openai.model_registry import get_model_registry
@@ -35,6 +34,8 @@ from app.modules.automations.repository import (
     AutomationRunCycleRecord,
     AutomationRunRecord,
     AutomationsRepository,
+    effective_compact_request_budget_seconds,
+    run_stale_started_before,
 )
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.proxy.helpers import _header_account_id
@@ -821,13 +822,17 @@ class AutomationsService:
     ) -> int:
         cycle_key = cycle.cycle_key
         existing_cycle_runs = await self._repository.list_runs_for_cycle_key(cycle_key=cycle_key)
-        stale_started_before = now_utc - timedelta(seconds=_manual_run_execution_claim_timeout_seconds())
+        fallback_budget_seconds = effective_compact_request_budget_seconds()
         if not cycle.accounts:
             if existing_cycle_runs:
                 existing_cycle_run = existing_cycle_runs[0]
-                existing_run_is_stale = existing_cycle_run.status == AUTOMATION_RUN_STATUS_RUNNING and (
-                    existing_cycle_run.started_at <= existing_cycle_run.scheduled_for
-                    or existing_cycle_run.started_at < stale_started_before
+                existing_run_is_stale = (
+                    existing_cycle_run.status == AUTOMATION_RUN_STATUS_RUNNING
+                    and _is_reclaimable_running_claim(
+                        existing_cycle_run,
+                        now_utc=now_utc,
+                        fallback_budget_seconds=fallback_budget_seconds,
+                    )
                 )
                 if not existing_run_is_stale:
                     return 0
@@ -835,7 +840,11 @@ class AutomationsService:
                     run_id=existing_cycle_run.id,
                     observed_started_at=existing_cycle_run.started_at,
                     claimed_started_at=now_utc,
-                    stale_started_before=stale_started_before,
+                    stale_started_before=_run_stale_started_before(
+                        existing_cycle_run,
+                        now_utc=now_utc,
+                        fallback_budget_seconds=fallback_budget_seconds,
+                    ),
                 )
                 if claim is None:
                     return 0
@@ -906,9 +915,10 @@ class AutomationsService:
                     if deleted:
                         cycle_expected_accounts = max(0, cycle_expected_accounts - 1)
                     continue
-                existing_run_is_stale = (
-                    existing_cycle_run.started_at <= existing_cycle_run.scheduled_for
-                    or existing_cycle_run.started_at < stale_started_before
+                existing_run_is_stale = _is_reclaimable_running_claim(
+                    existing_cycle_run,
+                    now_utc=now_utc,
+                    fallback_budget_seconds=fallback_budget_seconds,
                 )
                 if not existing_run_is_stale:
                     continue
@@ -916,7 +926,11 @@ class AutomationsService:
                     run_id=existing_cycle_run.id,
                     observed_started_at=existing_cycle_run.started_at,
                     claimed_started_at=now_utc,
-                    stale_started_before=stale_started_before,
+                    stale_started_before=_run_stale_started_before(
+                        existing_cycle_run,
+                        now_utc=now_utc,
+                        fallback_budget_seconds=fallback_budget_seconds,
+                    ),
                 )
                 if claim is None:
                     continue
@@ -932,9 +946,10 @@ class AutomationsService:
                 executed += 1
                 continue
             if existing_cycle_run is not None:
-                existing_run_is_stale = (
-                    existing_cycle_run.started_at <= existing_cycle_run.scheduled_for
-                    or existing_cycle_run.started_at < stale_started_before
+                existing_run_is_stale = _is_reclaimable_running_claim(
+                    existing_cycle_run,
+                    now_utc=now_utc,
+                    fallback_budget_seconds=fallback_budget_seconds,
                 )
                 if not existing_run_is_stale:
                     continue
@@ -942,7 +957,11 @@ class AutomationsService:
                     run_id=existing_cycle_run.id,
                     observed_started_at=existing_cycle_run.started_at,
                     claimed_started_at=now_utc,
-                    stale_started_before=stale_started_before,
+                    stale_started_before=_run_stale_started_before(
+                        existing_cycle_run,
+                        now_utc=now_utc,
+                        fallback_budget_seconds=fallback_budget_seconds,
+                    ),
                 )
                 if claim is None:
                     continue
@@ -973,14 +992,10 @@ class AutomationsService:
         return executed
 
     async def _run_due_manual_runs(self, *, now_utc: datetime, cycle_key: str | None = None) -> int:
-        stale_started_before = now_utc - timedelta(seconds=_manual_run_execution_claim_timeout_seconds())
-        due_runs = await self._repository.list_due_manual_runs(
-            now_utc=now_utc,
-            stale_started_before=stale_started_before,
-            cycle_key=cycle_key,
-        )
+        due_runs = await self._repository.list_due_manual_runs(now_utc=now_utc, cycle_key=cycle_key)
         if not due_runs:
             return 0
+        fallback_budget_seconds = effective_compact_request_budget_seconds()
         jobs_by_id = await self._repository.get_jobs_by_ids([run.job_id for run in due_runs])
         cycles_by_key: dict[str, AutomationRunCycleRecord | None] = {}
         executed = 0
@@ -1026,7 +1041,11 @@ class AutomationsService:
                 run.id,
                 observed_started_at=run.started_at,
                 claimed_started_at=claimed_started_at,
-                stale_started_before=stale_started_before,
+                stale_started_before=_run_stale_started_before(
+                    run,
+                    now_utc=now_utc,
+                    fallback_budget_seconds=fallback_budget_seconds,
+                ),
             )
             if claimed_run is None:
                 continue
@@ -1178,7 +1197,7 @@ class AutomationsService:
                         route=route,
                         allow_direct_egress=route is None,
                     ),
-                    timeout=_automation_compact_request_timeout_seconds(),
+                    timeout=_automation_compact_request_timeout_seconds(run),
                 )
                 latency_ms = _elapsed_ms(request_started_at)
                 request_id = _automation_request_id(getattr(compact_response, "id", None), run.id, attempt_count)
@@ -2433,13 +2452,42 @@ def _automation_request_id(response_id: str | None, run_id: str, attempt_count: 
     return f"automation-{run_id}-attempt-{attempt_count}"
 
 
-def _manual_run_execution_claim_timeout_seconds() -> float:
-    settings = with_dashboard_overrides(get_settings())
-    return max(30.0, settings.compact_request_budget_seconds + 30.0)
+def _automation_compact_request_timeout_seconds(run: AutomationRunRecord) -> float:
+    """The compact budget the run was claimed under; the current budget for legacy rows.
+
+    The reclaim window is derived from the same value, so a run can never be
+    reclaimed while its own compact request may still be in flight.
+    """
+    if run.claim_budget_seconds is not None:
+        return run.claim_budget_seconds
+    return effective_compact_request_budget_seconds()
 
 
-def _automation_compact_request_timeout_seconds() -> float:
-    return with_dashboard_overrides(get_settings()).compact_request_budget_seconds
+def _run_stale_started_before(
+    run: AutomationRunRecord,
+    *,
+    now_utc: datetime,
+    fallback_budget_seconds: float,
+) -> datetime:
+    return run_stale_started_before(
+        now_utc=now_utc,
+        claim_budget_seconds=run.claim_budget_seconds,
+        fallback_budget_seconds=fallback_budget_seconds,
+    )
+
+
+def _is_reclaimable_running_claim(
+    run: AutomationRunRecord,
+    *,
+    now_utc: datetime,
+    fallback_budget_seconds: float,
+) -> bool:
+    """True for an unclaimed placeholder or a claim held past its own reclaim window."""
+    return run.started_at <= run.scheduled_for or run.started_at < _run_stale_started_before(
+        run,
+        now_utc=now_utc,
+        fallback_budget_seconds=fallback_budget_seconds,
+    )
 
 
 def _elapsed_ms(started_at: float | None) -> int | None:

--- a/openspec/changes/automation-run-pinned-budget/.openspec.yaml
+++ b/openspec/changes/automation-run-pinned-budget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/automation-run-pinned-budget/proposal.md
+++ b/openspec/changes/automation-run-pinned-budget/proposal.md
@@ -1,0 +1,29 @@
+# Change: automation-run-pinned-budget
+
+## Why
+
+An automation run claim is reclaimable once it has been held longer than the compact request budget plus a 30 s grace. Until now the window was computed from the budget in effect *at reclaim time*. Since `dashboard-managed-upstream-timeouts` (#2221) made `compact_request_budget_seconds` a live dashboard setting, an operator lowering the budget while a run is in flight shrinks the window under that run: the scheduler (or a second replica) judges the claim stale, re-claims it and starts a second compact ping for the same slot while the first is still running. This was deferred from the #2221 review (codex R2 P2).
+
+## What Changes
+
+- `automation_runs` gains a nullable `claim_budget_seconds` column. Every claim — a fresh slot claim, the runs created by run-now, and a stale reclaim — stores the compact request budget in effect at that moment.
+- The stale-claim window of a run is derived from its stored budget (`max(30, stored + 30)` seconds), on every path that judges staleness: due-cycle discovery, the scheduled-cycle reclaim, due manual-run discovery and the manual reclaim. Rows claimed before the column existed (NULL) keep using the current effective budget.
+- The compact request timeout the run executes with is the same stored budget, so the execution timeout and the reclaim window can never disagree for one run.
+- Lowering the dashboard budget therefore applies to claims made after the change only; an in-flight run keeps the window it was claimed under. Raising the budget also leaves in-flight runs on their original window.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `automations`: the multi-replica safety requirement fixes the stale-claim reclaim window to the budget captured at claim time and gains scenarios for a lowered dashboard budget and for legacy rows.
+
+## Impact
+
+- Migration `20260909_060000_automation_run_claim_budget` (one nullable column, sqlite and PostgreSQL; downgrade drops it).
+- Code: `app/db/models.py`, `app/modules/automations/repository.py`, `app/modules/automations/service.py`.
+- API: none (the column is not exposed).
+- Operators: no action; existing running rows fall back to the current budget until they complete or are reclaimed.

--- a/openspec/changes/automation-run-pinned-budget/proposal.md
+++ b/openspec/changes/automation-run-pinned-budget/proposal.md
@@ -7,9 +7,9 @@ An automation run claim is reclaimable once it has been held longer than the com
 ## What Changes
 
 - `automation_runs` gains a nullable `claim_budget_seconds` column. Every claim — a fresh slot claim, the runs created by run-now, and a stale reclaim — stores the compact request budget in effect at that moment.
-- The stale-claim window of a run is derived from its stored budget (`max(30, stored + 30)` seconds), on every path that judges staleness: due-cycle discovery, the scheduled-cycle reclaim, due manual-run discovery and the manual reclaim. Rows claimed before the column existed (NULL) keep using the current effective budget.
-- The compact request timeout the run executes with is the same stored budget, so the execution timeout and the reclaim window can never disagree for one run.
-- Lowering the dashboard budget therefore applies to claims made after the change only; an in-flight run keeps the window it was claimed under. Raising the budget also leaves in-flight runs on their original window.
+- The stale-claim window of a run covers the larger of its stored budget and the current effective budget (`max(30, max(stored, current) + 30)` seconds), on every path that judges staleness: due-cycle discovery, the scheduled-cycle reclaim, due manual-run discovery and the manual reclaim. Rows claimed before the column existed (NULL) use the current effective budget alone.
+- The compact request timeout the run executes with is bounded by the same stored budget, so the execution timeout can never exceed the reclaim window for one run.
+- Lowering the dashboard budget therefore applies to claims made after the change only; an in-flight run keeps the window it was claimed under. Raising the budget widens in-flight windows as before, which also keeps a replica that advances `started_at` without refreshing the pin (pre-upgrade code during a rolling deploy) covered by the window while it executes under the current budget.
 
 ## Capabilities
 
@@ -19,11 +19,11 @@ None.
 
 ### Modified Capabilities
 
-- `automations`: the multi-replica safety requirement fixes the stale-claim reclaim window to the budget captured at claim time and gains scenarios for a lowered dashboard budget and for legacy rows.
+- `automations`: the multi-replica safety requirement derives the stale-claim reclaim window from the larger of the budget captured at claim time and the current budget, and gains scenarios for a lowered dashboard budget, a raised budget over a lower pin, and legacy rows.
 
 ## Impact
 
-- Migration `20260909_060000_automation_run_claim_budget` (one nullable column, sqlite and PostgreSQL; downgrade drops it).
+- Migration `20260909_070000_automation_run_claim_budget` (one nullable column, sqlite and PostgreSQL; downgrade drops it).
 - Code: `app/db/models.py`, `app/modules/automations/repository.py`, `app/modules/automations/service.py`.
 - API: none (the column is not exposed).
 - Operators: no action; existing running rows fall back to the current budget until they complete or are reclaimed.

--- a/openspec/changes/automation-run-pinned-budget/specs/automations/spec.md
+++ b/openspec/changes/automation-run-pinned-budget/specs/automations/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Scheduler is safe in multi-replica deployments
+
+The system MUST guarantee at-most-once execution for each due schedule slot `(job_id, scheduled_for)` across replicas. A running claim MUST be reclaimable only after it has been held longer than its own reclaim window, and that window MUST be derived from the compact request budget captured on the run row when the claim was made (`automation_runs.claim_budget_seconds`, stored on every fresh claim and every reclaim), not from the budget in effect when staleness is judged. A run's compact request MUST execute with that same captured budget. Rows claimed before the budget was stored (NULL) MUST fall back to the current effective compact request budget.
+
+#### Scenario: Two replicas contend for the same due job
+
+- **WHEN** two scheduler instances observe the same due job
+- **THEN** only one instance successfully claims and executes that `(job_id, scheduled_for)` slot
+- **AND** the other instance skips execution without creating duplicate run records
+
+#### Scenario: Scheduler run claiming remains deterministic after retries
+
+- **WHEN** one scheduler replica crashes after claiming a slot and before completion
+- **THEN** no second replica creates a duplicate claim row for the same slot
+- **AND** the existing run row remains the single source of truth for that slot
+
+#### Scenario: Lowering the dashboard compact budget does not reclaim an in-flight run
+
+- **GIVEN** a run claimed while the effective compact request budget was 600 seconds, 200 seconds ago
+- **WHEN** the dashboard lowers the compact request budget to 60 seconds and the scheduler evaluates the slot
+- **THEN** the run is not reclaimed and no second compact ping is started for that slot
+- **AND** the run becomes reclaimable only once it has been held longer than 630 seconds
+
+#### Scenario: Legacy claim without a captured budget follows the current budget
+
+- **GIVEN** a running claim whose `claim_budget_seconds` is NULL, held for 200 seconds
+- **WHEN** the effective compact request budget is 600 seconds
+- **THEN** the claim is still in flight
+- **AND** once the effective budget is 60 seconds the same claim is reclaimed

--- a/openspec/changes/automation-run-pinned-budget/specs/automations/spec.md
+++ b/openspec/changes/automation-run-pinned-budget/specs/automations/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Scheduler is safe in multi-replica deployments
 
-The system MUST guarantee at-most-once execution for each due schedule slot `(job_id, scheduled_for)` across replicas. A running claim MUST be reclaimable only after it has been held longer than its own reclaim window, and that window MUST be derived from the compact request budget captured on the run row when the claim was made (`automation_runs.claim_budget_seconds`, stored on every fresh claim and every reclaim), not from the budget in effect when staleness is judged. A run's compact request MUST execute with that same captured budget. Rows claimed before the budget was stored (NULL) MUST fall back to the current effective compact request budget.
+The system MUST guarantee at-most-once execution for each due schedule slot `(job_id, scheduled_for)` across replicas. A running claim MUST be reclaimable only after it has been held longer than its own reclaim window, and that window MUST cover the larger of the compact request budget captured on the run row when the claim was made (`automation_runs.claim_budget_seconds`, stored on every fresh claim and every reclaim) and the effective budget when staleness is judged, so a later dashboard change can only widen a live claim's window, never narrow it. A run's compact request timeout MUST NOT exceed that captured budget (the core compact deadline still follows the current budget, so lowering it can end the request early but never reclaims the slot early). Rows claimed before the budget was stored (NULL) MUST fall back to the current effective compact request budget.
 
 #### Scenario: Two replicas contend for the same due job
 
@@ -22,6 +22,13 @@ The system MUST guarantee at-most-once execution for each due schedule slot `(jo
 - **WHEN** the dashboard lowers the compact request budget to 60 seconds and the scheduler evaluates the slot
 - **THEN** the run is not reclaimed and no second compact ping is started for that slot
 - **AND** the run becomes reclaimable only once it has been held longer than 630 seconds
+
+#### Scenario: Raising the dashboard compact budget widens the window of a claim pinned lower
+
+- **GIVEN** a running claim whose captured budget is 60 seconds, held for 200 seconds
+- **WHEN** the effective compact request budget is 600 seconds (a writer that does not refresh the pin, such as a pre-upgrade replica during a rolling deploy, may be executing this claim under it)
+- **THEN** the claim is not reclaimed
+- **AND** it becomes reclaimable only once it has been held longer than 630 seconds
 
 #### Scenario: Legacy claim without a captured budget follows the current budget
 

--- a/openspec/changes/automation-run-pinned-budget/tasks.md
+++ b/openspec/changes/automation-run-pinned-budget/tasks.md
@@ -8,6 +8,6 @@
 
 ## 2. Verification
 
-- [x] 2.1 Integration: claims and reclaims store the budget in effect; a claim pinned at 600 s is not reclaimed after the dashboard lowers the budget to 60 s and is reclaimed past its own window; a legacy NULL row follows the current budget; `list_due_manual_runs` honours the pinned window.
+- [x] 2.1 Integration: claims and reclaims store the budget in effect; a claim pinned at 600 s is not reclaimed after the dashboard lowers the budget to 60 s and is reclaimed past its own window; a legacy NULL row follows the current budget; `list_due_manual_runs` honours the pinned window and its `limit` counts only eligible rows.
 - [x] 2.2 Unit: window helper, per-run staleness predicate and the pinned compact timeout.
 - [x] 2.3 Migration upgrade/downgrade test; `make lint`, `uv run ty check`, `make migration-check`, `openspec validate automation-run-pinned-budget --strict`.

--- a/openspec/changes/automation-run-pinned-budget/tasks.md
+++ b/openspec/changes/automation-run-pinned-budget/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## 1. Backend
+
+- [x] 1.1 Alembic revision adding nullable `automation_runs.claim_budget_seconds`; ORM column and `AutomationRunRecord` field.
+- [x] 1.2 Every claim path (`claim_run`, `claim_scheduled_cycle_account_run`, `create_run_cycle_with_runs`, `claim_manual_run_execution`, `claim_scheduled_cycle_run_execution`) stores the effective compact budget on the row.
+- [x] 1.3 Staleness is judged per run from the stored budget (current budget for NULL) in due-cycle discovery, due manual-run discovery and both reclaim paths; the compact request timeout uses the same stored budget.
+
+## 2. Verification
+
+- [x] 2.1 Integration: claims and reclaims store the budget in effect; a claim pinned at 600 s is not reclaimed after the dashboard lowers the budget to 60 s and is reclaimed past its own window; a legacy NULL row follows the current budget; `list_due_manual_runs` honours the pinned window.
+- [x] 2.2 Unit: window helper, per-run staleness predicate and the pinned compact timeout.
+- [x] 2.3 Migration upgrade/downgrade test; `make lint`, `uv run ty check`, `make migration-check`, `openspec validate automation-run-pinned-budget --strict`.

--- a/tests/integration/test_automations_api.py
+++ b/tests/integration/test_automations_api.py
@@ -9,17 +9,25 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import update
 
 from app.core.clients.proxy import ProxyResponseError
+from app.core.config.dashboard_overrides import dashboard_overrides_bound
+from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import openai_error
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
 from app.core.types import JsonValue
 from app.core.utils.time import naive_utc_to_epoch, utcnow
-from app.db.models import Account, AccountStatus, AutomationJob, AutomationRun
+from app.db.models import Account, AccountStatus, AutomationJob, AutomationRun, DashboardSettings
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.automations.repository import AutomationsRepository
-from app.modules.automations.service import AutomationsService, _manual_slot_key, _scheduled_slot_key
+from app.modules.automations.service import (
+    AutomationsService,
+    _manual_slot_key,
+    _scheduled_cycle_key,
+    _scheduled_slot_key,
+)
 from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.settings.repository import SettingsRepository
 
 pytestmark = pytest.mark.integration
 
@@ -5818,3 +5826,264 @@ async def test_automations_run_details_normalize_legacy_manual_cycle_key(async_c
     assert payload["totalAccounts"] == 2
     assert payload["completedAccounts"] == 1
     assert payload["pendingAccounts"] == 1
+
+
+async def _set_dashboard_compact_budget(seconds: float | None) -> None:
+    async with SessionLocal() as session:
+        await SettingsRepository(session).get_or_create()
+        await session.execute(update(DashboardSettings).values(compact_request_budget_seconds=seconds))
+        await session.commit()
+    await get_settings_cache().invalidate()
+
+
+async def _create_claimed_scheduled_run(
+    *,
+    account: Account,
+    due_slot: datetime,
+    claim_budget_seconds: float,
+) -> tuple[str, str]:
+    """A daily job whose slot at ``due_slot`` holds one in-flight claim pinned to ``claim_budget_seconds``."""
+    async with SessionLocal() as session:
+        automations_repository = AutomationsRepository(session)
+        job = await automations_repository.create_job(
+            name="Pinned claim budget",
+            enabled=True,
+            include_paused_accounts=False,
+            schedule_type="daily",
+            schedule_time=due_slot.strftime("%H:%M"),
+            schedule_timezone="UTC",
+            schedule_days=["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            schedule_threshold_minutes=0,
+            model="gpt-5.3-codex",
+            reasoning_effort=None,
+            prompt="ping",
+            account_ids=[account.id],
+        )
+        await _set_job_updated_at(job.id, due_slot)
+        cycle_key = _scheduled_cycle_key(job.id, due_slot)
+        await automations_repository.create_run_cycle(
+            cycle_key=cycle_key,
+            job_id=job.id,
+            trigger="scheduled",
+            cycle_expected_accounts=1,
+            cycle_window_end=due_slot,
+            accounts=[(account.id, due_slot)],
+        )
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=claim_budget_seconds)):
+            run = await automations_repository.claim_run(
+                job_id=job.id,
+                trigger="scheduled",
+                slot_key=_scheduled_slot_key(job.id, account_id=account.id, due_slot=due_slot),
+                cycle_key=cycle_key,
+                cycle_expected_accounts=1,
+                cycle_window_end=due_slot,
+                scheduled_for=due_slot,
+                started_at=due_slot + timedelta(seconds=1),
+                account_id=account.id,
+            )
+        assert run is not None
+        assert run.claim_budget_seconds == claim_budget_seconds
+        return job.id, run.id
+
+
+@pytest.mark.asyncio
+async def test_automations_claims_store_compact_budget_in_effect(db_setup):
+    del db_setup
+    account = (await _create_accounts("auto-claim-budget"))[0]
+    now = utcnow().replace(microsecond=0)
+
+    async with SessionLocal() as session:
+        automations_repository = AutomationsRepository(session)
+        job = await automations_repository.create_job(
+            name="Claim budget snapshot",
+            enabled=False,
+            include_paused_accounts=False,
+            schedule_type="daily",
+            schedule_time="05:00",
+            schedule_timezone="UTC",
+            schedule_days=["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            schedule_threshold_minutes=0,
+            model="gpt-5.3-codex",
+            reasoning_effort=None,
+            prompt="ping",
+            account_ids=[account.id],
+        )
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=45.0)):
+            run = await automations_repository.claim_run(
+                job_id=job.id,
+                trigger="scheduled",
+                slot_key=f"scheduled:{job.id}:claim-budget",
+                cycle_key=f"scheduled:{job.id}:claim-budget",
+                cycle_expected_accounts=1,
+                cycle_window_end=now,
+                scheduled_for=now,
+                started_at=now,
+                account_id=account.id,
+            )
+        assert run is not None
+        assert run.claim_budget_seconds == 45.0
+        stored_run = await automations_repository.get_run(run.id)
+        assert stored_run is not None
+        assert stored_run.claim_budget_seconds == 45.0
+
+        # A stale reclaim re-pins the row to the budget in effect at that moment.
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=90.0)):
+            reclaimed_run = await automations_repository.claim_scheduled_cycle_run_execution(
+                run_id=run.id,
+                observed_started_at=run.started_at,
+                claimed_started_at=now + timedelta(seconds=1),
+                stale_started_before=now + timedelta(seconds=1),
+            )
+        assert reclaimed_run is not None
+        assert reclaimed_run.claim_budget_seconds == 90.0
+        assert reclaimed_run.started_at == now + timedelta(seconds=1)
+
+        # A manual cycle created through run-now stores the budget on its runs too.
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=75.0)):
+            _cycle, manual_runs = await automations_repository.create_run_cycle_with_runs(
+                cycle_key=f"manual:{job.id}:claim-budget",
+                job_id=job.id,
+                trigger="manual",
+                cycle_expected_accounts=1,
+                cycle_window_end=now,
+                accounts=[(account.id, now)],
+                runs=[(_manual_slot_key(job.id, "claim-budget", account.id), now, account.id)],
+                started_at=now,
+            )
+        assert [manual_run.claim_budget_seconds for manual_run in manual_runs] == [75.0]
+
+
+@pytest.mark.asyncio
+async def test_automations_scheduler_reclaim_honours_budget_pinned_at_claim_when_dashboard_lowers_it(
+    db_setup, monkeypatch
+):
+    del db_setup
+    account = (await _create_accounts("auto-pinned-budget"))[0]
+    due_slot = datetime(2026, 9, 9, 1, 0, 0)
+    compact_calls: list[str | None] = []
+
+    async def _fake_compact(*_args, **kwargs):
+        compact_calls.append(kwargs.get("account_id"))
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.modules.automations.service.core_compact_responses", _fake_compact)
+    job_id, run_id = await _create_claimed_scheduled_run(account=account, due_slot=due_slot, claim_budget_seconds=600.0)
+
+    # The dashboard lowers the budget to 60 s while the run is 200 s into its
+    # 600 s window: the current 90 s window would reclaim it, the pinned one must not.
+    await _set_dashboard_compact_budget(60.0)
+    try:
+        assert await _run_due_jobs(now_utc=due_slot + timedelta(seconds=200)) == 0
+        async with SessionLocal() as session:
+            untouched_run = await AutomationsRepository(session).get_run(run_id)
+        assert untouched_run is not None
+        assert untouched_run.status == "running"
+        assert untouched_run.started_at == due_slot + timedelta(seconds=1)
+        assert untouched_run.claim_budget_seconds == 600.0
+        assert compact_calls == []
+
+        # Past the pinned window (600 s + 30 s grace) the claim is reclaimable again.
+        assert await _run_due_jobs(now_utc=due_slot + timedelta(seconds=700)) == 1
+        async with SessionLocal() as session:
+            runs = await AutomationsRepository(session).list_runs(job_id, limit=10)
+        assert [run.id for run in runs] == [run_id]
+        assert runs[0].status == "success"
+        assert runs[0].claim_budget_seconds == 60.0
+        assert compact_calls == [account.chatgpt_account_id]
+    finally:
+        await _set_dashboard_compact_budget(None)
+
+
+@pytest.mark.asyncio
+async def test_automations_scheduler_reclaim_uses_current_budget_for_legacy_row_without_pinned_budget(
+    db_setup, monkeypatch
+):
+    del db_setup
+    account = (await _create_accounts("auto-legacy-budget"))[0]
+    due_slot = datetime(2026, 9, 9, 1, 0, 0)
+    compact_calls: list[str | None] = []
+
+    async def _fake_compact(*_args, **kwargs):
+        compact_calls.append(kwargs.get("account_id"))
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.modules.automations.service.core_compact_responses", _fake_compact)
+    job_id, run_id = await _create_claimed_scheduled_run(account=account, due_slot=due_slot, claim_budget_seconds=600.0)
+    async with SessionLocal() as session:
+        await session.execute(update(AutomationRun).where(AutomationRun.id == run_id).values(claim_budget_seconds=None))
+        await session.commit()
+
+    try:
+        # With the current budget at 600 s the 200 s old legacy claim is still in flight.
+        await _set_dashboard_compact_budget(600.0)
+        assert await _run_due_jobs(now_utc=due_slot + timedelta(seconds=200)) == 0
+        assert compact_calls == []
+
+        # Lowering the current budget to 60 s makes the same legacy claim stale.
+        await _set_dashboard_compact_budget(60.0)
+        assert await _run_due_jobs(now_utc=due_slot + timedelta(seconds=200)) == 1
+        async with SessionLocal() as session:
+            runs = await AutomationsRepository(session).list_runs(job_id, limit=10)
+        assert [run.id for run in runs] == [run_id]
+        assert runs[0].status == "success"
+        assert runs[0].claim_budget_seconds == 60.0
+        assert compact_calls == [account.chatgpt_account_id]
+    finally:
+        await _set_dashboard_compact_budget(None)
+
+
+@pytest.mark.asyncio
+async def test_list_due_manual_runs_honours_budget_pinned_at_claim(db_setup):
+    del db_setup
+    account = (await _create_accounts("auto-manual-pinned-budget"))[0]
+    scheduled_for = datetime(2026, 9, 9, 1, 0, 0)
+
+    async with SessionLocal() as session:
+        automations_repository = AutomationsRepository(session)
+        job = await automations_repository.create_job(
+            name="Manual pinned budget",
+            enabled=False,
+            include_paused_accounts=False,
+            schedule_type="daily",
+            schedule_time="05:00",
+            schedule_timezone="UTC",
+            schedule_days=["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            schedule_threshold_minutes=0,
+            model="gpt-5.3-codex",
+            reasoning_effort=None,
+            prompt="ping",
+            account_ids=[account.id],
+        )
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=600.0)):
+            run = await automations_repository.claim_run(
+                job_id=job.id,
+                trigger="manual",
+                slot_key=_manual_slot_key(job.id, "pinned", account.id),
+                cycle_key=f"manual:{job.id}:pinned",
+                cycle_expected_accounts=1,
+                cycle_window_end=scheduled_for,
+                scheduled_for=scheduled_for,
+                started_at=scheduled_for + timedelta(seconds=1),
+                account_id=account.id,
+            )
+        assert run is not None
+
+        lowered_budget = DashboardSettings(compact_request_budget_seconds=60.0)
+        with dashboard_overrides_bound(lowered_budget):
+            still_in_flight = await automations_repository.list_due_manual_runs(
+                now_utc=scheduled_for + timedelta(seconds=200)
+            )
+            past_pinned_window = await automations_repository.list_due_manual_runs(
+                now_utc=scheduled_for + timedelta(seconds=700)
+            )
+        assert still_in_flight == []
+        assert [due_run.id for due_run in past_pinned_window] == [run.id]
+
+        # A legacy row without a pinned budget is judged by the current budget.
+        await session.execute(update(AutomationRun).where(AutomationRun.id == run.id).values(claim_budget_seconds=None))
+        await session.commit()
+        with dashboard_overrides_bound(lowered_budget):
+            legacy_due = await automations_repository.list_due_manual_runs(
+                now_utc=scheduled_for + timedelta(seconds=200)
+            )
+        assert [due_run.id for due_run in legacy_due] == [run.id]

--- a/tests/integration/test_automations_api.py
+++ b/tests/integration/test_automations_api.py
@@ -6087,3 +6087,79 @@ async def test_list_due_manual_runs_honours_budget_pinned_at_claim(db_setup):
                 now_utc=scheduled_for + timedelta(seconds=200)
             )
         assert [due_run.id for due_run in legacy_due] == [run.id]
+
+        # A pin below the current budget (left behind by a pre-pin writer that
+        # advanced ``started_at`` during a rolling deploy) does not shorten the
+        # window: the raised current budget covers the live attempt.
+        await session.execute(update(AutomationRun).where(AutomationRun.id == run.id).values(claim_budget_seconds=60.0))
+        await session.commit()
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=600.0)):
+            stale_pin_in_flight = await automations_repository.list_due_manual_runs(
+                now_utc=scheduled_for + timedelta(seconds=200)
+            )
+            stale_pin_past_window = await automations_repository.list_due_manual_runs(
+                now_utc=scheduled_for + timedelta(seconds=700)
+            )
+        assert stale_pin_in_flight == []
+        assert [due_run.id for due_run in stale_pin_past_window] == [run.id]
+
+
+@pytest.mark.asyncio
+async def test_list_due_manual_runs_limit_counts_only_eligible_rows(db_setup):
+    """An in-flight claim ordered ahead of a due placeholder must not consume the
+    batch slot owed to the placeholder (the SQL bound is looser than the per-row
+    pinned window, so candidates are paged until ``limit`` eligible rows are found)."""
+    del db_setup
+    account = (await _create_accounts("auto-manual-limit-eligible"))[0]
+    scheduled_for = datetime(2026, 9, 9, 2, 0, 0)
+
+    async with SessionLocal() as session:
+        automations_repository = AutomationsRepository(session)
+        job = await automations_repository.create_job(
+            name="Manual limit eligible",
+            enabled=False,
+            include_paused_accounts=False,
+            schedule_type="daily",
+            schedule_time="05:00",
+            schedule_timezone="UTC",
+            schedule_days=["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            schedule_threshold_minutes=0,
+            model="gpt-5.3-codex",
+            reasoning_effort=None,
+            prompt="ping",
+            account_ids=[account.id],
+        )
+        with dashboard_overrides_bound(DashboardSettings(compact_request_budget_seconds=600.0)):
+            in_flight = await automations_repository.claim_run(
+                job_id=job.id,
+                trigger="manual",
+                slot_key=_manual_slot_key(job.id, "in-flight", account.id),
+                cycle_key=f"manual:{job.id}:in-flight",
+                cycle_expected_accounts=1,
+                cycle_window_end=scheduled_for,
+                scheduled_for=scheduled_for,
+                started_at=scheduled_for + timedelta(seconds=1),
+                account_id=account.id,
+            )
+            # Sorted after the in-flight claim (later scheduled_for) but still due.
+            placeholder = await automations_repository.claim_run(
+                job_id=job.id,
+                trigger="manual",
+                slot_key=_manual_slot_key(job.id, "placeholder", account.id),
+                cycle_key=f"manual:{job.id}:placeholder",
+                cycle_expected_accounts=1,
+                cycle_window_end=scheduled_for + timedelta(seconds=10),
+                scheduled_for=scheduled_for + timedelta(seconds=10),
+                started_at=scheduled_for + timedelta(seconds=10),
+                account_id=account.id,
+            )
+        assert in_flight is not None
+        assert placeholder is not None
+
+        due = await automations_repository.list_due_manual_runs(now_utc=scheduled_for + timedelta(seconds=200), limit=1)
+        assert [due_run.id for due_run in due] == [placeholder.id]
+
+        past_window = await automations_repository.list_due_manual_runs(
+            now_utc=scheduled_for + timedelta(seconds=700), limit=1
+        )
+        assert [due_run.id for due_run in past_window] == [in_flight.id]

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -2552,8 +2552,8 @@ async def test_automation_run_claim_budget_migration_upgrade_and_downgrade(tmp_p
     from app.db.migrate import _build_alembic_config
 
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'automation-run-claim-budget.sqlite'}"
-    parent_revision = "20260909_050000_dashboard_routing_overload_settings"
-    claim_budget_revision = "20260909_060000_automation_run_claim_budget"
+    parent_revision = "20260909_060000_add_report_rollup"
+    claim_budget_revision = "20260909_070000_automation_run_claim_budget"
 
     async def _automation_run_columns(engine) -> set[str]:
         async with engine.connect() as conn:

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -2540,3 +2540,40 @@ async def test_retired_prewarm_canary_columns_stay_insertable_for_legacy_replica
 
     # The retained physical columns are an allow-listed drift, not a schema defect.
     assert await to_thread.run_sync(lambda: check_schema_drift(db_url)) == ()
+
+
+@pytest.mark.asyncio
+async def test_automation_run_claim_budget_migration_upgrade_and_downgrade(tmp_path):
+    """Upgrade adds the nullable ``automation_runs.claim_budget_seconds`` column,
+    downgrade drops it, and a final walk to head proves the revision sits on a
+    single-head graph."""
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'automation-run-claim-budget.sqlite'}"
+    parent_revision = "20260909_050000_dashboard_routing_overload_settings"
+    claim_budget_revision = "20260909_060000_automation_run_claim_budget"
+
+    async def _automation_run_columns(engine) -> set[str]:
+        async with engine.connect() as conn:
+            rows = await conn.execute(text("PRAGMA table_info('automation_runs')"))
+            return {row[1] for row in rows}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        assert "claim_budget_seconds" not in await _automation_run_columns(engine)
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, claim_budget_revision, bootstrap_legacy=False))
+        assert "claim_budget_seconds" in await _automation_run_columns(engine)
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        assert "claim_budget_seconds" not in await _automation_run_columns(engine)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert "claim_budget_seconds" in await _automation_run_columns(engine)
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_automations_service.py
+++ b/tests/unit/test_automations_service.py
@@ -5,11 +5,13 @@ from datetime import datetime, timedelta
 import pytest
 
 from app.db.models import Account, AccountStatus
-from app.modules.automations.repository import AutomationRunRecord
+from app.modules.automations.repository import AutomationRunRecord, run_claim_timeout_seconds
 from app.modules.automations.service import (
     AutomationsService,
     AutomationValidationError,
+    _automation_compact_request_timeout_seconds,
     _AutomationRunCycleSummary,
+    _is_reclaimable_running_claim,
     _normalize_chatgpt_model,
     _normalize_reasoning_effort,
     _pick_dispatch_offsets_seconds,
@@ -248,6 +250,7 @@ def test_to_run_data_falls_back_to_run_finished_at_when_cycle_summary_finished_a
         error_code=None,
         error_message=None,
         attempt_count=1,
+        claim_budget_seconds=None,
     )
     summary = _AutomationRunCycleSummary(
         cycle_key="cycle",
@@ -265,3 +268,68 @@ def test_to_run_data_falls_back_to_run_finished_at_when_cycle_summary_finished_a
     run_data = AutomationsService._to_run_data(run, summary=summary, apply_cycle_terminal_overrides=True)
 
     assert run_data.finished_at == run_finished_at
+
+
+def _running_run(
+    *, started_at: datetime, scheduled_for: datetime, claim_budget_seconds: float | None
+) -> AutomationRunRecord:
+    return AutomationRunRecord(
+        id="run-id",
+        job_id="job-id",
+        job_name="job",
+        model="gpt-5.3-codex",
+        reasoning_effort=None,
+        prompt="ping",
+        trigger="scheduled",
+        status="running",
+        slot_key="slot",
+        cycle_key="cycle",
+        cycle_expected_accounts=1,
+        cycle_window_end=scheduled_for,
+        scheduled_for=scheduled_for,
+        started_at=started_at,
+        finished_at=None,
+        account_id="account-id",
+        error_code=None,
+        error_message=None,
+        attempt_count=1,
+        claim_budget_seconds=claim_budget_seconds,
+    )
+
+
+def test_run_claim_timeout_seconds_uses_pinned_budget_and_falls_back_for_legacy_rows() -> None:
+    assert run_claim_timeout_seconds(600.0, fallback_budget_seconds=60.0) == 630.0
+    assert run_claim_timeout_seconds(None, fallback_budget_seconds=60.0) == 90.0
+    assert run_claim_timeout_seconds(0.5, fallback_budget_seconds=600.0) == 30.5
+
+
+def test_compact_request_timeout_uses_budget_pinned_at_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.modules.automations.service.effective_compact_request_budget_seconds",
+        lambda: 60.0,
+    )
+    scheduled_for = datetime(2026, 9, 9, 1, 0, 0)
+    pinned = _running_run(started_at=scheduled_for, scheduled_for=scheduled_for, claim_budget_seconds=600.0)
+    legacy = _running_run(started_at=scheduled_for, scheduled_for=scheduled_for, claim_budget_seconds=None)
+
+    assert _automation_compact_request_timeout_seconds(pinned) == 600.0
+    assert _automation_compact_request_timeout_seconds(legacy) == 60.0
+
+
+def test_is_reclaimable_running_claim_judges_each_run_by_its_own_pinned_window() -> None:
+    scheduled_for = datetime(2026, 9, 9, 1, 0, 0)
+    started_at = scheduled_for + timedelta(seconds=1)
+    now_utc = started_at + timedelta(seconds=200)
+    pinned = _running_run(started_at=started_at, scheduled_for=scheduled_for, claim_budget_seconds=600.0)
+    legacy = _running_run(started_at=started_at, scheduled_for=scheduled_for, claim_budget_seconds=None)
+    placeholder = _running_run(started_at=scheduled_for, scheduled_for=scheduled_for, claim_budget_seconds=600.0)
+
+    # The dashboard budget dropped to 60 s: only rows without a pinned budget follow it.
+    assert not _is_reclaimable_running_claim(pinned, now_utc=now_utc, fallback_budget_seconds=60.0)
+    assert _is_reclaimable_running_claim(legacy, now_utc=now_utc, fallback_budget_seconds=60.0)
+    assert _is_reclaimable_running_claim(placeholder, now_utc=now_utc, fallback_budget_seconds=60.0)
+    assert _is_reclaimable_running_claim(
+        pinned,
+        now_utc=started_at + timedelta(seconds=631),
+        fallback_budget_seconds=60.0,
+    )

--- a/tests/unit/test_automations_service.py
+++ b/tests/unit/test_automations_service.py
@@ -298,9 +298,14 @@ def _running_run(
 
 
 def test_run_claim_timeout_seconds_uses_pinned_budget_and_falls_back_for_legacy_rows() -> None:
+    # Lowered dashboard budget: the pinned window stands.
     assert run_claim_timeout_seconds(600.0, fallback_budget_seconds=60.0) == 630.0
+    # No pin: the current budget alone.
     assert run_claim_timeout_seconds(None, fallback_budget_seconds=60.0) == 90.0
-    assert run_claim_timeout_seconds(0.5, fallback_budget_seconds=600.0) == 30.5
+    # Raised dashboard budget: the window widens to cover an attempt started by
+    # a pre-pin writer under the current budget (rolling deploy).
+    assert run_claim_timeout_seconds(0.5, fallback_budget_seconds=600.0) == 630.0
+    assert run_claim_timeout_seconds(0.5, fallback_budget_seconds=0.0) == 30.5
 
 
 def test_compact_request_timeout_uses_budget_pinned_at_claim(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -332,4 +337,14 @@ def test_is_reclaimable_running_claim_judges_each_run_by_its_own_pinned_window()
         pinned,
         now_utc=started_at + timedelta(seconds=631),
         fallback_budget_seconds=60.0,
+    )
+    # The dashboard budget was raised to 600 s after a 60 s pin: a legacy
+    # writer may be executing this row under 600 s, so it is not reclaimable
+    # at +200 s and the pin alone does not shorten the window.
+    stale_pin = _running_run(started_at=started_at, scheduled_for=scheduled_for, claim_budget_seconds=60.0)
+    assert not _is_reclaimable_running_claim(stale_pin, now_utc=now_utc, fallback_budget_seconds=600.0)
+    assert _is_reclaimable_running_claim(
+        stale_pin,
+        now_utc=started_at + timedelta(seconds=631),
+        fallback_budget_seconds=600.0,
     )


### PR DESCRIPTION
## Summary

The automation stale-claim reclaim window (compact budget + 30 s) was computed from the compact request budget in effect *at reclaim time*. Since #2221 made that budget a live dashboard setting, lowering it while a run is in flight shrinks the window under that run and lets the scheduler (or another replica) reclaim it and start a second compact ping for the same slot. Every claim now stores the budget it was made under on the run row and staleness is judged from the larger of that stored value and the current budget, so a dashboard change can only widen a live claim's window, never narrow it. Deferred follow-up from #2221 (codex R2 P2).

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: follow-up to #2221 (deferred review item)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/automation-run-pinned-budget/` — MODIFIED delta on the `automations` requirement "Scheduler is safe in multi-replica deployments" (pinned reclaim window, three new scenarios: lowered budget, raised budget over a lower pin, legacy NULL row).

## Changes

- **Schema**: `automation_runs.claim_budget_seconds` (nullable float). Migration `20260909_070000_automation_run_claim_budget` (`down_revision = 20260909_060000_add_report_rollup`, i.e. chained after #2227; single head); downgrade drops the column. Verified on sqlite and PostgreSQL 16 (upgrade, downgrade, `check` → `schema_drift=none`).
- **Repository**: `claim_run`, `claim_scheduled_cycle_account_run`, `create_run_cycle_with_runs`, `claim_manual_run_execution` and `claim_scheduled_cycle_run_execution` stamp the effective compact budget on the row. New helpers `effective_compact_request_budget_seconds`, `run_claim_timeout_seconds`, `run_stale_started_before` (`max(30, max(pinned, current) + 30)`; NULL → current budget alone). Using the larger of the two also covers a rolling deploy where a pre-upgrade replica advances `started_at` without refreshing the pin: its attempt runs under the current budget, which the window covers (codex review finding). `_filter_due_scheduled_run_cycles` judges each running row by its own window. `list_due_manual_runs` drops the caller-supplied `stale_started_before`: the SQL keeps the shortest possible window (30 s) as a bound, the exact per-row window is applied on the fetched rows, and candidates are paged (`offset`/`limit`) until `limit` eligible rows are collected so an in-flight claim inside its own window never consumes a batch slot owed to a due row behind it (review finding).
- **Service**: the three scheduled reclaim checks and the manual reclaim compute the run's own `stale_started_before` (`_is_reclaimable_running_claim` / `_run_stale_started_before`) and pass it into the compare-and-swap UPDATE guards. The compact request timeout (`asyncio.wait_for`) uses the run's stored budget (the core compact deadline still follows the current budget), so the execution timeout never exceeds the reclaim window for one run; `_manual_run_execution_claim_timeout_seconds` is removed.
- **Not changed**: API/schemas (the column is not exposed), dashboard, settings.

## Simplicity

No new setting, README section, nav item or default change.

## Test plan

```
uv run pytest tests/unit/test_automations_service.py -q                     # 21 passed
uv run pytest tests/integration/test_automations_api.py -q                   # 91 passed (sqlite) / 91 passed (PostgreSQL 18)
uv run pytest tests/integration/test_automations_history_queries.py tests/integration/test_migrations.py -q   # sqlite: passed, 7 skipped (pg-only); pg: claim-budget + startup-migration subset passed
make lint && uv run ty check && make migration-check                         # ok; current_revision=20260909_070000_automation_run_claim_budget, migration_policy=ok, schema_drift=none
openspec validate automation-run-pinned-budget --strict && openspec validate --specs --strict
python3 .github/scripts/check_simplicity_budgets.py
```

New tests:
- `test_automations_claims_store_compact_budget_in_effect` — fresh claim, stale reclaim and run-now cycle each store the budget bound at that moment.
- `test_automations_scheduler_reclaim_honours_budget_pinned_at_claim_when_dashboard_lowers_it` — run pinned at 600 s, dashboard lowered to 60 s: not reclaimed at +200 s, reclaimed at +700 s (through `run_due_jobs` with the real settings cache).
- `test_automations_scheduler_reclaim_uses_current_budget_for_legacy_row_without_pinned_budget` — NULL row follows the current budget (in flight at 600 s, reclaimed at 60 s).
- `test_list_due_manual_runs_honours_budget_pinned_at_claim` — manual discovery honours the pinned window, the NULL fallback, and a raised current budget over a lower pin.
- `test_list_due_manual_runs_limit_counts_only_eligible_rows` — with `limit=1`, an in-flight claim sorted ahead of a due placeholder does not starve it; past its window the claim itself is returned.
- Unit: `run_claim_timeout_seconds` (lowered / raised / NULL / floor), `_is_reclaimable_running_claim` (incl. stale lower pin under a raised budget), `_automation_compact_request_timeout_seconds`.
- `test_automation_run_claim_budget_migration_upgrade_and_downgrade`.

## Screenshots / output

No user-visible surface.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (`make lint`, `make migration-check`, `uv run ty check`, targeted pytest).
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean (tasks all checked; each delta scenario maps to a named test above).
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

