### PR TITLE
test(db): keep the off-loop TestClient helper from hanging, leaking a lifespan or unregistering the outer poller

### DIFF
--- a/tests/integration/off_loop_test_client.py
+++ b/tests/integration/off_loop_test_client.py
@@ -19,21 +19,68 @@ The helper keeps the loop alive by entering and exiting the client from a
 worker thread, and flushes the deferred writers the loop owns before handing
 the client over so the test body's blocking ``client.*`` calls do not race a
 flush that would otherwise start a moment later.
+
+Keeping the test loop alive exposes a second cross-loop hazard, so the nested
+lifespan runs behind :class:`KeepPortalLoopAwake`: the app's process-global
+``anyio.Lock`` singletons (settings cache, SQLite writer section, account and
+rate-limit caches, ...) are now shared by two *running* loops. anyio hands lock
+ownership to the next waiter by resolving that waiter's future from the
+releasing task's thread; when the releaser runs on the test loop and the waiter
+on the portal loop, the wake-up is queued through a non-thread-safe
+``call_soon`` and the portal loop, asleep in ``select`` with nothing scheduled,
+never notices. The nested lifespan then hangs at startup and the test loop's
+next acquire of the same lock deadlocks behind it (observed with the ring
+heartbeat's ``settings_cache.get()`` against the nested startup's settings
+read). A short periodic timer on the portal loop makes every such queued
+wake-up run within one tick.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
 from starlette.testclient import TestClient
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
-from app.core.cache.invalidation import get_cache_invalidation_poller
+from app.core.cache.invalidation import get_cache_invalidation_poller, set_cache_invalidation_poller
 
 _DRAIN_TIMEOUT_SECONDS = 5.0
+_PORTAL_TICK_SECONDS = 0.05
+
+
+class KeepPortalLoopAwake:
+    """ASGI wrapper that keeps the portal loop polling for the whole nested lifespan.
+
+    Wake-ups queued on the portal loop from the test loop's thread (an
+    ``anyio.Lock`` handoff from a process-global singleton, see the module
+    docstring) are only executed once the portal loop wakes; the ticker
+    guarantees that happens within ``_PORTAL_TICK_SECONDS``. Non-lifespan
+    scopes pass straight through.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "lifespan":
+            await self.app(scope, receive, send)
+            return
+        ticker = asyncio.create_task(_tick_forever(), name="off-loop-test-client-portal-ticker")
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            ticker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker
+
+
+async def _tick_forever() -> None:
+    while True:
+        await asyncio.sleep(_PORTAL_TICK_SECONDS)
 
 
 async def flush_deferred_sqlite_writers(app: ASGIApp) -> None:
@@ -64,9 +111,40 @@ async def off_loop_test_client(app: ASGIApp, **client_kwargs: Any) -> AsyncItera
     loop owns is mid-transaction).
     """
     await flush_deferred_sqlite_writers(app)
-    client = TestClient(app, **client_kwargs)
-    await asyncio.to_thread(client.__enter__)
+    # The nested lifespan registers its own cache-invalidation poller and, on
+    # shutdown, clears the registration it finds (its own). The outer lifespan's
+    # poller keeps running but would be left unregistered, turning every later
+    # bump in the test into a silent no-op; put it back once the nested client
+    # is gone.
+    outer_poller = get_cache_invalidation_poller()
+    client = TestClient(KeepPortalLoopAwake(app), **client_kwargs)
     try:
-        yield client
+        await _enter_off_loop(client)
+        try:
+            yield client
+        finally:
+            await asyncio.to_thread(client.__exit__, None, None, None)
     finally:
-        await asyncio.to_thread(client.__exit__, None, None, None)
+        if outer_poller is not None and get_cache_invalidation_poller() is None:
+            set_cache_invalidation_poller(outer_poller)
+
+
+async def _enter_off_loop(client: TestClient) -> None:
+    """Run ``client.__enter__`` on a worker thread; never leave a lifespan behind.
+
+    Cancelling the awaiting task (test timeout, cancelled test) stops the wait
+    but not the worker thread, which would go on to finish startup and leave
+    the portal lifespan and its background writers running into later tests.
+    The startup call is shielded, awaited to completion on cancellation, and
+    the fully-entered client is exited before the cancellation propagates.
+    ``TestClient.__enter__`` tears its own portal down when startup raises.
+    """
+    enter = asyncio.ensure_future(asyncio.to_thread(client.__enter__))
+    try:
+        await asyncio.shield(enter)
+    except asyncio.CancelledError:
+        if not enter.done():
+            await asyncio.wait({enter})
+        if not enter.cancelled() and enter.exception() is None:
+            await asyncio.to_thread(client.__exit__, None, None, None)
+        raise

