### PR TITLE
fix(proxy): promote agentic HTTP continuations to reusable WebSockets

### DIFF
--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -68,6 +68,18 @@ if PROMETHEUS_AVAILABLE:
         ["downstream_transport", "upstream_transport", "policy", "sticky", "status"],
         registry=REGISTRY,
     )
+    http_bridge_routing_total = Counter(
+        "codex_lb_http_bridge_routing_total",
+        "HTTP bridge routing evaluations by stage and reason (not connection successes)",
+        ["stage", "reason"],
+        registry=REGISTRY,
+    )
+    http_bridge_connections_total = Counter(
+        "codex_lb_http_bridge_connections_total",
+        "HTTP bridge connection lifecycle events",
+        ["event"],
+        registry=REGISTRY,
+    )
     upstream_request_duration_seconds = Histogram(
         "codex_lb_upstream_request_duration_seconds",
         "Upstream request duration",
@@ -447,6 +459,8 @@ else:
     request_duration_seconds: HistogramLike | None = None
     upstream_requests_total: CounterLike | None = None
     upstream_transport_decisions_total: CounterLike | None = None
+    http_bridge_routing_total: CounterLike | None = None
+    http_bridge_connections_total: CounterLike | None = None
     upstream_request_duration_seconds: HistogramLike | None = None
     upstream_reasoning_replay_400_total: CounterLike | None = None
     image_requests_total: CounterLike | None = None
@@ -580,4 +594,6 @@ __all__ = [
     "upstream_request_duration_seconds",
     "upstream_requests_total",
     "upstream_transport_decisions_total",
+    "http_bridge_routing_total",
+    "http_bridge_connections_total",
 ]

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -60,6 +60,7 @@ from app.core.metrics.prometheus import (
     bridge_instance_mismatch_total,
     bridge_reattach_total,
     bridge_unanchored_handoff_recovery_total,
+    http_bridge_connections_total,
     http_bridge_prewarm_total,
     http_bridge_stuck_retire_total,
 )
@@ -197,6 +198,7 @@ from app.modules.proxy.helpers import (
     _normalize_error_code,
     _parse_openai_error,
 )
+from app.modules.proxy.http_continuation import inferred_http_bridge_key
 from app.modules.proxy.ring_membership import (
     RING_STALE_THRESHOLD_SECONDS,
     RingMembershipService,
@@ -2437,8 +2439,13 @@ def _make_http_bridge_session_key(
             affinity_kind = "session_header"
             strength = "hard"
         else:
-            affinity_key = affinity.key or request_id
-            affinity_kind = affinity.kind.value if affinity.kind is not None else "request"
+            inferred_key = (
+                inferred_http_bridge_key(payload) if payload.conversation or explicit_prompt_cache_key is None else None
+            )
+            affinity_key = inferred_key or affinity.key or request_id
+            affinity_kind = (
+                "prompt_cache" if inferred_key else affinity.kind.value if affinity.kind is not None else "request"
+            )
             strength = "soft"
     return _HTTPBridgeSessionKey(
         affinity_kind=affinity_kind,
@@ -3809,6 +3816,8 @@ def _log_http_bridge_event(
     response_events_seen: int | None = None,
     transport_classification: str | None = None,
 ) -> None:
+    if event in {"create", "reuse", "reconnect", "close", "evict_idle"} and http_bridge_connections_total is not None:
+        http_bridge_connections_total.labels(event=event).inc()
     level = logging.INFO
     if event in {
         "queue_full",

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -184,6 +184,9 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
+from app.modules.proxy._service.observability import (
+    record_http_bridge_routing,
+)
 from app.modules.proxy._service.support import (
     _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
@@ -977,6 +980,7 @@ class _HTTPBridgeStreamingMixin:
         )
         ws_payload_budget_bytes = _ws_transport_payload_budget_bytes(_service_get_settings())
         if runtime_config.enabled and payload_size_estimate_bytes > ws_payload_budget_bytes:
+            record_http_bridge_routing(stage="bypass", reason="payload_size")
             logger.info(
                 "stream_responses bypassing http bridge for large payload size=%s budget=%s request_id=%s",
                 payload_size_estimate_bytes,
@@ -988,6 +992,7 @@ class _HTTPBridgeStreamingMixin:
         image_generation_request = _responses_request_uses_image_generation(payload)
         force_upstream_stream_transport = "http" if image_request else None
         if runtime_config.enabled and (image_request or image_generation_request):
+            record_http_bridge_routing(stage="bypass", reason="image")
             logger.info(
                 "stream_responses bypassing http bridge for image-capable request input_image=%s "
                 "image_generation=%s request_id=%s",
@@ -1000,6 +1005,7 @@ class _HTTPBridgeStreamingMixin:
         # "http" upstream transport must bypass it; without this gate the
         # dashboard pin is silently ignored for bridged follow-up turns.
         if runtime_config.enabled and configured_upstream_stream_transport(dashboard_settings) == "http":
+            record_http_bridge_routing(stage="bypass", reason="explicit_http")
             logger.info(
                 "stream_responses bypassing http bridge for pinned http upstream transport request_id=%s",
                 request_id,
@@ -1012,6 +1018,7 @@ class _HTTPBridgeStreamingMixin:
         # policy can resolve a sticky follow-up straight back to the
         # unavailable websocket upstream.
         if force_upstream_stream_transport is None and upstream_websocket_transport_recently_failed():
+            record_http_bridge_routing(stage="bypass", reason="recent_ws_failure")
             if runtime_config.enabled:
                 logger.info(
                     "stream_responses bypassing http bridge for recent upstream websocket transport failure "
@@ -2870,6 +2877,7 @@ class _HTTPBridgeStreamingMixin:
             and not fresh_reattach_anchor_suppressed_quarantined
             and not proxy_injected_previous_response_id
             and effective_payload.previous_response_id is None
+            and not effective_payload.conversation
             and session.last_completed_response_id is not None
             and (session_anchor_trimmable or recovery_session_can_anchor)
         )

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1018,8 +1018,8 @@ class _HTTPBridgeStreamingMixin:
         # policy can resolve a sticky follow-up straight back to the
         # unavailable websocket upstream.
         if force_upstream_stream_transport is None and upstream_websocket_transport_recently_failed():
-            record_http_bridge_routing(stage="bypass", reason="recent_ws_failure")
             if runtime_config.enabled:
+                record_http_bridge_routing(stage="bypass", reason="recent_ws_failure")
                 logger.info(
                     "stream_responses bypassing http bridge for recent upstream websocket transport failure "
                     "request_id=%s",

--- a/app/modules/proxy/_service/observability.py
+++ b/app/modules/proxy/_service/observability.py
@@ -12,6 +12,7 @@ from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
     continuity_fail_closed_total,
     continuity_owner_resolution_total,
+    http_bridge_routing_total,
     upstream_reasoning_replay_400_total,
     upstream_transport_decisions_total,
 )
@@ -37,6 +38,17 @@ def _service_global(name: str, fallback: Any) -> Any:
 
 def _service_get_settings() -> Any:
     return cast(Callable[[], Any], _service_global("get_settings", get_settings))()
+
+
+def record_http_bridge_routing(*, stage: str, reason: str) -> None:
+    if http_bridge_routing_total is not None:
+        http_bridge_routing_total.labels(stage=stage, reason=reason).inc()
+    logger.info(
+        "http_bridge_routing stage=%s reason=%s request_id=%s",
+        stage,
+        reason,
+        get_request_id(),
+    )
 
 
 def _record_upstream_transport_decision(

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -55,6 +55,7 @@ from app.modules.proxy._service.observability import (
     _maybe_log_proxy_request_shape,
     _record_continuity_fail_closed,
     _record_upstream_transport_decision,
+    record_http_bridge_routing,
 )
 from app.modules.proxy._service.streaming.protocol import _StreamingServiceProtocol
 from app.modules.proxy._service.support import (
@@ -73,6 +74,7 @@ from app.modules.proxy._service.support import (
     _TransientStreamError,
     _WebSocketUpstreamControl,
     configured_upstream_stream_transport,
+    upstream_websocket_transport_recently_failed,
 )
 from app.modules.proxy._service.websocket.helpers import (
     _websocket_input_items_are_self_contained_fresh_replay,
@@ -82,7 +84,6 @@ from app.modules.proxy.affinity import (
     _owner_lookup_session_id_from_headers,
     _prompt_cache_key_from_request_model,
     _sticky_key_for_responses_request,
-    _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
     _websocket_continuity_key_from_headers,
 )
@@ -98,6 +99,7 @@ from app.modules.proxy.helpers import (
     is_upstream_burst_rejection,
     is_upstream_model_capacity_error,
 )
+from app.modules.proxy.http_continuation import http_continuation_signal
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection
 from app.modules.proxy.replay_safety import responses_payload_is_account_neutral_fresh_replay
 from app.modules.proxy.selection_errors import USAGE_LIMIT_REACHED, selection_failure_response
@@ -114,12 +116,7 @@ def _facade() -> Any:
 
 
 def _http_downstream_request_is_sticky(payload: ResponsesRequest, headers: Mapping[str, str]) -> bool:
-    return (
-        payload.previous_response_id is not None
-        or _prompt_cache_key_from_request_model(payload) is not None
-        or _sticky_key_from_session_header(headers) is not None
-        or _sticky_key_from_turn_state_header(headers) is not None
-    )
+    return http_continuation_signal(payload, headers) is not None
 
 
 _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR = "_codex_lb_post_refresh_transient_exhausted"
@@ -218,14 +215,17 @@ def _http_bridge_allowed_by_transport_policy(
     """Apply ordinary HTTP transport precedence before entering the WS bridge."""
 
     configured_transport, explicit_transport = _resolved_configured_stream_transport(dashboard_settings)
-    if explicit_transport:
-        return configured_transport == "websocket"
-    if _is_native_codex_request(headers):
-        # A first-party Codex client owns its WebSocket -> HTTP fallback. Once
-        # it submits HTTP, sticky metadata must not promote it back to WS.
-        return False
-    policy, _override_applied = _effective_http_downstream_transport_policy(api_key, dashboard_settings)
-    return _resolve_http_downstream_transport(policy, payload=payload, headers=headers) == "websocket"
+    if upstream_websocket_transport_recently_failed():
+        reason, allowed = "recent_ws_failure", False
+    elif explicit_transport:
+        reason, allowed = f"explicit_{configured_transport}", configured_transport == "websocket"
+    else:
+        policy, _override_applied = _effective_http_downstream_transport_policy(api_key, dashboard_settings)
+        allowed = _resolve_http_downstream_transport(policy, payload=payload, headers=headers) == "websocket"
+        signal = http_continuation_signal(payload, headers)
+        reason = f"smart_{signal or 'single_turn'}" if policy == "smart" else policy
+    record_http_bridge_routing(stage="admission", reason=reason)
+    return allowed
 
 
 async def _iter_account_capacity_recovery_wait(
@@ -398,8 +398,8 @@ class _StreamingRetryMixin:
                 and upstream_stream_transport == "websocket"
             ):
                 sticky = upstream_transport_sticky
-                if _is_native_codex_request(headers):
-                    policy = "native_codex_http"
+                if upstream_websocket_transport_recently_failed():
+                    policy = "recent_ws_failure"
                     override_applied = False
                     upstream_transport_policy_label = policy
                     upstream_stream_transport = "http"
@@ -426,6 +426,9 @@ class _StreamingRetryMixin:
                 upstream_stream_transport,
                 request_id,
             )
+        if request_transport == _REQUEST_TRANSPORT_HTTP and upstream_websocket_transport_recently_failed():
+            upstream_stream_transport = "http"
+            upstream_transport_policy_label = "recent_ws_failure"
         if rewritten_file_account_id is None and not file_account_resolution_complete:
             proxy._raise_for_unsupported_input_image_references(payload)
             rewritten_file_account_id = await proxy._resolve_file_account_for_responses(payload, headers)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5,8 +5,8 @@ import json
 import logging
 import math
 import time
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from functools import partial
@@ -245,6 +245,7 @@ from app.modules.model_sources.selection import (
 from app.modules.proxy import affinity as proxy_affinity_module
 from app.modules.proxy import images_service as images_service_module
 from app.modules.proxy import service as proxy_service_module
+from app.modules.proxy._service.observability import record_http_bridge_routing
 from app.modules.proxy._service.support import (
     _bind_propagated_capacity_startup_ready,
     _bind_propagated_capacity_startup_wait,
@@ -2349,6 +2350,53 @@ def _responses_cleanup_scheduler(service: object) -> _ResponsesCleanupScheduler 
     return None
 
 
+async def _guard_chat_bridge_reservation(
+    stream: AsyncIterator[str],
+    *,
+    reservation: ApiKeyUsageReservationData | None,
+    service: object,
+) -> AsyncIterator[str]:
+    cleanup = _ResponsesReservationCleanup(
+        owns_reservation=True,
+        reservation=reservation,
+        scheduler=_responses_cleanup_scheduler(service),
+        request_id=ensure_request_id(),
+    )
+    ready, dispatched, rejected = asyncio.Event(), asyncio.Event(), asyncio.Event()
+
+    @contextmanager
+    def settlement_signals() -> Iterator[None]:
+        ready_token = _bind_propagated_responses_service_cleanup_ready(ready)
+        dispatched_token = _bind_propagated_responses_owner_forward_dispatched(dispatched)
+        rejected_token = _bind_propagated_responses_owner_forward_rejected(rejected)
+        try:
+            yield
+        finally:
+            _reset_propagated_responses_owner_forward_rejected(rejected_token)
+            _reset_propagated_responses_owner_forward_dispatched(dispatched_token)
+            _reset_propagated_responses_service_cleanup_ready(ready_token)
+
+    try:
+        while True:
+            # Startup probes and response consumers can run in different tasks.
+            # Never retain a ContextVar token across a yield to either caller.
+            with settlement_signals():
+                try:
+                    line = await anext(stream)
+                except StopAsyncIteration:
+                    break
+            yield line
+    finally:
+        with anyio.CancelScope(shield=True), settlement_signals():
+            await _close_responses_stream_best_effort(stream, action="chat bridge")
+            if _responses_origin_may_release_reservation(
+                service_cleanup_ready_event=ready,
+                owner_forward_dispatched_event=dispatched,
+                owner_forward_rejected_event=rejected,
+            ):
+                await cleanup.release(action="chat bridge")
+
+
 def _select_codex_usage_limit(
     limits: list[V1UsageLimitResponse],
     window: str,
@@ -4301,6 +4349,7 @@ def _raw_optional_string(raw: Mapping[str, JsonValue], key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
+@v1_router.post("/chat/completions/", include_in_schema=False)
 @v1_router.post(
     "/chat/completions",
     response_model=ChatCompletionResult,
@@ -4402,6 +4451,11 @@ async def v1_chat_completions(
         )
         if admission_denial is not None:
             return admission_denial
+    bridge_active = (
+        await _http_bridge_active_for_request(responses_payload, request.headers, api_key, preferred=True)
+        if source is None
+        else False
+    )
     reservation = await _enforce_request_limits(
         api_key,
         request_model=request_model,
@@ -4425,17 +4479,38 @@ async def v1_chat_completions(
             prohibit_fast_mode=prohibit_fast_mode,
         )
     responses_payload.stream = True
-    stream = context.service.stream_responses(
-        responses_payload,
-        request.headers,
-        codex_session_affinity=False,
-        propagate_http_errors=True,
-        openai_cache_affinity=True,
-        api_key=api_key,
-        api_key_reservation=reservation,
-        suppress_text_done_events=True,
-        client_ip=resolve_request_client_host(request),
-    )
+    if bridge_active:
+        downstream_turn_state = proxy_affinity_module.ensure_http_downstream_turn_state(request.headers)
+        rate_limit_headers = {
+            **rate_limit_headers,
+            **proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state),
+        }
+        stream = context.service.stream_http_responses(
+            responses_payload,
+            request.headers,
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=api_key,
+            api_key_reservation=reservation,
+            suppress_text_done_events=True,
+            client_ip=resolve_request_client_host(request),
+            downstream_turn_state=downstream_turn_state,
+            http_bridge_active=True,
+        )
+        stream = _guard_chat_bridge_reservation(stream, reservation=reservation, service=context.service)
+    else:
+        stream = context.service.stream_responses(
+            responses_payload,
+            request.headers,
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=api_key,
+            api_key_reservation=reservation,
+            suppress_text_done_events=True,
+            client_ip=resolve_request_client_host(request),
+        )
     startup_probe_timeout = (
         _CURSOR_CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS
         if cursor_compat_client
@@ -4461,7 +4536,8 @@ async def v1_chat_completions(
         _reset_propagated_capacity_startup_wait(capacity_wait_token)
     if startup_error is not None:
         if cursor_compat_client and _is_context_length_startup_error(startup_error):
-            await _release_reservation(reservation)
+            if not bridge_active:
+                await _release_reservation(reservation)
             if payload.stream:
                 return _cursor_context_limit_usage_stream(
                     payload,
@@ -6689,6 +6765,7 @@ async def _http_bridge_active_for_request(
 ) -> bool:
     base_settings = proxy_service_module.get_settings()
     if not preferred or not base_settings.http_responses_session_bridge_enabled:
+        record_http_bridge_routing(stage="admission", reason="bridge_disabled" if preferred else "route_disabled")
         return False
     if policy_already_applied:
         # The origin already made the authoritative policy decision before

--- a/app/modules/proxy/http_continuation.py
+++ b/app/modules/proxy/http_continuation.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from hashlib import sha256
+
+from app.core.openai.requests import ResponsesRequest
+from app.modules.proxy.affinity import (
+    _prompt_cache_key_from_request_model,
+    _sticky_key_from_session_header,
+    _sticky_key_from_turn_state_header,
+)
+
+_TOOL_RESULTS = frozenset({"function_call_output", "custom_tool_call_output", "apply_patch_call_output"})
+
+
+def http_continuation_signal(payload: ResponsesRequest, headers: Mapping[str, str]) -> str | None:
+    """Classify supplied evidence, before affinity derives a cache key."""
+    if payload.previous_response_id is not None:
+        return "previous_response"
+    if payload.conversation and payload.conversation.strip():
+        return "conversation"
+    if _sticky_key_from_turn_state_header(headers) is not None:
+        return "turn_state"
+    if _sticky_key_from_session_header(headers) is not None:
+        return "session"
+    if _prompt_cache_key_from_request_model(payload) is not None:
+        return "prompt_cache"
+    return http_history_signal(payload)
+
+
+def http_history_signal(payload: ResponsesRequest) -> str | None:
+    if not isinstance(payload.input, list):
+        return None
+    assistant_seen = False
+    for item in payload.input:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if isinstance(item_type, str) and item_type in _TOOL_RESULTS:
+            return "tool_result"
+        if item.get("role") == "assistant":
+            assistant_seen = True
+        elif item.get("role") == "user" and assistant_seen:
+            return "history"
+    return None
+
+
+def inferred_http_bridge_key(payload: ResponsesRequest) -> str | None:
+    """Soft connection locality only; this key is never a continuity proof.
+
+    API-key isolation is supplied by _HTTPBridgeSessionKey. Hash complete
+    initial context, not the truncated prompt-cache prefix. Requests sharing
+    that context may share a socket, but must send their own complete history.
+    """
+    if payload.conversation and payload.conversation.strip():
+        identity = [payload.model, payload.conversation]
+        kind = "conversation"
+    elif http_history_signal(payload) is not None and isinstance(payload.input, list):
+        initial_context = []
+        for item in payload.input:
+            if not isinstance(item, dict):
+                continue
+            if item.get("role") in ("system", "developer", "user"):
+                initial_context.append(item)
+            if item.get("role") == "user":
+                break
+        else:
+            # A delta-only tool result cannot identify its conversation.
+            return None
+        identity = [payload.model, payload.instructions, initial_context]
+        kind = "history"
+    else:
+        return None
+    encoded = json.dumps(identity, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode()
+    return f"http-{kind}:{sha256(encoded).hexdigest()}"

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -90,3 +90,32 @@ Since the WP-E fix in #2124 the HTTP Responses session bridge returns the pool's
 ---
 
 *Specs: [account-routing](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/account-routing) · [frontend-architecture](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/frontend-architecture) · [model-source-routing](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/model-source-routing) · [usage-refresh-policy](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/usage-refresh-policy)*
+
+## HTTP to WebSocket promotion
+
+Owning spec: [Responses API compatibility](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat).
+
+With automatic upstream transport and the default `smart` HTTP policy, Responses
+and subscription-backed Chat Completions can reuse upstream WebSocket connections
+when requests carry response/cache/session identifiers, a `conversation`, tool
+results, or an assistant response followed by new user input. A first request
+containing only a user message remains HTTP. Native Codex HTTP callers follow
+this policy too; their User-Agent alone does not indicate a WebSocket failure.
+
+Real recent upstream WS failures temporarily keep requests on HTTP (the existing
+60-second cooldown). Explicit HTTP policy, image-capable requests and oversized
+payloads also bypass the bridge. Source-routed Chat requests keep their source.
+
+Clients resending full history need not retain response headers to reuse a
+connection. Inferred locality uses complete initial user input and instructions,
+scoped to the API key. It remains a connection preference: the full history is
+preserved, and an inferred key never authorizes response-anchor injection.
+
+The dashboard's HTTP badge describes client-to-LB transport; the upstream field
+shows the LB-to-provider transport. `codex_lb_http_bridge_routing_total` separates
+`admission` from `bypass` with bounded reasons such as `smart_history`,
+`smart_tool_result`, `smart_single_turn`, `recent_ws_failure`, `payload_size` and
+`image`. Structured `http_bridge_routing` logs include the request ID.
+`codex_lb_http_bridge_connections_total{event="reuse"}` measures actual connection
+reuse; admission counts are not successful-connection counts. Existing TTFT and
+queue latency metrics should be compared alongside reuse when measuring benefits.

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/context.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/context.md
@@ -1,0 +1,19 @@
+# Implementation notes
+
+Healthy native HTTP requests use normal policy. The proxy cannot infer every
+client-local WebSocket failure from HTTP alone; it uses its existing 60-second
+upstream-connect failure marker as concrete failure evidence. Operator HTTP
+pins, image and size bypasses remain effective. No new retry/session registry.
+
+History-only locality is soft, scoped by the bridge's full API-key identifier,
+and hashes the complete first user item plus instructions and model. No client
+prompt cache field is overwritten. Identical initial prompts may share an idle
+connection, but neither histories nor response anchors are merged; the complete
+request is sent each time. Existing hard-continuity paths retain their guarded
+incremental replay. Conversation IDs get their own hashed locality and are never
+combined with an injected previous_response_id.
+
+Chat keeps the existing stream conversion/usage/error/cleanup pipeline and uses
+the bridge only after the source-routing branch. Backend stream=false retains
+its native non-streaming upstream contract. No claimed latency percentage:
+connection reuse is measured separately from admission and successful transport.

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/proposal.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/proposal.md
@@ -1,0 +1,17 @@
+# Improve HTTP WebSocket promotion
+
+## Why
+HTTP agent loops resend full history or use Chat Completions, so metadata-only
+smart routing misses them. Native Codex identity also suppresses healthy WS
+bridging without evidence of a transport failure.
+
+## What Changes
+- Recognize structured multi-turn input and conversation identifiers in smart routing.
+- Apply normal policy to native HTTP callers; retain actual WS outage and explicit HTTP guards.
+- Use stable, API-key-scoped soft bridge locality for history-only/conversation requests.
+- Route subscription Chat Completions through the existing Responses bridge while preserving Chat output and accounting.
+- Record bounded admission/bypass reasons and connection lifecycle counters.
+
+## Impact
+Responses/Chat routing, bridge locality, transport metrics, compatibility tests.
+No new settings, schema, or deployment step. Source-routed Chat stays on its source.

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/specs/responses-api-compat/spec.md
@@ -1,0 +1,274 @@
+## ADDED Requirements
+
+### Requirement: Structured HTTP continuation promotion
+Under automatic upstream transport and smart HTTP policy, the proxy SHALL
+recognize a non-empty conversation identifier, a tool-result input item, or an
+assistant response followed by new user input as continuation evidence, in
+addition to existing response, cache, session and turn-state identifiers.
+Tool declarations, instruction messages, and multiple user-only messages SHALL
+NOT alone constitute continuation evidence.
+
+#### Scenario: Full-history agent turn
+- **WHEN** a smart HTTP request contains user, assistant, then user input without explicit continuity metadata
+- **THEN** it is eligible for the upstream WS bridge
+- **AND** the complete input remains intact unless existing verified hard-continuity rules authorize trimming
+
+#### Scenario: Native identity without failure evidence
+- **WHEN** a native Codex HTTP request has continuation evidence and upstream WS is healthy
+- **THEN** the same smart/override policy as other HTTP requests applies
+- **AND** native identity alone MUST NOT force HTTP
+
+#### Scenario: Real upstream outage
+- **WHEN** the existing recent upstream WS failure marker is active
+- **THEN** HTTP entry paths MUST use upstream HTTP during its existing cooldown
+- **AND** normal WS eligibility MUST return when it expires or clears
+
+### Requirement: Inferred continuation locality remains soft
+History-only bridge requests SHALL use a deterministic locality key based on
+complete initial user input and instruction context, isolated by API-key scope.
+Conversation identifiers SHALL have distinct locality from inferred histories.
+Inferred locality SHALL NOT authorize previous-response injection, cross-account
+replay, or dropping client history. Explicit turn/session ownership SHALL retain
+precedence and existing recovery/fork/queue safeguards.
+
+#### Scenario: Repeated history without response headers
+- **WHEN** two compatible multi-turn requests retain the same initial user input and instructions
+- **THEN** they can reuse the same healthy upstream connection without replaying response headers
+- **AND** divergent complete initial inputs MUST NOT share an inferred locality key merely because their first 512 characters match
+
+### Requirement: Chat Completions uses HTTP bridge policy
+Subscription-backed Chat Completions SHALL apply the same HTTP bridge admission
+and fallback policy to its converted Responses request for streaming and
+non-streaming clients. Chat chunks, JSON, usage, error envelopes, reservation
+settlement and source routing SHALL preserve their existing public contracts.
+
+#### Scenario: Chat trailing slash uses the same handler
+- **WHEN** a client posts to `/v1/chat/completions/`
+- **THEN** the same authentication, routing, bridge and response contract as `/v1/chat/completions` SHALL apply
+
+#### Scenario: Chat tool loop reuses upstream connection
+- **WHEN** successive Chat requests include tool results and retain compatible initial context
+- **THEN** eligible requests reuse the upstream WS bridge
+- **AND** clients still receive Chat Completions responses
+
+#### Scenario: Chat bridge fails before settlement handoff
+- **WHEN** bridge startup fails or is cancelled before dispatch or service settlement ownership
+- **THEN** the originating API releases its usage reservation
+- **AND** an ambiguous owner-forward dispatch MUST NOT release the reservation without a definitive rejection
+
+### Requirement: HTTP bridge routing reasons are observable
+The proxy SHALL emit structured admission and bypass reasons and bounded-label
+counters, and SHALL count bridge create/reuse/close/reconnect/idle-eviction events.
+Metrics SHALL NOT label raw request, conversation, session, account or API-key identifiers.
+
+#### Scenario: Identify policy exclusion and transport fallback
+- **WHEN** a request remains HTTP because it is single-turn, policy-pinned, bridge-disabled, oversized, image-capable, or affected by a recent WS outage
+- **THEN** its routing diagnostics distinguish that reason
+- **AND** admission counters MUST NOT be represented as successful WS connections
+
+## MODIFIED Requirements
+
+### Requirement: Downstream-HTTP upstream transport follows a configurable policy
+
+When a downstream HTTP/SSE request (`request_transport == "http"`) resolves its base upstream transport to `"websocket"`, the proxy MUST decide the final upstream transport using the configured `http_downstream_transport_policy`, after all higher-precedence rails have been applied, and the policy MUST NOT affect native WebSocket clients (`request_transport == "websocket"`), which keep their dedicated upstream WebSocket path.
+
+Precedence (highest first), evaluated before the policy:
+
+1. Outside the existing recent upstream WS failure cooldown, an explicit
+   `upstream_stream_transport` override of `"http"` or `"websocket"` wins.
+2. Oversized-payload bypass and image / image-generation bypass force
+   upstream HTTP.
+3. The effective policy (per-API-key `transport_policy_override` when
+   set, otherwise the global `http_downstream_transport_policy`) decides.
+
+Policy values and behavior:
+
+- `always_http` (and its alias `pinned`): the request MUST be sent over
+  upstream HTTP `POST`, preserving the legacy unconditional pin.
+- `always_websocket`: the request MUST keep upstream WebSocket whenever
+  the base transport resolved to `"websocket"` without replacing a base
+  `"auto"` transport mode with a hard `"websocket"` override.
+- `smart` (default): the request MUST keep upstream WebSocket **iff** at
+  least one sticky-continuation signal is present on the request, and
+  MUST otherwise fall back to upstream HTTP. The sticky-continuation
+  signals are:
+  - a non-null `previous_response_id` on the request payload, **OR**
+  - a `prompt_cache_key` present on the request model, **OR**
+  - a Codex session header (`session_id`, `x-codex-session-id`, or
+    `x-codex-conversation-id`), **OR**
+  - an `x-codex-turn-state` continuity header, **OR**
+  - a non-empty `conversation` identifier, **OR**
+  - a structured tool-result input item (`function_call_output`,
+    `custom_tool_call_output`, or `apply_patch_call_output`), **OR**
+  - an assistant message followed by new user input in the supplied history.
+
+Tool declarations, instruction messages, and user-only input sequences MUST NOT
+alone count as continuation evidence. The existing recent upstream WS failure
+cooldown MUST force upstream HTTP before these policy choices, including an
+explicit WebSocket preference; clearing or expiring the marker restores normal
+eligibility.
+
+When a policy decision keeps upstream WebSocket, the proxy MUST preserve
+the configured/base downstream transport mode passed to the upstream
+client. In particular, a base `"auto"` mode MUST remain `"auto"` so the
+existing WebSocket-handshake rejection fallback to upstream HTTP remains
+available. The policy MAY force a concrete transport override only when
+the decision is to downgrade to upstream HTTP.
+
+The per-API-key `transport_policy_override`, when non-null, MUST be used
+as the effective policy for requests authenticated by that key and MUST
+take precedence over the global default. A null override MUST fall
+through to the global `http_downstream_transport_policy`.
+
+#### Scenario: single-shot downstream-HTTP request falls back to HTTP under smart policy
+
+- **GIVEN** `http_downstream_transport_policy` is `"smart"` and the base
+  upstream transport resolves to `"websocket"`
+- **AND** a downstream HTTP request carries no `previous_response_id`, no
+  `prompt_cache_key`, no Codex session header, and no `x-codex-turn-state`
+  header, conversation identifier, tool result, or assistant-to-user history
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`
+
+#### Scenario: sticky downstream-HTTP request keeps WebSocket under smart policy
+
+- **GIVEN** `http_downstream_transport_policy` is `"smart"` and the base
+  upstream transport mode is `"auto"` and resolves to `"websocket"`
+- **AND** a downstream HTTP request carries any one of
+  `previous_response_id`, `prompt_cache_key`, a Codex session header, or
+  an `x-codex-turn-state` header
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket without converting
+  the downstream transport mode from `"auto"` to `"websocket"`
+- **AND** an upstream WebSocket handshake rejection status eligible for
+  auto fallback MUST transparently retry over upstream HTTP
+
+#### Scenario: always_http policy preserves the legacy pin
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_http"` (or
+  `"pinned"`) and the base upstream transport resolves to `"websocket"`
+- **WHEN** a downstream HTTP request resolves the upstream transport,
+  regardless of sticky signals
+- **THEN** the request MUST be sent over upstream HTTP `POST`
+
+#### Scenario: always_websocket policy never downgrades sticky-less HTTP
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+  and the base upstream transport mode is `"auto"` and resolves to
+  `"websocket"`
+- **WHEN** a downstream HTTP request with no sticky signals resolves the
+  upstream transport
+- **THEN** the request MUST keep upstream WebSocket without converting
+  the downstream transport mode from `"auto"` to `"websocket"`
+
+#### Scenario: per-key override wins over the global policy
+
+- **GIVEN** the global `http_downstream_transport_policy` is `"smart"`
+- **AND** the authenticating API key has
+  `transport_policy_override = "always_http"`
+- **WHEN** a sticky downstream HTTP request authenticated by that key
+  resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`,
+  because the per-key override takes precedence
+
+#### Scenario: null per-key override follows the global policy
+
+- **GIVEN** the global `http_downstream_transport_policy` is `"smart"`
+- **AND** the authenticating API key has `transport_policy_override =
+  null`
+- **WHEN** a sticky downstream HTTP request authenticated by that key
+  resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket, following the global
+  `smart` policy
+
+#### Scenario: explicit websocket override still beats the policy
+
+- **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
+- **AND** no recent upstream WS failure marker is active
+- **WHEN** a single-shot downstream HTTP request with no sticky signals
+  resolves the upstream transport under any policy
+- **THEN** the explicit override MUST win and the request MUST use
+  upstream WebSocket
+
+#### Scenario: oversized payload bypass still forces HTTP under always_websocket
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+- **AND** the serialized request payload exceeds the WebSocket frame
+  budget
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`, because the
+  oversized-payload bypass has higher precedence than the policy
+
+#### Scenario: native WebSocket clients are unaffected by the policy
+
+- **GIVEN** any value of `http_downstream_transport_policy`
+- **WHEN** a native WebSocket client (`request_transport == "websocket"`)
+  streams a request
+- **THEN** the client MUST keep its dedicated upstream WebSocket path and
+  the policy MUST NOT downgrade it to HTTP
+
+### Requirement: HTTP session bridge admission obeys downstream transport policy
+
+Before an HTTP/SSE Responses request enters the upstream WebSocket session bridge, the proxy MUST apply the same explicit-transport precedence and effective `http_downstream_transport_policy` used by the ordinary streaming retry path. Outside the existing recent upstream WS failure cooldown, an explicit upstream `http` selection MUST bypass the bridge, an explicit upstream `websocket` selection MUST retain it, and otherwise the per-key override or global policy MUST decide. A bridge bypass MUST continue through the ordinary HTTP streaming path without changing request or response shapes.
+
+#### Scenario: Always-HTTP bypasses an enabled bridge
+
+- **GIVEN** the HTTP Responses session bridge is enabled
+- **AND** the effective downstream-HTTP policy is `always_http` or `pinned`
+- **WHEN** a downstream HTTP/SSE request is handled
+- **THEN** the request bypasses the WebSocket session bridge
+- **AND** is sent through the ordinary upstream HTTP path
+
+#### Scenario: Smart bridge admission follows continuity signals
+
+- **GIVEN** the HTTP Responses session bridge is enabled
+- **AND** the effective policy is `smart`
+- **WHEN** a request has no sticky-continuation signal
+- **THEN** it bypasses the bridge
+- **BUT WHEN** any defined sticky-continuation signal is present
+- **THEN** it remains eligible for the bridge
+
+#### Scenario: Explicit transport wins before bridge admission
+
+- **GIVEN** the HTTP Responses session bridge is enabled and no recent upstream WS failure marker is active
+- **WHEN** upstream transport is explicitly `http`
+- **THEN** the bridge is bypassed under every policy
+- **BUT WHEN** upstream transport is explicitly `websocket`
+- **THEN** the bridge remains enabled under every policy
+
+#### Scenario: Per-key policy controls bridge admission
+
+- **GIVEN** a per-API-key transport policy override is non-null
+- **WHEN** bridge admission is evaluated
+- **THEN** that override is used instead of the global policy
+
+## RENAMED Requirements
+- FROM: `### Requirement: Native Codex HTTP attempts preserve client transport choice`
+- TO: `### Requirement: Native Codex HTTP attempts preserve verified transport fallback`
+
+## MODIFIED Requirements
+
+### Requirement: Native Codex HTTP attempts preserve verified transport fallback
+
+Native Codex HTTP/SSE requests SHALL follow the same effective HTTP transport
+policy as other HTTP requests. First-party User-Agent or originator identity
+alone MUST NOT imply a previous WS failure or force upstream HTTP. The existing
+recent upstream WS connect-failure marker and explicit upstream HTTP preference
+MUST preserve HTTP fallback. Native downstream WebSocket requests MUST remain
+on their dedicated WebSocket path.
+
+#### Scenario: Healthy native HTTP continuation is promoted
+- **GIVEN** a native Codex HTTP request carries continuation evidence
+- **WHEN** upstream transport is automatic, HTTP policy is smart, and no recent WS failure is active
+- **THEN** the request is eligible for the upstream WS bridge
+
+#### Scenario: Verified Codex HTTP fallback is retained during outage
+- **GIVEN** the existing recent upstream WS connect-failure marker is active
+- **WHEN** a native Codex HTTP request arrives
+- **THEN** codex-lb sends the attempt upstream over HTTP
+- **AND** normal promotion eligibility returns when the marker clears or expires
+
+#### Scenario: Explicit WebSocket remains authoritative when healthy
+- **GIVEN** a native Codex HTTP request with no active WS transport failure marker
+- **WHEN** the operator explicitly configures upstream WebSocket transport
+- **THEN** the explicit WebSocket selection remains authoritative

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/tasks.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/tasks.md
@@ -1,0 +1,11 @@
+## Implementation
+- [x] Recognize multi-turn evidence and remove identity-only native HTTP pin.
+- [x] Add stable soft locality without inventing hard continuity or trimming unproved history.
+- [x] Enable Chat Completions bridge for streaming and collected responses.
+- [x] Expose admission/bypass reasons and connection reuse counters.
+
+## Validation
+- [x] Exercise smart/native/history/tool/conversation policy and real HTTP endpoint connector behavior.
+- [x] Verify repeated Chat and Responses turns reuse WS, preserve full input and isolate unrelated/API-key scopes.
+- [x] Verify outage, image/size, explicit-policy, source routing, and cleanup regressions.
+- [x] Run focused tests, lint/type/architecture, strict OpenSpec validation; sync and archive.

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/verification.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/verification.md
@@ -1,0 +1,72 @@
+# Verification — 2026-09-09
+
+Initial validation base: `0083bc639` (origin/main when implementation started).
+The results below were collected before PR preparation. No runtime settings or
+production deployment were changed.
+
+## Passing checks
+
+- Continuation/policy/HTTP bridge/transport fallback/safe continuity/Responses
+  contract unit suite: **2,587 passed**.
+- HTTP bridge + Chat + Responses integration suite: **287 passed**, one existing
+  idle-recovery timeout documented below.
+- Chat model-source routing and dispatch: **34 passed**, 104 unrelated cases deselected.
+- Final Chat, API-key accounting, cancellation/task-handoff checks: **30 passed**.
+  Includes API-key socket isolation and settled reservations, per-key HTTP pin,
+  image/large-payload bypass, lifecycle metrics, predispatch rejection, Cursor
+  context-limit handling, and remote settlement ownership.
+- Final promoted Chat tool-loop, conversation/session-anchor, outage and first-turn
+  routing checks: **8 passed**, 175 unrelated cases deselected. Earlier focused
+  Responses route tests cover native/ordinary requests and both Responses aliases.
+- Ruff lint/format, `ty check`, proxy architecture check, and `git diff --check` passed.
+- Strict OpenSpec change validation passed; all **64 main specifications** passed.
+
+Suite counts overlap and should not be summed as unique test coverage.
+
+## Existing baseline failure
+
+`tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_idle_recovery_hands_reader_to_replacement`
+exceeds the 60-second pytest timeout. Reproduced individually with the same
+interpreter and command in an unmodified detached worktree of `0083bc639`
+(63.23 seconds) and this implementation (62.65 seconds). Both fail at the same
+await with `Failed: Timeout (>60.0s) from pytest-timeout`. The test remains intact;
+this change does not claim to repair that separate idle-recovery issue.
+
+Reproduction:
+
+```sh
+python -m pytest tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_idle_recovery_hands_reader_to_replacement -q --tb=short --timeout=60
+```
+
+## Scope of evidence
+
+Integration tests exercise real HTTP handlers, admission, session reuse, Chat
+conversion, and database reservation settlement with mocked upstream connectors.
+No live provider latency benchmark or production promotion-rate measurement was
+performed after these edits. Full-history locality reuses connections while
+preserving full input; it does not claim automatic incremental-input savings.
+
+## PR preparation validation
+
+Rebased onto `e4c0164da` (v1.25.0-beta.6), including the upstream 429 backoff fix.
+The rebase applied without conflicts and preserved the original change apart
+from surrounding imports.
+
+- **2,603 unit tests passed** in 109.89s:
+  `test_http_continuation.py`, `test_chat_bridge_cleanup.py`,
+  `test_proxy_utils.py`, `test_proxy_http_bridge.py`,
+  `test_websocket_transport_fallback.py`, `test_http_bridge_safe_continuity.py`,
+  and `test_proxy_api_responses_contract.py` under `tests/unit/`.
+- **41 integration tests passed** in 77.99s: full
+  `test_http_promotion_accounting.py` and `test_proxy_chat_completions.py`,
+  plus the promoted history, Chat tool-loop, outage recovery, conversation,
+  explicit-session/conversation, and first-turn routing cases in
+  `test_http_responses_bridge.py`.
+- `make lint typecheck` passed, including repository-wide Ruff checks and
+  architecture, cancellation safety, timing seam, and settings-tier checks.
+- `openspec validate --specs --strict`: **64 specifications passed**.
+- `git diff origin/main...HEAD --check` passed.
+
+Tests used `python -m pytest ... -q --tb=short --timeout=60`. The previously
+reproduced idle-recovery timeout is documented above; that unrelated test was
+not rerun in this focused post-rebase validation.

--- a/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/verification.md
+++ b/openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/verification.md
@@ -70,3 +70,13 @@ from surrounding imports.
 Tests used `python -m pytest ... -q --tb=short --timeout=60`. The previously
 reproduced idle-recovery timeout is documented above; that unrelated test was
 not rerun in this focused post-rebase validation.
+
+## Review follow-up
+
+The recent-WS-failure counter is now emitted only if that gate disables an
+admitted bridge. Configuration-disabled and image-generation bypasses no longer
+produce a second outage bypass count; forced upstream HTTP behavior is unchanged.
+
+`test_http_promotion_accounting.py`: **13 passed**, including three explicit
+configuration/image-generation/outage precedence cases. `make lint typecheck`
+and `git diff --check` passed after this fix.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -265,3 +265,35 @@ OpenSpec change first.
 - Post-deploy: correlate retry-circuit `opened`, `half_open`, and `reset` events with bridge `pending` and `response_events_seen` diagnostics. An idle `pending=0` retirement must not precede an immediate two-failure cooldown.
 - Post-deploy: monitor `previous_response_not_found` on `/backend-api/codex/responses`; recurring spikes show repeated continuity failures, which may come from malformed client identifiers, server-side invalidation, or connection lifecycle. Clients should perform the documented full-context retry without `previous_response_id`. Investigate socket-lifecycle remediation only when a separate close-reason, reconnect, or transport diagnostic correlates with the failures.
 - Websocket/Codex CLI tier verification runbook: `openspec/specs/responses-api-compat/ops.md`
+
+
+## HTTP continuation promotion
+
+Healthy native HTTP requests use normal policy. The proxy cannot infer every
+client-local WebSocket failure from HTTP alone; it uses its existing 60-second
+upstream-connect failure marker as concrete failure evidence. Operator HTTP
+pins, image and size bypasses remain effective. No new retry/session registry.
+
+History-only locality is soft, scoped by the bridge's full API-key identifier,
+and hashes the complete first user item plus instructions and model. No client
+prompt cache field is overwritten. Identical initial prompts may share an idle
+connection, but neither histories nor response anchors are merged; the complete
+request is sent each time. Existing hard-continuity paths retain their guarded
+incremental replay. Conversation IDs get their own hashed locality and are never
+combined with an injected previous_response_id.
+
+Chat keeps the existing stream conversion/usage/error/cleanup pipeline and uses
+the bridge only after the source-routing branch. Backend stream=false retains
+its native non-streaming upstream contract. No claimed latency percentage:
+connection reuse is measured separately from admission and successful transport.
+
+For example, a Chat client sending `[user(task), assistant(answer), user(next)]`
+without session headers can open a bridge connection. Appending the next
+assistant/user pair reuses that connection while sending the entire new history.
+The same initial task under a different API key selects a separate connection.
+
+Chat binds existing settlement ownership signals while advancing its bridged
+stream. Predispatch failures and cancellation release origin-owned reservations;
+accepted or delivery-ambiguous owner forwards retain their settlement owner.
+Context bindings do not span yields because startup probes and consumers may
+advance the stream from different tasks.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -4513,8 +4513,8 @@ When a downstream HTTP/SSE request (`request_transport == "http"`) resolves its 
 
 Precedence (highest first), evaluated before the policy:
 
-1. An explicit `upstream_stream_transport` override of `"http"` or
-   `"websocket"` wins outright.
+1. Outside the existing recent upstream WS failure cooldown, an explicit
+   `upstream_stream_transport` override of `"http"` or `"websocket"` wins.
 2. Oversized-payload bypass and image / image-generation bypass force
    upstream HTTP.
 3. The effective policy (per-API-key `transport_policy_override` when
@@ -4535,7 +4535,17 @@ Policy values and behavior:
   - a `prompt_cache_key` present on the request model, **OR**
   - a Codex session header (`session_id`, `x-codex-session-id`, or
     `x-codex-conversation-id`), **OR**
-  - an `x-codex-turn-state` continuity header.
+  - an `x-codex-turn-state` continuity header, **OR**
+  - a non-empty `conversation` identifier, **OR**
+  - a structured tool-result input item (`function_call_output`,
+    `custom_tool_call_output`, or `apply_patch_call_output`), **OR**
+  - an assistant message followed by new user input in the supplied history.
+
+Tool declarations, instruction messages, and user-only input sequences MUST NOT
+alone count as continuation evidence. The existing recent upstream WS failure
+cooldown MUST force upstream HTTP before these policy choices, including an
+explicit WebSocket preference; clearing or expiring the marker restores normal
+eligibility.
 
 When a policy decision keeps upstream WebSocket, the proxy MUST preserve
 the configured/base downstream transport mode passed to the upstream
@@ -4555,7 +4565,7 @@ through to the global `http_downstream_transport_policy`.
   upstream transport resolves to `"websocket"`
 - **AND** a downstream HTTP request carries no `previous_response_id`, no
   `prompt_cache_key`, no Codex session header, and no `x-codex-turn-state`
-  header
+  header, conversation identifier, tool result, or assistant-to-user history
 - **WHEN** the proxy resolves the upstream transport
 - **THEN** the request MUST be sent over upstream HTTP `POST`
 
@@ -4613,6 +4623,7 @@ through to the global `http_downstream_transport_policy`.
 #### Scenario: explicit websocket override still beats the policy
 
 - **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
+- **AND** no recent upstream WS failure marker is active
 - **WHEN** a single-shot downstream HTTP request with no sticky signals
   resolves the upstream transport under any policy
 - **THEN** the explicit override MUST win and the request MUST use
@@ -6951,7 +6962,7 @@ Direct Responses HTTP/SSE requests sent through native egress MUST preserve the 
 
 ### Requirement: HTTP session bridge admission obeys downstream transport policy
 
-Before an HTTP/SSE Responses request enters the upstream WebSocket session bridge, the proxy MUST apply the same explicit-transport precedence and effective `http_downstream_transport_policy` used by the ordinary streaming retry path. An explicit upstream `http` selection MUST bypass the bridge, an explicit upstream `websocket` selection MUST retain it, and otherwise the per-key override or global policy MUST decide. A bridge bypass MUST continue through the ordinary HTTP streaming path without changing request or response shapes.
+Before an HTTP/SSE Responses request enters the upstream WebSocket session bridge, the proxy MUST apply the same explicit-transport precedence and effective `http_downstream_transport_policy` used by the ordinary streaming retry path. Outside the existing recent upstream WS failure cooldown, an explicit upstream `http` selection MUST bypass the bridge, an explicit upstream `websocket` selection MUST retain it, and otherwise the per-key override or global policy MUST decide. A bridge bypass MUST continue through the ordinary HTTP streaming path without changing request or response shapes.
 
 #### Scenario: Always-HTTP bypasses an enabled bridge
 
@@ -6972,7 +6983,7 @@ Before an HTTP/SSE Responses request enters the upstream WebSocket session bridg
 
 #### Scenario: Explicit transport wins before bridge admission
 
-- **GIVEN** the HTTP Responses session bridge is enabled
+- **GIVEN** the HTTP Responses session bridge is enabled and no recent upstream WS failure marker is active
 - **WHEN** upstream transport is explicitly `http`
 - **THEN** the bridge is bypassed under every policy
 - **BUT WHEN** upstream transport is explicitly `websocket`
@@ -7101,27 +7112,28 @@ streams.
 - **AND** existing request-log and account-health error handling remains
   unchanged
 
-### Requirement: Native Codex HTTP attempts preserve client transport choice
+### Requirement: Native Codex HTTP attempts preserve verified transport fallback
 
-For a downstream HTTP/SSE Responses request identified as a native Codex
-request by the existing first-party `User-Agent` or `originator` rules, the
-proxy MUST retain upstream HTTP when transport is otherwise controlled by the
-HTTP downstream policy. This native pin MUST take precedence over sticky
-continuation signals and the `smart` or `always_websocket` policy, but it MUST
-NOT override an explicit operator `upstream_stream_transport="websocket"` or
-an existing higher-precedence mandatory transport rail. Native downstream
-WebSocket requests MUST remain on their dedicated WebSocket path.
+Native Codex HTTP/SSE requests SHALL follow the same effective HTTP transport
+policy as other HTTP requests. First-party User-Agent or originator identity
+alone MUST NOT imply a previous WS failure or force upstream HTTP. The existing
+recent upstream WS connect-failure marker and explicit upstream HTTP preference
+MUST preserve HTTP fallback. Native downstream WebSocket requests MUST remain
+on their dedicated WebSocket path.
 
-#### Scenario: Codex HTTP fallback is not promoted again
+#### Scenario: Healthy native HTTP continuation is promoted
+- **GIVEN** a native Codex HTTP request carries continuation evidence
+- **WHEN** upstream transport is automatic, HTTP policy is smart, and no recent WS failure is active
+- **THEN** the request is eligible for the upstream WS bridge
 
-- **GIVEN** a native Codex client retries a WebSocket turn as an HTTP request
-- **AND** the HTTP request carries a prompt cache key or Codex session header
-- **WHEN** the configured transport is automatic and the HTTP policy is smart
+#### Scenario: Verified Codex HTTP fallback is retained during outage
+- **GIVEN** the existing recent upstream WS connect-failure marker is active
+- **WHEN** a native Codex HTTP request arrives
 - **THEN** codex-lb sends the attempt upstream over HTTP
+- **AND** normal promotion eligibility returns when the marker clears or expires
 
-#### Scenario: Explicit WebSocket remains authoritative
-
-- **GIVEN** a native Codex HTTP request
+#### Scenario: Explicit WebSocket remains authoritative when healthy
+- **GIVEN** a native Codex HTTP request with no active WS transport failure marker
 - **WHEN** the operator explicitly configures upstream WebSocket transport
 - **THEN** the explicit WebSocket selection remains authoritative
 
@@ -10682,3 +10694,70 @@ original upstream code is retained for account-health recovery.
 - **AND** the request-log error code is `previous_response_owner_unavailable`
 - **AND** no raw stale-anchor identifier or source-ownership detail is exposed
 
+
+
+### Requirement: Structured HTTP continuation promotion
+Under automatic upstream transport and smart HTTP policy, the proxy SHALL
+recognize a non-empty conversation identifier, a tool-result input item, or an
+assistant response followed by new user input as continuation evidence, in
+addition to existing response, cache, session and turn-state identifiers.
+Tool declarations, instruction messages, and multiple user-only messages SHALL
+NOT alone constitute continuation evidence.
+
+#### Scenario: Full-history agent turn
+- **WHEN** a smart HTTP request contains user, assistant, then user input without explicit continuity metadata
+- **THEN** it is eligible for the upstream WS bridge
+- **AND** the complete input remains intact unless existing verified hard-continuity rules authorize trimming
+
+#### Scenario: Native identity without failure evidence
+- **WHEN** a native Codex HTTP request has continuation evidence and upstream WS is healthy
+- **THEN** the same smart/override policy as other HTTP requests applies
+- **AND** native identity alone MUST NOT force HTTP
+
+#### Scenario: Real upstream outage
+- **WHEN** the existing recent upstream WS failure marker is active
+- **THEN** HTTP entry paths MUST use upstream HTTP during its existing cooldown
+- **AND** normal WS eligibility MUST return when it expires or clears
+
+### Requirement: Inferred continuation locality remains soft
+History-only bridge requests SHALL use a deterministic locality key based on
+complete initial user input and instruction context, isolated by API-key scope.
+Conversation identifiers SHALL have distinct locality from inferred histories.
+Inferred locality SHALL NOT authorize previous-response injection, cross-account
+replay, or dropping client history. Explicit turn/session ownership SHALL retain
+precedence and existing recovery/fork/queue safeguards.
+
+#### Scenario: Repeated history without response headers
+- **WHEN** two compatible multi-turn requests retain the same initial user input and instructions
+- **THEN** they can reuse the same healthy upstream connection without replaying response headers
+- **AND** divergent complete initial inputs MUST NOT share an inferred locality key merely because their first 512 characters match
+
+### Requirement: Chat Completions uses HTTP bridge policy
+Subscription-backed Chat Completions SHALL apply the same HTTP bridge admission
+and fallback policy to its converted Responses request for streaming and
+non-streaming clients. Chat chunks, JSON, usage, error envelopes, reservation
+settlement and source routing SHALL preserve their existing public contracts.
+
+#### Scenario: Chat trailing slash uses the same handler
+- **WHEN** a client posts to `/v1/chat/completions/`
+- **THEN** the same authentication, routing, bridge and response contract as `/v1/chat/completions` SHALL apply
+
+#### Scenario: Chat tool loop reuses upstream connection
+- **WHEN** successive Chat requests include tool results and retain compatible initial context
+- **THEN** eligible requests reuse the upstream WS bridge
+- **AND** clients still receive Chat Completions responses
+
+#### Scenario: Chat bridge fails before settlement handoff
+- **WHEN** bridge startup fails or is cancelled before dispatch or service settlement ownership
+- **THEN** the originating API releases its usage reservation
+- **AND** an ambiguous owner-forward dispatch MUST NOT release the reservation without a definitive rejection
+
+### Requirement: HTTP bridge routing reasons are observable
+The proxy SHALL emit structured admission and bypass reasons and bounded-label
+counters, and SHALL count bridge create/reuse/close/reconnect/idle-eviction events.
+Metrics SHALL NOT label raw request, conversation, session, account or API-key identifiers.
+
+#### Scenario: Identify policy exclusion and transport fallback
+- **WHEN** a request remains HTTP because it is single-turn, policy-pinned, bridge-disabled, oversized, image-capable, or affected by a recent WS outage
+- **THEN** its routing diagnostics distinguish that reason
+- **AND** admission counters MUST NOT be represented as successful WS connections

--- a/tests/integration/test_daybreak_capability_routes.py
+++ b/tests/integration/test_daybreak_capability_routes.py
@@ -60,6 +60,7 @@ _FAIL_CLOSED_HTTP_ROUTES: frozenset[_RouteKey] = frozenset(
         ("HTTP", "POST", "/v1/images/generations"),
         ("HTTP", "POST", "/v1/images/edits"),
         ("HTTP", "POST", "/v1/chat/completions"),
+        ("HTTP", "POST", "/v1/chat/completions/"),
         ("HTTP", "POST", "/v1/embeddings"),
         ("HTTP", "POST", "/v1/responses/compact"),
         ("HTTP", "POST", "/backend-api/transcribe"),
@@ -176,6 +177,12 @@ _PROVIDER_ROUTING_CASES = [
     ),
     pytest.param(
         "POST",
+        "/v1/chat/completions/",
+        {"json": {"model": "gpt-5.6-sol", "messages": [{"role": "user", "content": "inert"}]}},
+        id="chat-completions-slash",
+    ),
+    pytest.param(
+        "POST",
         "/v1/embeddings",
         {"json": {"model": "text-embedding-3-small", "input": "inert"}},
         id="embeddings",
@@ -275,6 +282,7 @@ async def test_daybreak_capability_unsupported_http_authenticates_before_denial(
         "/v1/responses",
         "/backend-api/codex/responses",
         "/v1/chat/completions",
+        "/v1/chat/completions/",
         "/v1/embeddings",
         "/v1/images/generations",
         "/v1/warmup",

--- a/tests/integration/test_http_promotion_accounting.py
+++ b/tests/integration/test_http_promotion_accounting.py
@@ -11,7 +11,7 @@ from app.db.session import SessionLocal
 from app.dependencies import get_proxy_service_for_app
 from app.modules.proxy import service as proxy_module
 from app.modules.proxy._service import observability, support
-from app.modules.proxy._service.http_bridge import helpers
+from app.modules.proxy._service.http_bridge import helpers, streaming
 from tests.integration.test_http_responses_bridge import (
     _cleanup_http_bridge_sessions as cleanup_http_bridge_sessions,  # noqa: F401
 )
@@ -126,6 +126,35 @@ async def test_promotion_counts_reuse_separately_from_admission(async_client, pr
     assert routing_counter.labels.call_count == 2
     connection_counter.labels.assert_any_call(event="create")
     connection_counter.labels.assert_any_call(event="reuse")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gate", ["disabled", "image_generation", "recent_failure"])
+async def test_http_bridge_outage_counts_only_the_gate_that_disables_bridge(
+    async_client, promotion_transport, monkeypatch, gate
+):
+    upstreams, raw_calls, _ = promotion_transport
+    routing_counter = Mock()
+    monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
+    # Model an outage observed after API admission, at the service bypass gates.
+    monkeypatch.setattr(streaming, "upstream_websocket_transport_recently_failed", lambda: True)
+    body = {"model": "gpt-5.4", "input": _promotion_history()}
+    if gate == "disabled":
+        app_settings = _make_app_settings(enabled=False)
+        monkeypatch.setattr(proxy_module, "get_settings", lambda: app_settings)
+    elif gate == "image_generation":
+        body["tools"] = [{"type": "image_generation"}]
+
+    response = await async_client.post("/v1/responses", json=body)
+
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+    bypass_reasons = [
+        call.kwargs["reason"] for call in routing_counter.labels.call_args_list if call.kwargs["stage"] == "bypass"
+    ]
+    expected = {"disabled": [], "image_generation": ["image"], "recent_failure": ["recent_ws_failure"]}
+    assert bypass_reasons == expected[gate]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_http_promotion_accounting.py
+++ b/tests/integration/test_http_promotion_accounting.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import select
+
+from app.core.clients.proxy import ProxyResponseError
+from app.db.models import ApiKeyUsageReservation
+from app.db.session import SessionLocal
+from app.dependencies import get_proxy_service_for_app
+from app.modules.proxy import service as proxy_module
+from app.modules.proxy._service import observability, support
+from app.modules.proxy._service.http_bridge import helpers
+from tests.integration.test_http_responses_bridge import (
+    _cleanup_http_bridge_sessions as cleanup_http_bridge_sessions,  # noqa: F401
+)
+from tests.integration.test_http_responses_bridge import (
+    _make_app_settings,
+    _promotion_history,
+)
+from tests.integration.test_http_responses_bridge import (
+    promotion_transport as promotion_transport,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _key(async_client, name, *, policy=None):
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings.status_code == 200, settings.text
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": name,
+            "transportPolicyOverride": policy,
+            "limits": [{"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 100_000}],
+        },
+    )
+    assert created.status_code == 200, created.text
+    return created.json()
+
+
+@pytest.mark.asyncio
+async def test_promoted_chat_keys_isolate_connections_and_settle_usage(async_client, app_instance, promotion_transport):
+    upstreams, _, _ = promotion_transport
+    keys = [await _key(async_client, "first"), await _key(async_client, "second")]
+    for key in [keys[0], keys[1], keys[0]]:
+        response = await async_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-5.4",
+                "messages": _promotion_history(),
+            },
+            headers={"Authorization": f"Bearer {key['key']}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["usage"]["total_tokens"] == 26
+    assert len(upstreams) == 2
+    assert [len(upstream.sent_text) for upstream in upstreams] == [2, 1]
+    service = get_proxy_service_for_app(app_instance)
+    await service.drain_persistence_tasks(timeout_seconds=5)
+    async with SessionLocal() as session:
+        rows = (await session.execute(select(ApiKeyUsageReservation))).scalars().all()
+        assert len(rows) == 3
+        assert all(row.status != "reserved" and row.status != "settling" for row in rows)
+        assert {row.api_key_id for row in rows} == {key["id"] for key in keys}
+
+
+@pytest.mark.asyncio
+async def test_per_key_http_override_suppresses_native_history_promotion(async_client, promotion_transport, caplog):
+    upstreams, raw_calls, _ = promotion_transport
+    key = await _key(async_client, "http-only", policy="always_http")
+    response = await async_client.post(
+        "/v1/responses",
+        json={"model": "gpt-5.4", "input": _promotion_history()},
+        headers={"Authorization": f"Bearer {key['key']}", "user-agent": "codex_exec/0.153.4"},
+    )
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bypass", ["image", "payload_size"])
+async def test_promoted_http_bypass_reasons_are_counted(async_client, promotion_transport, monkeypatch, bypass):
+    upstreams, raw_calls, _ = promotion_transport
+    routing_counter = Mock()
+    monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
+    if bypass == "payload_size":
+        app_settings = _make_app_settings(enabled=True).model_copy(update={"max_sse_event_bytes": 3 * 1024 * 1024})
+        monkeypatch.setattr(proxy_module, "get_settings", lambda: app_settings)
+        history = _promotion_history("x" * (1024 * 1024 + 1))
+    else:
+        history = _promotion_history()
+        history[-1] = {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="},
+            ],
+        }
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+    routing_counter.labels.assert_any_call(stage="admission", reason="smart_history")
+    routing_counter.labels.assert_any_call(stage="bypass", reason=bypass)
+
+
+@pytest.mark.asyncio
+async def test_promotion_counts_reuse_separately_from_admission(async_client, promotion_transport, monkeypatch):
+    routing_counter, connection_counter = Mock(), Mock()
+    monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
+    monkeypatch.setattr(helpers, "http_bridge_connections_total", connection_counter)
+    for _ in range(2):
+        response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": _promotion_history()})
+        assert response.status_code == 200, response.text
+    assert routing_counter.labels.call_count == 2
+    connection_counter.labels.assert_any_call(event="create")
+    connection_counter.labels.assert_any_call(event="reuse")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cursor", [False, True])
+async def test_chat_bridge_predispatch_error_releases_limited_key(
+    async_client, app_instance, promotion_transport, monkeypatch, cursor
+):
+    key = await _key(async_client, "failed")
+
+    async def reject(*args, **kwargs):
+        raise ProxyResponseError(
+            400,
+            {
+                "error": {
+                    "code": "context_length_exceeded" if cursor else "invalid_request_error",
+                    "type": "invalid_request_error",
+                    "message": "rejected before dispatch",
+                }
+            },
+        )
+
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", reject)
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-5.4",
+            "messages": _promotion_history(),
+        },
+        headers={"Authorization": f"Bearer {key['key']}", "User-Agent": "Cursor" if cursor else "test"},
+    )
+    assert response.status_code == (200 if cursor else 400), response.text
+    if not cursor:
+        assert response.json()["error"]["code"] == "invalid_request_error"
+    await get_proxy_service_for_app(app_instance).drain_persistence_tasks(timeout_seconds=5)
+    async with SessionLocal() as session:
+        rows = (await session.execute(select(ApiKeyUsageReservation))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].status == "released"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handoff", "expected_status"),
+    [("dispatched", "reserved"), ("rejected", "released"), ("settlement_owned", "reserved")],
+)
+async def test_chat_bridge_error_respects_reservation_handoff(
+    async_client, app_instance, promotion_transport, monkeypatch, handoff, expected_status
+):
+    key = await _key(async_client, "forwarded")
+
+    async def forwarded_error(*args, **kwargs):
+        support._signal_propagated_responses_owner_forward_dispatched()
+        if handoff == "rejected":
+            support._signal_propagated_responses_owner_forward_rejected()
+        elif handoff == "settlement_owned":
+            support._signal_propagated_responses_service_cleanup_ready()
+        raise ProxyResponseError(502, {"error": {"code": "upstream_unavailable", "message": "owner connection closed"}})
+        yield  # pragma: no cover -- preserve async iterator contract
+
+    monkeypatch.setattr(get_proxy_service_for_app(app_instance), "stream_http_responses", forwarded_error)
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-5.4", "messages": _promotion_history()},
+        headers={"Authorization": f"Bearer {key['key']}"},
+    )
+    assert response.status_code == 502, response.text
+    await get_proxy_service_for_app(app_instance).drain_persistence_tasks(timeout_seconds=5)
+    async with SessionLocal() as session:
+        rows = (await session.execute(select(ApiKeyUsageReservation))).scalars().all()
+        assert len(rows) == 1
+        # Ambiguous dispatch and accepted ownership remain the remote service's
+        # responsibility; only definitive rejection permits origin release.
+        assert rows[0].status == expected_status

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -17470,3 +17470,236 @@ async def test_v1_responses_http_bridge_retries_accepted_output_free_capacity_er
     assert first_account.id in selection_exclusions[-1]
     assert len(failing_upstream.sent_text) == 1
     assert len(retry_upstream.sent_text) == 1
+
+
+class _PromotionUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        await super().send_text(text)
+        created = self._messages.get_nowait()
+        completed = self._messages.get_nowait()
+        self._messages.put_nowait(created)
+        self._messages.put_nowait(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.output_text.delta",
+                        "delta": "OK",
+                        "output_index": 0,
+                        "content_index": 0,
+                    }
+                ),
+            )
+        )
+        self._messages.put_nowait(completed)
+
+
+@pytest_asyncio.fixture
+async def promotion_transport(async_client, app_instance, monkeypatch):
+    """Real routes, bridge/session/accounting; only replace upstream I/O."""
+    dashboard = _make_dashboard_settings()
+    dashboard.http_downstream_transport_policy = "smart"
+    _install_proxy_settings(monkeypatch, app_settings=_make_app_settings(enabled=True), dashboard_settings=dashboard)
+    account_id = await _import_account(async_client, "acc_promotion", "promotion@example.com")
+    account = await _get_account(account_id)
+    upstreams = []
+    raw_calls = []
+
+    async def select_account(self, *args, **kwargs):
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fresh(self, target, **kwargs):
+        return target
+
+    async def connect(*args, **kwargs):
+        upstream = _PromotionUpstreamWebSocket(response_id_prefix=f"resp_promoted_{len(upstreams)}")
+        upstreams.append(upstream)
+        return upstream
+
+    async def raw(payload, *args, upstream_stream_transport_override=None, **kwargs):
+        raw_calls.append({**kwargs, "upstream_transport": upstream_stream_transport_override})
+        response = {
+            "id": "resp_raw",
+            "object": "response",
+            "status": "in_progress",
+            "output": [{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "OK"}]}],
+            "usage": {"input_tokens": 24, "output_tokens": 2, "total_tokens": 26},
+        }
+        yield "data: " + json.dumps({"type": "response.created", "response": response}) + "\n\n"
+        yield 'data: {"type":"response.output_text.delta","delta":"OK","output_index":0,"content_index":0}\n\n'
+        response["status"] = "completed"
+        yield "data: " + json.dumps({"type": "response.completed", "response": response}) + "\n\n"
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", select_account)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fresh)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", connect)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", raw)
+    proxy_support.clear_upstream_websocket_transport_failure()
+    yield upstreams, raw_calls, dashboard
+    proxy_support.clear_upstream_websocket_transport_failure()
+    await get_proxy_service_for_app(app_instance).drain_persistence_tasks(timeout_seconds=5.0)
+
+
+def _promotion_history(first="task"):
+    return [
+        {"role": "user", "content": first},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "continue"},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1/responses", "/v1/responses/", "/backend-api/codex/responses"])
+@pytest.mark.parametrize("native", [False, True])
+async def test_smart_history_http_promotes_and_reuses_without_dropping_context(
+    async_client,
+    promotion_transport,
+    path,
+    native,
+    caplog,
+):
+    upstreams, raw_calls, _ = promotion_transport
+    headers = {"user-agent": "codex_exec/0.153.4" if native else "OpenAI/Python"}
+    caplog.set_level(logging.INFO)
+    history = _promotion_history()
+    body = {"model": "gpt-5.4", "instructions": "test", "stream": True, "input": history}
+    first = await _collect_sse_events(async_client, path, json_body=body, headers=headers)
+    second_history = [*history, {"role": "assistant", "content": "OK"}, {"role": "user", "content": "next"}]
+    second = await _collect_sse_events(async_client, path, json_body={**body, "input": second_history}, headers=headers)
+    assert first[-1]["type"] == second[-1]["type"] == "response.completed"
+    assert len(upstreams) == 1
+    assert not raw_calls
+    frames = [json.loads(frame) for frame in upstreams[0].sent_text]
+    assert len(frames[0]["input"]) == len(history)
+    assert len(frames[1]["input"]) == len(second_history)
+    assert all("previous_response_id" not in frame for frame in frames)
+    assert "reason=smart_history" in caplog.text
+    assert "event=reuse" in caplog.text
+    # Same first 512 characters do not coalesce different conversations.
+    await _collect_sse_events(
+        async_client, path, json_body={**body, "input": _promotion_history("different")}, headers=headers
+    )
+    assert len(upstreams) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/chat/completions/"])
+async def test_smart_chat_tool_loop_reuses_bridge_with_chat_contract(
+    async_client,
+    promotion_transport,
+    stream,
+    path,
+    caplog,
+):
+    upstreams, raw_calls, _ = promotion_transport
+    caplog.set_level(logging.INFO)
+    messages = [
+        {"role": "user", "content": "read file"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_read", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_read", "content": "file contents"},
+    ]
+    body = {"model": "gpt-5.4", "messages": messages, "stream": stream}
+    if stream:
+        body["stream_options"] = {"include_usage": True}
+    for _ in range(2):
+        response = await async_client.post(path, json=body)
+        assert response.status_code == 200, response.text
+        if stream:
+            chunks = [
+                json.loads(line[6:])
+                for line in response.text.splitlines()
+                if line.startswith("data: ") and line[6:] != "[DONE]"
+            ]
+            assert chunks and all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
+            assert chunks[-1]["usage"]["total_tokens"] == 26
+            assert "data: [DONE]" in response.text
+        else:
+            assert response.json()["object"] == "chat.completion"
+            assert response.json()["choices"][0]["message"]["content"] == "OK"
+            assert response.json()["usage"]["total_tokens"] == 26
+    assert len(upstreams) == 1
+    assert not raw_calls
+    assert "reason=smart_tool_result" in caplog.text
+    for frame in upstreams[0].sent_text:
+        payload = json.loads(frame)
+        assert any(item.get("type") == "function_call_output" for item in payload["input"])
+        assert "previous_response_id" not in payload
+
+
+@pytest.mark.asyncio
+async def test_smart_promotion_follows_real_outage_and_recovers(async_client, promotion_transport, caplog):
+    upstreams, raw_calls, dashboard = promotion_transport
+    caplog.set_level(logging.INFO)
+    body = {"model": "gpt-5.4", "input": _promotion_history()}
+    headers = {"user-agent": "codex_exec/0.153.4"}
+    proxy_support.mark_upstream_websocket_transport_failure()
+    response = await async_client.post("/v1/responses", json=body, headers=headers)
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+    assert "reason=recent_ws_failure" in caplog.text
+    proxy_support.clear_upstream_websocket_transport_failure()
+    response = await async_client.post("/v1/responses", json=body, headers=headers)
+    assert response.status_code == 200, response.text
+    assert len(upstreams) == 1
+    dashboard.http_downstream_transport_policy = "always_http"
+    await async_client.post("/v1/responses", json=body, headers=headers)
+    assert len(upstreams[0].sent_text) == 1
+    assert "reason=always_http" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_smart_conversation_keeps_wire_conversation_and_separates_keys(async_client, promotion_transport):
+    upstreams, raw_calls, _ = promotion_transport
+    body = {"model": "gpt-5.4", "input": "continue", "conversation": "conv_a"}
+    for conversation in ["conv_a", "conv_a", "conv_b"]:
+        response = await async_client.post("/v1/responses", json={**body, "conversation": conversation})
+        assert response.status_code == 200, response.text
+    assert len(upstreams) == 2
+    assert not raw_calls
+    assert len(upstreams[0].sent_text) == 2
+    assert all(json.loads(frame)["conversation"] == "conv_a" for frame in upstreams[0].sent_text)
+    assert all("previous_response_id" not in json.loads(frame) for frame in upstreams[0].sent_text)
+
+
+@pytest.mark.asyncio
+async def test_smart_conversation_with_session_never_injects_conflicting_response_anchor(
+    async_client, promotion_transport
+):
+    upstreams, _, _ = promotion_transport
+    history = _promotion_history()
+    for items in [history, [*history, {"role": "assistant", "content": "OK"}, {"role": "user", "content": "again"}]]:
+        response = await async_client.post(
+            "/v1/responses",
+            json={"model": "gpt-5.4", "input": items, "conversation": "conv_session"},
+            headers={"session_id": "explicit-session"},
+        )
+        assert response.status_code == 200, response.text
+    assert len(upstreams) == 1
+    frames = [json.loads(frame) for frame in upstreams[0].sent_text]
+    assert len(frames) == 2
+    assert all(frame["conversation"] == "conv_session" and "previous_response_id" not in frame for frame in frames)
+    assert len(frames[-1]["input"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_smart_single_turn_stays_http_before_history_promotes(async_client, promotion_transport, caplog):
+    upstreams, raw_calls, _ = promotion_transport
+    caplog.set_level(logging.INFO)
+    body = {"model": "gpt-5.4", "messages": [{"role": "user", "content": "task"}]}
+    first = await async_client.post("/v1/chat/completions", json=body)
+    assert first.status_code == 200, first.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+    second = await async_client.post("/v1/chat/completions", json={**body, "messages": _promotion_history()})
+    assert second.status_code == 200, second.text
+    assert len(upstreams) == 1
+    assert "reason=smart_single_turn" in caplog.text
+    assert "reason=smart_history" in caplog.text

--- a/tests/unit/test_chat_bridge_cleanup.py
+++ b/tests/unit/test_chat_bridge_cleanup.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.modules.proxy import api
+from app.modules.proxy._service import support
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_owns", [False, True])
+async def test_chat_bridge_cancellation_preserves_settlement_owner(monkeypatch, service_owns):
+    release = AsyncMock()
+    monkeypatch.setattr(api, "_release_reservation_best_effort", release)
+    started, closed = asyncio.Event(), asyncio.Event()
+
+    async def upstream():
+        if service_owns:
+            support._signal_propagated_responses_service_cleanup_ready()
+        try:
+            started.set()
+            await asyncio.Future()
+            yield "unreachable"
+        finally:
+            closed.set()
+
+    guarded = api._guard_chat_bridge_reservation(upstream(), reservation=None, service=object())
+
+    async def next_item():
+        return await anext(guarded)
+
+    probe = asyncio.create_task(next_item())
+    await asyncio.wait_for(started.wait(), timeout=2)
+    probe.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await probe
+    assert closed.is_set()
+    assert release.await_count == (0 if service_owns else 1)
+
+
+@pytest.mark.asyncio
+async def test_chat_bridge_task_handoff_closes_underlying_stream_and_restores_context(monkeypatch):
+    release = AsyncMock()
+    monkeypatch.setattr(api, "_release_reservation_best_effort", release)
+    closed = asyncio.Event()
+    outer_signal = asyncio.Event()
+
+    async def upstream():
+        try:
+            yield "created"
+            yield "delta"
+        finally:
+            # Service can transfer cleanup during close as well as startup.
+            support._signal_propagated_responses_service_cleanup_ready()
+            closed.set()
+
+    outer_token = support._bind_propagated_responses_service_cleanup_ready(outer_signal)
+    try:
+        guarded = api._guard_chat_bridge_reservation(upstream(), reservation=None, service=object())
+
+        async def next_item():
+            return await anext(guarded)
+
+        assert await asyncio.create_task(next_item()) == "created"
+        assert await asyncio.create_task(next_item()) == "delta"
+        await api._aclose_stream(guarded)
+        assert closed.is_set()
+        release.assert_not_awaited()
+        assert not outer_signal.is_set()
+        support._signal_propagated_responses_service_cleanup_ready()
+        assert outer_signal.is_set()
+    finally:
+        support._reset_propagated_responses_service_cleanup_ready(outer_token)

--- a/tests/unit/test_http_continuation.py
+++ b/tests/unit/test_http_continuation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from app.core.openai.requests import ResponsesRequest
+from app.db.models import StickySessionKind
+from app.modules.proxy._service.http_bridge.helpers import _make_http_bridge_session_key
+from app.modules.proxy.affinity import _AffinityPolicy
+from app.modules.proxy.http_continuation import http_continuation_signal, inferred_http_bridge_key
+
+pytestmark = pytest.mark.unit
+
+
+def _payload(items, **kwargs):
+    return ResponsesRequest(model="gpt-5.4", instructions="Instructions", input=items, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("items", "signal"),
+    [
+        ([{"role": "user", "content": "hi"}], None),
+        ([{"role": "user", "content": "hi"}, {"role": "user", "content": "more"}], None),
+        ([{"role": "system", "content": "policy"}, {"role": "user", "content": "hi"}], None),
+        ([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}], None),
+        (
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "more"},
+            ],
+            "history",
+        ),
+        ([{"type": "function_call_output", "call_id": "call_a", "output": "done"}], "tool_result"),
+        ([{"type": "custom_tool_call_output", "call_id": "call_a", "output": "done"}], "tool_result"),
+    ],
+)
+def test_continuation_evidence(items, signal):
+    assert http_continuation_signal(_payload(items), {}) == signal
+
+
+def test_tools_declared_alone_do_not_promote():
+    payload = _payload("hi", tools=[{"type": "function", "name": "read", "parameters": {}}])
+    assert http_continuation_signal(payload, {}) is None
+
+
+def test_history_key_uses_complete_initial_input_and_is_soft_and_scoped():
+    first = "a" * 512
+    items = [
+        {"role": "user", "content": first + "one"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "next"},
+    ]
+    payload = _payload(items)
+    key = inferred_http_bridge_key(payload)
+    extended = _payload([*items, {"role": "assistant", "content": "again"}, {"role": "user", "content": "next"}])
+    assert inferred_http_bridge_key(extended) == key
+    distinct = _payload([{**items[0], "content": first + "two"}, *items[1:]])
+    assert inferred_http_bridge_key(distinct) != key
+    assert inferred_http_bridge_key(_payload(items, conversation="conv_a")) != key
+    affinity = _AffinityPolicy(key="truncated-cache", kind=StickySessionKind.PROMPT_CACHE)
+    bridge_key = _make_http_bridge_session_key(payload, headers={}, affinity=affinity, api_key=None, request_id="req")
+    assert bridge_key.affinity_key == key
+    assert bridge_key.strength == "soft"
+    assert replace(bridge_key, api_key_id="key_a") != replace(bridge_key, api_key_id="key_b")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6828,7 +6828,7 @@ def test_http_downstream_always_websocket_policy_keeps_websocket_without_sticky_
     )
 
 
-def test_native_codex_http_fallback_bypasses_sticky_websocket_bridge() -> None:
+def test_native_codex_http_without_failure_enters_sticky_websocket_bridge() -> None:
     dashboard_settings = _make_proxy_settings()
     dashboard_settings.http_downstream_transport_policy = "always_websocket"
     dashboard_settings.upstream_stream_transport = "auto"
@@ -6844,7 +6844,7 @@ def test_native_codex_http_fallback_bypasses_sticky_websocket_bridge() -> None:
             dashboard_settings=dashboard_settings,
             base_settings=base_settings,
         )
-        is False
+        is True
     )
 
 
@@ -7009,7 +7009,7 @@ async def test_http_downstream_sticky_smart_policy_preserves_auto_transport_mode
 
 
 @pytest.mark.asyncio
-async def test_native_codex_http_fallback_preserves_http_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_native_codex_http_without_failure_preserves_auto_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = await _capture_stream_retry_transport(
         monkeypatch,
         dashboard_policy="always_websocket",
@@ -7017,7 +7017,7 @@ async def test_native_codex_http_fallback_preserves_http_transport(monkeypatch: 
         headers={"user-agent": "codex_exec/0.150.1 (Ubuntu; x86_64)", "originator": "codex_exec"},
     )
 
-    assert transport == "http"
+    assert transport == "auto"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Agent loops that resend full history or use Chat Completions can stay on upstream HTTP under `smart`, and native Codex identity suppresses promotion even when WS is healthy. Recognize structured continuation evidence and reuse the existing WS bridge for Responses and subscription-backed Chat, while preserving full history and reservation ownership.

## Type of change

- [x] `fix:` — missed HTTP-to-WS promotion and bridge startup reservation cleanup

Linked issue: user-reported behavior; no associated GitHub issue.

## OpenSpec

- [x] Includes an archived OpenSpec change and synchronized main spec/context.
- [x] Preserves Responses framing and Chat response shapes on the affected upstream path.

Change: [`improve-http-websocket-promotion`](openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/).

## Changes

- Extend `smart` to conversation IDs, structured tool results, and assistant-to-user history. Tool declarations and user-only messages do not qualify.
- Apply normal policy to healthy native Codex HTTP callers. Preserve explicit HTTP/image/size bypasses and the existing 60-second upstream WS failure cooldown.
- Derive stable, API-key-scoped soft connection locality from complete initial context. Full history stays intact; inferred keys do not authorize response-anchor injection or account replay.
- Use the bridge for streaming and collected subscription-backed Chat, including the trailing-slash alias. Keep source routing and Chat usage/error contracts intact.
- Release Chat reservations on predispatch errors/cancellation while preserving remote settlement ownership after ambiguous or accepted dispatch.
- Add bounded admission/bypass reasons and connection lifecycle counters; distinguish eligibility from actual connection reuse.

## Simplicity

- [x] Works with existing defaults and requires no new setup.
- [x] No new setting, database schema, README section, environment variable, or dashboard navigation item.
- New settings/tiers: none. Routing documentation links to its owning OpenSpec capability.

## Test plan

After rebasing onto `e4c0164da` (v1.25.0-beta.6):

- **2,603 unit tests passed**, including the updated upstream retry-policy cases.
- **41 integration tests passed** for Chat, promotion/reuse, fallback, and accounting.
- `make lint typecheck` passed (repository-wide lint/format/type and architecture/cancellation/timing/settings checks).
- `openspec validate --specs --strict`: **64 specifications passed**.
- `git diff origin/main...HEAD --check` passed.

Earlier implementation validation: 2,587 unit tests passed; 287 Responses/Chat/bridge integration tests passed; 34 source-routing tests passed. Counts overlap with focused reruns. Validation details and limitations are in [verification.md](openspec/changes/archive/2026-09-09-improve-http-websocket-promotion/verification.md).

Local timeout note: `test_v1_responses_http_bridge_idle_recovery_hands_reader_to_replacement` exceeded a 60-second timeout on both the initial implementation and unmodified `0083bc639`. It **passes with the CI-standard 180-second timeout** on `eb5e9bd91` (62.09s); the test remains unchanged.

Review follow-up `eb5e9bd91` prevents redundant outage bypass counts when configuration or image generation already disabled the bridge. All 13 accounting/routing integration tests, including three added bypass-precedence cases, and `make lint typecheck` passed.

CI follow-up `304c3b88a` updates the explicit capability-policy route inventory for the new Chat trailing-slash alias and exercises its capability rejection and pre-body authentication. The full capability-routing suite passes: **130 tests**. This follow-up changes tests only.

## Example

With automatic upstream transport and `smart`, this HTTP Chat request now qualifies for the WS bridge without a cache key or session header:

```json
{"model":"gpt-5.4","messages":[{"role":"user","content":"task"},{"role":"assistant","content":"answer"},{"role":"user","content":"next"}]}
```

The HTTP response remains a Chat Completion (`object: "chat.completion"`), and subsequent compatible history can reuse the socket. Diagnostics report `stage=admission reason=smart_history`; connection reuse is counted separately. Provider latency and production promotion rates have not been benchmarked, and this PR has not been deployed.

## Checklist

- [x] Conventional Commit title; no associated issue to close.
- [x] Tests cover promotion, wire contracts, isolation, fallback, and settlement ownership.
- [x] Relevant local lint/type/architecture and test checks run; baseline failure disclosed above.
- [x] Main specs pass strict validation and the verified change is archived.
- [x] Simplicity principles P1–P6 reviewed.
- [x] CHANGELOG left to release-please.
