### PR TITLE
refactor(egress): complete native HTTP Responses streams in Rust

### DIFF
--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -34,6 +34,7 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
         "http_compact_sse_v1",
         "http_sse_v1",
         "http_responses_events_v1",
+        "http_responses_completion_v1",
         "websocket",
         "websocket_responses_events_v1",
         "websocket_send_ack",
@@ -302,18 +303,29 @@ class NativeEgressResponse:
                 if event_type == "responses_event":
                     kind = event.get("event_type")
                     python_normalization = event.get("python_normalization")
+                    stream_complete = event.get("stream_complete", False)
                     if (
                         "event_type" not in event
                         or (kind is not None and not isinstance(kind, str))
                         or (isinstance(kind, str) and len(kind.encode("utf-8")) > 16 * 1024)
                         or type(python_normalization) is not bool
+                        or type(stream_complete) is not bool
                         or (more and (kind is not None or python_normalization))
+                        or (
+                            stream_complete
+                            and (more or kind not in {"response.completed", "response.failed", "response.incomplete"})
+                        )
                     ):
                         raise NativeEgressProtocolError("native Responses event has invalid metadata")
                     if not more:
                         text = "".join(fragments) + text
                         fragments.clear()
+                        if stream_complete:
+                            self._completed = True
+                            self._client._finish_request(self._request_id, self._generation, self._events)
                         yield NativeResponsesEvent(text, kind, python_normalization)
+                        if stream_complete:
+                            return
                         continue
                 if more:
                     fragments.append(text)

--- a/crates/codex-lb-egress/src/http.rs
+++ b/crates/codex-lb-egress/src/http.rs
@@ -234,6 +234,7 @@ async fn consume_sse(
         }
     } else if interpret_responses {
         let mut event = interpret(text);
+        let stream_complete = event.completes_http_stream();
         // Type metadata is not fragmented; keep it within the text budget too.
         if event
             .event_type
@@ -253,10 +254,12 @@ async fn consume_sse(
                         more,
                         event_type: if more { None } else { event.event_type.clone() },
                         python_normalization: !more && event.python_normalization,
+                        stream_complete: !more && stream_complete,
                     },
                 )
                 .await?;
         }
+        return Ok(stream_complete);
     } else {
         emit_sse(output, request_id, text, batch).await?;
     }

--- a/crates/codex-lb-protocol/src/lib.rs
+++ b/crates/codex-lb-protocol/src/lib.rs
@@ -14,6 +14,7 @@ pub const CAPABILITIES: &[&str] = &[
     "http_compact_sse_v1",
     "http_sse_v1",
     "http_responses_events_v1",
+    "http_responses_completion_v1",
     "websocket",
     "websocket_responses_events_v1",
     "websocket_send_ack",
@@ -121,6 +122,8 @@ pub enum NativeEvent {
         more: bool,
         event_type: Option<String>,
         python_normalization: bool,
+        #[serde(default, skip_serializing_if = "is_false")]
+        stream_complete: bool,
     },
     SseEventTooLarge {
         request_id: String,

--- a/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
+++ b/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
@@ -15,9 +15,10 @@
       "http_compact_sse_v1",
       "http_sse_v1",
       "http_responses_events_v1",
-    "websocket",
-    "websocket_responses_events_v1",
-    "websocket_send_ack"
+      "http_responses_completion_v1",
+      "websocket",
+      "websocket_responses_events_v1",
+      "websocket_send_ack"
     ]
   }
 }

--- a/crates/codex-lb-responses/src/stream.rs
+++ b/crates/codex-lb-responses/src/stream.rs
@@ -25,6 +25,17 @@ pub struct StreamEvent<'a> {
     pub python_normalization: bool,
 }
 
+impl StreamEvent<'_> {
+    /// These response terminals end both SDK and native HTTP streams.
+    /// Bare errors still require the caller's normalization policy.
+    pub fn completes_http_stream(&self) -> bool {
+        matches!(
+            self.event_type.as_deref(),
+            Some("response.completed" | "response.failed" | "response.incomplete")
+        )
+    }
+}
+
 #[derive(Deserialize)]
 struct Payload<'a> {
     #[serde(default, borrow, rename = "type")]

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -40,8 +40,12 @@ event byte limit as per-request options. Rust owns the deadline between body
 reads, including partial events. Ordinary HTTP streaming additionally requires
 `http_responses_events_v1`: the synchronous Responses library normalizes legacy
 text/audio/audio-transcript aliases and classifies event types. Unchanged event
