### PR TITLE
test(db): eliminate SQLite "database is locked" flakes in the integration suites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,42 @@ def _disable_leader_election_startup(monkeypatch):
     monkeypatch.setattr(main_module, "get_leader_election", lambda: election)
 
 
+@pytest.fixture(autouse=True)
+def _forbid_blocking_test_client_on_running_loop(monkeypatch):
+    """Fail fast when starlette's blocking ``TestClient`` is entered on the running test loop.
+
+    ``TestClient.__enter__`` blocks the calling thread until the app lifespan
+    has started on the client's portal thread. Called from an ``async def``
+    test, the blocked thread is the shared session loop — the loop that owns
+    the ``async_client`` lifespan's background SQLite writers. A write
+    transaction one of them has in flight (INSERT executed, COMMIT not yet
+    dispatched) can no longer release the single writer slot, so the portal
+    lifespan's startup stamps wait out the 30 s ``busy_timeout`` and fail with
+    ``database is locked`` (issue #1949). That deadlock is nondeterministic
+    and looked like a lock-contention bug in production code; turn it into an
+    immediate, explanatory failure instead. Async tests use
+    ``tests.integration.off_loop_test_client.off_loop_test_client``; sync
+    tests (no running loop on the calling thread) are unaffected.
+    """
+    from starlette.testclient import TestClient
+
+    original_enter = TestClient.__enter__
+
+    def _guarded_enter(self):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return original_enter(self)
+        raise RuntimeError(
+            "TestClient.__enter__ called on a thread with a running event loop: this blocks the loop "
+            "that owns the app lifespan's SQLite writers and deadlocks the portal lifespan's startup "
+            "writes until busy_timeout (issue #1949). In async tests use "
+            "`async with off_loop_test_client(app) as client:` from tests.integration.off_loop_test_client."
+        )
+
+    monkeypatch.setattr(TestClient, "__enter__", _guarded_enter)
+
+
 @pytest_asyncio.fixture(scope="session", autouse=True)
 async def dispose_engine():
     yield

