### PR TITLE
test: disable harness background loops via app.main seam, not env

### DIFF
--- a/openspec/specs/responses-api-compat/ops.md
+++ b/openspec/specs/responses-api-compat/ops.md
@@ -139,10 +139,11 @@ Interpretation:
 
 ## Step 3: Verify `Codex CLI` Through Local `codex-lb`
 
-Start a local proxy instance on a spare port:
+Start a local proxy instance on a spare port (from a `codex-lb` checkout; the
+background usage/model-registry loops may run and do not affect the probe):
 
 ```bash
-cd /home/egor/services/codex-lb-defin85 && env CODEX_LB_USAGE_REFRESH_ENABLED=false CODEX_LB_MODEL_REGISTRY_ENABLED=false .venv/bin/python -m app.cli --host 127.0.0.1 --port 2460
+.venv/bin/python -m app.cli --host 127.0.0.1 --port 2460
 ```
 
 Prepare an isolated `HOME` for the CLI:

--- a/scripts/run_dashboard_browser_smoke.py
+++ b/scripts/run_dashboard_browser_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import os
 import secrets
 import signal
@@ -10,12 +11,60 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 FRONTEND_ROOT = REPOSITORY_ROOT / "frontend"
 STARTUP_TIMEOUT_SECONDS = 90.0
 SHUTDOWN_TIMEOUT_SECONDS = 30.0
+
+# Background loops the app lifespan builds through ``app.main`` seams. The smoke
+# backend replaces every builder with a no-op in-process (mirroring the autouse
+# ``_disable_background_loop_schedulers`` fixture in tests/conftest.py, which
+# pins this tuple) instead of exporting ``CODEX_LB_*_ENABLED=false``: the
+# dashboard under test never needs them, several would leave the process
+# (public GitHub/npm catalog lookups, upstream usage polls), and an env override
+# silently stops working the day the toggle behind it is constantized.
+BACKGROUND_LOOP_BUILDERS: tuple[str, ...] = (
+    "build_usage_refresh_scheduler",
+    "build_model_refresh_scheduler",
+    "build_sticky_session_cleanup_scheduler",
+    "build_quota_planner_scheduler",
+    "build_auth_guardian_scheduler",
+    "build_automations_scheduler",
+    "build_rate_limit_reset_credits_scheduler",
+    "build_account_usage_rollup_scheduler",
+    "build_data_retention_scheduler",
+    "build_telemetry_scheduler",
+)
+
+
+class _NoopScheduler:
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+def _disable_background_loops(
+    main_module: ModuleType,
+    *,
+    setter: Callable[[ModuleType, str, Any], None] = setattr,
+) -> None:
+    """Make the app lifespan skip every background loop and the live-usage ingestor.
+
+    The lifespan resolves these names from ``app.main`` globals at startup, so
+    rebinding them here is sufficient. The live-usage ingestor is a queue
+    consumer fed only by proxied responses; the smoke drives the dashboard, so
+    returning ``None`` matches the disabled path exactly (``stop`` accepts it).
+    """
+    for builder_name in BACKGROUND_LOOP_BUILDERS:
+        setter(main_module, builder_name, lambda: _NoopScheduler())
+    setter(main_module, "start_live_usage_ingestor", lambda: None)
 
 
 def _run_backend(listener_fd: int) -> None:
@@ -27,6 +76,10 @@ def _run_backend(listener_fd: int) -> None:
     empty_env_file = Path(os.environ["CODEX_LB_DATA_DIR"]) / ".dashboard-browser-smoke.env"
     settings_module.ENV_FILES = (empty_env_file, empty_env_file)
     settings_module.Settings.model_config["env_file"] = None
+
+    # uvicorn imports the same module object below, so the lifespan sees the
+    # no-op builders bound here.
+    _disable_background_loops(importlib.import_module("app.main"))
 
     import uvicorn
 
@@ -40,19 +93,15 @@ def _smoke_environment(data_dir: Path) -> dict[str, str]:
             "CODEX_LB_DATA_DIR": str(data_dir),
             "CODEX_LB_UPSTREAM_BASE_URL": "http://127.0.0.1:9/backend-api",
             "CODEX_LB_UPSTREAM_WEBSOCKET_TRUST_ENV": "false",