-text stays byte-for-byte intact. Python retains terminal detection, archives,
-and request-context-dependent public error mapping. HTTP error bodies and
+text stays byte-for-byte intact. With `http_responses_completion_v1`, Rust stops
+at recognized `response.completed`, `response.failed`, and `response.incomplete`
+events, flushes their fragments, and releases the body without waiting for EOF.
+The final fragment carries `stream_complete`; Python validates it and retires
+the exchange without a cancellation round trip. Python retains completion for
+context-dependent error handoffs, archives, and public error mapping. HTTP error bodies and
 non-streaming requests keep the raw chunk contract.
 
 Interpreted events carry the effective type and an explicit Python-normalization
@@ -50,7 +54,10 @@ cannot be rewritten exactly (such as alias payloads containing floats, huge
 integers, or escaped surrogate strings) use that marker without replaying the
 request. Type metadata is limited to 16 KiB too; longer types use the same
 handoff. Shared Python/Rust fixtures pin SDK and native passthrough behavior.
-WebSocket interpretation remains a later transport slice.
+WebSocket Responses classification uses `websocket_responses_events_v1` and
+embeds the raw payload in IPC for the Python decoder. Persistent socket lifetime,
+request matching, sequence tracking, retries, and settlement remain in Python;
+a terminal response does not close a shared WebSocket.
 
 Compact requests additionally require `http_compact_sse_v1`. Their
 `content_type_aware` framing option preserves raw JSON success bodies, while

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/context.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/context.md
@@ -1,0 +1,19 @@
+# Ownership
+
+The first lifecycle slice owns one native HTTP exchange. It does not move shared
+WebSocket request matching, retries, settlement, or downstream delivery into the
+worker. Those require their own domain boundaries.
+
+For example, an upstream can send `response.completed` and leave its chunked body
+open indefinitely. Rust must send the entire terminal event and drop that body;
+Python must not send `cancel` just to finish a successfully completed exchange.
+Events after that terminal, even in the same read, are ignored just as the
+existing public Python consumer ignores them. A marker only on the last fragment
+prevents partial terminal delivery from looking complete.
+The false marker is omitted from ordinary fragments so this change adds no
+per-delta IPC bytes; only the final terminal fragment carries the new marker.
+
+Bare errors and events requiring context-dependent normalization may still end
+through Python cancellation. Uninterpreted SSE, compact collection, raw HTTP, and
+persistent WebSockets retain their existing protocols. Application admission,
+retry eligibility, usage settlement, and public error mapping stay in Python.

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/proposal.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/proposal.md
@@ -1,0 +1,16 @@
+# Move native HTTP stream completion into Rust
+
+## Why
+
+Native HTTP Responses streams currently send their terminal SSE block to Python
+and continue reading until Python cancels the helper request. Move completion of
+recognized response terminals into the Rust transport, preserving the existing
+Python error normalization and fallback paths.
+
+## What Changes
+
+Rust stops after `response.completed`, `response.failed`, or
+`response.incomplete`, flushes all fragments of that event, and releases the HTTP
+body without waiting for upstream EOF. A negotiated final-fragment marker lets
+Python retire the request without a cancellation round trip. WebSocket sessions,
+account policy, and context-dependent error completion remain separate owners.

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/specs/outbound-http-clients/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Rust owns recognized native HTTP Responses completion
+
+The native adapter MUST require `http_responses_completion_v1` before dispatch.
+For interpreted HTTP Responses streams, Rust MUST stop reading the upstream body
+after classifying `response.completed`, `response.failed`, or
+`response.incomplete`, deliver the entire terminal event, and release the body
+without waiting for EOF. It MUST ignore subsequent bytes of that exchange.
+Only the final fragment of a recognized terminal MAY carry `stream_complete=true`.
+An absent completion marker MUST mean false. Python MUST validate this marker and retire that request without sending cancel
+once its complete terminal block has been assembled. Malformed or truncated
+fragments MUST fail without replay. Cancellation before completion and bounded
+queue overflow MUST still release that request without invalidating its peers.
+
+#### Scenario: Upstream remains open after a terminal
+
+- **WHEN** a direct or routed native HTTP stream sends a recognized terminal and leaves its body open
+- **THEN** the full terminal reaches the consumer and Rust releases the upstream body
+- **AND** Python sends no cancellation command for normal completion
+
+#### Scenario: Fragmented terminal followed by invalid bytes
+
+- **WHEN** a recognized terminal spans multiple IPC fragments and is followed by an oversized event
+- **THEN** all terminal fragments are delivered before completion
+- **AND** the later event causes no size failure or additional output
+
+#### Scenario: Cancellation or malformed completion
+
+- **WHEN** a consumer cancels before completion or receives an invalid completion marker
+- **THEN** its request is cleaned up without replay
+- **AND** another request on the same helper remains usable
+
+#### Scenario: Other lifecycle owners remain active
+
+- **WHEN** a stream uses raw HTTP, uninterpreted SSE, compact collection, a Python fallback, or a persistent WebSocket
+- **THEN** that transport retains its existing termination protocol

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/specs/outbound-http-clients/spec.md
@@ -7,11 +7,17 @@ For interpreted HTTP Responses streams, Rust MUST stop reading the upstream body
 after classifying `response.completed`, `response.failed`, or
 `response.incomplete`, deliver the entire terminal event, and release the body
 without waiting for EOF. It MUST ignore subsequent bytes of that exchange.
