### PR TITLE
fix(proxy): retire a denied proxy-injected WebSocket anchor instead of re-injecting it

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1476,6 +1476,16 @@
         "test",
         "bug"
       ]
+    },
+    {
+      "login": "Abaddollyon",
+      "name": "Abaddollyon",
+      "avatar_url": "https://avatars.githubusercontent.com/u/31712865?v=4",
+      "profile": "https://github.com/Abaddollyon",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -329,6 +329,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/janaki-sasidhar"><img src="https://avatars.githubusercontent.com/u/42799643?v=4?s=100" width="100px;" alt="flameboy"/><br /><sub><b>flameboy</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=janaki-sasidhar" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/elmakus"><img src="https://avatars.githubusercontent.com/u/76910687?v=4?s=100" width="100px;" alt="elmakus"/><br /><sub><b>elmakus</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=elmakus" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=elmakus" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/issues?q=author%3Aelmakus" title="Bug reports">🐛</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Abaddollyon"><img src="https://avatars.githubusercontent.com/u/31712865?v=4?s=100" width="100px;" alt="Abaddollyon"/><br /><sub><b>Abaddollyon</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=Abaddollyon" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=Abaddollyon" title="Tests">⚠️</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -713,6 +713,7 @@ def _websocket_continuity_anchor_for_payload(
     codex_session_affinity: bool,
     api_key_id: str | None = None,
 ) -> _WebSocketContinuityAnchor | None:
+    """Select a matching session anchor, retiring any known upstream rejection."""
     if continuity_state is None or not codex_session_affinity:
         return None
     if responses_payload.previous_response_id is not None:
@@ -808,6 +809,7 @@ def _record_websocket_continuity_completion(
     request_state: _WebSocketRequestState,
     response_id: str | None,
 ) -> None:
