### PR TITLE
test(oauth): control callback expiry deadline in integration test

### DIFF
--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -1154,6 +1154,9 @@ async def test_abandoned_browser_flow_expiry_releases_callback_port_without_foll
 ):
     monkeypatch.setattr(oauth_module, "OAUTH_CALLBACK_PORT", unused_tcp_port)
     monkeypatch.setattr(oauth_module, "_PENDING_BROWSER_OAUTH_FLOW_TTL_SECONDS", 0.25)
+    # Keep the flow pending until the listener is observed, even on a slow runner.
+    now = time.time()
+    monkeypatch.setattr(oauth_module, "time", SimpleNamespace(time=lambda: now))
     stopped = asyncio.Event()
     original_stop = oauth_module.OAuthCallbackServer.stop
 
@@ -1169,6 +1172,7 @@ async def test_abandoned_browser_flow_expiry_releases_callback_port_without_foll
     writer.close()
     await writer.wait_closed()
 
+    now += oauth_module._PENDING_BROWSER_OAUTH_FLOW_TTL_SECONDS
     # Only the deadline can trigger cleanup: no status, callback, or new start.
     await asyncio.wait_for(stopped.wait(), timeout=5)
     store = oauth_module._OAUTH_STORE


### PR DESCRIPTION
## Summary

The abandoned browser OAuth expiry test can lose its callback listener before checking that it opened: a slow start-response handler crosses the fixture's 250 ms deadline. Freeze only the OAuth service's wall clock until the connection is confirmed, then advance to the deadline and let the real asyncio timer perform cleanup.

Closes #2284

## Type of change

- [x] `test:` — test-only change

## OpenSpec

Test stabilization is exempt under CONTRIBUTING's merge gates. No production behavior, deadline policy, API, or requirement changes. The test continues to verify [Browser OAuth callback listeners expire without follow-up requests](https://github.com/Soju06/codex-lb/blob/main/openspec/specs/replica-operations/spec.md#requirement-browser-oauth-callback-listeners-expire-without-follow-up-requests).

## Changes

- Hold the service's wall clock steady until the callback port accepts a connection; the shared Python clock and asyncio monotonic clock remain real.
- Advance by the existing fixture TTL. No synthetic wake-up or cleanup call is added; automatic expiry must still remove the flow and state lookup, close the listener, and permit immediate port reuse.

## Test plan

All local application/test runs used the same dedicated absolute temporary SQLite URL for `CODEX_LB_DATABASE_URL` and `CODEX_LB_TEST_DATABASE_URL`, with foreground, background, and test engine URLs checked before fixtures could reset the database.

- Deterministic reproduction on base `efe0f581a18a36f4d491b92a36ef79b0c432d252`: inject 400 ms after the real `/api/oauth/start` response; the unchanged test fails with `ConnectionRefusedError`.
- Same 400 ms injection passes with this patch; a 2 s injection also passes.
- Negative control: disable `_ensure_browser_flow_expiry_task_locked`; the patched test fails waiting for automatic listener cleanup (`TimeoutError`).
- `pytest -q tests/integration/test_oauth_flow.py`: 62 passed.
- `ruff check .`, `ruff format --check .`, `ty check`, all four architecture checks: passed.
- `npx --yes @fission-ai/openspec validate --specs --strict`: 64 passed, 0 failed.
- Independent source review of this diff against the pinned base: no findings. Hosted CI and CodeRabbit remain required before merge.

## Checklist

- [x] Conventional Commit title and issue link.
- [x] Updated the affected integration test and ran the relevant local checks.
- [x] Simplicity gates reviewed; no new configuration, defaults, docs, or dashboard surfaces.
- [x] CHANGELOG unchanged.