-Only the final fragment of a recognized terminal MAY carry `stream_complete=true`.
+The final fragment of every recognized terminal MUST carry `stream_complete=true`.
+All other fragments MUST omit the completion marker or set it to false.
 An absent completion marker MUST mean false. Python MUST validate this marker and retire that request without sending cancel
 once its complete terminal block has been assembled. Malformed or truncated
 fragments MUST fail without replay. Cancellation before completion and bounded
 queue overflow MUST still release that request without invalidating its peers.
+
+Frames that do not classify as one of these three terminal types, including bare
+`error` events and typeless error envelopes, MUST retain Python's existing
+SDK-dependent normalization, termination decisions, and cancellation cleanup.
+Rust MUST NOT mark such a frame complete solely because it contains an error.
 
 #### Scenario: Upstream remains open after a terminal
 
@@ -35,3 +41,10 @@ queue overflow MUST still release that request without invalidating its peers.
 
 - **WHEN** a stream uses raw HTTP, uninterpreted SSE, compact collection, a Python fallback, or a persistent WebSocket
 - **THEN** that transport retains its existing termination protocol
+
+#### Scenario: Typeless error normalization depends on the SDK contract
+
+- **WHEN** a native HTTP stream receives a typeless error envelope followed by a recognized terminal
+- **THEN** without SDK-contract enforcement, the envelope is delivered unchanged and the stream continues to the recognized terminal
+- **AND** with SDK-contract enforcement, Python normalizes the envelope to `response.failed` and terminates through its existing cleanup path
+- **AND** both modes preserve the corresponding Python fallback result

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/tasks.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/tasks.md
@@ -1,0 +1,6 @@
+## Implementation
+
+- [x] Negotiate native HTTP Responses completion and mark the final terminal fragment.
+- [x] Stop Rust body reads at the recognized terminal and retire the Python adapter without cancellation.
+- [x] Verify direct/routed SDK/native parity, fragmented terminals, late errors, cancellation, and peer isolation with the real helper.
+- [x] Run Rust checks, Python regression suites, and strict OpenSpec validation; synchronize ownership documentation.

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
@@ -28,6 +28,29 @@ their previous owners. There is no throughput claim.
 - Built dashboard browser smoke: 5 passed.
 - `make lint`, full `uv run ty check`, and 64 strict OpenSpec specs passed.
 