+    """Record completed context and pending tools, or clear an absent response anchor."""
     if response_id is None:
         _retire_websocket_continuity_anchor(continuity_state)
         return

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -697,11 +697,21 @@ def _prepare_websocket_request_state_for_account_switch(
     return _install_verified_fresh_replay(request_state)
 
 
+def _retire_websocket_continuity_anchor(continuity_state: _WebSocketContinuityState) -> None:
+    """Drop the completed-response anchor and the state that only exists for it."""
+    continuity_state.last_completed_response_id = None
+    continuity_state.last_completed_input_count = 0
+    continuity_state.last_completed_input_prefix_fingerprint = None
+    continuity_state.last_pending_function_call_ids = []
+    continuity_state.last_pending_tool_call_types = {}
+
+
 def _websocket_continuity_anchor_for_payload(
     continuity_state: _WebSocketContinuityState | None,
     *,
     responses_payload: ResponsesRequest,
     codex_session_affinity: bool,
+    api_key_id: str | None = None,
 ) -> _WebSocketContinuityAnchor | None:
     if continuity_state is None or not codex_session_affinity:
         return None
@@ -709,6 +719,18 @@ def _websocket_continuity_anchor_for_payload(
         return None
     previous_response_id = continuity_state.last_completed_response_id
     if previous_response_id is None:
+        return None
+    if _is_websocket_stale_previous_response(previous_response_id=previous_response_id, api_key_id=api_key_id):
+        # Upstream already denied this anchor (``previous_response_not_found``)
+        # and the fail-closed path remembered it. Injecting it again would
+        # fail the client's retry identically (#1921): retire it from session
+        # continuity so the full-context resend goes unanchored, and so the
+        # same id cannot return once the negative cache entry expires.
+        _retire_websocket_continuity_anchor(continuity_state)
+        _facade().logger.info(
+            "websocket_session_anchor_retired response_id=%s reason=stale_previous_response",
+            previous_response_id,
+        )
         return None
     stored_count = continuity_state.last_completed_input_count
     if not _facade()._input_prefix_matches_stored_context(
@@ -787,11 +809,7 @@ def _record_websocket_continuity_completion(
     response_id: str | None,
 ) -> None:
     if response_id is None:
-        continuity_state.last_completed_response_id = None
-        continuity_state.last_completed_input_count = 0
-        continuity_state.last_completed_input_prefix_fingerprint = None
-        continuity_state.last_pending_function_call_ids = []
-        continuity_state.last_pending_tool_call_types = {}
+        _retire_websocket_continuity_anchor(continuity_state)
         return
     # Record the completed response id and pending tool-call metadata
     # regardless of input shape (string inputs leave ``input_item_count`` at

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -3298,6 +3298,7 @@ class _WebSocketMixin:
                 continuity_state,
                 responses_payload=responses_payload,
                 codex_session_affinity=codex_session_affinity,
+                api_key_id=refreshed_api_key.id if refreshed_api_key is not None else None,
             )
         if session_anchor is not None:
             original_input_items = cast(list[JsonValue], responses_payload.input)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -3165,6 +3165,7 @@ class _WebSocketMixin:
         synthesized_turn_state: str | None = None,
         capability_header_values: tuple[str, ...] | None = None,
     ) -> _PreparedWebSocketRequest:
+        """Validate a create frame, reserve usage, and prepare safe continuity metadata."""
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         refreshed_api_key = await proxy._refresh_websocket_api_key_policy(api_key)

--- a/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/.openspec.yaml
+++ b/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/proposal.md
+++ b/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+On the direct Responses WebSocket surface, codex-lb injects a session-continuity
+`previous_response_id` (`continuity_state.last_completed_response_id`) into a
+follow-up `response.create` and trims the already-stored history prefix. When
+upstream denies that proxy-injected anchor with `previous_response_not_found`
+and the retained payload is not a retry-safe fresh replay (for example tool
+outputs whose calls are not in the same `input` after client-side compaction),
+the turn fails closed and the fail-closed path remembers the denied id in the
+process-local stale previous-response memory. That memory was consulted only by
+owner lookup, never by anchor injection, and the continuity anchor itself was
+cleared only on a completion without a response id. The client's retry therefore
+re-sent the same prefix, the same dead anchor was injected again, and the turn
+failed identically until the client abandoned the thread (issue #1921,
+mechanism 3 in the maintainer's 2026-09-08 breakdown; six identical failures in
+eight seconds on one thread in the 1.25.0-beta.5 reproduction).
+
+## What Changes
+
+- The session-anchor decision (`_websocket_continuity_anchor_for_payload`)
+  consults the stale previous-response memory for the request's API key before
+  the stored-prefix comparison. When the candidate anchor is remembered as
+  denied, the anchor is retired from session continuity (response id, stored
+  input count and prefix fingerprint, pending tool-call metadata), a
+  `websocket_session_anchor_retired … reason=stale_previous_response` line is
+  logged, and no anchor is injected.
+- The request then goes upstream exactly as the client sent it: no
+  `previous_response_id`, untrimmed `input`, and the request state is not
+  marked as carrying a proxy-injected anchor.
+- The completion path that clears an absent response anchor reuses the same
+  retirement helper (no behavior change).
+- A client-supplied `previous_response_id` is untouched; the rule applies only
+  to the proxy-injected session anchor.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: adds a direct-WebSocket requirement that a session
+  anchor already remembered as denied is retired instead of re-injected, the
+  WebSocket counterpart of the existing HTTP-bridge rule "Explicit upstream
+  previous-response denials retire proxy-injected anchors".
+
+## Impact
+
+- `app/modules/proxy/_service/websocket/helpers.py`
+  (`_retire_websocket_continuity_anchor`, `_websocket_continuity_anchor_for_payload`
+  gains `api_key_id`, `_record_websocket_continuity_completion` reuses the
+  helper) and `app/modules/proxy/_service/websocket/mixin.py` (passes the
+  refreshed API key id, the same key the fail-closed path used to remember the
+  denial).
+- No new setting, dependency, migration, route, or error envelope. The stale
+  memory keeps its existing 60-second TTL and 4096-entry bound; retiring the
+  continuity anchor is what prevents the id from returning after expiry.
+- Codex-faithful: the only wire effect is that a retry whose injected anchor is
+  known-dead is sent as the client's own unanchored full-context
+  `response.create` instead of a proxy-trimmed body with a rejected anchor.
+- Regression coverage:
+  `tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_retires_injected_anchor_remembered_stale`.

--- a/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/specs/responses-api-compat/spec.md
@@ -1,0 +1,31 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Direct WebSocket session anchors remembered as denied are retired instead of re-injected
+
+When a direct Responses WebSocket `response.create` carries no client `previous_response_id`, Codex session affinity is enabled, and session continuity holds a completed-response anchor (`last_completed_response_id`) that the process-local stale previous-response memory records as denied for the request's API key id, the service MUST NOT inject that anchor. Before the stored-prefix comparison it MUST retire the anchor from session continuity — clearing the completed response id, the stored input count, the stored input prefix fingerprint, and the pending tool-call metadata that exist only for that anchor — so the same id cannot be injected again once the stale memory entry expires. The service MUST log `websocket_session_anchor_retired` with `reason=stale_previous_response` for the retired anchor. The request MUST then be dispatched with the client's own untrimmed `input`, without `previous_response_id`, and its request state MUST NOT be marked as carrying a proxy-injected anchor. The stale memory MUST be consulted with the same API key id the fail-closed path used when it remembered the denial. This rule MUST NOT alter a client-supplied `previous_response_id`, and a continuity anchor that is not remembered as denied MUST keep the existing injection behavior.
+
+#### Scenario: Full-context retry after a denied injected anchor goes upstream unanchored
+
+- **GIVEN** a direct Responses WebSocket session whose continuity state holds `last_completed_response_id = resp_denied_anchor` with a matching stored prefix and pending tool-call metadata
+- **AND** an earlier turn on that anchor failed closed with `previous_response_not_found` without a retry-safe fresh replay, so `resp_denied_anchor` is remembered as stale for the request's API key
+- **WHEN** the client re-sends its full context as a `response.create` without `previous_response_id`
+- **THEN** the upstream payload carries no `previous_response_id`
+- **AND** the upstream `input` is the client's full untrimmed input
+- **AND** the request state is not marked as carrying a proxy-injected anchor
+- **AND** continuity no longer holds `resp_denied_anchor`, its stored input count, its prefix fingerprint, or its pending tool-call metadata
+- **AND** the service logs `websocket_session_anchor_retired … reason=stale_previous_response`
+
+#### Scenario: Anchor not remembered as denied is still injected
+
+- **GIVEN** a direct Responses WebSocket session whose continuity anchor is not remembered as stale for the request's API key
+- **WHEN** the client sends a follow-up whose input prefix matches the stored context
+- **THEN** the service injects `previous_response_id = last_completed_response_id` and trims the stored prefix exactly as before
+
+#### Scenario: Client-supplied anchor is never retired by this rule
+
+- **GIVEN** a direct Responses WebSocket `response.create` that carries its own `previous_response_id`
+- **WHEN** the session-anchor decision runs
+- **THEN** no session anchor is injected or retired
+- **AND** the client's `previous_response_id` is forwarded unchanged

--- a/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/tasks.md
+++ b/openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/tasks.md
@@ -1,0 +1,31 @@
+## 1. Retire remembered-stale session anchors
+
+- [x] 1.1 Add `_retire_websocket_continuity_anchor` in
+  `app/modules/proxy/_service/websocket/helpers.py` clearing the completed
+  response id, stored input count, prefix fingerprint, and pending tool-call
+  metadata; reuse it from `_record_websocket_continuity_completion(response_id=None)`.
+- [x] 1.2 In `_websocket_continuity_anchor_for_payload`, accept `api_key_id`
+  and, before the stored-prefix comparison, consult
+  `_is_websocket_stale_previous_response`; on a hit retire the anchor, log
+  `websocket_session_anchor_retired … reason=stale_previous_response`, and
+  return no anchor.
+- [x] 1.3 In `_prepare_websocket_response_create_request`
+  (`app/modules/proxy/_service/websocket/mixin.py`), pass the refreshed API key
+  id so the lookup key matches the one the fail-closed path remembered.
+
+## 2. Regression coverage
+
+- [x] 2.1 `tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_retires_injected_anchor_remembered_stale`:
+  remember a denied anchor for the key, send the follow-up full-context frame,
+  and assert the upstream payload has no `previous_response_id`, the input is
+  untrimmed, the request state is not marked proxy-injected, and continuity no
+  longer holds the anchor.
+
+## 3. Verification
+
+- [x] 3.1 `uv run pytest tests/unit/test_proxy_utils.py`.
+- [x] 3.2 `ruff check` / `ruff format --check` on changed files, `ty check`,
+  and the proxy architecture / cancellation-safety / timing-seam /
+  settings-tier scripts.
+- [x] 3.3 `openspec validate retire-stale-websocket-session-anchor-before-reinjection --strict`
+  and `openspec validate --specs`.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -26431,6 +26431,87 @@ async def test_prepare_websocket_response_create_request_injects_anchor_for_code
 
 
 @pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_retires_injected_anchor_remembered_stale(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_stale_anchor",
+        name="ws-stale-anchor",
+        key_prefix="sk-ws-stale",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        trace_channels = frozenset()
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_old", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_denied_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        last_pending_function_call_ids=["call_old"],
+        last_pending_tool_call_types={"call_old": "function_call"},
+    )
+    # Upstream already denied this anchor on the previous attempt: the
+    # fail-closed path remembered it, so the client's retry must not carry
+    # the same proxy-injected ``previous_response_id`` again (#1921).
+    monkeypatch.setattr(websocket_helpers_module, "_websocket_stale_previous_response_index", {})
+    websocket_helpers_module._remember_websocket_stale_previous_response(
+        previous_response_id="resp_denied_anchor",
+        api_key_id=api_key.id,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_stale_anchor"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert "previous_response_id" not in upstream_payload
+    assert upstream_payload["input"] == [*historical_input, new_input]
+    assert prepared.request_state.previous_response_id is None
+    assert prepared.request_state.proxy_injected_previous_response_id is False
+    # The denied anchor is retired from session continuity so it cannot be
+    # re-injected once the negative cache entry expires.
+    assert continuity_state.last_completed_response_id is None
+    assert continuity_state.last_completed_input_count == 0
+    assert continuity_state.last_completed_input_prefix_fingerprint is None
+    assert continuity_state.last_pending_function_call_ids == []
+    assert continuity_state.last_pending_tool_call_types == {}
+
+
+@pytest.mark.asyncio
 async def test_prepare_websocket_goal_restart_keeps_full_resend_without_injected_anchor(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -26432,6 +26432,7 @@ async def test_prepare_websocket_response_create_request_injects_anchor_for_code
 
 @pytest.mark.asyncio
 async def test_prepare_websocket_response_create_request_retires_injected_anchor_remembered_stale(monkeypatch):
+    """Resend full client context and clear continuity when the injected anchor is stale."""
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     reserve_usage = AsyncMock(return_value=None)


### PR DESCRIPTION
## Summary

On the direct WebSocket surface, a proxy-injected `previous_response_id` that upstream denies with `previous_response_not_found` was never retired from session continuity, so every client retry had the same dead anchor injected again and failed identically. This retires the anchor at the injection decision by consulting the existing stale-anchor negative cache.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #1921 (the direct-WebSocket mechanism described in the maintainer's 2026-09-08 comment as still open on `main`)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/retire-stale-websocket-session-anchor-before-reinjection/`

`responses-api-compat` already requires the HTTP bridge to retire a proxy-injected anchor on the first `previous_response_not_found` denial, and requires the direct WebSocket to replay retry-safe fresh bodies and to emit stale-anchor diagnostics; nothing covered the direct-WebSocket case where the retained payload is *not* retry-safe and the same session anchor is re-injected on the client's retry. The change folder adds that requirement (retire the remembered-denied anchor before the prefix comparison, dispatch the client's own unanchored full context, log `websocket_session_anchor_retired`, leave client-supplied anchors alone) with scenarios for the retry, the not-denied anchor, and the client-supplied anchor. Strict validation passes (see Verification).

The only wire-shape effect is that a retry whose injected anchor is already known-dead is sent as the client's own unanchored full-context `response.create` — i.e. exactly what the client sent — instead of a proxy-trimmed body with a `previous_response_id` upstream has already rejected.

## Changes

- `_websocket_continuity_anchor_for_payload` takes the API key id and consults `_is_websocket_stale_previous_response` before injecting `continuity_state.last_completed_response_id`. When the candidate is known stale it retires the anchor (response id, prefix count/fingerprint, pending tool-call metadata) via a new `_retire_websocket_continuity_anchor` helper, logs `websocket_session_anchor_retired … reason=stale_previous_response`, and returns `None` so the request goes upstream unanchored with the client's full context.
- `_record_websocket_continuity_completion(response_id=None)` reuses the same helper (no behavior change).
- `_prepare_websocket_response_create_request` passes `refreshed_api_key.id`, matching the key the fail-closed path uses when it calls `_remember_websocket_stale_previous_response`.
- Regression test: `test_prepare_websocket_response_create_request_retires_injected_anchor_remembered_stale` — remembers a denied anchor, sends the follow-up full-context frame, and asserts the upstream payload carries no `previous_response_id`, the input is untrimmed, and the continuity state no longer holds the anchor.

## Reproduction (1.25.0-beta.5, Codex Desktop, single replica, SQLite)

Client cancelled a turn mid-stream and immediately re-sent the full context; the LB then produced six identical failures in eight seconds on one thread before the client fell back to HTTP:

```
websocket_session_anchor_injected request_id=… response_id=resp_003ddf… original_items=124 trimmed_to=5
continuity_fail_closed surface=websocket_stream reason=previous_response_not_found previous_response_id=sha256:92f8b51530db … previous_response_source=proxy_injected fresh_replay_available=false owner_lookup_source=request_cache owner_lookup_outcome=hit
websocket_session_anchor_injected request_id=… response_id=resp_003ddf… original_items=124 trimmed_to=5
continuity_fail_closed … previous_response_id=sha256:92f8b51530db … previous_response_source=proxy_injected fresh_replay_available=false
(×6, same response id each time)
```

`request_logs` for the thread: 6 × `websocket / error / previous_response_not_found` at 263–613 ms, then success on the HTTP transport. With this change the second attempt logs `websocket_session_anchor_retired … reason=stale_previous_response` and completes unanchored.

## Verification

- `openspec validate retire-stale-websocket-session-anchor-before-reinjection --strict` — valid; `openspec validate --specs` — 65 passed
- `pytest tests/unit/test_proxy_utils.py` (full module) — 1391 passed on the branch rebased onto current `main`
- `ruff check` / `ruff format --check` on changed files — clean
- `scripts/check_proxy_architecture.py`, `check_cancellation_safety.py`, `check_proxy_timing_seams.py`, `check_settings_tiers.py` — pass
- Patch applied on a live 1.25.0-beta.5 deployment; the affected thread shape no longer loops

