### PR TITLE
perf(request-logs): add live-row partial indexes for facet option queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_migrations.py::test_usage_history_bulk_covering_indexes_migration_upgrade_and_downgrade \
 	tests/integration/test_migrations.py::test_usage_history_covering_index_migration_repairs_invalid_leftover_postgresql \
 	tests/integration/test_migrations.py::test_usage_history_autovacuum_tuning_migration_sets_and_resets_reloptions_postgresql \
-	tests/integration/test_migrations.py::test_model_source_pins_index_migration_repairs_invalid_leftover_postgresql
+	tests/integration/test_migrations.py::test_model_source_pins_index_migration_repairs_invalid_leftover_postgresql \
+	tests/integration/test_migrations.py::test_request_logs_live_facet_index_migration_repairs_invalid_leftover_postgresql
 SHELL := bash
 
 .PHONY: help

--- a/app/db/alembic/versions/20260909_130000_add_request_logs_live_facet_indexes.py
+++ b/app/db/alembic/versions/20260909_130000_add_request_logs_live_facet_indexes.py
@@ -1,0 +1,96 @@
+"""Add live-row partial indexes for the unfiltered request-log facet skip scan.
+
+The unfiltered ``GET /api/request-logs/options`` facets are computed with a
+recursive ``facet_skip`` CTE: one ``min(column) WHERE deleted_at IS NULL AND
+column > previous`` probe per distinct value. The existing facet indexes
+(``idx_logs_model_effort_time``, ``idx_logs_status_error_time``,
+``idx_logs_api_key_time``) carry soft-deleted rows too, so every probe walks
+the whole soft-deleted cohort that shares a value before reaching the next
+live one, and probe cost grows with the number of soft-deleted rows instead of
+the number of distinct values. Partial indexes whose predicate matches the
+probe's ``deleted_at IS NULL`` restore the bounded-probe contract. Account ids
+need no live index: soft deletion detaches ``account_id`` (NULL), which an
+``account_id > previous`` probe never walks.
+
+PostgreSQL builds the indexes with ``CREATE INDEX CONCURRENTLY`` outside the
+migration transaction so the proxy write path keeps inserting, and rebuilds a
+leftover invalid index from an interrupted concurrent build instead of letting
+``IF NOT EXISTS`` accept it by name. SQLite uses plain partial indexes.
+
+Revision ID: 20260909_130000_add_request_logs_live_facet_indexes
+Revises: 20260909_120000_dashboard_conversation_archive
+Create Date: 2026-09-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260909_130000_add_request_logs_live_facet_indexes"
+down_revision = "20260909_120000_dashboard_conversation_archive"
+branch_labels = None
+depends_on = None
+
+_TABLE_NAME = "request_logs"
+_LIVE_ROW_PREDICATE = "deleted_at IS NULL"
+_LIVE_FACET_INDEXES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("idx_logs_live_api_key", ("api_key_id",)),
+    ("idx_logs_live_model_effort", ("model", "reasoning_effort")),
+    ("idx_logs_live_status_error", ("status", "error_code")),
+)
+
+
+def _drop_invalid_postgres_index(index_name: str) -> None:
+    """Drop a leftover invalid index from an interrupted CREATE INDEX CONCURRENTLY.
+
+    ``IF NOT EXISTS`` would silently accept the invalid index by name, leaving
+    the facet probes without a usable live-row index.
+    """
+    bind = op.get_bind()
+    invalid = bind.execute(
+        sa.text(
+            "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+            "WHERE c.relname = :name AND NOT i.indisvalid"
+        ),
+        {"name": index_name},
+    ).scalar()
+    if invalid:
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if bind.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            for index_name, columns in _LIVE_FACET_INDEXES:
+                _drop_invalid_postgres_index(index_name)
+                op.execute(
+                    sa.text(
+                        f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+                        f"ON {_TABLE_NAME} ({', '.join(columns)}) WHERE {_LIVE_ROW_PREDICATE}"
+                    )
+                )
+        return
+
+    for index_name, columns in _LIVE_FACET_INDEXES:
+        op.execute(
+            sa.text(
+                f"CREATE INDEX IF NOT EXISTS {index_name} "
+                f"ON {_TABLE_NAME} ({', '.join(columns)}) WHERE {_LIVE_ROW_PREDICATE}"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if bind.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            for index_name, _columns in _LIVE_FACET_INDEXES:
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+        return
+
+    for index_name, _columns in _LIVE_FACET_INDEXES:
+        op.drop_index(index_name, table_name=_TABLE_NAME, if_exists=True)

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -86,6 +86,9 @@ _MANUAL_DRIFT_INDEX_REQUIREMENTS: dict[str, frozenset[str]] = {
             "idx_logs_status_error_time",
             "idx_logs_source_requested_at",
             "idx_logs_dash_usage_covering",
+            "idx_logs_live_api_key",
+            "idx_logs_live_model_effort",
+            "idx_logs_live_status_error",
         }
     ),
     "additional_usage_history": frozenset(

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2414,6 +2414,32 @@ Index(
     RequestLog.requested_at.desc(),
     RequestLog.id.desc(),
 )
+# Live-row partial indexes for the unfiltered request-log facet skip scan
+# (recursive ``facet_skip`` probes: ``min(column) WHERE deleted_at IS NULL AND
+# column > previous``). The predicate matches the probe so a probe never walks
+# the soft-deleted cohort sharing a value. Account ids need none: soft deletion
+# detaches account_id (NULL), which ``account_id > previous`` never walks.
+# Enforced via the manual drift index requirements like the covering index.
+Index(
+    "idx_logs_live_api_key",
+    RequestLog.api_key_id,
+    postgresql_where=text("deleted_at IS NULL"),
+    sqlite_where=text("deleted_at IS NULL"),
+)
+Index(
+    "idx_logs_live_model_effort",
+    RequestLog.model,
+    RequestLog.reasoning_effort,
+    postgresql_where=text("deleted_at IS NULL"),
+    sqlite_where=text("deleted_at IS NULL"),
+)
+Index(
+    "idx_logs_live_status_error",
+    RequestLog.status,
+    RequestLog.error_code,
+    postgresql_where=text("deleted_at IS NULL"),
+    sqlite_where=text("deleted_at IS NULL"),
+)
 Index(
     "idx_logs_request_status_api_key_time",
     RequestLog.request_id,

--- a/openspec/changes/live-row-facet-indexes/proposal.md
+++ b/openspec/changes/live-row-facet-indexes/proposal.md
@@ -1,0 +1,29 @@
+# Change: live-row-facet-indexes
+
+## Why
+
+The unfiltered `GET /api/request-logs/options` facets are computed with a recursive `facet_skip` CTE: one `min(column) WHERE deleted_at IS NULL AND column > previous` probe per distinct value (`query-caching`, "Unfiltered request-log filter options avoid full DISTINCT passes"). The indexes those probes run on today — `idx_logs_model_effort_time`, `idx_logs_status_error_time`, `idx_logs_api_key_time` — carry soft-deleted rows too, so a probe whose next value belongs to a soft-deleted cohort walks the whole cohort (heap fetch + `deleted_at IS NULL` filter per row) before reaching the next live value. In production this is the `facet_skip` statement at ~1.4 s per filter-panel load (112 calls/day) after two accounts with large histories were soft-deleted; on a synthetic corpus one probe over a 160k-row dead cohort costs 150-160 ms and 160k buffers versus ~8-19 ms and tens of buffers when the index predicate excludes the cohort. The requirement's "bounded by the facet's distinct-value count, not by the size of `request_logs`" contract no longer holds once soft-deleted rows accumulate.
+
+## What Changes
+
+- Three partial indexes on `request_logs` whose predicate matches the probe's `deleted_at IS NULL`: `idx_logs_live_api_key (api_key_id)`, `idx_logs_live_model_effort (model, reasoning_effort)`, `idx_logs_live_status_error (status, error_code)`. Account ids need none: soft deletion detaches `account_id` (NULL), which an `account_id > previous` probe never walks.
+- Alembic `20260909_130000_add_request_logs_live_facet_indexes`: PostgreSQL builds with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` in an autocommit block and rebuilds a leftover invalid index from an interrupted concurrent build (same pattern as `20260717_000000_optimize_dashboard_hot_path_indexes`); SQLite uses plain partial indexes. Downgrade drops them (`CONCURRENTLY` on PostgreSQL).
+- ORM `Index` declarations with `postgresql_where`/`sqlite_where`, registered in the manual drift index requirements (partial-index reflection is not consistent across dialects).
+- No query change, no settings, no API change: the requirement gains the explicit clause that each successor probe MUST be served by an index whose predicate excludes soft-deleted rows.
+- The indexes are unconditional (no opt-in or kill switch). They are pure schema: the facet statements are unchanged and the planner picks them by cost, so there is no behaviour to toggle; the settings budget has zero headroom (130/130), and an `Index`-level toggle would need a runtime DDL path the schema drift check cannot reason about. The migration downgrade is the off switch.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `query-caching`: MODIFIED requirement "Unfiltered request-log filter options avoid full DISTINCT passes" — probe cost MUST be independent of the soft-deleted cohort size; new scenario "Soft-deleted cohorts do not lengthen facet probes".
+
+## Impact
+
+- Schema: three partial btree indexes on `request_logs` (SQLite and PostgreSQL). `request_logs` already carries 14 indexes; the three new ones add per-insert cost on the proxied-request write path. Before merging, record `pg_stat_user_indexes.idx_scan` for `idx_logs_model_effort_time`, `idx_logs_status_error_time` and `idx_logs_api_key_time` so a later change can drop any that the live-row indexes leave unused instead of growing the set indefinitely.
+- Operators: none. The concurrent build does not block writers; on a large table it runs for the duration of two table scans.
+- Code: `app/db/alembic/versions/20260909_130000_add_request_logs_live_facet_indexes.py` (new), `app/db/models.py`, `app/db/migrate.py`, migration and options tests, `Makefile` (PostgreSQL test target list).

--- a/openspec/changes/live-row-facet-indexes/specs/query-caching/spec.md
+++ b/openspec/changes/live-row-facet-indexes/specs/query-caching/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Unfiltered request-log filter options avoid full DISTINCT passes
+
+When `GET /api/request-logs/options` is requested without user-supplied filters, each facet (account ids, model/reasoning-effort pairs, api-key ids, status/error-code pairs) MUST be computed with loose-index-scan probes bounded by the facet's distinct-value count, not by the size of `request_logs`. Each successor probe over api-key ids, model/reasoning-effort pairs and status/error-code pairs MUST be served by an index whose predicate excludes soft-deleted rows (`deleted_at IS NULL`), so probe cost is independent of the number of soft-deleted rows sharing a value. The returned option sets, their ordering, and the soft-delete/status-facet semantics MUST be identical to the unbounded `DISTINCT` results.
+
+#### Scenario: Unfiltered facets return identical option sets via bounded probes
+
+- **GIVEN** request logs spanning multiple accounts, models with and without reasoning effort, api keys, and statuses with and without error codes
+- **WHEN** the options endpoint is called with no filters
+- **THEN** each facet MUST be produced by per-distinct-value index probes (recursive skip scan) rather than a full `DISTINCT` pass
+- **AND** the response MUST equal the legacy `DISTINCT` results, including `(value, NULL)` pairs and ordering
+
+#### Scenario: Soft-deleted rows stay excluded from skip-scanned facets
+
+- **GIVEN** request-log rows with `deleted_at` set
+- **WHEN** the options endpoint is called with no filters
+- **THEN** values appearing only on soft-deleted rows MUST NOT appear in any facet
+
+#### Scenario: Soft-deleted cohorts do not lengthen facet probes
+
+- **GIVEN** live request-log rows spread over several models, api keys and statuses, soft-deleted rows sharing those values, and a large soft-deleted cohort on a model, api-key id and error code that no live row carries
+- **WHEN** the options endpoint is called with no filters on PostgreSQL and each issued `facet_skip` statement for the model, api-key and status facets is explained
+- **THEN** every `min()` seed and successor probe MUST be served by the facet's live-row partial index (`idx_logs_live_model_effort`, `idx_logs_live_api_key`, `idx_logs_live_status_error`), remove no rows by filter and read a single index entry per probe
+- **AND** every `(value, NULL)` existence probe MUST be served by an index whose predicate excludes soft-deleted rows
+- **AND** the options response MUST exclude the soft-deleted cohort's values
+
+#### Scenario: Filtered requests keep bounded DISTINCT semantics
+
+- **WHEN** the options endpoint is called with any user filter (`since`, `until`, account, api-key, model, or reasoning-effort constraints)
+- **THEN** the facets MUST apply those filters with unchanged semantics and results

--- a/openspec/changes/live-row-facet-indexes/tasks.md
+++ b/openspec/changes/live-row-facet-indexes/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## 1. Schema
+
+- [x] 1.1 Alembic `20260909_130000_add_request_logs_live_facet_indexes`: `idx_logs_live_api_key`, `idx_logs_live_model_effort`, `idx_logs_live_status_error` with `WHERE deleted_at IS NULL`; PostgreSQL `CREATE INDEX CONCURRENTLY IF NOT EXISTS` in an autocommit block with invalid-leftover repair, SQLite plain partial indexes; downgrade drops them.
+- [x] 1.2 `app/db/models.py` `Index` declarations with `postgresql_where`/`sqlite_where`; `app/db/migrate.py` manual drift index requirements register the three names.
+
+## 2. Verification
+
+- [x] 2.1 `tests/integration/test_migrations.py`: SQLite upgrade/downgrade/re-upgrade round trip (re-upgrade over an operator-precreated index exercises `IF NOT EXISTS`) asserting the indexes are partial and drift-clean; head index-name set includes the three names; PostgreSQL-only test rebuilds an invalid leftover and keeps a valid precreated index (added to `POSTGRES_PYTEST_TARGETS`).
+- [x] 2.2 `tests/unit/test_db_migrate.py`: revision source builds concurrently, repairs invalid leftovers, carries the live-row predicate.
+- [x] 2.3 `tests/test_request_logs_options_api.py`: PostgreSQL-only (collection-time skip) plan pin over a production-shaped corpus (3k live rows across models/keys/statuses, 3k soft-deleted rows sharing them, 20k soft-deleted cohort on dead-only values) — captures the real `facet_skip` statements issued by the options call and EXPLAIN ANALYZEs each: every `min()` probe uses its live-row index with no rows removed by filter and one index entry, every `(value, NULL)` existence probe uses a live-row partial index, and the response excludes the dead values; existing skip-scan and soft-delete tests unchanged.
+- [x] 2.4 `uv run codex-lb-db upgrade head` + `check` on SQLite and PostgreSQL, `make lint` guards, `uv run ty check`, `openspec validate live-row-facet-indexes --strict`.

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -644,6 +644,9 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             assert "idx_logs_status_error_time" in request_log_index_names
             assert "idx_logs_api_key_time" in request_log_index_names
             assert "idx_logs_source_requested_at" in request_log_index_names
+            assert "idx_logs_live_api_key" in request_log_index_names
+            assert "idx_logs_live_model_effort" in request_log_index_names
+            assert "idx_logs_live_status_error" in request_log_index_names
             warmup_table_exists = (
                 await session.execute(
                     text("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='account_limit_warmups'")
@@ -2802,3 +2805,128 @@ async def test_dashboard_conversation_archive_migration_upgrade_and_downgrade(tm
 
 
 # end M5 conversation archive
+
+
+_LIVE_FACET_INDEXES = {
+    "idx_logs_live_api_key",
+    "idx_logs_live_model_effort",
+    "idx_logs_live_status_error",
+}
+_LIVE_FACET_PARENT_REVISION = "20260909_120000_dashboard_conversation_archive"
+_LIVE_FACET_REVISION = "20260909_130000_add_request_logs_live_facet_indexes"
+
+
+@pytest.mark.asyncio
+async def test_request_logs_live_facet_indexes_migration_upgrade_and_downgrade(tmp_path):
+    """The three live-row partial facet indexes round-trip and tolerate re-application."""
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'request-logs-live-facet.sqlite'}"
+
+    async def _request_log_indexes(engine) -> dict[str, bool]:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text("PRAGMA index_list('request_logs')"))).fetchall()
+            # PRAGMA index_list columns: seq, name, unique, origin, partial.
+            return {str(row[1]): bool(row[4]) for row in rows}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, _LIVE_FACET_PARENT_REVISION, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        indexes = await _request_log_indexes(engine)
+        assert not (_LIVE_FACET_INDEXES & indexes.keys())
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, _LIVE_FACET_REVISION, bootstrap_legacy=False))
+        indexes = await _request_log_indexes(engine)
+        assert _LIVE_FACET_INDEXES <= indexes.keys()
+        # Partial: the predicate excludes soft-deleted rows.
+        assert all(indexes[name] for name in _LIVE_FACET_INDEXES)
+
+        await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), _LIVE_FACET_PARENT_REVISION))
+        indexes = await _request_log_indexes(engine)
+        assert not (_LIVE_FACET_INDEXES & indexes.keys())
+
+        # Re-upgrade against an operator-precreated index (the out-of-band
+        # mitigation shares the migration's names) so IF NOT EXISTS is
+        # exercised on an existing index, not only the fresh-create branch.
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("CREATE INDEX idx_logs_live_api_key ON request_logs (api_key_id) WHERE deleted_at IS NULL")
+            )
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        indexes = await _request_log_indexes(engine)
+        assert _LIVE_FACET_INDEXES <= indexes.keys()
+        assert all(indexes[name] for name in _LIVE_FACET_INDEXES)
+    finally:
+        await engine.dispose()
+
+    assert await to_thread.run_sync(lambda: check_schema_drift(db_url)) == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _is_postgresql_database_url(_DATABASE_URL),
+    reason="PostgreSQL-only invalid live facet index repair test",
+)
+async def test_request_logs_live_facet_index_migration_repairs_invalid_leftover_postgresql(db_setup):
+    """An invalid leftover from an interrupted CREATE INDEX CONCURRENTLY is
+    rebuilt as a partial index, while a valid operator-precreated index (the
+    out-of-band mitigation shares the migration's names) is kept by IF NOT
+    EXISTS."""
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    index_name = "idx_logs_live_model_effort"
+    precreated_index_name = "idx_logs_live_api_key"
+
+    await run_startup_migrations(_DATABASE_URL)
+    await to_thread.run_sync(
+        lambda: command.downgrade(_build_alembic_config(_DATABASE_URL), _LIVE_FACET_PARENT_REVISION)
+    )
+
+    async with SessionLocal() as session:
+        await session.execute(
+            text(f"CREATE INDEX {precreated_index_name} ON request_logs (api_key_id) WHERE deleted_at IS NULL")
+        )
+        await session.execute(text(f"CREATE INDEX {index_name} ON request_logs (model)"))
+        await session.execute(
+            text("UPDATE pg_index SET indisvalid = false WHERE indexrelid = CAST(:name AS regclass)"),
+            {"name": index_name},
+        )
+        await session.commit()
+
+    result = await run_startup_migrations(_DATABASE_URL)
+    assert result.current_revision == _HEAD_REVISION
+
+    async with SessionLocal() as session:
+        validity = {
+            str(row[0]): bool(row[1])
+            for row in (
+                await session.execute(
+                    text(
+                        "SELECT c.relname, i.indisvalid FROM pg_index i "
+                        "JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname LIKE 'idx_logs_live_%'"
+                    )
+                )
+            ).fetchall()
+        }
+        indexdefs = {
+            str(row[0]): str(row[1])
+            for row in (
+                await session.execute(
+                    text(
+                        "SELECT indexname, indexdef FROM pg_indexes "
+                        "WHERE tablename = 'request_logs' AND indexname LIKE 'idx_logs_live_%'"
+                    )
+                )
+            ).fetchall()
+        }
+
+    assert validity == dict.fromkeys(_LIVE_FACET_INDEXES, True)
+    assert set(indexdefs) == _LIVE_FACET_INDEXES
+    assert "(model, reasoning_effort)" in indexdefs[index_name]  # rebuilt, not the accepted decoy
+    assert "(api_key_id)" in indexdefs[precreated_index_name]  # kept by IF NOT EXISTS
+    assert all("WHERE (deleted_at IS NULL)" in indexdef for indexdef in indexdefs.values())

--- a/tests/test_request_logs_options_api.py
+++ b/tests/test_request_logs_options_api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import text
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -542,3 +544,183 @@ async def test_request_logs_options_unfiltered_issues_no_distinct_statements(asy
     assert options_statements, "expected captured facet statements"
     assert not any(re.search(r"SELECT\s+DISTINCT\b", stmt, re.IGNORECASE) for stmt in options_statements)
     assert any("facet_skip" in stmt for stmt in options_statements)
+
+
+# PostgreSQL plan pin for the live-row partial facet indexes. Seed shape
+# mirrors production: thousands of live rows spread over several models, api
+# keys and statuses (so a full pass over any live-row index, including the
+# partial ``idx_logs_dash_usage_covering``, is materially costlier than a
+# probe), soft-deleted rows sharing the live values, and a large soft-deleted
+# cohort on values no live row carries, sorting before or between the live
+# values (``key_ghost`` < ``key_live_*``, ``gpt-5.1`` < ``gpt-ghost`` <
+# ``o4-mini``, ``ghost_error`` < ``rate_limit_exceeded``) so a non-partial
+# facet index walks the whole cohort before reaching the next live value
+# (measured: 20k ``Rows Removed by Filter`` on ``idx_logs_model_effort_time``
+# without the live index versus one index step with it).
+_LIVE_FACET_SEED_ROWS = 3_000
+_DEAD_SHARED_SEED_ROWS = 3_000
+_DEAD_COHORT_SEED_ROWS = 20_000
+# Each probe is a single btree step (``LIMIT 1`` MinMax form) on the live-row
+# index; the bound is a constant, never the soft-deleted cohort size.
+_PROBE_ROW_BOUND = 1
+# Statement -> live-row index it must be served by. Every facet statement
+# carries the status clause, so the status/error-code pair is matched last;
+# account probes have no live index (soft deletion detaches account_id).
+_LIVE_FACET_INDEX_BY_COLUMN: tuple[tuple[str, str | None], ...] = (
+    ("request_logs.api_key_id", "idx_logs_live_api_key"),
+    ("request_logs.model", "idx_logs_live_model_effort"),
+    ("request_logs.account_id", None),
+    ("request_logs.status", "idx_logs_live_status_error"),
+)
+
+
+_LIVE_FACET_INDEX_NAMES = tuple(name for _column, name in _LIVE_FACET_INDEX_BY_COLUMN if name is not None)
+
+
+def _expected_live_index(sql: str) -> str | None:
+    for column, index_name in _LIVE_FACET_INDEX_BY_COLUMN:
+        if column in sql:
+            return index_name
+    raise AssertionError(f"unrecognised facet statement: {sql}")
+
+
+async def _seed_live_facet_corpus() -> None:
+    """Bulk-seed the plan-pin corpus with PostgreSQL ``generate_series``."""
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_facets", "facets@example.com"))
+        session.add(ApiKey(id="key_live_a", name="Live A", key_hash="hash_live_a", key_prefix="sk-la"))
+        session.add(ApiKey(id="key_live_b", name="Live B", key_hash="hash_live_b", key_prefix="sk-lb"))
+        await session.commit()
+        live_values = (
+            "(ARRAY['key_live_a', 'key_live_b'])[1 + n % 2], "
+            "(ARRAY['gpt-4o', 'gpt-5.1', 'o4-mini'])[1 + n % 3], "
+            "CASE WHEN (n / 3) % 2 = 0 THEN 'high' END, "
+            "(ARRAY['success', 'error', 'cancelled'])[1 + (n / 6) % 3], "
+            "CASE WHEN (n / 6) % 3 = 1 AND n % 2 = 0 THEN 'rate_limit_exceeded' END"
+        )
+        columns = (
+            "(account_id, api_key_id, request_id, requested_at, deleted_at, "
+            "model, reasoning_effort, status, error_code)"
+        )
+        await session.execute(
+            text(
+                f"INSERT INTO request_logs {columns} "
+                "SELECT 'acc_facets', k, 'req_live_' || n, now() - n * interval '1 second', NULL, m, e, s, c "
+                f"FROM generate_series(1, :rows) AS n, LATERAL (SELECT {live_values}) AS v(k, m, e, s, c)"
+            ),
+            {"rows": _LIVE_FACET_SEED_ROWS},
+        )
+        # Soft-deleted rows sharing the live values, older than the live rows.
+        await session.execute(
+            text(
+                f"INSERT INTO request_logs {columns} "
+                "SELECT NULL, k, 'req_dead_shared_' || n, now() - interval '30 days' - n * interval '1 second', "
+                "now(), m, e, s, c "
+                f"FROM generate_series(1, :rows) AS n, LATERAL (SELECT {live_values}) AS v(k, m, e, s, c)"
+            ),
+            {"rows": _DEAD_SHARED_SEED_ROWS},
+        )
+        # Soft-deleted cohort on values no live row carries.
+        await session.execute(
+            text(
+                f"INSERT INTO request_logs {columns} "
+                "SELECT NULL, 'key_ghost', 'req_dead_cohort_' || n, "
+                "now() - interval '30 days' - n * interval '1 second', now(), "
+                "'gpt-ghost', 'high', 'error', 'ghost_error' FROM generate_series(1, :rows) AS n"
+            ),
+            {"rows": _DEAD_COHORT_SEED_ROWS},
+        )
+        await session.commit()
+    autocommit_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
+    async with autocommit_engine.connect() as conn:
+        await conn.execute(text("VACUUM (ANALYZE) request_logs"))
+
+
+def _plan_nodes(plan: dict) -> list[dict]:
+    nodes = [plan]
+    for child in plan.get("Plans", ()):
+        nodes.extend(_plan_nodes(child))
+    return nodes
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(engine.dialect.name != "postgresql", reason="PostgreSQL-only query plan test")
+async def test_request_logs_options_facet_probes_use_live_row_indexes_postgresql(async_client, db_setup):
+    """Every production ``facet_skip`` statement (leading skip scan, per-value
+    second-column skip scan and ``(value, NULL)`` probe) for the model, api-key
+    and status facets is served by its live-row partial index: no rows removed
+    by filter and a constant number of index entries per probe, independent of
+    the soft-deleted cohort. The statements are captured from the real options
+    call and re-run under EXPLAIN ANALYZE rather than hand-written."""
+    from sqlalchemy import event
+    from sqlalchemy.sql import Select
+
+    await _seed_live_facet_corpus()
+
+    captured: list[str] = []
+
+    def _capture(conn, clauseelement, multiparams, params, execution_options):
+        if isinstance(clauseelement, Select):
+            compiled = clauseelement.compile(dialect=engine.dialect, compile_kwargs={"literal_binds": True})
+            captured.append(str(compiled))
+
+    event.listen(engine.sync_engine, "before_execute", _capture)
+    try:
+        response = await async_client.get("/api/request-logs/options")
+    finally:
+        event.remove(engine.sync_engine, "before_execute", _capture)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["accountIds"] == ["acc_facets"]
+    assert sorted({option["model"] for option in payload["modelOptions"]}) == ["gpt-4o", "gpt-5.1", "o4-mini"]
+    assert [key["id"] for key in payload["apiKeys"]] == ["key_live_a", "key_live_b"]
+    assert payload["statuses"] == ["ok", "cancelled", "rate_limit", "error"]
+
+    facet_statements = [sql for sql in captured if "FROM request_logs" in sql]
+    assert any("facet_skip" in sql for sql in facet_statements)
+    # Leading skip scans, second-column skip scans and (value, NULL) probes.
+    assert any("request_logs.reasoning_effort IS NULL" in sql for sql in facet_statements)
+    assert any("min(request_logs.reasoning_effort)" in sql for sql in facet_statements)
+    assert any("min(request_logs.error_code)" in sql for sql in facet_statements)
+
+    async with SessionLocal() as session:
+        live_row_indexes = {
+            str(name)
+            for (name,) in (
+                await session.execute(
+                    text(
+                        "SELECT indexname FROM pg_indexes WHERE tablename = 'request_logs' "
+                        "AND indexdef LIKE '%WHERE (deleted_at IS NULL)'"
+                    )
+                )
+            ).all()
+        }
+        assert set(_LIVE_FACET_INDEX_NAMES) <= live_row_indexes
+        for sql in facet_statements:
+            expected_index = _expected_live_index(sql)
+            plan_rows = await session.execute(
+                text("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + sql.replace(":", r"\:"))
+            )
+            plan_document = plan_rows.scalar_one()
+            if isinstance(plan_document, str):
+                plan_document = json.loads(plan_document)
+            scans = [
+                node for node in _plan_nodes(plan_document[0]["Plan"]) if node.get("Relation Name") == "request_logs"
+            ]
+            assert scans, f"no request_logs scan in plan for {sql}"
+            if expected_index is None:
+                continue
+            index_names = {node.get("Index Name") for node in scans}
+            if "min(" not in sql:
+                # ``(value, NULL)`` existence probe: LIMIT-1 costed, so the
+                # planner may take any index whose predicate excludes the
+                # soft-deleted rows (the facet index or the partial covering
+                # index); either way the cohort is never walked.
+                assert index_names <= live_row_indexes, f"{sql}: {scans}"
+                assert all(int(node.get("Actual Rows", 0)) <= _PROBE_ROW_BOUND for node in scans), f"{sql}: {scans}"
+                continue
+            assert index_names == {expected_index}, f"{sql}: {scans}"
+            assert sum(int(node.get("Rows Removed by Filter", 0)) for node in scans) == 0, f"{sql}: {scans}"
+            assert all(int(node.get("Actual Rows", 0)) <= _PROBE_ROW_BOUND for node in scans), f"{sql}: {scans}"

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -2543,6 +2543,23 @@ def test_dashboard_hot_path_postgresql_indexes_build_concurrently() -> None:
     assert "indisvalid" in source
 
 
+def test_request_logs_live_facet_postgresql_indexes_build_concurrently() -> None:
+    revision_path = (
+        Path(__file__).resolve().parents[2]
+        / "app/db/alembic/versions/20260909_130000_add_request_logs_live_facet_indexes.py"
+    )
+    source = revision_path.read_text(encoding="utf-8")
+
+    # Built outside the migration transaction so the proxy write path keeps
+    # inserting; leftover invalid indexes from an interrupted concurrent build
+    # are rebuilt instead of being silently accepted by IF NOT EXISTS.
+    assert "autocommit_block" in source
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" in source
+    assert "DROP INDEX CONCURRENTLY IF EXISTS" in source
+    assert "indisvalid" in source
+    assert "deleted_at IS NULL" in source
+
+
 def test_dashboard_hot_path_index_migration_drops_redundant_indexes(tmp_path: Path) -> None:
     db_path = tmp_path / "hot-path-redundant-indexes.db"
     url = _db_url(db_path)


### PR DESCRIPTION
## Why

Production `pg_stat_statements` (2026-09-09) lists the `GET /api/request-logs/options` recursive `facet_skip` probes at mean 1.4s × 112 calls while a dashboard is open. The probes are `min(col) WHERE deleted_at IS NULL AND col > prev`; on a table with large soft-deleted cohorts a probe walks the dead rows sharing a value before stepping to the next live one.

## What changes (indexes only)

Three partial btree indexes on `request_logs`, all `WHERE deleted_at IS NULL`:
- `idx_logs_live_api_key (api_key_id)`
- `idx_logs_live_model_effort (model, reasoning_effort)`
- `idx_logs_live_status_error (status, error_code)`

`account_id` needs none because soft deletion NULLs it.

- Migration `20260909_040000_add_request_logs_live_facet_indexes`: PostgreSQL uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS` inside `autocommit_block()` (writers keep inserting) with a leftover-invalid-index check (`pg_index.indisvalid`) that drops and rebuilds rather than accepting a broken index; downgrade `DROP INDEX CONCURRENTLY IF EXISTS`. SQLite: plain partial `CREATE INDEX IF NOT EXISTS`.
- ORM `Index` declarations with `postgresql_where` / `sqlite_where`; names registered in `_MANUAL_DRIFT_INDEX_REQUIREMENTS` (partial-index reflection differs by dialect). No query, API, or settings change; the planner picks the indexes by cost and the downgrade is the off switch.
- Note: `request_logs` now carries 17 indexes. The proposal asks to snapshot `pg_stat_user_indexes.idx_scan` for the three older facet indexes before merge so a follow-up can drop any left unused.

## OpenSpec

`openspec/changes/live-row-facet-indexes/` — MODIFIED requirement "Unfiltered request-log filter options avoid full DISTINCT passes" under `query-caching`, new scenario "Soft-deleted cohorts do not lengthen facet probes". Validates `--strict`.

## Tests

- SQLite: `tests/integration/test_migrations.py`, `tests/test_request_logs_options_api.py`, `tests/unit/test_db_migrate.py` — 108 passed.
- PostgreSQL 16 (ephemeral container): 20 passed, including `test_request_logs_options_facet_probes_use_live_row_indexes_postgresql` which `EXPLAIN ANALYZE`s the real captured `facet_skip` statements over a 3k live / 3k dead-shared / 20k dead-cohort corpus, and the invalid-leftover repair test. `codex-lb-db upgrade head && check` on both dialects: `schema_drift=none`.
- Gates green: ruff, architecture, cancellation-safety, timing-seams, settings-tiers (130/130), ty, openspec. Local `codex review --base c38e4de15`: no actionable regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)