+## Failure-path test evidence
+
+The following exact tests were repeated together with the release helper on
+`a365a1fd9f099a671af8db6da49e811760b1b120`: **21 passed** in 1.56 seconds.
+
+- `tests/unit/test_native_egress.py::test_interpreted_sse_rejects_invalid_metadata_without_replay`:
+  **15 passed**. The `events7` case ends an unfinished interpreted event before
+  its final fragment; `events9` through `events14` reject invalid completion
+  marker types, completion on an intermediate fragment, and completion on
+  nonterminal event types. Every case verifies a protocol error, removal of the
+  owned stream, and a single request sequence (no replay).
+- `tests/unit/test_native_egress.py::test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get`:
+  **1 passed**. Both byte-budget and event-count overflow raise `QueueFull`;
+  draining releases bytes, including interpreted-event text and metadata.
+- `tests/unit/test_native_egress.py::test_client_close_does_not_hang_when_stream_queue_is_full`:
+  **1 passed**. A stalled consumer exceeds the shared adapter's per-request
+  byte budget, receives the bounded-queue transport error, and does not prevent
+  a healthy request on the same helper from completing or client cleanup.
+- `tests/integration/test_native_sse_egress.py::test_cancelling_native_stream_after_partial_event_keeps_peer_request_usable`:
+  **4 passed** (direct/routed, with/without an already-cancelled scope). The real
+  helper closes the cancelled upstream connection after a partial event while
+  its peer finishes on the same still-running helper process.
+
 ## Verification after updating to current main
 
 The PR branch was rebased onto `2a4303492f2c1fd209a7490cf1493c98b56ffde1`,
@@ -46,6 +69,30 @@ the implementation and regression tests were unchanged by the rebase.
 
 The full canonical unit run and other completed checks above were performed
 before this rebase; the selections here were repeated on the updated branch.
+
+## CI baseline update after the SQLite test fix
+
+CI run `34341623522` on the earlier PR head `50681965d` completed its
+integration-core-2 shard with 776 passed, 11 skipped, and one failure:
+`test_realtime_call_location_drives_supported_account_bound_sideband_routes[current-app-uppercase-uuid]`.
+The failure was `database is locked` while `TestClient` entered the application
+lifespan and inserted the `hard_sticky_outage_grace_seeded` sentinel. It occurred
+in the existing Realtime test's startup path, outside native HTTP Responses
+completion. The six cases of that test passed in a local reproduction attempt.
+
+Main then incorporated PR #2243, which moves blocking `TestClient` entry off the
+async test loop and drains deferred SQLite writers. This PR was rebased onto
+`88264ff8413ef1770cfec0aec516018fb23479bd` to include that fix. The rebase only
+reconciled independent additions to the outbound HTTP spec; native completion
+code and tests were unchanged. Checks repeated on the updated base:
+
+- Real release-helper integration selection: **332 passed, 1 warning**,
+  21.98 seconds (the same three native integration files listed above).
+- `tests/integration/test_proxy_realtime_live.py`,
+  `tests/integration/test_off_loop_test_client.py`, and
+  `tests/unit/test_native_egress.py`: **109 passed, 3 warnings**, 61.17 seconds.
+- Full `make lint`, `uv run ty check`, and strict OpenSpec validation passed
+  (**64 specs**).
 
 ## Broader suite and baseline comparison
 

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
@@ -1,0 +1,76 @@
+# Verification
+
+Original verification base: `3987abfdf4a9cf372dde2f6694df2e4469bee602` (2026-09-09).
+
+## Changed behavior
+
+Recognized completed/failed/incomplete HTTP Responses terminals now release the
+Rust HTTP exchange. Python consumes the final-fragment completion marker without
+sending cancel. Persistent WebSocket lifetime and context-dependent errors retain
+their previous owners. There is no throughput claim.
+
+## Completed checks
+
+- Canonical `make test-unit` (unit, simulation, request-log options API):
+  **9,083 passed, 4 skipped, 1 expected failure**, 523.27 seconds. The expected
+  failure is the repository's existing redundant reservation-release race canary.
+- Rust workspace tests, formatting, Clippy with warnings denied, locked release
+  helper build passed.
+- Final release-helper integration selection: **332 passed**, covering native SSE,
+  routed egress, and WebSocket event compatibility.
+- Twelve new direct/routed × SDK/native × terminal-type cases prove complete
+  delivery of fragmented terminals, upstream release without EOF, no Python
+  cancellation command, and suppression of oversized trailing data.
+- Release-helper terminal/cancellation subset: 16 passed, including isolation of
+  another request on the shared helper after partial-stream cancellation.
+- Native unit/shared-fixture selection: 148 passed.
+- SDK/Responses/cancel-drain E2E selection: 23 passed.
+- Built dashboard browser smoke: 5 passed.
+- `make lint`, full `uv run ty check`, and 64 strict OpenSpec specs passed.
+
+## Verification after updating to current main
+
+The PR branch was rebased onto `2a4303492f2c1fd209a7490cf1493c98b56ffde1`,
+including the subscription routing-hint and code-less upstream 429 fixes.
+The only conflict joined independent additions to the outbound HTTP spec;
+the implementation and regression tests were unchanged by the rebase.
+
+- Real release-helper integration selection: **332 passed** in 24.99 seconds
+  (`test_native_sse_egress.py`, `test_native_routed_egress.py`, and
+  `test_native_websocket_events.py`).
+- Adapter/routing/retry unit selection: **149 passed** in 16.79 seconds
+  (`test_native_egress.py`, `test_http_subscription_routing_hint.py`,
+  `test_responses_websocket_routing_hint.py`, `test_overload_backoff.py`, and
+  `test_streaming_retry_virtual_time.py`).
+- `openspec validate --specs --strict`: **64 passed, 0 failed**.
+
+The full canonical unit run and other completed checks above were performed
+before this rebase; the selections here were repeated on the updated branch.
+
+## Broader suite and baseline comparison
+
+The extra-dependency, work-stealing run of all unit tests completed with 9,023
+passed, 3 skipped, and 3 failed. All three failures reproduce on the unmodified
+beta.6 candidate (`38ae2f87817f4f7ed215d71360c806456ca084de`), whose `app/` and
+`tests/` differ from this base only in the version constant:
+
+- `test_stream_via_http_bridge_fails_closed_before_file_affinity_when_previous_response_owner_misses`
+  relies on a previously created `file_account_pins` table without requesting a
+  database fixture.
+- Two `test_metrics.py` no-Prometheus cases patch `__import__`, while the existing
+  implementation uses `import_module`. They fail when the optional real metrics
+  dependency is installed.
+
+These tests and production modules are unchanged by this slice. The canonical
+`make test-unit` run uses the repository's normal dependencies and serial order
+and passed as recorded above. An initial disk-backed parallel run was interrupted
+during SQLite migration tests; complete runs used a task-owned temporary tmpfs
+to avoid filesystem journal contention.
+
+The final serialization adjustment omits the false completion marker from
+ordinary events. Adapter unit tests were repeated (69 passed), and Rust tests,
+Clippy, release build, formatting, and static validation were repeated after it.
+
+Temporary PostgreSQL/Docker release-candidate probes belong to the deployment
+preflight, not this change. No live upstream credentials or production traffic
+were used for this slice's tests.

