### PR TITLE
fix(proxy): restore trusted Codex routing hints

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -937,6 +937,7 @@ def _build_upstream_headers(
     access_token: str,
     account_id: str | None,
     accept: str = "text/event-stream",
+    routing_hint: tuple[str, str | None] | None = None,
 ) -> dict[str, str]:
     native = _is_native_codex_request(inbound)
     if native:
@@ -988,6 +989,11 @@ def _build_upstream_headers(
             account_id,
             fallback_name="chatgpt-account-id" if native else _CHATGPT_ACCOUNT_ID_HEADER,
         )
+    if routing_hint is not None:
+        model, service_tier = routing_hint
+        headers[CODEX_ROUTING_HINT_HEADER] = f"model={model}" + (
+            f";tier={service_tier}" if service_tier is not None else ""
+        )
     return headers
 
 
@@ -1021,6 +1027,7 @@ def _build_upstream_websocket_headers(
     inbound: Mapping[str, str],
     access_token: str,
     account_id: str | None,
+    routing_hint: tuple[str, str | None] | None = None,
 ) -> dict[str, str]:
     connected_header_tokens: set[str] = set()
     for key, value in inbound.items():
@@ -1054,6 +1061,11 @@ def _build_upstream_websocket_headers(
             headers["chatgpt-account-id"] = account_id
         else:
             headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
+    if routing_hint is not None:
+        model, service_tier = routing_hint
+        headers[CODEX_ROUTING_HINT_HEADER] = f"model={model}" + (
+            f";tier={service_tier}" if service_tier is not None else ""
+        )
     return headers
 
 
@@ -3585,6 +3597,7 @@ async def stream_responses(
     codex_lb_account_id: str | None = None,
     suppress_live_usage: bool = False,
     native_egress_client: NativeEgressClient | None = None,
+    synthesize_routing_hint: bool = False,
 ) -> AsyncIterator[str]:
     effective_allow_direct_egress = allow_direct_egress or (route is None and session is not None)
     # aclosing() at every hop lets a consumer's aclose() reach the upstream
@@ -3610,6 +3623,7 @@ async def stream_responses(
                 codex_lb_account_id=codex_lb_account_id,
                 suppress_live_usage=suppress_live_usage,
                 native_egress_client=native_egress_client,
+                synthesize_routing_hint=synthesize_routing_hint,
             )
         ) as upstream_events,
     ):