--- a/tests/integration/test_off_loop_test_client.py
+++ b/tests/integration/test_off_loop_test_client.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import threading
 import time
 
 import pytest
@@ -13,11 +15,20 @@ from sqlalchemy import select
 from app.core.cache.invalidation import NAMESPACE_FIREWALL, get_cache_invalidation_poller
 from app.db.models import CacheInvalidation, RuntimeSentinel
 from app.db.session import SessionLocal
-from tests.integration.off_loop_test_client import flush_deferred_sqlite_writers, off_loop_test_client
+from tests.integration.off_loop_test_client import (
+    KeepPortalLoopAwake,
+    flush_deferred_sqlite_writers,
+    off_loop_test_client,
+)
 
 # Well under the 30 s SQLite busy_timeout the deadlock used to burn before failing.
 _STARTUP_DEADLINE_SECONDS = 15.0
 _HOLD_SECONDS = 1.0
+# Upper bound the dummy lifespan puts on a wake-up that arrives from a foreign
+# thread: a loop that never ticks only notices it when this timer fires, so a
+# broken ticker fails the timing assertion instead of hanging the test.
+_FOREIGN_WAKEUP_BOUND_SECONDS = 3.0
+_FOREIGN_WAKEUP_DELAY_SECONDS = 0.1
 
 
 @pytest.mark.asyncio