--- a/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
+++ b/openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md
@@ -94,6 +94,27 @@ code and tests were unchanged. Checks repeated on the updated base:
 - Full `make lint`, `uv run ty check`, and strict OpenSpec validation passed
   (**64 specs**).
 
+## Terminal-marker and error-handoff contract clarification
+
+The requirement now explicitly mandates `stream_complete=true` on each
+recognized terminal's final fragment. It also records the existing Python
+ownership of SDK-dependent error normalization and termination. Completion code
+is unchanged. In particular, a typeless error envelope remains nonterminal
+without SDK-contract enforcement, but becomes `response.failed` with it.
+Forcing Rust completion for both modes would break Python fallback parity.
+
+Repeated release-helper checks: **32 passed, 1 warning**, 1.23 seconds:
+
+- `test_native_stream_interpretation_matches_public_python_result`, filtered to
+  `error`, `error_envelope`, `typeless_error`, `canonical_escaped_error_key`, and
+  `data_only_escaped_error_key`: **20 passed** across direct/routed and SDK/native
+  modes. Each sends a later recognized terminal and compares full output with
+  the Python fallback.
+- `test_native_http_terminal_releases_upstream_without_python_cancel`:
+  **12 passed**, including mandatory true markers on final terminal fragments
+  and omitted markers on preceding fragments.
+- Strict OpenSpec validation: **64 passed**.
+
 ## Broader suite and baseline comparison
 
 The extra-dependency, work-stealing run of all unit tests completed with 9,023

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -1186,11 +1186,17 @@ For interpreted HTTP Responses streams, Rust MUST stop reading the upstream body
 after classifying `response.completed`, `response.failed`, or
 `response.incomplete`, deliver the entire terminal event, and release the body
 without waiting for EOF. It MUST ignore subsequent bytes of that exchange.