@@ -3641,6 +3655,7 @@ async def _stream_responses_with_session(
     codex_lb_account_id: str | None = None,
     suppress_live_usage: bool = False,
     native_egress_client: NativeEgressClient | None = None,
+    synthesize_routing_hint: bool = False,
 ) -> AsyncGenerator[str, None]:
     settings = with_dashboard_overrides(get_settings())
     headers = apply_codex_installation_headers(
@@ -3739,7 +3754,12 @@ async def _stream_responses_with_session(
         native_egress_client or discover_native_egress_client() if route is None and transport == "http" else None
     )
     if transport == "websocket":
-        upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_websocket_headers(
+            headers,
+            access_token,
+            account_id,
+            routing_hint=(payload.model, payload.service_tier) if synthesize_routing_hint else None,
+        )
         method = "GET"
     else:
         upstream_headers = _build_upstream_headers(
@@ -3747,6 +3767,7 @@ async def _stream_responses_with_session(
             access_token,
             account_id,
             accept="application/json" if non_streaming_http else "text/event-stream",
+            routing_hint=(payload.model, payload.service_tier) if synthesize_routing_hint else None,
         )
         _apply_responses_lite_http_header(
             upstream_headers,
@@ -4144,7 +4165,12 @@ async def _stream_responses_with_session(
         transport = "http"
         payload_dict = http_payload_dict
         payload_json = json.dumps(payload_dict, ensure_ascii=True, separators=(",", ":"))
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(
+            headers,
+            access_token,
+            account_id,
+            routing_hint=(payload.model, payload.service_tier) if synthesize_routing_hint else None,
+        )
         _apply_responses_lite_http_header(
             upstream_headers,
             payload_dict,
@@ -4702,6 +4728,7 @@ async def compact_responses(
     route_trace: UpstreamProxyRouteTrace | None = None,
     chatgpt_account_id: str | None = None,
     allow_direct_egress: bool = True,
+    synthesize_routing_hint: bool = False,
 ) -> CompactResponsePayload:
     async with lease_http_session(session) as client_session:
         transport = _CompactCommandTransport(
@@ -4715,6 +4742,7 @@ async def compact_responses(
             route_trace=route_trace,
             chatgpt_account_id=chatgpt_account_id,
             allow_direct_egress=allow_direct_egress,
+            synthesize_routing_hint=synthesize_routing_hint,
         )
         return await transport.execute()
 
@@ -4731,6 +4759,7 @@ class _CompactCommandTransport:
     route_trace: UpstreamProxyRouteTrace | None = None
     chatgpt_account_id: str | None = None
     allow_direct_egress: bool = False
+    synthesize_routing_hint: bool = False
 
     async def execute(self) -> CompactResponsePayload:
         settings = with_dashboard_overrides(get_settings())
@@ -4750,6 +4779,7 @@ class _CompactCommandTransport:
             self.access_token,
             upstream_account_id,
             accept="text/event-stream",
+            routing_hint=(self.payload.model, self.payload.service_tier) if self.synthesize_routing_hint else None,
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -43,6 +43,7 @@ from app.core.clients.proxy import (
     _CHATGPT_ACCOUNT_ID_HEADER,
     _HOP_BY_HOP_HEADER_NAMES,
     CODEX_INSTALLATION_ID_HEADER,
+    CODEX_ROUTING_HINT_HEADER,
     ProxyResponseError,
     _is_native_codex_request,
     _is_upstream_edge_challenge,
@@ -719,6 +720,7 @@ def _build_upstream_websocket_headers(
     *,
     include_responses_beta: bool = True,
     normalize_non_native_fingerprint: bool = True,
+    routing_hint: tuple[str, str | None] | None = None,
 ) -> dict[str, str]:
     headers = filter_inbound_websocket_headers(inbound)
     # ``filter_inbound_websocket_headers`` strips ``x-codex-installation-id`` because it
@@ -755,6 +757,11 @@ def _build_upstream_websocket_headers(
             headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
     if include_responses_beta:
         _ensure_responses_websocket_beta_header(headers)
+    if routing_hint is not None:
+        model, service_tier = routing_hint
+        headers[CODEX_ROUTING_HINT_HEADER] = f"model={model}"
+        if service_tier is not None:
+            headers[CODEX_ROUTING_HINT_HEADER] += f";tier={service_tier}"
     return headers
 
 
@@ -888,10 +895,13 @@ async def _connect_upstream_websocket(
     allow_direct_egress: bool = False,
     policy: _UpstreamWebSocketPolicy,
     subprotocols: Sequence[str] = (),
+    routing_hint: tuple[str, str | None] | None = None,
 ) -> UpstreamWebSocket:
     settings = with_dashboard_overrides(get_settings())
     if policy.include_responses_beta:
-        upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_websocket_headers(
+            headers, access_token, account_id, routing_hint=routing_hint
+        )
     else:
         upstream_headers = _build_upstream_live_websocket_headers(headers, access_token, account_id)
     require_route_or_direct_egress_opt_in(
@@ -1254,6 +1264,7 @@ async def connect_responses_websocket(
     route: ResolvedUpstreamRoute | None = None,
     codex_client: CodexClient | None = None,
     allow_direct_egress: bool = False,
+    routing_hint: tuple[str, str | None] | None = None,
 ) -> UpstreamWebSocket:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
@@ -1266,6 +1277,7 @@ async def connect_responses_websocket(
         codex_client=codex_client,
         allow_direct_egress=allow_direct_egress,
         policy=_RESPONSES_WEBSOCKET_POLICY,
+        routing_hint=routing_hint,
     )
 
 

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -1198,6 +1198,7 @@ class _CompactMixin:
                                     "allow_direct_egress": route is None,
                                     "route_trace": route_trace,
                                     "chatgpt_account_id": account_id,
+                                    "synthesize_routing_hint": True,
                                 },
                             ),
                             timeout=upstream_budget,

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1685,6 +1685,7 @@ class _HTTPBridgeMixin(
             request_id=f"http_bridge_connect_{uuid4().hex}",
             model=request_model,
             service_tier=request_service_tier,
+            requested_service_tier=request_service_tier,
             reasoning_effort=None,
             api_key_reservation=None,
             started_at=clock_for(self).monotonic(),

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3433,6 +3433,7 @@ class _HTTPBridgeStreamingMixin:
                             max_sessions=max_sessions,
                             previous_response_id=None,
                             gateway_safe_mode=runtime_config.gateway_safe_mode,
+                            request_service_tier=request_state.requested_service_tier,
                             allow_forward_to_owner=False,
                             forwarded_request=forwarded_request,
                             durable_lookup=None,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -580,6 +580,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 "codex_installation_id": account.codex_installation_id,
                 "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
                 "codex_lb_account_id": account.id,
+                # Selected subscription Account, independent of optional legacy header.
+                "synthesize_routing_hint": True,
             }
             if upstream_stream_transport is not None:
                 stream_optional_kwargs["upstream_stream_transport_override"] = upstream_stream_transport

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -4785,6 +4785,14 @@ class _WebSocketMixin:
                 optional_kwargs={
                     "route": route,
                     "allow_direct_egress": route is None,
+                    # This opener already selected a subscription account.
+                    # Preconnect without a model has no hint; reused sockets
+                    # retain their original handshake, as in the Codex CLI.
+                    "routing_hint": (
+                        (request_state.model, request_state.requested_service_tier)
+                        if request_state is not None and request_state.model is not None
+                        else None
+                    ),
                 },
             )
             if request_state is not None:

--- a/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/context.md
+++ b/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/context.md
@@ -1,0 +1,91 @@
+# Source comparison and live controls
+
+Baseline: minpeter `addaac05000f0544317bc7d7bf1794293b59d31b` and official
+Codex `rust-v0.153.4`, the installed and latest stable release checked on
+2026-09-09. The final PR ports only the routing-hint code onto main
+`3987abfdf4a9cf372dde2f6694df2e4469bee602` and adds compaction propagation.
+The remote-credential, retry, and benchmark-tooling changes from the fork are
+outside this PR. The patch has not been deployed.
+
+Routing-hint implementation adapted from minpeter commits
+`1359906bb093c72e94c7f54d160a007277bb5656`,
+`a406538eb888383f4b7b291062aa0aeddbe89c4d`,
+`8cfbe662ed274ee452a935f397cefea6282f20fb`, and
+`74d2c65699d89557e14fa29cc4aff1e43875378f`.
+
+## Source evidence
+
+- `codex-rs/core/src/client.rs:697` builds a compaction routing hint;
+  `:1107` restricts synthesis to the Codex backend and uses the final model/tier;
+  `:1622` and `:1769` apply it to HTTP and WebSocket requests.
+- `codex-rs/protocol/src/openai_models.rs:908` removes unsupported service tiers.
+- `codex-rs/core/src/client.rs:222` feeds the request tier into telemetry;
+  `codex-rs/otel/src/events/session_telemetry.rs:1012` reports that metadata on
+  completed events. It does not prove an upstream grant.
+- Native prewarm sends `generate=false`; persistent WebSocket reuse does not
+  necessarily replace its initial handshake when the tier changes. The fork's
+  reuse behavior is not by itself evidence of a tier bug.
+
+Sources:
+[client.rs](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/client.rs),
+[model tier filtering](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/protocol/src/openai_models.rs#L908),
+[telemetry](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/otel/src/events/session_telemetry.rs#L1012).
+
+## Direct OpenAI control
+
+On 2026-09-09 09:10–09:12 UTC, official Codex ran with an isolated temporary
+home, `model_provider="openai"`, ChatGPT OAuth from the same current Pro account,
+no base-URL override, no proxy environment variables, and no inherited user
+configuration. Model: `gpt-5.6-sol`, effort: low, one fixed sentence, no tools.
+
+| Configured tier | Request telemetry | Generated response tier | Input | Cached | Output |
+|---|---|---|---:|---:|---:|
+| default | absent | default | 11118 | 9600 | 14 |
+| fast | priority | default | 11121 | 9600 | 14 |
+| ultrafast | absent | default | 11124 | 9600 | 14 |
+
+The native catalog advertised priority/Fast but not ultrafast. Source filtering
+and the model-only routing hint explain the Ultrafast control: it ran without
+that requested tier. All three also emitted a separate prewarm completion with
+tier auto and zero output. Prewarm is excluded from the generated-response rows.
+These are token counts, not an account-quota or billing multiplier measurement.
+
+## Compaction regression and live check
+
+Before the patch, a public compact route test failed because the emitted hint
+was absent. The fixed transport receives explicit subscription provenance from
+the service; it never infers eligibility from an optional account header.
+
+At 09:16 UTC the actual fork compact transport made one call with synthesis off
+and one with it on, using the same account, proxy route and payload hash. Both
+returned a valid compaction and actual tier default. Input tokens were 69 in
+both; output tokens were 69 and 62, with no reasoning or cached tokens. The on
+variant emitted `model=gpt-5.6-sol;tier=priority`; the off variant emitted no
+hint. This verifies propagation without proving a speed or usage reduction.
+
+Native successful priority/ultrafast grants were not observed in these controls.
+The source gap is repaired, but upstream Fast activation remains unexplained.
+
+## Verification
+
+Final-branch validation: 422 focused tests passed (173 client/header/egress,
+111 compact/transport-selection, 59 compact integration, 2 HTTP-bridge,
+76 bridge-session/reroute, and 1 direct-WebSocket reuse). Repository-wide lint,
+formatting, architecture and type checks passed. Strict OpenSpec validation
+passed for all 64 specs. Coverage includes HTTP egress
+with and without an account-ID header, priority/ultrafast/model-only hints,
+non-subscription source exclusion, persistent WebSocket opens, model-less
+preconnects, connection reuse, pre-dispatch failover, WebSocket-to-HTTP fallback,
+and compact API normalization/policy enforcement.
+
+This PR scopes compact synthesis to proxy-routed client requests. Standalone
+low-level calls, including existing background warmup/automation probes, retain
+the default opt-out. No new setting is introduced.
+
+Public compact paths accept both backend and v1 requests. The existing
+trailing-slash contract remains HTTP 405 with an OpenAI error envelope and no
+upstream dispatch. The response tier is never rewritten to the requested tier.
+
+Live measurements above were collected before the port on the reviewed fork;
+local transport and route regressions validate the final main-based patch.
+Credential snapshots and full native traces were temporary and removed.

--- a/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/proposal.md
+++ b/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/proposal.md
@@ -1,0 +1,15 @@
+# Restore subscription Codex routing hints
+
+Codex 0.153.4 builds upstream routing hints from the final model and service
+tier. Main currently discards incoming hints without synthesizing replacements.
+Port the focused routing-hint changes from minpeter's fork and complete the
+missing compaction path found during source comparison.
+
+Subscription Responses HTTP, transient and persistent WebSocket handshakes,
+HTTP fallback, and compaction will synthesize hints from trusted request state.
+Inbound hints remain untrusted. Custom providers and non-subscription transports
+retain their existing behavior. No prompt, tier entitlement, retry, pricing, or
+quota policy changes are included.
+
+Native OpenAI controls on the tested account also returned actual tier default.
+This change restores request parity; it does not guarantee an upstream Fast grant.

--- a/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/specs/outbound-http-clients/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Client-to-LB routing hints remain hop-local
+
+The service MUST discard inbound `x-codex-routing-hint` values case-insensitively.
+Proxy-routed subscription Responses requests with a known model MUST synthesize a
+new hint from the final model and service tier when opening an HTTP request or
+WebSocket handshake. Inbound values MUST
+NOT determine that hint. Inbound LB API-key authentication MUST NOT prevent
+synthesis for a selected subscription account. Non-subscription transports MUST
+NOT synthesize a Codex-backend hint.
+
+#### Scenario: Inbound HTTP hint is replaced
+- **GIVEN** an inbound request advertises a different model or tier in its hint
+- **WHEN** a subscription-account Responses HTTP request is built
+- **THEN** any synthesized hint MUST reflect the final outbound body
+
+#### Scenario: Inbound WebSocket hint is discarded
+- **GIVEN** an inbound handshake includes any case spelling of the hint header
+- **WHEN** upstream WebSocket handshake headers are built
+- **THEN** the inbound value MUST NOT be forwarded
+- **AND** any synthesized hint MUST use trusted request state
+
+## ADDED Requirements
+
+### Requirement: Subscription Responses synthesize final routing hints
+
+Subscription-account Responses HTTP egress, transient WebSocket handshakes,
+persistent WebSocket handshakes and HTTP fallback MUST synthesize
+`x-codex-routing-hint: model=<model>;tier=<tier>` from the final normalized
+model and service tier. With no tier the hint MUST contain only `model=<model>`.
+A preconnect without a request model MUST omit the hint. Reusing an open
+WebSocket MUST NOT reconnect solely to replace its handshake hint. Synthesis
+MUST NOT alter request bodies, entitlement checks or actual response tiers.
+
+#### Scenario: Fast account request through either public API
+- **WHEN** a subscription request selects Fast through the backend or v1 route
+- **THEN** its outbound body and synthesized hint MUST use priority
+- **AND** caller API-key authentication MUST NOT disable hint synthesis
+
+#### Scenario: WebSocket fallback retains request routing
+- **WHEN** a subscription WebSocket attempt falls back to HTTP
+- **THEN** the HTTP hint MUST use the same final model and service tier
+
+#### Scenario: Custom provider does not gain a backend hint
+- **WHEN** a request is dispatched to a non-subscription model source
+- **THEN** no Codex-backend routing hint MUST be synthesized
+
+### Requirement: Subscription compaction propagates routing hints
+
+Compaction egress for proxy-routed subscription client requests MUST synthesize
+`x-codex-routing-hint: model=<model>;tier=<tier>` from the final normalized request.
+When no tier remains after policy enforcement, the hint MUST contain only
+`model=<model>`. Eligibility MUST use selected subscription provenance, including
+when the optional ChatGPT account-ID header is absent. Hint synthesis MUST NOT
+change compaction input, usage, retries, or the response's actual service tier.
+
+#### Scenario: Fast compaction uses the canonical tier
+- **WHEN** a subscription compaction request selects the Fast alias
+- **THEN** its outbound body and hint MUST both use `priority`
+
+#### Scenario: Ultrafast compaction preserves the requested tier
+- **WHEN** an eligible subscription compaction request selects `ultrafast`
+- **THEN** its outbound body and hint MUST both use `ultrafast`
+
+#### Scenario: Prohibited Fast does not leak through the hint
+- **WHEN** policy removes a subscription compaction request's Fast tier
+- **THEN** its outbound body MUST omit that tier
+- **AND** its hint MUST contain only the final model
+
+#### Scenario: Non-subscription compaction does not synthesize a hint
+- **WHEN** compaction transport is invoked without subscription provenance
+- **THEN** it MUST NOT synthesize or forward a routing hint

--- a/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/tasks.md
+++ b/openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/tasks.md
@@ -1,0 +1,7 @@
+## Tasks
+- [x] Compare official Codex and perform isolated OpenAI direct controls.
+- [x] Port subscription routing-hint propagation onto current main.
+- [x] Include compact egress using the final normalized model and tier.
+- [x] Verify public routes, WebSocket opens, fallback and non-subscription exclusion.
+- [x] Run focused regressions, lint/type/architecture checks and strict OpenSpec validation.
+- [x] Sync normative specs and archive verified evidence.

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -597,23 +597,24 @@ target.
 
 ### Requirement: Client-to-LB routing hints remain hop-local
 
-The service MUST treat `x-codex-routing-hint` as client-to-LB metadata. The
-header MAY be inspected by local routing or test harnesses, but it MUST NOT be
-included in any upstream HTTP request or WebSocket handshake. Header matching
-MUST be case-insensitive.
+The service MUST discard inbound `x-codex-routing-hint` values case-insensitively.
+Proxy-routed subscription Responses requests with a known model MUST synthesize a
+new hint from the final model and service tier when opening an HTTP request or
+WebSocket handshake. Inbound values MUST
+NOT determine that hint. Inbound LB API-key authentication MUST NOT prevent
+synthesis for a selected subscription account. Non-subscription transports MUST
+NOT synthesize a Codex-backend hint.
 
-#### Scenario: HTTP egress omits routing hint
+#### Scenario: Inbound HTTP hint is replaced
+- **GIVEN** an inbound request advertises a different model or tier in its hint
+- **WHEN** a subscription-account Responses HTTP request is built
+- **THEN** any synthesized hint MUST reflect the final outbound body
 
-- **GIVEN** an inbound request includes `x-codex-routing-hint`
-- **WHEN** codex-lb builds an upstream Responses HTTP request
-- **THEN** the upstream request MUST NOT include that header.
-
-#### Scenario: WebSocket egress omits routing hint
-
-- **GIVEN** an inbound WebSocket handshake includes any case spelling of
-  `x-codex-routing-hint`
-- **WHEN** codex-lb builds an upstream Responses WebSocket handshake
-- **THEN** the upstream handshake MUST NOT include that header.
+#### Scenario: Inbound WebSocket hint is discarded
+- **GIVEN** an inbound handshake includes any case spelling of the hint header
+- **WHEN** upstream WebSocket handshake headers are built
+- **THEN** the inbound value MUST NOT be forwarded
+- **AND** any synthesized hint MUST use trusted request state
 
 ### Requirement: Native HTTP/2 startup profile matches measured Codex
 
@@ -1087,3 +1088,51 @@ Events the native egress helper emits for one request MUST be buffered between t
 - **THEN** that request fails with `consumer_backpressure`
 - **AND** other requests on the same helper keep being served
 
+### Requirement: Subscription Responses synthesize final routing hints
+
+Subscription-account Responses HTTP egress, transient WebSocket handshakes,
+persistent WebSocket handshakes and HTTP fallback MUST synthesize
+`x-codex-routing-hint: model=<model>;tier=<tier>` from the final normalized
+model and service tier. With no tier the hint MUST contain only `model=<model>`.
+A preconnect without a request model MUST omit the hint. Reusing an open
+WebSocket MUST NOT reconnect solely to replace its handshake hint. Synthesis
+MUST NOT alter request bodies, entitlement checks or actual response tiers.
+
+#### Scenario: Fast account request through either public API
+- **WHEN** a subscription request selects Fast through the backend or v1 route
+- **THEN** its outbound body and synthesized hint MUST use priority
+- **AND** caller API-key authentication MUST NOT disable hint synthesis
+
+#### Scenario: WebSocket fallback retains request routing
+- **WHEN** a subscription WebSocket attempt falls back to HTTP
+- **THEN** the HTTP hint MUST use the same final model and service tier
+
+#### Scenario: Custom provider does not gain a backend hint
+- **WHEN** a request is dispatched to a non-subscription model source
+- **THEN** no Codex-backend routing hint MUST be synthesized
+
+### Requirement: Subscription compaction propagates routing hints
+
+Compaction egress for proxy-routed subscription client requests MUST synthesize
+`x-codex-routing-hint: model=<model>;tier=<tier>` from the final normalized request.
+When no tier remains after policy enforcement, the hint MUST contain only
+`model=<model>`. Eligibility MUST use selected subscription provenance, including
+when the optional ChatGPT account-ID header is absent. Hint synthesis MUST NOT
+change compaction input, usage, retries, or the response's actual service tier.
+
+#### Scenario: Fast compaction uses the canonical tier
+- **WHEN** a subscription compaction request selects the Fast alias
+- **THEN** its outbound body and hint MUST both use `priority`
+
+#### Scenario: Ultrafast compaction preserves the requested tier
+- **WHEN** an eligible subscription compaction request selects `ultrafast`
+- **THEN** its outbound body and hint MUST both use `ultrafast`
+
+#### Scenario: Prohibited Fast does not leak through the hint
+- **WHEN** policy removes a subscription compaction request's Fast tier
+- **THEN** its outbound body MUST omit that tier
+- **AND** its hint MUST contain only the final model
+
+#### Scenario: Non-subscription compaction does not synthesize a hint
+- **WHEN** compaction transport is invoked without subscription provenance
+- **THEN** it MUST NOT synthesize or forward a routing hint

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -1652,6 +1652,85 @@ class _PrewarmingBridgeUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
         )
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_routing_hint_is_first_handshake_only(async_client, monkeypatch):
+    from app.core.clients import proxy_websocket as websocket_client
+    from app.core.clients.native_egress import NativeWebSocketMessage, NativeWebSocketRequest
+
+    # Given real bridge selection, request preparation and client header building.
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(async_client, "acc_hint_reuse", "hint-reuse@example.com")
+    account = await _get_account(account_id)
+    upstream = _FakeBridgeUpstreamWebSocket("resp_hint_reuse")
+    handshakes: list[NativeWebSocketRequest] = []
+
+    async def select_account(self, deadline, **kwargs):
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def ensure_fresh(self, target, *, force=False, timeout_seconds):
+        return target
+
+    async def receive_native():
+        message = await upstream.receive()
+        return NativeWebSocketMessage(kind=message.kind, text=message.text)
+
+    async def close_native(code=1000, reason=""):
+        await upstream.close()
+
+    native_socket = Mock()
+    native_socket.send_text = upstream.send_text
+    native_socket.receive = receive_native
+    native_socket.close = close_native
+    native_socket.response_header = upstream.response_header
+
+    async def connect_native(request: NativeWebSocketRequest):
+        handshakes.append(request)
+        return native_socket
+
+    native_client = Mock()
+    native_client.websocket = connect_native
+    monkeypatch.setattr(websocket_client, "discover_native_egress_client", lambda: native_client)
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", select_account)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", ensure_fresh)
+
+    # When an anchored second turn changes tier on the existing connection.
+    with anyio.fail_after(_TEST_SYNC_TIMEOUT_SECONDS):
+        first = await _collect_sse_events(
+            async_client,
+            "/v1/responses",
+            json_body={
+                "model": "gpt-5.4",
+                "input": "first",
+                "prompt_cache_key": "routing-hint-reuse",
+                "service_tier": "priority",
+                "stream": True,
+            },
+            headers={"X-Codex-Routing-Hint": "model=spoof;tier=flex"},
+        )
+        first_response_id = next(event["response"]["id"] for event in first if event["type"] == "response.completed")
+        second = await _collect_sse_events(
+            async_client,
+            "/v1/responses",
+            json_body={
+                "model": "gpt-5.4",
+                "input": "second",
+                "prompt_cache_key": "routing-hint-reuse",
+                "previous_response_id": first_response_id,
+                "stream": True,
+            },
+        )
+
+    # Then the first header remains; second-frame tier absence never reconnects.
+    assert any(event["type"] == "response.completed" for event in second)
+    assert len(handshakes) == 1
+    assert handshakes[0].headers.get("x-codex-routing-hint") == "model=gpt-5.4;tier=priority"
+    frames = [json.loads(text) for text in upstream.sent_text]
+    assert len(frames) == 2
+    assert frames[0]["service_tier"] == "priority"
+    assert "service_tier" not in frames[1]
+    assert frames[1]["previous_response_id"] == first_response_id
+
+
 class _TurnStateBridgeUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     def __init__(self, turn_state: str) -> None:
         super().__init__()
@@ -1708,6 +1787,7 @@ async def test_v1_responses_http_bridge_fails_over_confirmed_proxy_connect_befor
     second_account = await _get_account(second_account_id)
     upstream = _FakeBridgeUpstreamWebSocket()
     connect_calls: list[str | None] = []
+    routing_hints: list[tuple[str, str | None] | None] = []
     selection_exclusions: list[set[str]] = []
     backed_off_accounts: list[str] = []
     handle_stream_error = AsyncMock()
@@ -1729,7 +1809,8 @@ async def test_v1_responses_http_bridge_fails_over_confirmed_proxy_connect_befor
         account_id_header,
         **kwargs,
     ):
-        del headers, access_token, kwargs
+        del headers, access_token
+        routing_hints.append(kwargs.get("routing_hint"))
         connect_calls.append(account_id_header)
         if len(connect_calls) == 1:
             raise proxy_module.ProxyResponseError(
@@ -1760,6 +1841,7 @@ async def test_v1_responses_http_bridge_fails_over_confirmed_proxy_connect_befor
             "instructions": "Return exactly OK.",
             "input": "hello",
             "prompt_cache_key": "http-bridge-proxy-connect-failover-key",
+            "service_tier": "priority",
             "stream": True,
         },
     )
@@ -1768,6 +1850,7 @@ async def test_v1_responses_http_bridge_fails_over_confirmed_proxy_connect_befor
     assert len(connect_calls) == 2
     assert selection_exclusions == [set(), {first_account.id}]
     assert backed_off_accounts == [first_account.id]
+    assert routing_hints == [("gpt-5.4", "priority"), ("gpt-5.4", "priority")]
     assert len(upstream.sent_text) == 1
     handle_stream_error.assert_not_awaited()
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+from dataclasses import replace
 from datetime import timedelta, timezone
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock
 
+import aiohttp
 import pytest
 from sqlalchemy import select
 
@@ -16,6 +18,7 @@ import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
+from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import CompactResponsePayload, OpenAIResponsePayload
 from app.core.openai.requests import ResponsesCompactRequest
 from app.core.utils.time import utcnow
@@ -908,6 +911,130 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert call_json["store"] is False
     call_headers = cast(dict[str, str], session.calls[0]["headers"])
     assert call_headers["Accept"] == "text/event-stream"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/backend-api/codex/responses/compact",
+        "/v1/responses/compact",
+    ],
+)
+@pytest.mark.parametrize(
+    ("tier", "prohibit_fast", "omit_account_header", "expected_tier"),
+    [
+        (None, False, False, None),
+        ("priority", False, False, "priority"),
+        ("fast", False, False, "priority"),
+        ("ultrafast", False, False, "ultrafast"),
+        ("priority", True, False, None),
+        ("priority", False, True, "priority"),
+    ],
+)
+async def test_proxy_compact_synthesizes_final_subscription_routing_hint(
+    async_client,
+    monkeypatch,
+    path: str,
+    tier: str | None,
+    prohibit_fast: bool,
+    omit_account_header: bool,
+    expected_tier: str | None,
+):
+    imported = await async_client.post(
+        "/api/accounts/import",
+        files={
+            "auth_json": (
+                "auth.json",
+                json.dumps(_make_auth_json("acc_compact_hint", "compact-hint@example.com")),
+                "application/json",
+            )
+        },
+    )
+    assert imported.status_code == 200
+    account_id = generate_unique_account_id("acc_compact_hint", "compact-hint@example.com")
+    model = "gpt-5.6-sol"
+    registry = get_model_registry()
+    catalog_model = replace(
+        registry.get_models_with_fallback()[model],
+        raw={"service_tiers": [{"id": "priority"}, {"id": "ultrafast"}]},
+    )
+    await registry.update(
+        {"plus": [catalog_model]},
+        per_account_results={account_id: ("plus", [catalog_model])},
+        active_account_plans={account_id: "plus"},
+    )
+    if omit_account_header:
+
+        async def fresh_without_account_header(self, account: Account, **kwargs: object) -> Account:
+            account.chatgpt_account_id = None
+            return account
+
+        monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fresh_without_account_header)
+    settings = await async_client.put(
+        "/api/settings", json={"prohibitFastMode": prohibit_fast, "apiKeyAuthEnabled": True}
+    )
+    assert settings.status_code == 200
+    _, key = await _create_api_key(name="compact-hint")
+    session = _JsonSession(_SseResponse())
+
+    @contextlib.asynccontextmanager
+    async def lease_session(session_override=None):
+        assert session_override is None
+        yield session
+
+    monkeypatch.setattr(proxy_client_module, "lease_http_session", lease_session)
+    payload: dict[str, object] = {"model": model, "instructions": "hi", "input": []}
+    if tier is not None:
+        payload["service_tier"] = tier
+    response = await async_client.post(
+        path,
+        json=payload,
+        headers={
+            "authorization": f"Bearer {key}",
+            "X-Codex-Routing-Hint": "model=untrusted;tier=ultrafast",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert len(session.calls) == 1
+    outbound = _session_call_json(session)
+    assert outbound.get("service_tier") == expected_tier
+    assert outbound["input"] == [{"type": "compaction_trigger"}]
+    assert outbound["instructions"] == "hi"
+    headers = cast(dict[str, str], session.calls[0]["headers"])
+    expected_hint = f"model={model}" + (f";tier={expected_tier}" if expected_tier else "")
+    assert headers.get("x-codex-routing-hint") == expected_hint
+    if omit_account_header:
+        assert not any(name.lower() == "chatgpt-account-id" for name in headers)
+    assert response.json()["output"][0]["encrypted_content"] == "enc_compact_summary_1"
+    assert response.json().get("service_tier") is None
+
+
+@pytest.mark.asyncio
+async def test_compact_transport_without_subscription_provenance_omits_routing_hint():
+    session = _JsonSession(_SseResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.6-sol", instructions="hi", input=[], service_tier="priority")
+    await proxy_client_module.compact_responses(
+        payload,
+        {"X-Codex-Routing-Hint": "model=untrusted;tier=priority"},
+        "test-token",
+        "account-header-is-not-provenance",
+        session=cast(aiohttp.ClientSession, session),
+    )
+    assert len(session.calls) == 1
+    headers = cast(dict[str, str], session.calls[0]["headers"])
+    assert not any(name.lower() == "x-codex-routing-hint" for name in headers)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses/compact/", "/v1/responses/compact/"])
+async def test_compact_trailing_slash_rejection_does_not_dispatch(async_client, monkeypatch, path: str):
+    compact = AsyncMock()
+    monkeypatch.setattr(proxy_module, "core_compact_responses", compact)
+    response = await async_client.post(path, json={"model": "gpt-5.6-sol", "instructions": "hi", "input": []})
+    assert response.status_code == 405
+    assert response.json()["error"]["code"] == "invalid_request_error"
+    compact.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -4660,6 +4660,7 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
         "model": "gpt-5.4",
         "input": "first",
         "promptCacheKey": "thread_a",
+        "service_tier": "priority",
         "stream": True,
     }
     second_request = {
@@ -4696,6 +4697,7 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "first"}]}],
+                "service_tier": "priority",
                 "store": False,
                 "include": [],
                 "prompt_cache_key": "thread_a",