@@ -82,10 +93,120 @@ async def test_flush_deferred_sqlite_writers_writes_pending_cache_bumps_now(asyn
 
 
 @pytest.mark.asyncio
+async def test_off_loop_test_client_restores_the_outer_cache_invalidation_poller(async_client, app_instance):
+    """The nested lifespan clears the poller registration it finds on shutdown (its own).
+
+    Without restoring the outer lifespan's poller, every ``bump_cache_invalidation``
+    for the rest of the test would be a silent no-op against a still-running poller.
+    """
+    del async_client
+    outer_poller = get_cache_invalidation_poller()
+    assert outer_poller is not None
+
+    async with off_loop_test_client(app_instance) as client:
+        assert client.get("/health/live").status_code == 200
+        nested_poller = get_cache_invalidation_poller()
+        assert nested_poller is not None
+        assert nested_poller is not outer_poller
+
+    assert get_cache_invalidation_poller() is outer_poller
+
+
+@pytest.mark.asyncio
+async def test_off_loop_test_client_exits_the_client_when_startup_is_cancelled(async_client, app_instance, monkeypatch):
+    """Cancelling the entering task must not leave the portal lifespan running."""
+    del async_client
+    outer_poller = get_cache_invalidation_poller()
+    entering = threading.Event()
+    exited: list[TestClient] = []
+    original_enter = TestClient.__enter__
+    original_exit = TestClient.__exit__
+
+    def recording_enter(self):
+        entering.set()
+        return original_enter(self)
+
+    def recording_exit(self, *args):
+        exited.append(self)
+        return original_exit(self, *args)
+
+    monkeypatch.setattr(TestClient, "__enter__", recording_enter)
+    monkeypatch.setattr(TestClient, "__exit__", recording_exit)
+
+    async def use_client() -> None:
+        async with off_loop_test_client(app_instance):
+            pytest.fail("startup was cancelled; the body must not run")
+
+    task = asyncio.create_task(use_client())
+    assert await asyncio.to_thread(entering.wait, 10.0), "worker thread never reached TestClient.__enter__"
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(exited) == 1
+    assert exited[0].portal is None, "the portal lifespan was left running"
+    assert get_cache_invalidation_poller() is outer_poller
+
+
+@pytest.mark.asyncio
 async def test_blocking_test_client_is_rejected_on_the_running_test_loop(app_instance):
     with pytest.raises(RuntimeError, match="off_loop_test_client"):
         with TestClient(app_instance):
             pytest.fail("the blocking client must not start a lifespan on the running loop")
+
+
+def _foreign_thread_wakeup_lifespan_app():
+    """ASGI app whose startup waits for a future that another thread resolves non-thread-safely.
+
+    This is exactly how an ``anyio.Lock`` released on the test loop hands ownership
+    to a waiter on the portal loop: ``fut.set_result`` from the wrong thread queues
+    the wake-up without waking the loop.
+    """
+    ready = threading.Event()
+    state: dict[str, object] = {}
+
+    async def app(scope, receive, send) -> None:
+        assert scope["type"] == "lifespan"
+        await receive()
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[None] = loop.create_future()
+        state["future"] = future
+        ready.set()
+        # The bound timer is the only thing that wakes a bare portal loop; when it
+        # fires, the queued wake-up and the timeout race, so treat both as "done".
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(future), _FOREIGN_WAKEUP_BOUND_SECONDS)
+        await send({"type": "lifespan.startup.complete"})
+        await receive()
+        await send({"type": "lifespan.shutdown.complete"})
+
+    def resolve_from_foreign_thread() -> None:
+        assert ready.wait(10.0)
+        time.sleep(_FOREIGN_WAKEUP_DELAY_SECONDS)
+        future = state["future"]
+        assert isinstance(future, asyncio.Future)
+        future.set_result(None)  # deliberately not call_soon_threadsafe
+
+    return app, resolve_from_foreign_thread
+
+
+def _startup_seconds(app) -> float:
+    dummy_app, resolve = _foreign_thread_wakeup_lifespan_app()
+    resolver = threading.Thread(target=resolve, daemon=True)
+    started = time.monotonic()
+    resolver.start()
+    with TestClient(app(dummy_app)):
+        elapsed = time.monotonic() - started
+    resolver.join(10.0)
+    return elapsed
+
+
+def test_keep_portal_loop_awake_delivers_wakeups_queued_from_a_foreign_thread():
+    # Control: a bare portal loop only notices the foreign wake-up when the
+    # bound timer fires, which is how the nested lifespan hung in CI.
+    assert _startup_seconds(lambda app: app) >= _FOREIGN_WAKEUP_BOUND_SECONDS * 0.8
+    # With the ticker the queued wake-up runs on the next tick.
+    assert _startup_seconds(KeepPortalLoopAwake) < _FOREIGN_WAKEUP_BOUND_SECONDS * 0.5
 
 
 def test_blocking_test_client_still_works_from_sync_tests(app_instance):


### PR DESCRIPTION
## Summary

Follow-up to #2243 (merged before its local `codex review` round could land). Three defects in the `off_loop_test_client` harness helper, each with a contract test; no production code changes:

1. **Nested-lifespan startup could hang forever** (found while verifying the review fixes; reproduced 4 times locally, both loops idle): the app's process-global `anyio.Lock` singletons are shared by the test loop and the portal loop once both are running, and an ownership handoff from the test loop to a portal-loop waiter is a lost wake-up. The nested lifespan now runs behind a wrapper that keeps the portal loop ticking.
2. The helper left the outer lifespan's cache-invalidation poller unregistered after the nested `TestClient` lifespan exited (codex review P2).
3. Cancelling the awaiting task during startup could leak a running portal lifespan (codex review P2).

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #2243, Refs #1949 (test-harness follow-up; the sub-second lock-error class in #1949 is still open)

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only (test harness only; no runtime, contract, schema or default changes)
- [ ] This PR touches a codex-faithful path

Change directory: n/a

## Changes