-Only the final fragment of a recognized terminal MAY carry `stream_complete=true`.
+The final fragment of every recognized terminal MUST carry `stream_complete=true`.
+All other fragments MUST omit the completion marker or set it to false.
 An absent completion marker MUST mean false. Python MUST validate this marker and retire that request without sending cancel
 once its complete terminal block has been assembled. Malformed or truncated
 fragments MUST fail without replay. Cancellation before completion and bounded
 queue overflow MUST still release that request without invalidating its peers.
+
+Frames that do not classify as one of these three terminal types, including bare
+`error` events and typeless error envelopes, MUST retain Python's existing
+SDK-dependent normalization, termination decisions, and cancellation cleanup.
+Rust MUST NOT mark such a frame complete solely because it contains an error.
 
 #### Scenario: Upstream remains open after a terminal
 
@@ -1214,3 +1220,10 @@ queue overflow MUST still release that request without invalidating its peers.
 
 - **WHEN** a stream uses raw HTTP, uninterpreted SSE, compact collection, a Python fallback, or a persistent WebSocket
 - **THEN** that transport retains its existing termination protocol
+
+#### Scenario: Typeless error normalization depends on the SDK contract
+
+- **WHEN** a native HTTP stream receives a typeless error envelope followed by a recognized terminal
+- **THEN** without SDK-contract enforcement, the envelope is delivered unchanged and the stream continues to the recognized terminal
+- **AND** with SDK-contract enforcement, Python normalizes the envelope to `response.failed` and terminates through its existing cleanup path
+- **AND** both modes preserve the corresponding Python fallback result

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -1179,3 +1179,38 @@ The upstream connect timeout applied to every outbound upstream request — Resp
 - **THEN** one WARN names the shadowed variable and points at the dashboard
 - **AND** no WARN is logged when the variable is unset or the column is NULL
 
+### Requirement: Rust owns recognized native HTTP Responses completion
+
+The native adapter MUST require `http_responses_completion_v1` before dispatch.
+For interpreted HTTP Responses streams, Rust MUST stop reading the upstream body
+after classifying `response.completed`, `response.failed`, or
+`response.incomplete`, deliver the entire terminal event, and release the body
+without waiting for EOF. It MUST ignore subsequent bytes of that exchange.
+Only the final fragment of a recognized terminal MAY carry `stream_complete=true`.
+An absent completion marker MUST mean false. Python MUST validate this marker and retire that request without sending cancel
+once its complete terminal block has been assembled. Malformed or truncated
+fragments MUST fail without replay. Cancellation before completion and bounded
+queue overflow MUST still release that request without invalidating its peers.
+
+#### Scenario: Upstream remains open after a terminal
+
+- **WHEN** a direct or routed native HTTP stream sends a recognized terminal and leaves its body open
+- **THEN** the full terminal reaches the consumer and Rust releases the upstream body
+- **AND** Python sends no cancellation command for normal completion
+
+#### Scenario: Fragmented terminal followed by invalid bytes
+
+- **WHEN** a recognized terminal spans multiple IPC fragments and is followed by an oversized event
+- **THEN** all terminal fragments are delivered before completion
+- **AND** the later event causes no size failure or additional output
+
+#### Scenario: Cancellation or malformed completion
+
+- **WHEN** a consumer cancels before completion or receives an invalid completion marker
+- **THEN** its request is cleaned up without replay
+- **AND** another request on the same helper remains usable
+
+#### Scenario: Other lifecycle owners remain active
+
+- **WHEN** a stream uses raw HTTP, uninterpreted SSE, compact collection, a Python fallback, or a persistent WebSocket
+- **THEN** that transport retains its existing termination protocol

