### PR TITLE
test(shutdown): wait for assertions before completing the response

### DIFF
--- a/tests/fixtures/graceful_websocket_server.py
+++ b/tests/fixtures/graceful_websocket_server.py
@@ -141,6 +141,10 @@ class _LifecycleApp:
 
         while not shutdown_state.is_draining():
             await asyncio.sleep(0.01)
+        if self._mode == "controlled_complete":
+            release_message = await receive()
+            assert release_message["type"] == "websocket.receive"
+            assert release_message.get("text") == "complete"
         await asyncio.sleep(self._completion_delay_seconds)
         await send(
             {
@@ -165,7 +169,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", required=True, type=int)
     parser.add_argument("--drain-timeout-seconds", required=True, type=float)
-    parser.add_argument("--mode", choices=("complete", "stuck", "cleanup_stuck"), required=True)
+    parser.add_argument("--mode", choices=("complete", "controlled_complete", "stuck", "cleanup_stuck"), required=True)
     parser.add_argument("--completion-delay-seconds", type=float, default=0.0)
     parser.add_argument("--post-drain-cleanup-timeout-seconds", type=float, default=25.0)
     return parser.parse_args(argv)

--- a/tests/integration/test_graceful_websocket_process_shutdown.py
+++ b/tests/integration/test_graceful_websocket_process_shutdown.py
@@ -178,9 +178,8 @@ async def test_sigint_exits_when_lifespan_absorbs_cleanup_cancellation() -> None
 @pytest.mark.asyncio
 async def test_prestop_commits_deadline_before_sigterm_and_cannot_reopen() -> None:
     async with _run_server(
-        mode="complete",
+        mode="controlled_complete",
         drain_timeout_seconds=2.0,
-        completion_delay_seconds=0.25,
     ) as server:
         async with connect(server.websocket_url) as websocket:
             await websocket.send(json.dumps({"type": "response.create"}))
@@ -213,6 +212,7 @@ async def test_prestop_commits_deadline_before_sigterm_and_cannot_reopen() -> No
                 async with connect(server.websocket_url):
                     pytest.fail("late WebSocket admission unexpectedly succeeded")
 
+            await websocket.send("complete")
             terminal = json.loads(await websocket.recv())
             assert terminal["type"] == "response.completed"
             with pytest.raises(ConnectionClosed):


### PR DESCRIPTION
## Summary

The preStop process test can fail when its drain-status check runs late. Its fixture finishes the active response after 250 ms, before the test verifies that the response is still in flight.

Closes #2282.

## Changes

Add a controlled-completion fixture mode. The test releases the response only after checking drain commitment, refusal to reopen and late WebSocket rejection.

This changes two test files and extracts the remaining shutdown-test correction from #1953. It starts directly from main and has no dependency on the proxy fixes. Production behavior and the existing graceful-shutdown contract are unchanged, so no OpenSpec change is needed.

## Test plan

On main, a 700 ms delay before the drain-status check causes `in_flight` to be `"0"` instead of `"1"`. With the handshake, all five process tests pass with that delay, and all five pass normally.

Lint and formatting pass for both files. Tests and subprocesses used the same isolated temporary SQLite database. The injected delay is a regression probe, not part of the patch. Full repository CI has not run locally; [hosted checks](https://github.com/Soju06/codex-lb/pull/2283/checks) remain required.