--- a/tests/unit/test_http_subscription_routing_hint.py
+++ b/tests/unit/test_http_subscription_routing_hint.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from app.core.clients import proxy as client
+from app.core.clients.http import lease_http_session
+from app.core.config.settings import get_settings
+from app.core.openai.requests import ResponsesRequest
+from app.core.utils.sse import parse_sse_data_json
+from app.db.models import Account, ModelSource
+from app.modules.model_sources import forwarding
+from app.modules.proxy import service as proxy_service
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass(frozen=True, slots=True)
+class _WireRequest:
+    headers: Mapping[str, str]
+    payload: ResponsesRequest
+
+
+@pytest.fixture
+async def loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[tuple[TestServer, list[_WireRequest], asyncio.Event]]:
+    received: list[_WireRequest] = []
+    completed = asyncio.Event()
+
+    async def respond(request: web.Request) -> web.StreamResponse:
+        try:
+            received.append(_WireRequest(request.headers.copy(), ResponsesRequest.model_validate(await request.json())))
+            response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await response.prepare(request)
+            await response.write(
+                b'data: {"type":"response.completed","response":{"id":"resp_loopback","status":"completed"}}\n\n'
+            )
+            await response.write_eof()
+            return response
+        finally:
+            completed.set()
+
+    app = web.Application()
+    app.router.add_post("/backend-api/codex/responses", respond)
+    app.router.add_post("/v1/responses", respond)
+    server = TestServer(app, host="127.0.0.1")
+    async with asyncio.timeout(5):
+        await server.start_server()
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5), trust_env=False) as session:
+
+            def local_lease(
+                existing: aiohttp.ClientSession | None = None,
+            ) -> AbstractAsyncContextManager[aiohttp.ClientSession]:
+                return lease_http_session(existing or session)
+
+            monkeypatch.setattr(client, "lease_http_session", local_lease)
+            monkeypatch.setattr(forwarding, "lease_model_source_session", local_lease)
+            monkeypatch.setattr(client, "discover_native_egress_client", lambda: None)
+            monkeypatch.setattr(get_settings(), "upstream_base_url", str(server.make_url("/backend-api")))
+            yield server, received, completed
+    finally:
+        async with asyncio.timeout(5):
+            await server.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_id", ["subscription-account", None, "email_legacy", "local_legacy"])
+@pytest.mark.parametrize("tier", ["priority", "ultrafast", None])
+async def test_selected_subscription_synthesizes_hint_without_requiring_account_header(
+    monkeypatch: pytest.MonkeyPatch,
+    loopback: tuple[TestServer, list[_WireRequest], asyncio.Event],
+    account_id: str | None,
+    tier: str | None,
+) -> None:
+    # Given a selected subscription Account and the final normalized request.
+    _, received, completed = loopback
+    service = proxy_service.ProxyService(MagicMock())
+    account = Account(
+        id="selected-subscription",
+        chatgpt_account_id=account_id,
+        access_token_encrypted=service._encryptor.encrypt("fixture-subscription-token"),
+    )
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5", "instructions": "", "input": "hello", "service_tier": tier}
+    )
+    settlement = proxy_service._StreamSettlement()
+    # Only persistence and route lookup are isolated; admission, streaming,
+    # optional-kwarg dispatch, header construction and aiohttp egress are real.
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_write_request_log", AsyncMock())
+
+    # When the real service attempt reaches a local HTTP Responses endpoint.
+    async with asyncio.timeout(5):
+        stream = service._stream_once(
+            account,
+            payload,
+            {"Authorization": "Bearer fixture-downstream-key", "X-Codex-Routing-Hint": "model=spoof;tier=flex"},
+            "req_subscription_hint",
+            False,
+            request_started_at=service._clock.monotonic(),
+            api_key=None,
+            api_key_reservation=None,
+            settlement=settlement,
+            suppress_text_done_events=False,
+            upstream_stream_transport="http",
+            request_transport="http",
+        )
+        events = [parse_sse_data_json(event) async for event in stream]
+        await completed.wait()
+
+    # Then the wire hint follows subscription provenance, not the optional ID.
+    assert len(received) == 1
+    wire = received[0]
+    expected = "model=gpt-5" + (f";tier={tier}" if tier is not None else "")
+    assert wire.headers.get("x-codex-routing-hint") == expected
+    assert wire.headers.get("ChatGPT-Account-ID") == (account_id if account_id == "subscription-account" else None)
+    assert wire.headers["Authorization"] == "Bearer fixture-subscription-token"
+    assert wire.payload.model == "gpt-5"
+    assert wire.payload.service_tier == tier
+    assert events == [{"type": "response.completed", "response": {"id": "resp_loopback", "status": "completed"}}]
+    assert settlement.status == "success"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_id", ["subscription-account", None])
+async def test_low_level_http_client_keeps_routing_hint_default_off(
+    loopback: tuple[TestServer, list[_WireRequest], asyncio.Event], account_id: str | None
+) -> None:
+    # Given a standalone low-level caller, without subscription opt-in.
+    _, received, completed = loopback
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5", "instructions": "", "input": "hello", "service_tier": "priority"}
+    )
+
+    # When the actual HTTP client sends the request without the opt-in kwarg.
+    async with asyncio.timeout(5):
+        events = [
+            event
+            async for event in client.stream_responses(
+                payload,
+                {"X-Codex-Routing-Hint": "model=spoof;tier=flex"},
+                "fixture-low-level-token",
+                account_id,
+                upstream_stream_transport_override="http",
+            )
+        ]
+        await completed.wait()
+
+    # Then neither an account header nor an inbound hint enables synthesis.
+    assert len(received) == 1
+    assert "x-codex-routing-hint" not in received[0].headers
+    assert events
+
+
+@pytest.mark.asyncio
+async def test_external_model_source_does_not_gain_subscription_routing_hint(
+    loopback: tuple[TestServer, list[_WireRequest], asyncio.Event],
+) -> None:
+    # Given an external model source, which bypasses subscription streaming.
+    server, received, completed = loopback
+    source = ModelSource(
+        id="fixture-external", name="Fixture", kind="openai_compatible", base_url=str(server.make_url("/v1"))
+    )
+
+    # When its real forwarding client dispatches a priority Responses request.
+    async with asyncio.timeout(5):
+        response = await forwarding.stream_responses(
+            source, {"model": "external-model", "instructions": "", "input": "hello", "service_tier": "priority"}
+        )
+        events = [chunk async for chunk in response.body]
+        await completed.wait()
+
+    # Then external traffic stays outside subscription hint synthesis.
+    assert len(received) == 1
+    assert "x-codex-routing-hint" not in received[0].headers
+    assert received[0].payload.model == "external-model"
+    assert events

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -11723,6 +11723,7 @@ async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
             "instructions": "hi",
             "input": "hello",
             "prompt_cache_key": "soft-queue-full",