- `tests/integration/off_loop_test_client.py`
  - **Keep the portal loop awake (`KeepPortalLoopAwake`).** Root cause of the hang, from a per-loop task dump taken while hung (evidence folder, `taskdump.out`): the test loop's ring-heartbeat task was blocked in `refresh_cap_partition -> settings_cache.get() -> anyio.Lock.acquire`, and the portal loop's lifespan task was suspended inside the app lifespan with nothing scheduled on that loop, all aiosqlite worker threads gone. `SettingsCache._lock` (like `_sqlite_writer_lock`, the account/rate-limit caches, ...) is a process-global `anyio.Lock`; anyio's `release()` hands ownership to the next waiter by `fut.set_result(None)` on *that waiter's* future from the releasing task's thread. When the releaser is on the test loop and the waiter on the portal loop, the wake-up is queued via a non-thread-safe `call_soon` and the portal loop, asleep in `select` with no timers yet (startup has not started its schedulers), never runs it; the test loop's next acquire then queues behind the phantom owner and both loops sit idle forever. In production there is one loop, so this is a test-harness-only hazard, but #2243 made it reachable by keeping the test loop alive during the nested startup. The helper now enters `TestClient(KeepPortalLoopAwake(app))`: an ASGI pass-through that runs a 50 ms ticker task on the portal loop for the lifespan's duration, so any wake-up queued from the other thread executes within one tick. Non-lifespan scopes pass straight through.
  - **Restore the outer poller.** The nested lifespan registers its own `CacheInvalidationPoller` and, on shutdown, clears the registration it finds (`app/main.py`: `if get_cache_invalidation_poller() is cache_poller: set_cache_invalidation_poller(None)`). With the fixture's `async_client` lifespan still running, its poller was left unregistered, so every later `bump_cache_invalidation` in the test became a silent no-op against a still-running poller. The helper now snapshots the registered poller before entering the nested client and puts it back once the nested client has exited (also on the cancellation path).
  - **Never leave a lifespan behind on cancellation.** `await asyncio.to_thread(client.__enter__)` stopped waiting when the awaiting task was cancelled (test timeout, cancelled test) but the worker thread kept going, finished startup and left the portal lifespan and its background SQLite writers running into later tests. `_enter_off_loop` shields the startup call, waits for it to complete on cancellation, exits the fully-entered client, and only then propagates the `CancelledError`. Startup failures need no extra handling: `TestClient.__enter__` closes its own `ExitStack` (portal included) when `wait_startup` raises.
- `tests/integration/test_off_loop_test_client.py`: three contract tests — a dummy lifespan whose startup waits on a future resolved from a foreign thread with a plain `set_result` (exactly the anyio handoff) completes only when a 3 s bound timer fires on a bare portal loop (control, >= 2.4 s) but within one tick behind `KeepPortalLoopAwake` (< 1.5 s); the ticker breaking therefore fails a timing assertion instead of hanging the suite; the registered poller after `async with off_loop_test_client(...)` is the outer one (and the nested one was distinct while inside); cancelling the entering task once the worker thread is inside `TestClient.__enter__` results in exactly one `__exit__`, a torn-down portal (`client.portal is None`) and the outer poller re-registered.

Found by `codex review --base origin/main` on #2243 (two P2s) after the PR had been merged.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** (test harness only; nothing user-facing)
- [x] No new required setup step
- New setting(s) and why each can't be a default: none
- Tier of each new setting: none
- [x] README sections / `.env.example` / dashboard nav within budget (unchanged by this PR)

## Test plan

```
uv run pytest -q tests/integration/test_off_loop_test_client.py tests/integration/test_proxy_realtime_live.py
uv run ruff check / ruff format --check on the two touched files
uv run ty check
python3 .github/scripts/check_simplicity_budgets.py
```

Results (host load avg 10-40):

- `tests/integration/test_off_loop_test_client.py`: 12 consecutive runs, 7 passed each, no stall (before the ticker, the same file with the review fixes hung in `TestClient.__enter__ -> portal.call(wait_startup)` in 4 of ~14 runs; faulthandler + per-loop task dumps of the hung processes are in the evidence folder).
- `tests/integration/test_off_loop_test_client.py tests/integration/test_proxy_realtime_live.py`: 3 runs, 43 passed each (48-51 s, no 30 s stalls).
- `ruff check` / `ruff format --check` clean on both files; `uv run ty check`: All checks passed; `check_simplicity_budgets.py`: env 46/60, nav 5/5, root 0/0.
- `codex review --base origin/main` on this branch: see the review note below the checklist.

## Screenshots / output

n/a (test harness only).

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (ruff, ty, targeted pytest, simplicity budgets).
- [x] If touching specs: n/a (no spec changes).
- [x] Simplicity gates reviewed: no new setting, README section, nav item or default.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
