### PR TITLE
test(request-logs): control live facet indexes in both layouts

### DIFF
--- a/tests/integration/test_request_log_facet_sqlite.py
+++ b/tests/integration/test_request_log_facet_sqlite.py
@@ -85,17 +85,20 @@ async def test_options_avoid_repeated_live_cohort_scans(
             ],
         )
         await session.commit()
-        if live_facet_indexes:
-            # The independently proposed partial indexes must remain compatible.
-            for name, columns in (
-                ("api_key", "api_key_id"),
-                ("model_effort", "model, reasoning_effort"),
-                ("status_error", "status, error_code"),
-            ):
+        # Model metadata now creates these indexes by default (#2246).
+        # Build both parameterized layouts explicitly so the pre-index case
+        # stays covered and the indexed case cannot duplicate a schema index.
+        for name, columns in (
+            ("api_key", "api_key_id"),
+            ("model_effort", "model, reasoning_effort"),
+            ("status_error", "status, error_code"),
+        ):
+            await session.execute(text(f"DROP INDEX IF EXISTS idx_logs_live_{name}"))
+            if live_facet_indexes:
                 await session.execute(
                     text(f"CREATE INDEX idx_logs_live_{name} ON request_logs ({columns}) WHERE deleted_at IS NULL")
                 )
-            await session.commit()
+        await session.commit()
         assert not (await session.execute(text("SELECT name FROM sqlite_master WHERE name = 'sqlite_stat1'"))).all()
 
     # Count SQLite VM work for the real HTTP endpoint, including its actual


### PR DESCRIPTION
After #2246 added live facet indexes to the model schema, the test from #2253 tries to create `idx_logs_live_api_key` again and fails integration-core-3. Its `False` parameter also silently keeps the newly default indexes, so it no longer exercises the pre-index layout.

Recreate the three indexes explicitly for each parameter: remove them first, then create them only for the indexed case. Preserve the real HTTP response assertions and the <20,000 SQLite VM-operation budget in both layouts. This only changes the disposable test database; runtime and migrations are unchanged.

Refs #2246, #2253. Also blocks the current CI of #1621 and other branches containing both changes.

Validation: reproduced on current main (1 passed, indexed case fails with `index ... already exists`); fixed two-layout regression passes (2 tests). Ruff and formatting pass. OpenSpec exemption: test-fixture repair, no product contract change.

Measured SQLite VM operations on the fixed real-endpoint tests: `test_options_avoid_repeated_live_cohort_scans[False]` = 900, `test_options_avoid_repeated_live_cohort_scans[True]` = 900. Both remain below the unchanged 20,000-operation bound.