--- a/tests/integration/off_loop_test_client.py
+++ b/tests/integration/off_loop_test_client.py
@@ -1,0 +1,72 @@
+"""Enter starlette's blocking ``TestClient`` from an async test without freezing the loop.
+
+``TestClient.__enter__`` runs the app lifespan on a private portal thread and
+blocks the *calling* thread until startup finishes; ``__exit__`` blocks the
+same way for shutdown. Inside an ``async def`` test the calling thread is the
+shared session event loop, which also owns the ``async_client`` lifespan's
+background writers (cache-invalidation bump flush, ring heartbeat, last-used
+coalescer, ...). Every one of those writers is an aiosqlite round trip per
+statement, so a write transaction that has executed its INSERT but not yet its
+COMMIT needs the loop to run before it can release SQLite's single writer slot.
+Freezing the loop therefore freezes the holder, and every write the portal
+lifespan performs at startup (encryption-key fingerprint stamp, hard-sticky
+outage-grace seed) waits the full 30 s ``busy_timeout`` before failing with
+``database is locked`` (issue #1949). Retrying or ``BEGIN IMMEDIATE`` on the
+startup path cannot help: the holder is frozen precisely because the caller is
+blocked on it.
+
+The helper keeps the loop alive by entering and exiting the client from a
+worker thread, and flushes the deferred writers the loop owns before handing
+the client over so the test body's blocking ``client.*`` calls do not race a
+flush that would otherwise start a moment later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from starlette.testclient import TestClient
+from starlette.types import ASGIApp
+
+from app.core.cache.invalidation import get_cache_invalidation_poller
+
+_DRAIN_TIMEOUT_SECONDS = 5.0
+
+
+async def flush_deferred_sqlite_writers(app: ASGIApp) -> None:
+    """Complete the loop-owned SQLite writes that are deferred from the request path.
+
+    Detached request-log / settlement persistence is drained the same way the
+    ``async_client`` response hook drains it; the cache-invalidation poller's
+    pending bumps are flushed now instead of on its next tick so no write can
+    start on this loop while the caller is blocked in a portal call.
+    """
+    service = getattr(getattr(app, "state", None), "proxy_service", None)
+    if service is not None and hasattr(service, "drain_persistence_tasks"):
+        await service.drain_persistence_tasks(timeout_seconds=_DRAIN_TIMEOUT_SECONDS)
+    poller = get_cache_invalidation_poller()
+    if poller is not None:
+        # The poller has no public "flush now"; its tick is `_flush_pending_bumps`
+        # followed by the version read, and only the flush writes.
+        await poller._flush_pending_bumps()
+
+
+@asynccontextmanager
+async def off_loop_test_client(app: ASGIApp, **client_kwargs: Any) -> AsyncIterator[TestClient]:
+    """``async with off_loop_test_client(app) as client:`` for async tests.
+
+    Drop-in for ``with TestClient(app) as client:``; the yielded client is the
+    ordinary blocking ``TestClient`` (its ``websocket_connect`` / ``get`` /
+    ``post`` calls still block the loop briefly, which is safe once nothing the
+    loop owns is mid-transaction).
+    """
+    await flush_deferred_sqlite_writers(app)
+    client = TestClient(app, **client_kwargs)
+    await asyncio.to_thread(client.__enter__)
+    try:
+        yield client
+    finally:
+        await asyncio.to_thread(client.__exit__, None, None, None)

--- a/tests/integration/test_off_loop_test_client.py
+++ b/tests/integration/test_off_loop_test_client.py
@@ -1,0 +1,93 @@
+"""Pin the harness contract that keeps the shared test loop alive while a blocking
+``TestClient`` lifespan starts on its portal thread (issue #1949)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.core.cache.invalidation import NAMESPACE_FIREWALL, get_cache_invalidation_poller
+from app.db.models import CacheInvalidation, RuntimeSentinel
+from app.db.session import SessionLocal
+from tests.integration.off_loop_test_client import flush_deferred_sqlite_writers, off_loop_test_client
+
+# Well under the 30 s SQLite busy_timeout the deadlock used to burn before failing.
+_STARTUP_DEADLINE_SECONDS = 15.0
+_HOLD_SECONDS = 1.0
+
+
+@pytest.mark.asyncio
+async def test_off_loop_test_client_starts_while_loop_owned_write_transaction_is_open(async_client, app_instance):
+    """A loop-owned write that only COMMITs after the loop runs must not stall portal startup.
+
+    The holder mimics a background writer caught between INSERT and COMMIT at
+    the moment the test enters the second lifespan: it releases only via a
+    timer on this loop. With a blocking ``with TestClient(...)`` the timer could
+    never fire and the portal lifespan's sentinel stamps waited out busy_timeout.
+    """
+    del async_client  # the first lifespan (and its background writers) live on this loop
+    loop = asyncio.get_running_loop()
+    insert_done = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_write_transaction() -> None:
+        async with SessionLocal() as session:
+            session.add(RuntimeSentinel(name="test_off_loop_client_holder", value="held"))
+            await session.flush()  # INSERT executed: the SQLite writer slot is held from here
+            insert_done.set()
+            await release.wait()
+            await session.commit()
+
+    holder = asyncio.create_task(hold_write_transaction())
+    await insert_done.wait()
+    loop.call_later(_HOLD_SECONDS, release.set)
+
+    started = time.monotonic()
+    async with off_loop_test_client(app_instance) as client:
+        elapsed = time.monotonic() - started
+        assert elapsed < _STARTUP_DEADLINE_SECONDS, f"portal lifespan startup took {elapsed:.1f}s"
+        assert client.get("/health/live").status_code == 200
+
+    await holder
+    async with SessionLocal() as session:
+        stored = await session.scalar(
+            select(RuntimeSentinel.value).where(RuntimeSentinel.name == "test_off_loop_client_holder")
+        )
+    assert stored == "held"
+
+
+@pytest.mark.asyncio
+async def test_flush_deferred_sqlite_writers_writes_pending_cache_bumps_now(async_client, app_instance):
+    del async_client
+    poller = get_cache_invalidation_poller()
+    assert poller is not None
+
+    async def firewall_version() -> int:
+        async with SessionLocal() as session:
+            version = await session.scalar(
+                select(CacheInvalidation.version).where(CacheInvalidation.namespace == NAMESPACE_FIREWALL)
+            )
+        return int(version or 0)
+
+    before = await firewall_version()
+    poller.request_bump(NAMESPACE_FIREWALL)
+
+    await flush_deferred_sqlite_writers(app_instance)
+
+    assert await firewall_version() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_blocking_test_client_is_rejected_on_the_running_test_loop(app_instance):
+    with pytest.raises(RuntimeError, match="off_loop_test_client"):
+        with TestClient(app_instance):
+            pytest.fail("the blocking client must not start a lifespan on the running loop")
+
+
+def test_blocking_test_client_still_works_from_sync_tests(app_instance):
+    with TestClient(app_instance) as client:
+        assert client.get("/health/live").status_code == 200

--- a/tests/integration/test_proxy_realtime_live.py
+++ b/tests/integration/test_proxy_realtime_live.py
@@ -32,6 +32,7 @@ from app.db.models import RequestLog
 from app.db.session import SessionLocal
 from app.dependencies import get_proxy_service_for_app
 from app.modules.proxy.account_cache import AccountSelectionCache
+from tests.integration.off_loop_test_client import off_loop_test_client
 
 pytestmark = pytest.mark.integration
 
@@ -685,7 +686,7 @@ async def test_realtime_call_location_drives_supported_account_bound_sideband_ro
         ("rotated-access-token", "acc_live_rotated"),
     ]
 