--- a/tests/integration/test_native_sse_egress.py
+++ b/tests/integration/test_native_sse_egress.py
@@ -234,7 +234,8 @@ async def test_buffered_native_burst_preserves_responses_result(
         "               'text/event-stream' if kind == 'sse' else 'application/json']]}]\n"
         "    if kind == 'sse':\n"
         "        events.extend({'type': 'responses_event', 'text': 'data: ' + json.dumps(payload) + '\\n\\n',\n"
-        "                       'more': False, 'event_type': payload['type'], 'python_normalization': False}\n"
+        "                       'more': False, 'event_type': payload['type'], 'python_normalization': False,\n"
+        "                       'stream_complete': payload['type'] == 'response.completed'}\n"
         "                      for payload in payloads)\n"
         "    else:\n"
         "        body = body.encode() + b' ' * 256\n"
@@ -1435,6 +1436,92 @@ async def test_native_interpretation_drains_large_fragments_without_python_norma
     assert result == [expected, terminal]
     assert len(fragments) > 2
     assert max(fragments) <= 16 * 1024
+    assert not native_worker._streams
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_type", ["response.completed", "response.failed", "response.incomplete"])
+@pytest.mark.parametrize("sdk", [False, True])
+async def test_native_http_terminal_releases_upstream_without_python_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+    native_worker: SubprocessNativeEgressClient,
+    routed: bool,
+    terminal_type: str,
+    sdk: bool,
+) -> None:
+    closed = asyncio.Event()
+    terminal = (
+        "data: "
+        + json.dumps({"type": terminal_type, "response": {"id": "done", "output": [], "padding": "한글😀" * 5000}})
+        + "\n\n"
+    )
+    commands: list[str] = []
+    fragments: list[dict[str, object]] = []
+    send = native_worker._send_command
+    read = native_module._read_event
+
+    async def record_command(*args: Any, **kwargs: Any) -> None:
+        command = args[2]
+        commands.append(command["type"])
+        await send(*args, **kwargs)
+
+    async def record_event(stdout: asyncio.StreamReader) -> dict[str, object]:
+        event = await read(stdout)
+        if event.get("type") == "responses_event":
+            fragments.append(event)
+        return event
+
+    monkeypatch.setattr(native_worker, "_send_command", record_command)
+    monkeypatch.setattr(native_module, "_read_event", record_event)
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, _head: bytes, _body: bytes) -> None:
+        await _start_chunked_response(writer)
+        # The later event would exceed the configured limit if Rust kept framing.
+        await _write_chunk(writer, terminal.encode() + b"data: " + b"x" * (256 * 1024))
+        with contextlib.suppress(ConnectionError):
+            await reader.read()
+        closed.set()
+
+    monkeypatch.setattr(proxy_module.get_settings(), "max_sse_event_bytes", 256 * 1024)
+    async with _serve_http(handler) as base_url:
+        session = _UnexpectedPythonSession()
+        route = (
+            ResolvedUpstreamRoute(
+                mode="account_bound",
+                pool_id="terminal-parity",
+                endpoint=ResolvedProxyEndpoint("terminal-proxy", "http", "127.0.0.1", urlsplit(base_url).port or 80),
+            )
+            if routed
+            else None
+        )
+        result = await asyncio.wait_for(
+            _collect(
+                stream_responses(
+                    _request("terminal"),
+                    {},
+                    "test-access-token",
+                    "test-account",
+                    base_url="http://upstream.invalid" if routed else base_url,
+                    session=cast(aiohttp.ClientSession, session),
+                    route=route,
+                    codex_client=CodexClient(cast(aiohttp.ClientSession, session), native_egress_client=native_worker)
+                    if routed
+                    else None,
+                    upstream_stream_transport_override="http",
+                    allow_direct_egress=False,
+                    suppress_live_usage=True,
+                    native_egress_client=native_worker,
+                    enforce_openai_sdk_contract=sdk,
+                )
+            ),
+            5,
+        )
+        await asyncio.wait_for(closed.wait(), 5)
+    assert result == [terminal]
+    assert commands == ["request"]
+    assert len(fragments) > 1
+    assert all("stream_complete" not in event for event in fragments[:-1])
+    assert fragments[-1]["stream_complete"] is True
     assert not native_worker._streams
 
 

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -46,6 +46,7 @@ print(json.dumps({
         "http_compact_sse_v1",
         "http_sse_v1",
         "http_responses_events_v1",
+        "http_responses_completion_v1",
         "websocket",
         "websocket_responses_events_v1",
         "websocket_send_ack",
@@ -960,7 +961,14 @@ async def test_native_sse_failure_releases_owned_stream(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "capability", ["http_sse_v1", "http_compact_sse_v1", "http_compact_collect_v1", "http_responses_events_v1"]
+    "capability",
+    [
+        "http_sse_v1",
+        "http_compact_sse_v1",
+        "http_compact_collect_v1",
+        "http_responses_events_v1",
+        "http_responses_completion_v1",
+    ],
 )
 async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path, capability: str) -> None:
     helper = tmp_path / "native-helper"
@@ -1293,12 +1301,35 @@ for line in sys.stdin:
             {"type": "end"},
         ],
         [{"type": "sse", "text": "data: {}\n\n", "more": False}],
+        *[
+            [
+                {
+                    "type": "responses_event",
+                    "text": "data: {}\n\n",
+                    "more": more,
+                    "event_type": kind,
+                    "python_normalization": False,
+                    "stream_complete": complete,
+                }
+            ]
+            for more, kind, complete in [
+                (False, "response.completed", None),
+                (False, "response.completed", 1),
+                (False, "response.completed", "true"),
+                (True, None, True),
+                (False, "response.output_text.delta", True),
+                (False, "error", True),
+            ]
+        ],
     ],
 )
 async def test_interpreted_sse_rejects_invalid_metadata_without_replay(
     tmp_path: Path, events: list[dict[str, object]]
 ) -> None:
     helper = tmp_path / "native-helper"
