### PR TITLE
chore: release v1.25.0-beta.7

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.6"  # x-release-please-version
+__version__ = "1.25.0-beta.7"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.6
-appVersion: 1.25.0-beta.6
+version: 1.25.0-beta.7
+appVersion: 1.25.0-beta.7
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.6",
+  "version": "1.25.0-beta.7",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.6"
+version = "1.25.0-beta.7"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0b6"
+version = "1.25.0-beta.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.7 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.7 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.6
- fix(routing): resolve soft-drain from the dashboard snapshot on background paths (#2233) (
6cdf29)
- feat(frontend): show provenance and reset-to-inherited on data retention settings (#2231) (
8aecad)
- fix(proxy): promote agentic HTTP continuations to reusable WebSockets (#2247) (
ffaf68)
- fix(automations): pin the stale-claim reclaim window to the budget captured at run start (#2241) (
0da41b)
- feat(settings): manage Codex session prewarm from the dashboard (#2264) (
120523)
- feat(settings): manage stream and bridge request budgets from the dashboard (#2279) (
efe0f5)
- feat(settings): per-model context window overrides in the dashboard (#2265) (
f1ff7c)
- feat(settings): pause background schedulers from the dashboard (#2281) (
069b82)
- feat(settings): conversation archive toggle in the dashboard (#2275) (
39e5f4)
- fix(load-balancer): keep soft sticky owner when it is only request-locally unavailable (#2234) (
81b9fb)
- perf(dashboard): bound the raw tail of the conversation presence union to constant windows (#2235) (
a408b5)
- feat(proxy): trace terminal-frame delivery on Responses SSE streams (#2244) (
95a9ca)
- feat(proxy): subscription-exhaustion overflow to a designated model source (ship-dark) (#2257) (
66a3e7)
- perf(dashboard): memoize weekly demand delta aggregates with a short TTL (#2236) (
913c6e)
- perf(request-logs): speed up SQLite filter options (#2253) (
8e6e26)
- perf(request-logs): add live-row partial indexes for facet option queries (#2246) (
44c635)
- feat(load-balancer): discount relatively slow accounts (first-token latency + per-model output throughput) in weighted selection (#2258) (
dda902)
- fix(warmup): warm unused Free quota once (#2205) (
a7785a)
- fix(db): preserve rollback after SQLite invalidation (#2193) (
d2b2e7)
- feat(metadata): automate pricing and Codex version updates with cost backfill (#2298) (
2554fd)
- fix(proxy): sanitize rebuilt HTTP hop-by-hop headers (
5be82e)
- fix(ui): constrain model source dialogs to viewport (#2059) (
68dfc0)
- fix(ui): offer the reactivate action for deactivated accounts (#2060) (
0f6a31)

## Release-candidate validation
Validated candidate: c176fe79664b007d7a1268774a72cd6d0c009505

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required

Evidence (CI on candidate `c176fe79664b007d7a1268774a72cd6d0c009505`, all 38 checks green):
- Backend gates: `Tests (pytest, unit)`, `integration-core`, `integration-core-1/2/3`, `integration-bridge`, `e2e`, `PostgreSQL`, `Migration check (alembic)` + `(alembic, PostgreSQL)`
- Frontend: `Frontend tests (vitest + coverage)`, `Frontend build (vite)`, `Frontend lint (eslint)`, `Frontend type check (tsc)`
- Package: `Package (build)`
- Container: `Docker build` + `Helm smoke install (kind)` (container actually started in-cluster)
- Live upstream/account smoke: not required for a beta pre-release; the live verification runs against prod after the blue/green deploy (`zdt-deploy.sh` health + request-success gate and its 180 s observation window with auto-rollback).

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b7" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.7
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.7 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.