-    with TestClient(app_instance) as client:
+    async with off_loop_test_client(app_instance) as client:
         app_instance.state.proxy_service._load_balancer._selection_inputs_cache = selection_cache
         with pytest.raises(WebSocketDenialResponse) as denied:
             with client.websocket_connect(
@@ -817,7 +818,7 @@ async def test_realtime_sideband_unexpected_setup_log_is_content_free(
 
     caplog.clear()
     with caplog.at_level(logging.ERROR, logger=proxy_api_module.__name__):
-        with TestClient(app_instance) as client:
+        async with off_loop_test_client(app_instance) as client:
             with pytest.raises(WebSocketDenialResponse) as denied:
                 with client.websocket_connect(
                     "/v1/live/rtc_setup_failure",
@@ -922,7 +923,7 @@ async def test_realtime_sideband_failure_log_is_content_free(
     )
     assert created.status_code == 201
 
-    with TestClient(app_instance) as client:
+    async with off_loop_test_client(app_instance) as client:
         with pytest.raises(WebSocketDenialResponse) as denied:
             with client.websocket_connect(
                 f"/v1/live/{call_id}?intent=quicksilver&token=query-secret",
@@ -1104,7 +1105,7 @@ async def test_realtime_sideband_rejects_reassigned_key_scope_before_owner_use(
     route_calls.clear()
     connector_calls.clear()
 
-    with TestClient(app_instance) as client:
+    async with off_loop_test_client(app_instance) as client:
         with pytest.raises(WebSocketDenialResponse) as denied:
             with client.websocket_connect(
                 f"/v1/live/{call_id}",


### PR DESCRIPTION
## Summary

Root-causes the dominant recurring shape of the `sqlite3.OperationalError: database is locked` CI flake in the integration shards (`test_proxy_realtime_live.py`, 30 s stalls at the `runtime_sentinels` startup stamps) and fixes it in the test harness where the deadlock actually lives: an `async def` test entering starlette's **blocking** `TestClient` freezes the session event loop that owns the `async_client` lifespan's background SQLite writers, so a write transaction they have in flight can never `COMMIT`, and the portal lifespan's startup writes wait out the full `busy_timeout` before failing. No production code changes. This fixes the async-test `TestClient` deadlock class; the sub-second lock-error class recorded in #1949 (sync tests, fixture setup) is a different holder and is listed under "Not covered".

> **Post-merge note (2026-09-09).** This PR was merged before its `codex review --base origin/main` round and the verifier follow-ups could land. The review found two real P2 defects in the new helper (outer cache-invalidation poller left unregistered after the nested lifespan exits; a cancelled startup could leak the portal lifespan), and verifying those fixes surfaced a third: keeping the test loop alive lets a process-global `anyio.Lock` handoff between the two loops lose its wake-up, so the nested lifespan can hang at startup. All three are fixed in follow-up PR #2254. The body below was revised in place to fill the template's Simplicity section and to scope the claims (see "Not covered").

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #1949 — fixes the CI lock failures at the async-test `TestClient` sites in `test_proxy_realtime_live.py` (the 09-07..09-08 integration-core logs captured below); the sync integration-bridge sites, the `test_dashboard_overview` fixture-setup failure and the `test_otel` unit occurrence recorded in the issue are a different holder and remain open, so the issue is not closed by this PR.

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only (test harness only; no runtime, contract, schema or default changes)
- [ ] This PR touches a codex-faithful path

Change directory: n/a

## Root cause (evidence)

**What CI shows.** The four integration-core job logs captured for this investigation (jobs 101665385527, 101847583007 and two runs of the 09-07 23:33 UTC job; 09-07..09-08, `ci-logs` kept locally under the slop-removal evidence folder) all have the same lock-failure shape:

- The failing test took **30.0–31.1 s** (`--durations`), i.e. exactly `_SQLITE_BUSY_TIMEOUT_MS = 30_000`. This is a plain `SQLITE_BUSY` after the busy handler timed out, **not** `SQLITE_BUSY_SNAPSHOT` (which returns instantly).
- The teardown log of the same tests carries `event_loop_lag lag_seconds=30.273 ... (event loop starved)`: the pytest session loop was blocked for the whole 30 s.
- The failing lock frame in those logs is always `TestClient.__enter__ -> portal.call(self.wait_startup) -> ... lifespan -> seed_hard_sticky_outage_grace_on_startup` (or `_stamp_if_absent`) at `tests/integration/test_proxy_realtime_live.py:688` / `:1107` — an `async def` test that already holds the `async_client` lifespan and then enters a second, blocking `TestClient` lifespan on the same app.

**Who holds the writer slot.** Reproduced locally on a loaded host (load avg ~20; 3 failures in 7 runs of the file, all at the same sites) with a throwaway diagnostics plugin that records every aiosqlite operation per `sqlite3.Connection` and dumps connections with `in_transaction=True` at the instant `TestClient.__enter__` is called. The holder each time:

```
##### LOCKDIAG TestClient.__enter__ HAZARD (loop about to block) thread=MainThread
##### CONN ... in_transaction=True opened_thread=Thread-587 (_connection_worker_thread)
      0.012s ago ... task=Task-1622 :: aio:execute INSERT INTO cache_invalidation (namespace, version)
                     VALUES (?, ?) ON CONFLICT (namespace) DO UPDATE SET version = (cache_invalidation.version + ?)
      last task stack: app/core/cache/invalidation.py:271 in _run -> await self._poll_once()
```

i.e. the **first lifespan's `CacheInvalidationPoller` flushing the bumps queued by the test's own `/api/accounts/import` and `/api/api-keys/` mutations**, 12 ms before the loop was frozen. Its `INSERT` has run on the aiosqlite worker thread (writer slot taken); its `COMMIT` is the next loop round-trip, which never comes while `portal.call()` blocks the loop. The portal lifespan's `INSERT INTO runtime_sentinels ...` then waits 30 s and fails. Any loop-owned write caught between its first statement and `COMMIT` produces the same deadlock; the poller flush is simply the one that reliably lands right after the tests' setup mutations.

**Why the direction proposed in #1949 cannot fix this.** `busy_timeout` is already 30 s and *is* honoured (that is the 30 s). Retrying the stamp on a fresh session, a longer jittered budget, or `BEGIN IMMEDIATE` all still need the writer slot, whose holder is frozen precisely because the retrying caller is the thing blocking its loop; they would only change how the 30 s is spent. The production watchdog (`sqlite_long_write_transaction`) is blind to this holder for the same reason: `after_cursor_execute` only fires after the loop resumes, so the measured hold excludes the frozen window.

## Changes

- `tests/integration/off_loop_test_client.py` (new): `async with off_loop_test_client(app) as client:` — drop-in for `with TestClient(app) as client:` in async tests. Flushes the loop-owned deferred writers (detached persistence drain + pending cache-invalidation bumps) so nothing on the loop is mid-transaction, then enters/exits the blocking client via `asyncio.to_thread` so the loop keeps running while the portal lifespan starts and stops.
- `tests/integration/test_proxy_realtime_live.py`: the four `async def` tests that entered `TestClient` inline (the exact CI failure sites) use the helper; test bodies unchanged.
- `tests/conftest.py`: autouse `_forbid_blocking_test_client_on_running_loop` — `TestClient.__enter__` on a thread with a running event loop now raises an explanatory `RuntimeError` pointing at the helper, so the anti-pattern fails in milliseconds instead of flaking after 30 s. Sync tests (no running loop on the calling thread) and the helper's worker-thread entry are unaffected. An AST scan confirms the four converted sites were the only `TestClient(...)` uses inside `async def` tests.
- `tests/integration/test_off_loop_test_client.py` (new): pins the contract — startup completes (<15 s, measured ~1.2 s) while a loop-owned write transaction is open and released only by a timer on that loop (the old pattern could never fire the timer and burned the 30 s); `flush_deferred_sqlite_writers` writes a pending bump immediately; the guard rejects the blocking client on the running loop; the blocking client still works from sync tests.

## Not covered / follow-up leads

- **Sub-second lock failures in sync tests / fixture setup** (the class #1949 was opened for): the fingerprint-stamp failures in the original report and run 33192082270 (`tests/integration/test_dashboard_overview.py::test_dashboard_overview_maps_weekly_only_primary_to_secondary`, failing during fixture setup with no `key_fingerprint` frames) surface in 1–2 s, not after the 30 s `busy_timeout`, and the tests involved are `def` tests with no running loop on the calling thread, so the frozen-loop mechanism fixed here does not apply and the autouse guard is a no-op there. Re-verification on this branch under heavy host load (load avg ~89) reproduced that class once in 9 runs: `test_realtime_sideband_websocket_rejections_log_redacted_server_scope[current-app]` (sync, `TestClient.__enter__` at `test_proxy_realtime_live.py:265`) failed on the `encryption_key_fingerprint` `INSERT` in < 2.5 s. `busy_timeout` is set on every connection, so a fast `SQLITE_BUSY` from a first-statement `INSERT` points at a lock held by a connection whose owning loop is gone or at a `BEGIN`/snapshot upgrade on a pooled connection; that holder still needs to be identified (same lead as the `test_otel` occurrence below).
- The two sync `test_proxy_websocket_responses.py` hangs listed in #1949 (integration-bridge, runs 33191378626 / 33190444434) are likewise not touched by this PR: the full file passed on PR head `004ae34cc` during the review round (154 passed), but no mechanism there is changed.

- The unit-shard occurrence (`test_otel.py::test_lifespan_registers_bridge_without_waiting_for_advertise_self_probe`, run 34155889526) has the same 30.05 s signature but runs its lifespan on the session loop with no blocking client, so its holder must be a connection whose owning loop is gone. It did not reproduce locally (6 runs of `tests/unit/test_otel.py`, 1 full unit shard run with leaked-transaction detection at every test boundary: none). The pre-existing `PytestUnhandledThreadExceptionWarning: ... _connection_worker_thread ... RuntimeError: Event loop is closed` emitted by the suite is the matching lead (an aiosqlite worker finishing a statement after its loop closed) and is worth a separate investigation.
- Production code is intentionally untouched; the startup stamps are not the bug.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** (test harness only; nothing user-facing)
- [x] No new required setup step
- New setting(s) and why each can't be a default: none
- Tier of each new setting: none
- [x] README sections / `.env.example` / dashboard nav within budget (`check_simplicity_budgets.py`: env 46/60, nav 5/5, root 0/0; unchanged by this PR)

## Test plan

```
uv run pytest -q tests/integration/test_proxy_realtime_live.py tests/integration/test_off_loop_test_client.py   # x5 on a loaded host (load avg ~20): 40 passed each, no 30 s stalls
uv run pytest -q tests/integration/test_dashboard_overview.py tests/unit/test_otel.py tests/unit/test_db_*.py
make lint
uv run ty check
python3 .github/scripts/check_simplicity_budgets.py
uv run python .github/scripts/pytest_shards.py --shard-count 3 --verify
```

After rebasing onto `main` (`2a4303492`) for the review round: `tests/integration/test_proxy_realtime_live.py` + `test_off_loop_test_client.py`, `tests/unit/test_otel.py` + `tests/integration/test_dashboard_overview.py`, and `ruff check`/`ruff format --check` on the four touched files re-run green (results in the evidence folder as `fix-verify-*.log`).

Before the change, the same realtime file failed 3 of 7 local runs under the same load with the identical `database is locked` traceback and 30 s durations.

## Screenshots / output

n/a (test harness only).

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (`make lint`, `uv run ty check`, targeted pytest, shard verify, simplicity budgets).
- [x] If touching specs: n/a (no spec changes).
- [x] Simplicity gates reviewed: no new setting, README section, nav item or default.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