+            "service_tier": "priority",
         }
     )
     saturated_session = _make_bridge_session(key_value="soft-queue-full", queued_request_count=8)
@@ -11811,6 +11812,8 @@ async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
     assert get_or_create.await_args_list[1].kwargs["previous_response_id"] is None
     assert get_or_create.await_args_list[2].kwargs["previous_response_id"] is None
     assert "internal_soft_affinity_reroute" in caplog.text
+    assert get_or_create.await_args_list[1].kwargs["request_service_tier"] == "priority"
+    assert get_or_create.await_args_list[2].kwargs["request_service_tier"] == "priority"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from app.core.clients import proxy as proxy_module
 from app.core.clients.proxy import (
     _build_upstream_headers,
@@ -13,6 +15,17 @@ from app.core.clients.proxy import (
 
 def _lower_keys(headers: dict[str, str]) -> set[str]:
     return {key.lower() for key in headers}
+
+
+@pytest.mark.parametrize("builder", [_build_upstream_headers, _build_upstream_websocket_headers])
+def test_absent_effective_tier_uses_official_model_only_hint(builder):
+    headers = builder(
+        {"X-Codex-Routing-Hint": "model=untrusted;tier=priority"},
+        "fixture-access",
+        "fixture-account",
+        routing_hint=("gpt-6-astra", None),
+    )
+    assert headers["x-codex-routing-hint"] == "model=gpt-6-astra"
 
 
 def test_build_codex_user_agent_matches_codex_cli_format():
@@ -59,6 +72,26 @@ def test_routing_hint_is_hop_local_for_responses_http_and_websocket():
 
     assert "x-codex-routing-hint" not in _lower_keys(http_headers)
     assert "x-codex-routing-hint" not in _lower_keys(websocket_headers)
+
+
+def test_chatgpt_account_route_synthesizes_priority_routing_hint_with_api_key():
+    headers = _build_upstream_headers(
+        {"User-Agent": "OpenAI/Python", "X-Codex-Routing-Hint": "model=evil;tier=default"},
+        "tok",
+        "acct-1",
+        routing_hint=("gpt-6-astra", "priority"),
+    )
+    assert headers["x-codex-routing-hint"] == "model=gpt-6-astra;tier=priority"
+
+
+def test_api_key_authentication_does_not_disable_account_backend_hint():
+    headers = _build_upstream_websocket_headers(
+        {"User-Agent": "OpenAI/Python", "X-Codex-Routing-Hint": "model=evil;tier=default"},
+        "tok",
+        "acct-1",
+        routing_hint=("gpt-6-astra", "priority"),
+    )
+    assert headers["x-codex-routing-hint"] == "model=gpt-6-astra;tier=priority"
 
 
 def test_non_native_request_uses_pascalcase_account_header():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11926,7 +11926,8 @@ async def test_stream_responses_auto_transport_keeps_http_for_bare_session_affin
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket_upgrade_required(monkeypatch):
+@pytest.mark.parametrize("tier", [None, "priority", "ultrafast"])
+async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket_upgrade_required(monkeypatch, tier):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 8.0
@@ -11944,6 +11945,8 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
 
     async def fake_open_upstream_websocket(**kwargs):
         attempts["websocket"] += 1
+        expected = "model=gpt-5.4" + (f";tier={tier}" if tier is not None else "")
+        assert kwargs["headers"]["x-codex-routing-hint"] == expected
         raise proxy_module.aiohttp.WSServerHandshakeError(request_info, (), status=426, message="Upgrade Required")
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
@@ -11964,6 +11967,7 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
             "instructions": "hi",
             "input": [additional_tools, {"role": "user", "content": "hi"}],
             "reasoning": {"context": "last_turn", "effort": "high"},
+            "service_tier": tier,
         }
     )
 