+    for event in events:
+        if event.get("type") == "responses_event":
+            event.setdefault("stream_complete", False)
     source = _sse_helper_source(events).replace('"interpret_responses": False', '"interpret_responses": True')
     _write_helper(helper, source)
     client = SubprocessNativeEgressClient(helper)


### PR DESCRIPTION
## Summary

Native HTTP Responses streams currently keep reading after a terminal SSE event until Python cancels the helper request. Rust now flushes recognized `response.completed`, `response.failed`, and `response.incomplete` events and releases the upstream body immediately; Python retires the exchange from the validated final-fragment completion marker.

## Type of change

- [x] `refactor:` — move HTTP stream termination into the native helper

This is the first HTTP lifecycle slice of the Rust migration. No issue is closed by this PR.

## OpenSpec

- [x] Includes an implemented and verified OpenSpec change
- [x] Preserves upstream-equivalent SSE content and public response shape

Change directory: [`openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/`](openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/).

## Changes

- Negotiate `http_responses_completion_v1`, requiring the Python adapter and bundled helper to be upgraded together.
- Emit `stream_complete: true` only on the final terminal fragment, omit false markers, stop reading trailing bytes, and close the upstream body without waiting for EOF.
- Validate completion metadata in Python and retire the exchange before delivering its assembled terminal event, eliminating the normal-completion cancel round trip.
- Cover direct/routed and SDK/native streams, fragmented terminals, invalid trailing data, malformed metadata, cancellation, and shared-helper isolation.

Bare/context-dependent errors retain Python normalization and cleanup. Persistent WebSocket lifetime, request matching, retries, settlement, and queue ownership remain outside this slice. There are no new settings or database changes, and no throughput improvement is claimed.

## Test plan

Original implementation validation, before the subsequent main updates:

- `make test-unit`: **9,083 passed, 4 skipped, 1 expected failure**.
- Rust workspace tests, Clippy with warnings denied, formatting, and locked release helper build passed.
- SDK/Responses cancellation E2E: **23 passed**; dashboard browser smoke: **5 passed**.
- `make lint` and full `uv run ty check` passed.

After rebasing onto main at `88264ff84`, which includes the SQLite test-fixture fix in #2243:

- Real release-helper integration suite: **332 passed**.
- Realtime, off-loop test-client, and native-adapter selection: **109 passed**.
- `make lint` and full `uv run ty check` passed again.
- `openspec validate --specs --strict`: **64 passed, 0 failed**.

The earlier adapter/routing/retry selection passed 149 tests, and the review-requested failure-path selection passed 21 tests.

Full results and test selections are recorded in the change's [`verification.md`](openspec/changes/archive/2026-09-09-migrate-native-http-stream-completion/verification.md), including the earlier baseline diagnostics.

## Proxy behavior example

For an HTTP Responses request whose upstream emits `data: {"type":"response.completed","response":{"id":"done","output":[]}}` and leaves the connection open, the complete SSE terminal reaches the caller and Rust releases the upstream connection. The regression test observes only the helper `request` command, with no Python `cancel` command. Equivalent tests cover failed/incomplete terminals and large UTF-8 payloads spanning multiple IPC fragments.

## Checklist

- [x] Conventional Commit title
- [x] Tests cover the behavior change
- [x] Relevant local CI targets passed
- [x] OpenSpec validation and implementation verification completed
- [x] Simplicity rules reviewed; no new configuration, defaults, or dashboard surface
- [x] CHANGELOG left to release automation