-            "CODEX_LB_USAGE_REFRESH_ENABLED": "false",
-            "CODEX_LB_LIVE_USAGE_INGESTION_ENABLED": "false",
-            "CODEX_LB_MODEL_REGISTRY_ENABLED": "false",
-            "CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED": "false",
+            # The session bridge is a request-path feature with a T4 env kill
+            # switch; the smoke never proxies, so keep it on the raw path.
             "CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED": "false",
-            "CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED": "false",
-            "CODEX_LB_AUTOMATIONS_SCHEDULER_ENABLED": "false",
-            "CODEX_LB_AUTH_GUARDIAN_ENABLED": "false",
             "CODEX_LB_METRICS_ENABLED": "false",
             "CODEX_LB_OTEL_ENABLED": "false",
-            # Always-on database maintenance loops remain harmless because the
-            # isolated database starts empty; every configurable external loop
-            # is disabled above.
+            # Background loops are disabled in-process by ``_run_backend`` (see
+            # ``_disable_background_loops``), not through env overrides. The
+            # always-on database maintenance loops remain harmless because the
+            # isolated database starts empty.
             # Suppress first-run token logging while keeping standard localhost
             # authentication active. The generated value never leaves this process tree.
             "CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN": secrets.token_urlsafe(32),

--- a/scripts/run_dashboard_browser_smoke.py
+++ b/scripts/run_dashboard_browser_smoke.py
@@ -60,7 +60,10 @@ def _disable_background_loops(
     The lifespan resolves these names from ``app.main`` globals at startup, so
     rebinding them here is sufficient. The live-usage ingestor is a queue
     consumer fed only by proxied responses; the smoke drives the dashboard, so
-    returning ``None`` matches the disabled path exactly (``stop`` accepts it).
+    returning ``None`` is equivalent to the disabled path in this fresh
+    backend process: the disabled branch additionally resets the hub publisher
+    to ``None``, which is already its initial value here, and
+    ``stop_live_usage_ingestor(None)`` is a no-op.
     """
     for builder_name in BACKGROUND_LOOP_BUILDERS:
         setter(main_module, builder_name, lambda: _NoopScheduler())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,26 +19,30 @@ os.environ["CODEX_LB_DATABASE_URL"] = os.environ.get(
     "CODEX_LB_TEST_DATABASE_URL", f"sqlite+aiosqlite:///{TEST_DB_PATH}"
 )
 os.environ["CODEX_LB_UPSTREAM_BASE_URL"] = "https://example.invalid/backend-api"
+# ``usage_refresh_enabled`` is not only the scheduler's switch: it also gates
+# request-path refreshes (``UsageUpdater.refresh_accounts`` on account import,
+# ``request_refresh`` after a streamed ``usage_limit_reached``), which would
+# otherwise fetch usage from the unreachable upstream on every imported account
+# (measured 20-30 s per import). The scheduler itself is disabled by the
+# fixture seam below; this export only covers the request path.
 os.environ["CODEX_LB_USAGE_REFRESH_ENABLED"] = "false"
-os.environ["CODEX_LB_MODEL_REGISTRY_ENABLED"] = "false"
-os.environ["CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED"] = "false"
+# The HTTP responses session bridge is a request-path feature with a T4 env
+# kill switch (see app/core/config/tiers.py). The suite runs on the raw
+# upstream path by default; bridge suites opt in with explicit ``Settings``.
 os.environ["CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED"] = "false"
-os.environ["CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED"] = "false"
 # Route-resolution caching is opt-in per test (cache-specific tests set a TTL
 # explicitly); keeping it off preserves fresh-read semantics everywhere else.
 os.environ["CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS"] = "0"
-# The app-level automations scheduler ticks on the real clock; with leader
-# election enabled its startup tick runs as a background task and can land
-# inside a test that stages its own due-now jobs, racing the test's
-# claim_run. Tests drive automations via AutomationsService.run_due_jobs
-# with explicit clocks or construct AutomationsScheduler directly.
-os.environ["CODEX_LB_AUTOMATIONS_SCHEDULER_ENABLED"] = "false"
-# NOTE: Leader election is intentionally NOT disabled via an env override here.
-# It is default-enabled in production, and a global override would leak into
-# every ``Settings()`` constructed anywhere in the suite — breaking the
-# production-default assertion in test_settings_multi_replica.py. Instead the
-# ambient app lifespan's leader election is replaced with a no-op by the autouse
-# ``_disable_leader_election_startup`` fixture below (see its docstring).
+# NOTE: Background loops (model registry, sticky cleanup, quota planner,
+# automations, auth guardian, usage refresh, ...) and leader election are
+# intentionally NOT disabled via ``CODEX_LB_*_ENABLED`` env overrides here. They
+# are default-enabled in production, and a global override would leak into every
+# ``Settings()`` constructed anywhere in the suite — breaking production-default
+# assertions such as test_settings_multi_replica.py — while silently turning
+# into a no-op the day a toggle is constantized. Instead the ambient app
+# lifespan's scheduler builders are replaced with no-ops by the autouse
+# ``_disable_background_loop_schedulers`` fixture and its leader election by
+# ``_disable_leader_election_startup`` (see their docstrings below).
 
 from app.db.models import Base  # noqa: E402
 from app.db.session import engine  # noqa: E402
@@ -51,6 +55,33 @@ class _NoopScheduler:
 
     async def stop(self) -> None:
         return None
+
+
+# Every background loop the app lifespan builds through an ``app.main``
+# ``build_*_scheduler`` seam and then ``start()``s. The autouse
+# ``_disable_background_loop_schedulers`` fixture swaps each builder for a
+# ``_NoopScheduler`` factory so the ambient test lifespan never starts them; a
+# scheduler that does real work in the suite (external GitHub/npm lookups,
+# upstream usage polls, no-op planner decision rows, real-clock automation
+# ticks racing a test's own due-now jobs) shows up as SQLite lock flakes and
+# cross-test poisoning. tests/unit/test_background_loop_harness.py pins this
+# tuple against the builders ``app.main`` actually imports, so adding a loop
+# without classifying it here fails the suite instead of silently running.
+# Tests that exercise a scheduler construct it directly or patch the builder
+# themselves (e.g. test_otel, test_telemetry_consent,
+# test_model_registry_replication) and keep working.
+BACKGROUND_LOOP_BUILDERS: tuple[str, ...] = (
+    "build_usage_refresh_scheduler",
+    "build_model_refresh_scheduler",
+    "build_sticky_session_cleanup_scheduler",
+    "build_quota_planner_scheduler",
+    "build_auth_guardian_scheduler",
+    "build_automations_scheduler",
+    "build_rate_limit_reset_credits_scheduler",
+    "build_account_usage_rollup_scheduler",
+    "build_data_retention_scheduler",
+    "build_telemetry_scheduler",
+)
 
 
 class _NoopLeaderElection:
@@ -164,7 +195,6 @@ async def app_instance(_reset_db_state, monkeypatch):
         return None
 
     monkeypatch.setattr(main_module, "init_db", _noop_init_db)
-    monkeypatch.setattr(main_module, "build_rate_limit_reset_credits_scheduler", lambda: _NoopScheduler())
     app = create_app()
     yield app
     await _reap_leaked_http_bridge_recovery_settlement_tasks(app)
@@ -192,38 +222,30 @@ def _disable_account_usage_summary_cache(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _disable_rate_limit_reset_credits_scheduler_startup(monkeypatch):
+def _disable_background_loop_schedulers(monkeypatch) -> tuple[str, ...]:
+    """Replace every ambient app-lifespan background loop with a no-op.
+
+    The lifespan in ``app.main`` resolves each ``build_*_scheduler`` name from
+    its own module globals at startup, so patching those names is enough to
+    keep the loops from ever starting — without touching ``Settings`` (unit
+    tests still observe the real production defaults such as
+    ``model_registry_enabled is True``) and without depending on a
+    ``CODEX_LB_*_ENABLED`` env override that would silently stop working once
+    the toggle behind it is constantized. Returns the patched builder names so
+    the coverage test can assert the seam is complete.
+    """
     import app.main as main_module
 
-    monkeypatch.setattr(main_module, "build_rate_limit_reset_credits_scheduler", lambda: _NoopScheduler())
-
-
-@pytest.fixture(autouse=True)
-def _disable_account_usage_rollup_scheduler_startup(monkeypatch):
-    import app.main as main_module
-
-    monkeypatch.setattr(main_module, "build_account_usage_rollup_scheduler", lambda: _NoopScheduler())
-
-
-@pytest.fixture(autouse=True)
-def _disable_data_retention_scheduler_startup(monkeypatch):
-    import app.main as main_module
-
-    monkeypatch.setattr(main_module, "build_data_retention_scheduler", lambda: _NoopScheduler())
-
-
-@pytest.fixture(autouse=True)
-def _disable_telemetry_scheduler_startup(monkeypatch):
-    import app.main as main_module
-
-    monkeypatch.setattr(main_module, "build_telemetry_scheduler", lambda: _NoopScheduler())
+    for builder_name in BACKGROUND_LOOP_BUILDERS:
+        monkeypatch.setattr(main_module, builder_name, lambda: _NoopScheduler())
+    return BACKGROUND_LOOP_BUILDERS
 
 
 @pytest.fixture(autouse=True)
 def _disable_leader_election_startup(monkeypatch):
     """Replace the ambient app-lifespan leader election with a no-op.
 
-    Scoped exactly like the sibling ``_disable_*_scheduler_startup`` fixtures:
+    Scoped exactly like the sibling ``_disable_background_loop_schedulers`` fixture:
     it swaps what ``get_leader_election()`` resolves to (both the reference the
     app lifespan imported into ``app.main`` and the source-module singleton
     every scheduler resolves via ``importlib``), so the lifespan's release

--- a/tests/unit/test_background_loop_harness.py
+++ b/tests/unit/test_background_loop_harness.py
@@ -1,0 +1,100 @@
+"""Pin the test harness's background-loop seam.
+
+The ambient app lifespan must never start a real background loop inside the
+suite (SQLite lock flakes, no-op planner decision rows, public GitHub/npm
+catalog lookups). tests/conftest.py achieves that by patching the
+``build_*_scheduler`` seams in ``app.main`` — not by exporting
+``CODEX_LB_*_ENABLED=false`` — so the seam has to be complete: every builder
+the lifespan imports is either replaced with a no-op or explicitly listed here
+as an always-on maintenance loop the suite tolerates.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+import app.main as main_module
+from tests.conftest import BACKGROUND_LOOP_BUILDERS, _NoopScheduler
+
+# Always-on database maintenance loops the suite deliberately leaves running:
+# they only touch the isolated per-test database and several integration tests
+# depend on their lifespan wiring. A new ``build_*_scheduler`` import in
+# ``app.main`` must be added to exactly one of the two tuples.
+LIVE_MAINTENANCE_LOOP_BUILDERS: tuple[str, ...] = (
+    "build_api_key_limit_reset_scheduler",
+    "build_api_key_last_used_flush_scheduler",
+    "build_account_deletion_scheduler",
+)
+
+# ``CODEX_LB_*_ENABLED`` toggles the harness used to export as ``false``. They
+# stay unset so ``Settings()`` keeps its production defaults inside the suite.
+# ``CODEX_LB_USAGE_REFRESH_ENABLED`` is deliberately absent: it still gates the
+# request-path refresh on account import (see the note in tests/conftest.py).
+RETIRED_HARNESS_ENV_OVERRIDES: tuple[str, ...] = (
+    "CODEX_LB_MODEL_REGISTRY_ENABLED",
+    "CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED",
+    "CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED",
+    "CODEX_LB_AUTOMATIONS_SCHEDULER_ENABLED",
+    "CODEX_LB_AUTH_GUARDIAN_ENABLED",
+    "CODEX_LB_LIVE_USAGE_INGESTION_ENABLED",
+)
+
+
+def _lifespan_scheduler_builders() -> set[str]:
+    return {
+        name
+        for name, value in vars(main_module).items()
+        if name.startswith("build_") and name.endswith("_scheduler") and callable(value)
+    }
+
+
+def test_background_loop_seam_is_explicit_and_complete() -> None:
+    assert BACKGROUND_LOOP_BUILDERS == (
+        "build_usage_refresh_scheduler",
+        "build_model_refresh_scheduler",
+        "build_sticky_session_cleanup_scheduler",
+        "build_quota_planner_scheduler",
+        "build_auth_guardian_scheduler",
+        "build_automations_scheduler",
+        "build_rate_limit_reset_credits_scheduler",
+        "build_account_usage_rollup_scheduler",
+        "build_data_retention_scheduler",
+        "build_telemetry_scheduler",
+    )
+    patched = set(BACKGROUND_LOOP_BUILDERS)
+    live = set(LIVE_MAINTENANCE_LOOP_BUILDERS)
+    assert not patched & live
+    assert _lifespan_scheduler_builders() == patched | live, (
+        "app.main imports a build_*_scheduler that tests/conftest.py neither patches nor "
+        "classifies as an always-on maintenance loop"
+    )
+
+
+def test_every_patched_builder_is_started_by_the_lifespan() -> None:
+    source = inspect.getsource(main_module)
+    for builder_name in BACKGROUND_LOOP_BUILDERS + LIVE_MAINTENANCE_LOOP_BUILDERS:
+        assert f"{builder_name}()" in source, f"{builder_name} is imported but never built by the lifespan"
+
+
+@pytest.mark.asyncio
+async def test_autouse_fixture_replaces_every_background_loop_builder(
+    _disable_background_loop_schedulers: tuple[str, ...],
+) -> None:
+    assert _disable_background_loop_schedulers == BACKGROUND_LOOP_BUILDERS
+    for builder_name in BACKGROUND_LOOP_BUILDERS:
+        scheduler = getattr(main_module, builder_name)()
+        assert isinstance(scheduler, _NoopScheduler), builder_name
+        assert await scheduler.start() is None
+        assert await scheduler.stop() is None
+
+
+def test_harness_does_not_export_background_loop_env_kill_switches() -> None:
+    exported = sorted(name for name in RETIRED_HARNESS_ENV_OVERRIDES if name in os.environ)
+    assert exported == [], f"tests must disable loops through the fixture seam, not env: {exported}"
+    conftest_source = (Path(__file__).parents[1] / "conftest.py").read_text(encoding="utf-8")
+    leaked = sorted(name for name in RETIRED_HARNESS_ENV_OVERRIDES if f'os.environ["{name}"]' in conftest_source)
+    assert leaked == []

--- a/tests/unit/test_background_loop_harness.py
+++ b/tests/unit/test_background_loop_harness.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 import app.main as main_module
+from app.core.config.settings import Settings
 from tests.conftest import BACKGROUND_LOOP_BUILDERS, _NoopScheduler
 
 # Always-on database maintenance loops the suite deliberately leaves running:
@@ -93,8 +94,40 @@ async def test_autouse_fixture_replaces_every_background_loop_builder(
 
 
 def test_harness_does_not_export_background_loop_env_kill_switches() -> None:
+    """The retired toggles must be unset in the whole test process, not just absent from conftest.
+
+    The suite already relies on a clean process environment for these names
+    (test_settings_multi_replica.py asserts the production default of
+    ``auth_guardian_enabled``), so an inherited shell export is a harness
+    misconfiguration and is reported as such rather than surfacing as an
+    unrelated default assertion elsewhere.
+    """
     exported = sorted(name for name in RETIRED_HARNESS_ENV_OVERRIDES if name in os.environ)
-    assert exported == [], f"tests must disable loops through the fixture seam, not env: {exported}"
+    assert exported == [], (
+        "tests must disable loops through the fixture seam, not env; unset these in the shell "
+        f"or the pytest launcher before running the suite: {exported}"
+    )
     conftest_source = (Path(__file__).parents[1] / "conftest.py").read_text(encoding="utf-8")
     leaked = sorted(name for name in RETIRED_HARNESS_ENV_OVERRIDES if f'os.environ["{name}"]' in conftest_source)
     assert leaked == []
+
+
+def test_usage_refresh_env_export_still_has_a_settings_field_behind_it() -> None:
+    """Hand-off guard for the follow-up that constantizes ``usage_refresh_enabled``.
+
+    tests/conftest.py still exports ``CODEX_LB_USAGE_REFRESH_ENABLED=false``
+    because the field also gates request-path refreshes (``UsageUpdater.
+    refresh_accounts`` on account import, ``request_refresh`` after a streamed
+    ``usage_limit_reached``); without it every account-importing test spends
+    20-30 s failing to reach ``example.invalid``. ``Settings`` ignores unknown
+    env names, so the day the field is removed this export becomes a silent
+    no-op and the suite slows ~30x with no failing test. Fail loudly instead.
+    """
+    conftest_source = (Path(__file__).parents[1] / "conftest.py").read_text(encoding="utf-8")
+    if 'os.environ["CODEX_LB_USAGE_REFRESH_ENABLED"]' not in conftest_source:
+        return
+    assert "usage_refresh_enabled" in Settings.model_fields, (
+        "usage_refresh_enabled was removed from Settings but tests/conftest.py still exports "
+        "CODEX_LB_USAGE_REFRESH_ENABLED: replace the export with a request-path seam (autouse patch of "
+        "UsageUpdater.refresh_accounts / request_refresh, or a stubbed usage client) before deleting the env line"
+    )

--- a/tests/unit/test_dashboard_browser_smoke.py
+++ b/tests/unit/test_dashboard_browser_smoke.py
@@ -4,9 +4,11 @@ from typing import cast
 
 import pytest
 
+import app.main as main_module
 from app.core.auth.dashboard_mode import DashboardAuthMode
 from app.core.config import settings as settings_module
 from app.core.config.settings import Settings
+from tests.conftest import BACKGROUND_LOOP_BUILDERS
 
 
 def _load_smoke_harness():
@@ -41,8 +43,11 @@ def test_smoke_backend_disables_dotenv_sources_before_importing_the_app(
         captured.update(kwargs)
 
     monkeypatch.setattr("uvicorn.run", fake_run)
+    disabled_modules: list[object] = []
+    monkeypatch.setattr(smoke_harness, "_disable_background_loops", disabled_modules.append)
     smoke_harness._run_backend(123)
 
+    assert disabled_modules == [main_module]
     settings = Settings()
     assert settings.data_dir == tmp_path
     assert settings.database_url == f"sqlite+aiosqlite:///{tmp_path / 'store.db'}"
@@ -102,3 +107,35 @@ def test_smoke_main_rejects_invalid_backend_fd(
 
     assert smoke_harness.main(["--backend-fd", listener_fd]) == 2
     assert capsys.readouterr().err == "Invalid --backend-fd value.\n"
+
+
+def test_smoke_backend_disables_the_same_background_loops_as_the_test_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    smoke_harness = _load_smoke_harness()
+    assert smoke_harness.BACKGROUND_LOOP_BUILDERS == BACKGROUND_LOOP_BUILDERS
+
+    smoke_harness._disable_background_loops(main_module, setter=monkeypatch.setattr)
+
+    for builder_name in BACKGROUND_LOOP_BUILDERS:
+        assert isinstance(getattr(main_module, builder_name)(), smoke_harness._NoopScheduler), builder_name
+    assert main_module.start_live_usage_ingestor() is None
+
+
+def test_smoke_environment_does_not_export_background_loop_env_kill_switches(tmp_path: Path) -> None:
+    smoke_harness = _load_smoke_harness()
+    environment = smoke_harness._smoke_environment(tmp_path)
+
+    exported = sorted(
+        key
+        for key in environment
+        if key.startswith("CODEX_LB_")
+        and key.endswith("_ENABLED")
+        and key
+        not in {
+            "CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED",
+            "CODEX_LB_METRICS_ENABLED",
+            "CODEX_LB_OTEL_ENABLED",
+        }
+    )
+    assert exported == []


### PR DESCRIPTION
## Summary

Stop gating the app lifespan's background loops through `CODEX_LB_*_ENABLED=false` env exports in `tests/conftest.py` and `scripts/run_dashboard_browser_smoke.py`. Both harnesses now replace the `app.main` `build_*_scheduler` seams with no-ops in-process (one autouse fixture; one helper in the smoke backend), and a unit test pins the seam against every builder the lifespan imports. No production code changes.

Preparatory commit for the settings slop-removal wave (`slop-removal-0908/migrating-triage` PLAN §2 K0): the follow-up PRs constantize toggles such as `usage_refresh_enabled` / `model_registry_enabled` / `sticky_session_cleanup_enabled` / `quota_planner_scheduler_enabled` / `automations_scheduler_enabled`. With the env exports still in place those deletions would silently turn the exports into no-ops and start the real loops on the first test lifespan tick (SQLite lock flakes, `no_op` planner decision rows, public GitHub/npm catalog lookups).

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: preparatory step for the #1340-style settings constantization wave (no issue).

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only (test harness + one runbook command; no requirement, contract, or schema changes; `openspec validate --specs --strict` passes)
- [ ] This PR touches a codex-faithful path

Change directory: n/a

## Changes

- `tests/conftest.py`
  - Drop the `CODEX_LB_{MODEL_REGISTRY,STICKY_SESSION_CLEANUP,QUOTA_PLANNER_SCHEDULER,AUTOMATIONS_SCHEDULER}_ENABLED=false` exports. `Settings()` inside the suite now sees the production defaults for these toggles (same rationale as the existing leader-election note).
  - `CODEX_LB_USAGE_REFRESH_ENABLED=false` is kept with a comment explaining why: besides the scheduler (now covered by the fixture) it gates the request-path refresh on account import (`AccountsService` -> `UsageUpdater.refresh_accounts`) and the post-`usage_limit_reached` `request_refresh`. Measured: with the export removed, `test_proxy_responses.py -k "usage_limit or rate_limit or quota"` goes from 2.97 s to 67.6 s (each account import fetches usage from `example.invalid`). See "Deviations".
  - Add `BACKGROUND_LOOP_BUILDERS` (10 builders) and ONE autouse fixture `_disable_background_loop_schedulers` that swaps each `app.main.build_*_scheduler` for a `_NoopScheduler` factory. It replaces the four per-loop `_disable_*_scheduler_startup` fixtures and the duplicate reset-credits patch in `app_instance`; it also covers `auth_guardian`, which previously ran (jitter-delayed) inside every ambient test lifespan.
  - `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED=false` is intentionally kept: the session bridge is a request-path feature, not a background loop, and the plan (§7) retains its field as a T4 kill switch (not constantized). See "Deviations" below.
- `tests/unit/test_background_loop_harness.py` (new)
  - Asserts the fixture's tuple is exactly the explicit 10-name list, that the set of `build_*_scheduler` names in `app.main` equals patched ∪ the three explicitly listed always-on maintenance loops (`api_key_limit_reset`, `api_key_last_used_flush`, `account_deletion`), that each patched builder is actually built by the lifespan source, that the autouse fixture yields `_NoopScheduler` for every name, and that none of the retired `CODEX_LB_*_ENABLED` names is exported by the harness. Adding a new loop to `app.main` without classifying it fails the suite. The env assertion checks the live process environment (the suite already relies on a clean env for these names: test_settings_multi_replica.py asserts the `auth_guardian_enabled` production default), so an inherited shell export fails here with an explanatory message instead of surfacing as an unrelated default assertion.
  - `test_usage_refresh_env_export_still_has_a_settings_field_behind_it` is the hand-off guard for K1: while `tests/conftest.py` still exports `CODEX_LB_USAGE_REFRESH_ENABLED`, the `usage_refresh_enabled` field must exist on `Settings`. `Settings` ignores unknown env names, so without this guard the constantizing PR would turn the export into a silent no-op and the suite would slow ~30x with no failing test (see "Deviations").
- `scripts/run_dashboard_browser_smoke.py`
  - Drop the seven loop env exports (usage refresh, live usage ingestion, model registry, sticky cleanup, quota planner, automations, auth guardian). `_run_backend` now imports `app.main` and calls `_disable_background_loops(...)`, which binds the same 10 builders to no-ops and `start_live_usage_ingestor` to `lambda: None` (equivalent to the disabled path in the fresh backend process: the disabled branch additionally resets the hub publisher to `None`, which is already its initial value there; `stop_live_usage_ingestor(None)` is a no-op). Bridge/metrics/OTel env lines are unchanged.
- `tests/unit/test_dashboard_browser_smoke.py`
  - Assert `_run_backend` disables loops on `app.main` before `uvicorn.run`, that the smoke's builder tuple equals the conftest tuple and every builder resolves to a no-op after `_disable_background_loops`, and that `_smoke_environment` exports no loop `*_ENABLED` keys (the smoke keeps only the bridge/metrics/OTel exports; it never imports accounts, so the request-path refresh gate is moot there and the usage-refresh export is dropped).
- `openspec/specs/responses-api-compat/ops.md` Step 3: the local-proxy command no longer relies on `CODEX_LB_USAGE_REFRESH_ENABLED=false CODEX_LB_MODEL_REGISTRY_ENABLED=false` (and no longer hardcodes a personal checkout path); the loops do not affect the fast-tier probe.

## Simplicity

No setting, README section, dashboard nav item, or default changes. `check_settings_tiers` and `check_simplicity_budgets` unchanged.

## Test plan

```
uv run pytest tests/unit/test_background_loop_harness.py tests/unit/test_dashboard_browser_smoke.py -q   # 13 passed
uv run pytest tests/unit -q -x                                                                          # 9131 passed, 3 skipped in 16:04 (after rebase onto main @ #2254)
uv run pytest tests/integration -q -x -k lifespan                                                       # 7 passed, 3093 deselected (after rebase)
uv run pytest tests/integration/test_live_usage_ingest.py tests/integration/test_startup_bridge_cleanup.py -q  # 15 passed, 4 skipped (PostgreSQL-only, after rebase)
uv run pytest tests/integration/test_proxy_responses.py tests/integration/test_proxy_api_extended.py \
  tests/integration/test_automations_api.py tests/integration/test_model_registry_replication.py \
  tests/integration/test_live_usage_ingest.py tests/integration/test_startup_bridge_cleanup.py \
  tests/integration/test_proxy_sticky_sessions.py tests/integration/test_proxy_transient_retry.py \
  tests/integration/test_runtime_api.py tests/integration/test_replica_guardrails.py \
  tests/integration/test_graceful_websocket_process_shutdown.py tests/integration/test_quota_planner_api.py \
  tests/integration/test_sticky_sessions_api.py tests/integration/test_accounts_api.py -q                 # 492 passed, 4 skipped (PostgreSQL-only) in 11:45
uv run pytest tests/unit/test_settings_reference.py tests/unit/test_settings_trace_and_removed.py -q     # 17 passed
make lint            # check_settings_tiers ok, ruff check/format clean
uv run ty check      # All checks passed
make migration-check # migration_policy=ok schema_drift=none
python3 .github/scripts/check_simplicity_budgets.py
openspec validate --specs --strict   # 64 passed
cd frontend && bun run build && cd .. && uv run python scripts/run_dashboard_browser_smoke.py --frontend-built   # 5 passed (18.5s), exit 0
```

## Screenshots / output

No user-visible surface.

## Deviations from the K0 plan text

- The session-bridge env line stays in both harnesses. PLAN §7 (2026-09-09 orchestrator decision) reclassifies `http_responses_session_bridge_enabled` as a retained T4 kill switch instead of constantizing it, so the export is not at risk of becoming a silent no-op. A fixture-only replacement would either flip the whole suite onto the bridge-promotion path (coverage shift) or require a test-only override inside production code at the four gate sites (`main.py`, `health/api.py`, `proxy/api.py`, bridge `helpers.py`); neither is warranted while the field exists. If the field is ever removed, the raw path must be forced via the dashboard `upstream_stream_transport="http"` pin.
- `CODEX_LB_USAGE_REFRESH_ENABLED=false` stays in `tests/conftest.py`. `usage_refresh_enabled` is a request-path gate as well as the scheduler switch (`updater.py` `refresh_accounts` / `force_refresh_result` / `request_refresh`; `AccountsService` calls `refresh_accounts([saved], ...)` on import). Removing the export made every account-importing integration test spend 20-30 s failing to fetch usage from `example.invalid` (2.97 s -> 67.6 s for a 2-test sample), i.e. a real coverage and runtime shift rather than a harness no-op. The scheduler side is covered by the fixture; the follow-up that constantizes `usage_refresh_enabled` (K1) must add the request-path seam (e.g. stub the import-time refresh) when it deletes the three gates. This is called out so that PR does not inherit a silent 30x slowdown, and `test_usage_refresh_env_export_still_has_a_settings_field_behind_it` enforces it mechanically: deleting the field while the export is still in `tests/conftest.py` fails the suite with the seam requirement in the message.
- `openspec/specs/responses-api-compat/ops.md` keeps the `.venv/bin/python -m app.cli --host 127.0.0.1 --port 2460` launcher verbatim because `tests/unit/test_proxy_header_launcher_contract.py` pins that exact string; only the env prefix and the personal checkout path were removed.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (`make lint`, `make migration-check`, `uv run ty check`, pytest targets above).
- [x] If touching specs: `openspec validate --specs --strict` passes (ops.md runbook text only; no spec.md change).
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