@@ -11975,6 +11979,7 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
             access_token="token",
             account_id="acc_1",
             session=cast(proxy_module.aiohttp.ClientSession, session),
+            synthesize_routing_hint=True,
         )
     ]
 
@@ -11982,6 +11987,8 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
     assert session.calls
     upstream_headers = cast(dict[str, str], session.calls[0]["headers"])
     assert upstream_headers[proxy_module.CODEX_RESPONSES_LITE_HEADER] == "true"
+    expected = "model=gpt-5.4" + (f";tier={tier}" if tier is not None else "")
+    assert upstream_headers["x-codex-routing-hint"] == expected
     upstream_payload = cast(dict[str, JsonValue], session.calls[0]["json"])
     assert upstream_payload["reasoning"] == {"context": "all_turns", "effort": "high"}
     assert proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY not in cast(

--- a/tests/unit/test_responses_websocket_routing_hint.py
+++ b/tests/unit/test_responses_websocket_routing_hint.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from app.core.clients import proxy_websocket as client
+from app.core.clients.native_egress import NativeWebSocketRequest
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy.request_policy import apply_api_key_enforcement
+from tests.unit.test_proxy_utils import (
+    _make_account,
+    _repo_factory,
+    _RequestLogsRecorder,
+)
+from tests.unit.test_proxy_websocket_client import _FakeNativeWebSocket
+from tests.unit.test_proxy_websocket_model_source_guard import _api_key
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frontend_key", [False, True])
+@pytest.mark.parametrize("account_header", ["subscription-account", None])
+@pytest.mark.parametrize("tier", ["priority", "ultrafast", None])
+async def test_subscription_handshake_uses_normalized_request_not_inbound_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    frontend_key: bool,
+    account_header: str | None,
+    tier: str | None,
+) -> None:
+    # Given a final normalized request and selected subscription Account.
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("subscription-account")
+    account.chatgpt_account_id = account_header
+    key = replace(_api_key(), enforced_model="gpt-5-high") if frontend_key else None
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5-high", "instructions": "", "input": "hello", "service_tier": tier}
+    )
+    apply_api_key_enforcement(payload, key)
+    state, _ = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=key,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport="websocket",
+        client_metadata=None,
+    )
+    # Response-observed tier is deliberately different: it is not wire intent.
+    state.service_tier = "flex"
+    state.actual_service_tier = "flex"
+    native = AsyncMock()
+    native.websocket.return_value = _FakeNativeWebSocket()
+    monkeypatch.setattr(client, "discover_native_egress_client", lambda: native)
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+
+    # When the real service opener reaches the real persistent client builder.
+    with anyio.fail_after(5):
+        upstream = await service._open_upstream_websocket(
+            account,
+            {"X-Codex-Routing-Hint": "model=spoof;tier=flex"},
+            request_state=state,
+        )
+        await upstream.close()
+
+    # Inspect the emitted handshake at the native transport boundary.
+    request = native.websocket.await_args.args[0]
+    assert isinstance(request, NativeWebSocketRequest)
+    expected = "model=gpt-5" + (f";tier={tier}" if tier is not None else "")
+    assert request.headers.get("x-codex-routing-hint") == expected
+    assert "X-Codex-Routing-Hint" not in request.headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_state", [False, True])
+async def test_model_less_preconnect_omits_hint(monkeypatch: pytest.MonkeyPatch, with_state: bool) -> None:
+    # Given preconnect has no request model (or no request state at all).
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("subscription-preconnect")
+    state = proxy_service._WebSocketRequestState(
+        request_id="preconnect",
+        model=None,
+        service_tier="priority",
+        requested_service_tier="priority",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=anyio.current_time(),
+    )
+    native = AsyncMock()
+    native.websocket.return_value = _FakeNativeWebSocket()
+    monkeypatch.setattr(client, "discover_native_egress_client", lambda: native)
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+
+    # When opening through the production service and client.
+    with anyio.fail_after(5):
+        upstream = await service._open_upstream_websocket(
+            account,
+            {"x-codex-routing-hint": "model=spoof;tier=priority"},
+            request_state=state if with_state else None,
+        )
+        await upstream.close()
+
+    # Then no guessed model or tier is emitted.
+    request = native.websocket.await_args.args[0]
+    assert isinstance(request, NativeWebSocketRequest)
+    assert "x-codex-routing-hint" not in request.headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("live", [False, True])
+async def test_unopted_client_and_live_do_not_forward_hint(monkeypatch: pytest.MonkeyPatch, live: bool) -> None:
+    # Given a low-level caller without trusted Responses routing context.
+    native = AsyncMock()
+    native.websocket.return_value = _FakeNativeWebSocket()
+    monkeypatch.setattr(client, "discover_native_egress_client", lambda: native)
+    headers = {"X-Codex-Routing-Hint": "model=spoof;tier=priority"}
+
+    # When opening live or a standalone Responses connection without opt-in.
+    with anyio.fail_after(5):
+        if live:
+            upstream = await client.connect_live_websocket(
+                "rtc_hint_test",
+                headers,
+                "test-token",
+                "subscription-account",
+                protocol=client.RealtimeWebSocketProtocol.LIVE_V3,
+                allow_direct_egress=True,
+            )
+        else:
+            upstream = await client.connect_responses_websocket(headers, "test-api-key", None, allow_direct_egress=True)
+        await upstream.close()
+
+    # Then inbound hints remain stripped and account-id alone is not opt-in.
+    request = native.websocket.await_args.args[0]
+    assert isinstance(request, NativeWebSocketRequest)
+    assert all(key.lower() != "x-codex-routing-hint" for key in request.headers)

--- a/tests/unit/test_websocket_upstream_transport_observability.py
+++ b/tests/unit/test_websocket_upstream_transport_observability.py
@@ -115,12 +115,14 @@ async def test_direct_websocket_connect_egress_uses_selected_installation_metada
         *,
         route: object,
         allow_direct_egress: bool,
+        routing_hint: tuple[str, str | None] | None = None,
     ) -> object:
         captured["headers"] = dict(headers)
         captured["access_token"] = access_token
         captured["account_id"] = account_id
         captured["route"] = route
         captured["allow_direct_egress"] = allow_direct_egress
+        captured["routing_hint"] = routing_hint
         return expected_upstream
 
     class _DirectWebSocketFacade(_DummyFacade):
@@ -158,6 +160,7 @@ async def test_direct_websocket_connect_egress_uses_selected_installation_metada
     assert captured["account_id"] == "account-123"
     assert captured["route"] is None
     assert captured["allow_direct_egress"] is True
+    assert captured["routing_hint"] is None
     upstream_headers = cast(dict[str, str], captured["headers"])
     assert "x-codex-installation-id" not in upstream_headers
     assert json.loads(upstream_headers["x-codex-turn-metadata"]) == {


### PR DESCRIPTION
## Summary

Subscription requests currently discard `x-codex-routing-hint` without rebuilding the hint that official Codex sends upstream. Synthesize it from the final normalized model and requested tier across Responses HTTP, WebSocket handshakes, HTTP fallback, and client-request compaction; preserve the tier when the HTTP bridge opens or reroutes a connection.

This restores request parity with Codex 0.153.4. It does **not** establish that upstream grants Fast: controlled runs of both the fork and the built-in OpenAI provider returned actual tier `default` on the tested account.

## Type of change

- [x] `fix:` — bug fix

Related to #1454 and #2000; partial investigation, not an issue-closing claim.

## Changes

- Build trusted outbound hints after model/tier normalization. An absent tier produces `model=<model>`; priority and ultrafast retain their exact values.
- Enable synthesis from selected subscription-account provenance, including LB API-key callers and accounts without the optional account-ID header. Discard inbound hints; keep non-subscription providers and standalone low-level clients outside synthesis.
- Carry requested tier through HTTP-bridge connection creation and soft reroutes. Existing WebSockets retain their original handshake when later frames change tier, matching native reuse behavior.
- Complete the compaction path omitted by the fork. Fast prohibition removes the tier from both the request body and synthesized hint.

The focused Responses changes are adapted from [minpeter's branch](https://github.com/minpeter/codex-lb/commits/feature/remote-credential-replica/) at `addaac050`. Remote credentials, retry-policy changes, and the fork-only benchmark tool are outside this PR. There are no prompt, entitlement, quota/pricing, or retry-count changes.

## OpenSpec

- [x] Includes an archived, verified change and synchronized main spec.
- [x] Touches a Codex request-shape path and preserves upstream-equivalent hint construction.

Change directory: `openspec/changes/archive/2026-09-09-sync-codex-subscription-routing-hints/`

The context records source links, live controls, and limits. Official [client.rs](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/client.rs#L1107) constructs model/tier hints; [compaction](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/client.rs#L697) uses the same logic.

## Test plan

422 focused tests passed on the main-based port:

| Coverage | Passed |
|---|---:|
| HTTP subscription egress, persistent WebSocket hints, fingerprints, WebSocket clients, upstream paths | 173 |
| Compact and automatic transport selection in `test_proxy_utils.py` | 111 |
| Compact routes and triggers | 59 |
| HTTP bridge handshake reuse and pre-dispatch failover | 2 |
| Bridge session creation and soft queue-full rerouting | 76 |
| Direct WebSocket sequential-request reuse | 1 |

Repository-wide `make lint` (including architecture/cancellation/timing/settings checks), `ty check`, `openspec validate --specs --strict` (64 specs), and `git diff --check` passed. Tests used the existing Python environment with `PYTHONPATH=.`. The first full cloud unit run exposed one stale WebSocket observability fixture that rejected the new optional routing context. Follow-up `f05fb43da` updates that fixture and asserts a model-less connection receives no hint; its observability and routing suites pass (26 tests). Cloud CI is rerunning on that head; the full suite was not run locally.

## Measured output

Same Pro account, `gpt-5.6-sol`, low effort, isolated official Codex 0.153.4, built-in `openai`, ChatGPT OAuth, no base-URL override or proxy environment variables:

| Configured tier | Request telemetry | Actual generated response tier |
|---|---|---|
| default | absent | default |
| fast | priority | default |
| ultrafast | absent | default |

The native catalog advertised priority but not ultrafast, so Codex filtered ultrafast before sending. Native completed-event telemetry records the **request** tier; the table uses the raw terminal response and excludes zero-output prewarm events.

The fork's real compact transport also succeeded with synthesis off/on: input tokens were 69/69, output tokens 69/62, and actual tiers default/default. The enabled call emitted `model=gpt-5.6-sol;tier=priority`. These measurements verify propagation, not a speed improvement or a billing multiplier. They were collected before the port; local regressions validate the final branch. No production deployment was performed.

## Checklist

- [x] Conventional Commits title; related issues linked with partial scope.
- [x] Regression tests cover emitted transport requests and public routes.
- [x] Relevant local checks passed; strict OpenSpec validation passed.
- [x] Simplicity reviewed: zero configuration, no new settings, README sections, or dashboard navigation.
- [x] CHANGELOG left to release tooling.

