### PR TITLE
refactor(egress): interpret WebSocket routing metadata in Rust

### DIFF
--- a/app/core/clients/native_egress.py
+++ b/app/core/clients/native_egress.py
@@ -37,6 +37,7 @@ _REQUIRED_NATIVE_CAPABILITIES = frozenset(
         "http_responses_completion_v1",
         "websocket",
         "websocket_responses_events_v1",
+        "websocket_responses_routing_v1",
         "websocket_send_ack",
     }
 )
@@ -69,6 +70,12 @@ def _event_payload_size(item: object) -> int:
     if isinstance(text, str):
         kind = item.get("event_type")
         metadata_size = len(kind.encode("utf-8")) if isinstance(kind, str) else 0
+        response_id = item.get("payload_response_id")
+        if isinstance(response_id, str):
+            metadata_size += len(response_id.encode("utf-8", errors="surrogatepass"))
+        sequence = item.get("sequence_number")
+        if isinstance(sequence, int):
+            metadata_size += len(str(sequence))
         # Responses WebSocket IPC embeds the original JSON a second time as
         # payload. Charge both copies without reserializing the decoded object.
         copies = 2 if item.get("type") == "websocket_responses_text" else 1
@@ -186,6 +193,12 @@ class NativeWebSocketRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class NativeWebSocketRoutingMetadata:
+    payload_response_id: str | None
+    sequence_number: int | None
+
+
+@dataclass(frozen=True, slots=True)
 class NativeWebSocketMessage:
     kind: str
     text: str | None = None
@@ -195,6 +208,7 @@ class NativeWebSocketMessage:
     responses_interpreted: bool = False
     event_type: str | None = None
     payload: dict[str, JsonValue] | None = None
+    routing: NativeWebSocketRoutingMetadata | None = None
 
 
 class NativeEgressClient(Protocol):
@@ -584,11 +598,17 @@ class NativeEgressWebSocket:
                     text = item.get("text")
                     kind = item.get("event_type")
                     payload = item.get("payload")
+                    response_id = item.get("payload_response_id")
+                    sequence = item.get("sequence_number")
                     if (
                         not isinstance(text, str)
                         or "event_type" not in item
                         or (kind is not None and not isinstance(kind, str))
                         or not isinstance(payload, dict)
+                        or "payload_response_id" not in item
+                        or (response_id is not None and not isinstance(response_id, str))
+                        or "sequence_number" not in item
+                        or (sequence is not None and type(sequence) is not int)
                     ):
                         raise NativeEgressProtocolError("native Responses websocket event is invalid")
                     self._queue_message(
@@ -598,6 +618,7 @@ class NativeEgressWebSocket:
                             responses_interpreted=True,
                             event_type=kind,
                             payload=cast(dict[str, JsonValue], payload),
+                            routing=NativeWebSocketRoutingMetadata(response_id, sequence),
                         )
                     )
                     continue

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -37,6 +37,7 @@ from app.core.clients.native_egress import (
     NativeEgressUnavailable,
     NativeEgressWebSocket,
     NativeWebSocketRequest,
+    NativeWebSocketRoutingMetadata,
     discover_native_egress_client,
 )
 from app.core.clients.proxy import (
@@ -198,6 +199,7 @@ class UpstreamWebSocketMessage:
     responses_interpreted: bool = False
     event_type: str | None = None
     payload: dict[str, JsonValue] | None = None
+    routing: NativeWebSocketRoutingMetadata | None = None
 
 
 class UpstreamWebSocketTransportError(RuntimeError):
@@ -453,6 +455,7 @@ class NativeUpstreamWebSocket:
             responses_interpreted=message.responses_interpreted,
             event_type=message.event_type,
             payload=message.payload,
+            routing=message.routing,
         )
 
     async def close(self, code: int = 1000, reason: str = "") -> None:

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -2512,9 +2512,11 @@ class _HTTPBridgeUpstreamEventsMixin:
             # Preserve its SSE-field semantics for whitespace/multiline text.
             payload = message.payload
             event_type = message.event_type
+            routing = message.routing
         else:
             payload = parse_sse_data_json_text(text)
             event_type = classify_event_type(payload)
+            routing = None
         event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
         completed_delivery_scope = _HTTPBridgeCompletedDeliveryScope() if event_type == "response.completed" else None
         claimed_terminal_request_states: list[_WebSocketRequestState] = []
@@ -2526,6 +2528,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 payload=payload,
                 event=event,
                 event_type=event_type,
+                response_id=_websocket_response_id(event, payload, routing=routing),
                 completed_delivery_scope=completed_delivery_scope,
                 claimed_terminal_request_states=claimed_terminal_request_states,
                 scheduler=scheduler,
@@ -2641,13 +2644,13 @@ class _HTTPBridgeUpstreamEventsMixin:
         payload: dict[str, JsonValue] | None,
         event: OpenAIEvent | None,
         event_type: str | None,
+        response_id: str | None,
         completed_delivery_scope: _HTTPBridgeCompletedDeliveryScope | None,
         claimed_terminal_request_states: list[_WebSocketRequestState],
         scheduler: Scheduler,
         clock: Clock,
     ) -> None:
         original_text = text
-        response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
         is_typeless_error_event = (
             isinstance(payload, dict)

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -15,6 +15,7 @@ from app.core.balancer.types import UpstreamError
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
 from app.core.clients.files import finalize_file as core_finalize_file  # noqa: F401
 from app.core.clients.http import lease_http_session as lease_http_session  # noqa: F401
+from app.core.clients.native_egress import NativeWebSocketRoutingMetadata
 from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     ImageFetchSession,
@@ -834,9 +835,16 @@ def _record_websocket_responses_lite_acceptance(
     )
 
 
-def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:
+def _websocket_response_id(
+    event: OpenAIEvent | None,
+    payload: dict[str, JsonValue] | None,
+    *,
+    routing: NativeWebSocketRoutingMetadata | None = None,
+) -> str | None:
     if event is not None and event.response is not None and event.response.id:
         return event.response.id
+    if routing is not None:
+        return routing.payload_response_id
     if not isinstance(payload, dict):
         return None
     direct_response_id = payload.get("response_id")

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -701,11 +701,10 @@ def _archive_received_websocket_message(
 def _websocket_archive_request_state_for_payload(
     pending_requests: deque[_WebSocketRequestState],
     *,
-    event: OpenAIEvent | None,
+    response_id: str | None,
     payload: dict[str, JsonValue] | None,
     event_type: str | None,
 ) -> _WebSocketRequestState | None:
-    response_id = _websocket_response_id(event, payload)
     if event_type == "response.created":
         if response_id is not None:
             existing = _find_websocket_request_state_by_response_id(pending_requests, response_id)
@@ -766,6 +765,8 @@ class _ParsedUpstreamWebSocketFrame:
     payload: dict[str, JsonValue] | None
     event_type: str | None
     event: OpenAIEvent | None
+    response_id: str | None
+    sequence_number: int | None
 
 
 def _parse_upstream_websocket_text_frame(
@@ -789,21 +790,26 @@ def _parse_upstream_websocket_text_frame(
         and isinstance(native_payload, dict)
         and (native_event_type is None or isinstance(native_event_type, str))
     ):
-        event = parse_sse_event_payload(native_payload) if native_event_type in _LIFECYCLE_EVENT_TYPES else None
-        return _ParsedUpstreamWebSocketFrame(
-            payload=native_payload,
-            event_type=native_event_type,
-            event=event,
-        )
-
-    try:
-        raw_payload = json.loads(text)
-    except json.JSONDecodeError:
-        raw_payload = None
-    payload = cast(dict[str, JsonValue], raw_payload) if isinstance(raw_payload, dict) else None
-    event_type = classify_event_type(payload)
+        payload = native_payload
+        event_type = native_event_type
+        routing = getattr(message, "routing", None)
+    else:
+        try:
+            raw_payload = json.loads(text)
+        except json.JSONDecodeError:
+            raw_payload = None
+        payload = cast(dict[str, JsonValue], raw_payload) if isinstance(raw_payload, dict) else None
+        event_type = classify_event_type(payload)
+        routing = None
     event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
-    return _ParsedUpstreamWebSocketFrame(payload=payload, event_type=event_type, event=event)
+    sequence = routing.sequence_number if routing is not None else payload.get("sequence_number") if payload else None
+    return _ParsedUpstreamWebSocketFrame(
+        payload=payload,
+        event_type=event_type,
+        event=event,
+        response_id=_websocket_response_id(event, payload, routing=routing),
+        sequence_number=sequence if isinstance(sequence, int) and not isinstance(sequence, bool) else None,
+    )
 
 
 async def _websocket_archive_request_id_for_message(
@@ -829,7 +835,7 @@ async def _websocket_archive_request_id_for_message(
     async with pending_lock:
         request_state = _websocket_archive_request_state_for_payload(
             pending_requests,
-            event=frame.event,
+            response_id=frame.response_id,
             payload=frame.payload,
             event_type=frame.event_type,
         )
@@ -5450,7 +5456,7 @@ class _WebSocketMixin:
         payload = parsed_frame.payload
         event_type = parsed_frame.event_type
         event = parsed_frame.event
-        response_id = _websocket_response_id(event, payload)
+        response_id = parsed_frame.response_id
         error_message = _websocket_event_error_message(event_type, payload)
         is_typeless_error_event = (
             isinstance(payload, dict)
@@ -5527,12 +5533,11 @@ class _WebSocketMixin:
                 replay_created_will_be_suppressed = (
                     event_type == "response.created" and request_state.suppress_next_created_downstream
                 )
-                sequence_number = payload.get("sequence_number") if payload is not None else None
+                sequence_number = parsed_frame.sequence_number
                 if (
                     request_state.replay_downstream_response_id is not None
                     and request_state.last_downstream_sequence_number is not None
-                    and isinstance(sequence_number, int)
-                    and not isinstance(sequence_number, bool)
+                    and sequence_number is not None
                     and sequence_number <= request_state.last_downstream_sequence_number
                     and not replay_created_will_be_suppressed
                 ):
@@ -5595,8 +5600,8 @@ class _WebSocketMixin:
                     if rewritten_payload is not payload:
                         payload = rewritten_payload
                         text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
-                    sequence_number = payload.get("sequence_number")
-                    if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
+                    sequence_number = parsed_frame.sequence_number
+                    if sequence_number is not None:
                         upstream_control.downstream_sequence_request_state = request_state
                         upstream_control.downstream_sequence_number = sequence_number
             if (

--- a/crates/codex-lb-egress/src/websocket.rs
+++ b/crates/codex-lb-egress/src/websocket.rs
@@ -213,6 +213,8 @@ pub(crate) async fn execute_websocket(
                                     text,
                                     event_type: event.event_type,
                                     payload: event.payload,
+                                    payload_response_id: event.payload_response_id,
+                                    sequence_number: event.sequence_number,
                                 },
                             )
                             .await?;

--- a/crates/codex-lb-protocol/src/lib.rs
+++ b/crates/codex-lb-protocol/src/lib.rs
@@ -17,6 +17,7 @@ pub const CAPABILITIES: &[&str] = &[
     "http_responses_completion_v1",
     "websocket",
     "websocket_responses_events_v1",
+    "websocket_responses_routing_v1",
     "websocket_send_ack",
 ];
 
@@ -152,6 +153,8 @@ pub enum NativeEvent {
         text: String,
         event_type: Option<String>,
         payload: Box<serde_json::value::RawValue>,
+        payload_response_id: Option<String>,
+        sequence_number: Option<Box<serde_json::value::RawValue>>,
     },
     WebsocketBinary {
         request_id: String,

--- a/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
+++ b/crates/codex-lb-protocol/tests/fixtures/handshake-v1.json
@@ -18,6 +18,7 @@
       "http_responses_completion_v1",
       "websocket",
       "websocket_responses_events_v1",
+      "websocket_responses_routing_v1",
       "websocket_send_ack"
     ]
   }

--- a/crates/codex-lb-responses/src/stream.rs
+++ b/crates/codex-lb-responses/src/stream.rs
@@ -138,7 +138,7 @@ pub fn interpret_websocket(text: &str) -> Option<WebSocketEvent> {
             (!digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()))
                 .then(|| (*value).to_owned())
         }),
-        payload: RawValue::from_string(compact_json_whitespace(text)).ok()?,
+        payload: RawValue::from_string(compact_json_whitespace(text)?).ok()?,
         event_type,
     })
 }
@@ -171,11 +171,16 @@ fn payload_response_id(fields: &BTreeMap<String, &RawValue>) -> Result<Option<St
 // RawValue emits bytes verbatim. Strip only JSON whitespace outside strings so
 // a pretty-printed object cannot split the newline-delimited IPC record. Numeric
 // tokens, duplicate keys, string escapes and all string content stay untouched.
-fn compact_json_whitespace(text: &str) -> String {
+// Keep integers beyond Python's minimum configurable digit limit opaque: any
+// such token (including nested or overwritten values) could fail the shared IPC
+// decoder before Python can attribute the failure to an individual exchange.
+fn compact_json_whitespace(text: &str) -> Option<String> {
+    const MAX_PYTHON_INTEGER_DIGITS: usize = 640;
     let mut result = String::with_capacity(text.len());
     let mut in_string = false;
     let mut escaped = false;
-    for ch in text.chars() {
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
         if in_string {
             result.push(ch);
             if escaped {
@@ -188,11 +193,25 @@ fn compact_json_whitespace(text: &str) -> String {
         } else if ch == '"' {
             in_string = true;
             result.push(ch);
+        } else if ch == '-' || ch.is_ascii_digit() {
+            let start = result.len();
+            result.push(ch);
+            while let Some(next) =
+                chars.next_if(|next| matches!(next, '0'..='9' | '.' | 'e' | 'E' | '+' | '-'))
+            {
+                result.push(next);
+            }
+            let token = &result[start..];
+            if !token.contains(['.', 'e', 'E'])
+                && token.strip_prefix('-').unwrap_or(token).len() > MAX_PYTHON_INTEGER_DIGITS
+            {
+                return None;
+            }
         } else if !matches!(ch, ' ' | '\t' | '\r' | '\n') {
             result.push(ch);
         }
     }
-    result
+    Some(result)
 }
 
 fn alias(kind: &str) -> Option<&'static str> {

--- a/crates/codex-lb-responses/src/stream.rs
+++ b/crates/codex-lb-responses/src/stream.rs
@@ -100,6 +100,9 @@ pub fn interpret(block: &str) -> StreamEvent<'_> {
 pub struct WebSocketEvent {
     pub payload: Box<RawValue>,
     pub event_type: Option<String>,
+    /// Payload-only precedence; validated lifecycle IDs remain caller policy.
+    pub payload_response_id: Option<String>,
+    pub sequence_number: Option<Box<RawValue>>,
 }
 
 /// Match Python's WebSocket classification: a string type wins, otherwise an
@@ -128,9 +131,41 @@ pub fn interpret_websocket(text: &str) -> Option<WebSocketEvent> {
         _ => None,
     };
     Some(WebSocketEvent {
+        payload_response_id: payload_response_id(&fields).ok()?,
+        sequence_number: fields.get("sequence_number").and_then(|value| {
+            let token = value.get();
+            let digits = token.strip_prefix('-').unwrap_or(token);
+            (!digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()))
+                .then(|| (*value).to_owned())
+        }),
         payload: RawValue::from_string(compact_json_whitespace(text)).ok()?,
         event_type,
     })
+}
+
+fn payload_response_id(fields: &BTreeMap<String, &RawValue>) -> Result<Option<String>, ()> {
+    fn stripped_id(value: Option<&&RawValue>) -> Result<Option<String>, ()> {
+        let Some(value) = value.filter(|value| value.get().starts_with('"')) else {
+            return Ok(None);
+        };
+        let value: String = serde_json::from_str(value.get()).map_err(|_| ())?;
+        // Python str.strip also treats these four information separators as whitespace.
+        let value = value
+            .trim_matches(|ch: char| ch.is_whitespace() || ('\u{1c}'..='\u{1f}').contains(&ch));
+        Ok((!value.is_empty()).then(|| value.to_owned()))
+    }
+    if let Some(id) = stripped_id(fields.get("response_id"))? {
+        return Ok(Some(id));
+    }
+    let Some(response) = fields
+        .get("response")
+        .filter(|value| value.get().starts_with('{'))
+    else {
+        return Ok(None);
+    };
+    let response: BTreeMap<String, &RawValue> =
+        serde_json::from_str(response.get()).map_err(|_| ())?;
+    stripped_id(response.get("id"))
 }
 
 // RawValue emits bytes verbatim. Strip only JSON whitespace outside strings so

--- a/crates/codex-lb-responses/tests/fixtures/websocket-routing-v1.json
+++ b/crates/codex-lb-responses/tests/fixtures/websocket-routing-v1.json
@@ -1,0 +1,290 @@
+[
+  {
+    "name": "sequence_zero",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":0}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": "0"
+  },
+  {
+    "name": "sequence_negative_zero",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":-0}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": "-0"
+  },
+  {
+    "name": "sequence_negative",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":-17}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": "-17"
+  },
+  {
+    "name": "sequence_huge",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":-9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": "-9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+  },
+  {
+    "name": "sequence_boolean",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":true}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "sequence_false",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":false}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "sequence_float",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":17.0}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "sequence_exponent",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":1e2}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "sequence_null",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":null}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "sequence_string",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"r2\",\"sequence_number\":\"17\"}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "r2",
+    "response_id": "r2",
+    "sequence_token": null
+  },
+  {
+    "name": "duplicate_sequence",
+    "text": "{\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"sequence_number\":29}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": null,
+    "response_id": null,
+    "sequence_token": "29"
+  },
+  {
+    "name": "escaped_sequence_override",
+    "text": "{\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"sequence_\\u006eumber\":false}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": null,
+    "response_id": null,
+    "sequence_token": null
+  },
+  {
+    "name": "direct_id_precedence",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\" direct \",\"response\":{\"id\":\" nested \"}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "direct",
+    "response_id": "direct",
+    "sequence_token": null
+  },
+  {
+    "name": "python_whitespace",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"\\u001c\\u001d\\u001e\\u001f\\u0085\\u2007 direct \\u202f\\u3000\"}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "direct",
+    "response_id": "direct",
+    "sequence_token": null
+  },
+  {
+    "name": "blank_direct_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"\\u001c\\u2007\",\"response\":{\"id\":\" nested \"}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "nested",
+    "response_id": "nested",
+    "sequence_token": null
+  },
+  {
+    "name": "nonstring_direct_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":3,\"response\":{\"id\":\" nested \"}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "nested",
+    "response_id": "nested",
+    "sequence_token": null
+  },
+  {
+    "name": "nonstring_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response\":{\"id\":3}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": null,
+    "response_id": null,
+    "sequence_token": null
+  },
+  {
+    "name": "nonobject_response",
+    "text": "{\"type\":\"response.output_text.delta\",\"response\":[\"r2\"]}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": null,
+    "response_id": null,
+    "sequence_token": null
+  },
+  {
+    "name": "duplicate_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"first\",\"response_\\u0069d\":\"last\"}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "last",
+    "response_id": "last",
+    "sequence_token": null
+  },
+  {
+    "name": "duplicate_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response\":{\"id\":\"first\",\"id\":\"last\"}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "last",
+    "response_id": "last",
+    "sequence_token": null
+  },
+  {
+    "name": "lifecycle_response.created",
+    "text": "{\"type\":\"response.created\",\"response_id\":\"direct\",\"response\":{\"id\":\" nested \",\"status\":\"completed\"}}",
+    "interpreted": true,
+    "event_type": "response.created",
+    "payload_response_id": "direct",
+    "response_id": " nested ",
+    "sequence_token": null
+  },
+  {
+    "name": "lifecycle_response.completed",
+    "text": "{\"type\":\"response.completed\",\"response_id\":\"direct\",\"response\":{\"id\":\" nested \",\"status\":\"completed\"}}",
+    "interpreted": true,
+    "event_type": "response.completed",
+    "payload_response_id": "direct",
+    "response_id": " nested ",
+    "sequence_token": null
+  },
+  {
+    "name": "lifecycle_response.failed",
+    "text": "{\"type\":\"response.failed\",\"response_id\":\"direct\",\"response\":{\"id\":\" nested \",\"status\":\"completed\"}}",
+    "interpreted": true,
+    "event_type": "response.failed",
+    "payload_response_id": "direct",
+    "response_id": " nested ",
+    "sequence_token": null
+  },
+  {
+    "name": "lifecycle_response.incomplete",
+    "text": "{\"type\":\"response.incomplete\",\"response_id\":\"direct\",\"response\":{\"id\":\" nested \",\"status\":\"completed\"}}",
+    "interpreted": true,
+    "event_type": "response.incomplete",
+    "payload_response_id": "direct",
+    "response_id": " nested ",
+    "sequence_token": null
+  },
+  {
+    "name": "lifecycle_error",
+    "text": "{\"type\":\"error\",\"response_id\":\"direct\",\"response\":{\"id\":\" nested \",\"status\":\"completed\"}}",
+    "interpreted": true,
+    "event_type": "error",
+    "payload_response_id": "direct",
+    "response_id": " nested ",
+    "sequence_token": null
+  },
+  {
+    "name": "invalid_lifecycle_status",
+    "text": "{\"type\":\"response.completed\",\"response_id\":\" direct \",\"response\":{\"id\":\" nested \",\"status\":3}}",
+    "interpreted": true,
+    "event_type": "response.completed",
+    "payload_response_id": "direct",
+    "response_id": "direct",
+    "sequence_token": null
+  },
+  {
+    "name": "blank_lifecycle_id",
+    "text": "{\"type\":\"response.completed\",\"response_id\":\" direct \",\"response\":{\"id\":\" \"}}",
+    "interpreted": true,
+    "event_type": "response.completed",
+    "payload_response_id": "direct",
+    "response_id": " ",
+    "sequence_token": null
+  },
+  {
+    "name": "empty_lifecycle_id",
+    "text": "{\"type\":\"response.completed\",\"response_id\":\" direct \",\"response\":{\"id\":\"\"}}",
+    "interpreted": true,
+    "event_type": "response.completed",
+    "payload_response_id": "direct",
+    "response_id": "direct",
+    "sequence_token": null
+  },
+  {
+    "name": "surrogate_direct_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"\\ud800\"}",
+    "interpreted": false,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "\ud800",
+    "response_id": "\ud800",
+    "sequence_token": null
+  },
+  {
+    "name": "surrogate_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response\":{\"id\":\"\\ud800\"}}",
+    "interpreted": false,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "\ud800",
+    "response_id": "\ud800",
+    "sequence_token": null
+  },
+  {
+    "name": "ignored_surrogate_nested_id",
+    "text": "{\"type\":\"response.output_text.delta\",\"response_id\":\"direct\",\"response\":{\"id\":\"\\ud800\"}}",
+    "interpreted": true,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "direct",
+    "response_id": "direct",
+    "sequence_token": null
+  },
+  {
+    "name": "surrogate_nested_key",
+    "text": "{\"type\":\"response.output_text.delta\",\"response\":{\"id\":\"nested\",\"\\ud800\":1}}",
+    "interpreted": false,
+    "event_type": "response.output_text.delta",
+    "payload_response_id": "nested",
+    "response_id": "nested",
+    "sequence_token": null
+  }
+]

--- a/crates/codex-lb-responses/tests/websocket.rs
+++ b/crates/codex-lb-responses/tests/websocket.rs
@@ -34,3 +34,34 @@ fn large_websocket_object_retains_opaque_delivery() {
     );
     assert!(interpret_websocket(&text).is_none());
 }
+
+#[derive(Deserialize)]
+struct RoutingCase {
+    name: String,
+    text: String,
+    interpreted: bool,
+    // Opaque cases may contain an unpaired surrogate ID.
+    payload_response_id: Box<serde_json::value::RawValue>,
+    sequence_token: Option<String>,
+}
+
+#[test]
+fn shared_websocket_routing_fixtures_preserve_id_and_integer_semantics() {
+    let cases: Vec<RoutingCase> =
+        serde_json::from_str(include_str!("fixtures/websocket-routing-v1.json")).unwrap();
+    for case in cases {
+        let result = interpret_websocket(&case.text);
+        assert_eq!(result.is_some(), case.interpreted, "{}", case.name);
+        if let Some(event) = result {
+            let expected: Option<String> =
+                serde_json::from_str(case.payload_response_id.get()).unwrap();
+            assert_eq!(event.payload_response_id, expected, "{}", case.name);
+            assert_eq!(
+                event.sequence_number.as_ref().map(|value| value.get()),
+                case.sequence_token.as_deref(),
+                "{}",
+                case.name
+            );
+        }
+    }
+}

--- a/crates/codex-lb-responses/tests/websocket.rs
+++ b/crates/codex-lb-responses/tests/websocket.rs
@@ -35,6 +35,39 @@ fn large_websocket_object_retains_opaque_delivery() {
     assert!(interpret_websocket(&text).is_none());
 }
 
+#[test]
+fn python_integer_decode_limits_keep_the_entire_object_opaque() {
+    for sign in ["", "-"] {
+        let accepted = format!(r#"{{"sequence_number":{sign}{}}}"#, "9".repeat(640));
+        let event = interpret_websocket(&accepted).unwrap();
+        assert_eq!(event.payload.get(), accepted);
+        assert_eq!(
+            event.sequence_number.unwrap().get(),
+            format!("{sign}{}", "9".repeat(640))
+        );
+        for digits in [641, 5000] {
+            let token = format!("{sign}{}", "9".repeat(digits));
+            for text in [
+                format!(r#"{{"sequence_number":{token}}}"#),
+                format!(r#"{{"response":{{"extra":[{token}]}},"sequence_number":1}}"#),
+                format!(r#"{{"sequence_number":{token},"sequence_number":1}}"#),
+            ] {
+                assert!(interpret_websocket(&text).is_none());
+            }
+            for value in [
+                format!(r#""{token}""#),
+                format!("{token}.0"),
+                format!("{token}e-5000"),
+            ] {
+                let text = format!(r#"{{"sequence_number":{value}}}"#);
+                let event = interpret_websocket(&text).unwrap();
+                assert_eq!(event.payload.get(), text);
+                assert!(event.sequence_number.is_none());
+            }
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct RoutingCase {
     name: String,

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -64,9 +64,15 @@ integers, or escaped surrogate strings) use that marker without replaying the
 request. Type metadata is limited to 16 KiB too; longer types use the same
 handoff. Shared Python/Rust fixtures pin SDK and native passthrough behavior.
 WebSocket Responses classification uses `websocket_responses_events_v1` and
-embeds the raw payload in IPC for the Python decoder. Persistent socket lifetime,
-request matching, sequence tracking, retries, and settlement remain in Python;
-a terminal response does not close a shared WebSocket.
+embeds the raw payload in IPC for the Python decoder. With
+`websocket_responses_routing_v1`, Rust also extracts the stripped payload response
+ID and recognizes integer sequence values without narrowing their precision.
+Python consumes these for direct WebSocket matching, archive attribution,
+bridge matching and replay checks. Validated lifecycle response IDs retain their
+existing unstripped precedence in Python. Unsupported ID strings use opaque
+delivery. Persistent socket lifetime, pending queues, retries and settlement
+remain in Python; sequence watermarks advance only after downstream delivery,
+and a terminal response does not close a shared WebSocket.
 
 Compact requests additionally require `http_compact_sse_v1`. Their
 `content_type_aware` framing option preserves raw JSON success bodies, while

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -69,9 +69,12 @@ embeds the raw payload in IPC for the Python decoder. With
 ID and recognizes integer sequence values without narrowing their precision.
 Python consumes these for direct WebSocket matching, archive attribution,
 bridge matching and replay checks. Validated lifecycle response IDs retain their
-existing unstripped precedence in Python. Unsupported ID strings use opaque
-delivery. Persistent socket lifetime, pending queues, retries and settlement
-remain in Python; sequence watermarks advance only after downstream delivery,
+existing unstripped precedence in Python. Unsupported ID strings and objects
+containing integer tokens over 640 digits use opaque delivery, keeping Python
+integer conversion failures out of the shared IPC reader. The adapter and
+bundled helper must be updated together for the routing capability; incompatible
+helpers fail closed before dispatch. Persistent socket lifetime, pending queues,
+retries and settlement remain in Python; sequence watermarks advance only after downstream delivery,
 and a terminal response does not close a shared WebSocket.
 
 Compact requests additionally require `http_compact_sse_v1`. Their

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/context.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/context.md
@@ -19,3 +19,17 @@ after successful downstream delivery. Suppressed replay-created events, send
 failures, retry and settlement retain their current policy. Bridge multiline
 SSE interpretation and non-Responses/oversized/unsupported opaque frames retain
 their existing Python path. No throughput improvement is claimed.
+
+The adapter and bundled helper must be updated together for
+`websocket_responses_routing_v1`; an incompatible helper fails closed before
+dispatch. No new deployment mechanism is introduced.
+
+Interpreted payloads admit integer tokens up to 640 digits, excluding the sign.
+This is Python's smallest configurable integer-string limit, so it protects even
+processes configured below the default 4,300 digits. Larger integers anywhere
+in an object (including nested or overwritten values) keep the entire frame
+opaque. The legacy Python parser may reject that exchange, but its integer
+conversion cannot fail the shared IPC reader or interrupt peer exchanges.
+For example, a 5,000-digit sequence is relayed as original text, while a
+640-digit negative sequence remains interpreted without precision loss.
+Strings and floating-point tokens do not use Python's integer conversion limit.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/context.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/context.md
@@ -1,0 +1,21 @@
+# Ownership and compatibility
+
+Rust owns payload-only response-ID extraction and integer sequence recognition.
+Python retains Pydantic lifecycle validation. A valid lifecycle response's
+nonempty nested ID wins without stripping; otherwise Rust's payload ID wins.
+For example, a valid completed event with nested ID ` nested ` and top-level ID
+`direct` matches ` nested `. If response.status is invalid, validation fails
+and the same event instead matches `direct`. Porting Pydantic's entire lifecycle
+model solely to reproduce that precedence would duplicate policy.
+
+Payload ID extraction uses Python string.strip semantics, including U+001C
+through U+001F, and the last duplicate JSON key. Selected lone-surrogate IDs
+retain opaque delivery. Sequence values exclude booleans, floats and exponent
+notation but preserve negative and arbitrary-precision integers. Raw JSON
+integer tokens cross IPC without Rust numeric conversion.
+
+This does not transfer pending-queue ownership. Sequence watermark updates stay
+after successful downstream delivery. Suppressed replay-created events, send
+failures, retry and settlement retain their current policy. Bridge multiline
+SSE interpretation and non-Responses/oversized/unsupported opaque frames retain
+their existing Python path. No throughput improvement is claimed.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/proposal.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/proposal.md
@@ -19,4 +19,6 @@ operations to the reusable Responses crate as the next lifecycle migration slice
 ## Impact
 
 Internal helper/adapter contract, Responses crate, Python native adapter and
-WebSocket consumers. No new setting, dependency, schema or deployment action.
+WebSocket consumers. No new setting, dependency, schema or deployment mechanism.
+The Python adapter and bundled helper must be updated together to support
+`websocket_responses_routing_v1`; incompatible helpers fail closed before dispatch.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/proposal.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/proposal.md
@@ -1,0 +1,22 @@
+# Native WebSocket routing metadata
+
+## Why
+
+Rust already interprets Responses WebSocket objects, but Python still extracts
+payload response IDs and sequence values for every event. Transfer these pure
+operations to the reusable Responses crate as the next lifecycle migration slice.
+
+## What Changes
+
+- Include payload response ID and lossless integer sequence metadata in native
+  interpreted WebSocket events, negotiated by a new capability.
+- Consume the metadata in direct WebSocket matching, archive attribution,
+  replay sequence checks, and bridge response matching.
+- Preserve Python's validated lifecycle response-ID precedence and downstream
+  delivery acknowledgement; pending queues, retry, settlement and socket
+  lifetime retain their current owners.
+
+## Impact
+
+Internal helper/adapter contract, Responses crate, Python native adapter and
+WebSocket consumers. No new setting, dependency, schema or deployment action.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/specs/outbound-http-clients/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Rust supplies payload routing metadata for interpreted WebSocket events
+
+The native adapter MUST require `websocket_responses_routing_v1` before dispatch.
+Every interpreted Responses WebSocket event MUST include `payload_response_id`
+and `sequence_number`, each explicitly null when absent. Rust MUST select the
+first nonempty stripped string from top-level `response_id` then nested
+`response.id`, using Python whitespace and last-duplicate-key semantics.
+Sequence metadata MUST accept only JSON integer tokens, excluding booleans,
+floats and exponent notation, and MUST preserve arbitrary precision and sign.
+Unsupported selected ID strings MUST retain opaque delivery without replay.
+
+Python MUST consume native payload metadata for direct WebSocket matching,
+archive attribution, bridge matching and sequence checks. A successfully
+validated lifecycle event's nonempty nested response ID MUST retain its existing
+unstripped precedence over payload metadata. Bridge frames requiring legacy SSE
+field parsing MUST retain that parsing. Opaque frames MUST retain Python
+extraction. Malformed or missing metadata MUST fail the affected exchange
+without replay. Rust MUST NOT advance the downstream sequence watermark, mutate
+Python pending queues, settle requests, or close shared sockets on response
+terminals as part of this metadata transfer.
+
+#### Scenario: Lifecycle validation controls response-ID precedence
+
+- **WHEN** a lifecycle event has both a direct ID and a nested ID
+- **THEN** a valid nonempty lifecycle ID wins without stripping
+- **AND** failed lifecycle validation uses Rust's stripped payload ID
+
+#### Scenario: Lossless sequence metadata reaches delivery policy
+
+- **WHEN** an interpreted frame includes a negative or arbitrarily large integer sequence
+- **THEN** Python receives that exact integer for replay checks
+- **AND** only successful downstream delivery advances the watermark
+
+#### Scenario: Noninteger sequence is ignored
+
+- **WHEN** a sequence is boolean, null, float, exponent notation or a string
+- **THEN** Rust emits null sequence metadata and Python does not track that value
+
+#### Scenario: Invalid metadata does not replay an exchange
+
+- **WHEN** an interpreted event omits routing metadata or carries invalid field types
+- **THEN** the adapter fails and releases that exchange without resending the request
+- **AND** other exchanges on the helper remain usable

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/specs/outbound-http-clients/spec.md
@@ -8,7 +8,10 @@ and `sequence_number`, each explicitly null when absent. Rust MUST select the
 first nonempty stripped string from top-level `response_id` then nested
 `response.id`, using Python whitespace and last-duplicate-key semantics.
 Sequence metadata MUST accept only JSON integer tokens, excluding booleans,
-floats and exponent notation, and MUST preserve arbitrary precision and sign.
+floats and exponent notation, and MUST preserve precision and sign.
+Objects containing any integer token over 640 digits (excluding its sign),
+including nested and overwritten values, MUST retain opaque delivery so Python
+integer conversion limits cannot interrupt unrelated helper exchanges.
 Unsupported selected ID strings MUST retain opaque delivery without replay.
 
 Python MUST consume native payload metadata for direct WebSocket matching,
@@ -29,7 +32,7 @@ terminals as part of this metadata transfer.
 
 #### Scenario: Lossless sequence metadata reaches delivery policy
 
-- **WHEN** an interpreted frame includes a negative or arbitrarily large integer sequence
+- **WHEN** an interpreted frame includes a negative or large integer sequence within the interpretation bound
 - **THEN** Python receives that exact integer for replay checks
 - **AND** only successful downstream delivery advances the watermark
 
@@ -43,3 +46,9 @@ terminals as part of this metadata transfer.
 - **WHEN** an interpreted event omits routing metadata or carries invalid field types
 - **THEN** the adapter fails and releases that exchange without resending the request
 - **AND** other exchanges on the helper remain usable
+
+#### Scenario: Oversized integers cannot fail the shared IPC decoder
+
+- **WHEN** an upstream object contains an integer over 640 digits anywhere in its payload
+- **THEN** the helper delivers the original text through the opaque path without embedding raw numeric metadata
+- **AND** other exchanges remain usable on the same helper even if Python rejects that frame

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/tasks.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/tasks.md
@@ -1,0 +1,8 @@
+## Implementation
+
+- [x] Add Rust payload response-ID and lossless sequence interpretation.
+- [x] Negotiate and validate native WebSocket routing metadata.
+- [x] Use metadata at direct WebSocket and bridge consumers with lifecycle parity.
+- [x] Cover shared fixtures, invalid IPC, actual helper and replay/delivery paths.
+- [x] Run Rust, Python, architecture/type and strict OpenSpec checks.
+- [x] Sync normative specs and architecture context; archive after verification.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/tasks.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/tasks.md
@@ -6,3 +6,6 @@
 - [x] Cover shared fixtures, invalid IPC, actual helper and replay/delivery paths.
 - [x] Run Rust, Python, architecture/type and strict OpenSpec checks.
 - [x] Sync normative specs and architecture context; archive after verification.
+
+- [x] Address review: bound all raw integer tokens before shared IPC decoding and verify peer isolation.
+- [x] Clarify the synchronized adapter/helper rollout.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/verification.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/verification.md
@@ -80,3 +80,22 @@ The command had already exited when a local stop was attempted; the exact source
 of the termination was not established. The host also lacks `kind`, which the
 final Helm smoke target requires. This was not a full CI pass. Complete GitHub
 Actions checks remain a PR gate.
+
+## PR review corrections
+
+CodeRabbit identified that a raw integer beyond Python's conversion limit could
+fail the shared IPC decoder before attribution to an exchange. Rust now keeps
+objects containing integer tokens over 640 digits opaque, including nested and
+overwritten tokens. This bound covers Python's minimum configurable limit;
+strings and floating-point tokens remain unaffected. The synchronized helper
+and adapter rollout is explicit in the proposal, context and architecture docs.
+
+- `make rust-check`: formatting, Clippy, **28 Rust tests**, and locked release build passed.
+- Actual release-helper native SSE/routed/WebSocket integration plus adapter and
+  routing fixtures: **447 passed** in 24.17 seconds. The new peer-isolation probe
+  uses Python's 640-digit limit and tests 641- and 5,000-digit values at the
+  top level, nested in arrays, and overwritten by duplicate keys. Both sockets
+  then receive exact 640-digit sequences from the same helper process.
+- Full `make lint`, `uv run ty check`, and **64** strict OpenSpec specs passed.
+- The initial cloud CI failed on a duplicate SQLite index in the unrelated
+  facet test. Main already contains the correction in PR #2296.

--- a/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/verification.md
+++ b/openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/verification.md
@@ -1,0 +1,82 @@
+# Verification
+
+Original verification base: `dda902de6` (`origin/main` fetched 2026-09-10).
+
+## Completed checks
+
+- Broad proxy/WebSocket/HTTP bridge regression run: **1,729 passed**, 988.53
+  seconds (`tests/unit/test_proxy_utils.py`,
+  `tests/integration/test_proxy_websocket_responses.py`,
+  `tests/integration/test_http_responses_bridge.py`).
+
+- `make rust-check` using the existing scratch target: formatting, Clippy with
+  warnings denied, 27 Rust tests and locked release helper build passed.
+- Release-helper SSE/routed/WebSocket integration suite: **336 passed**.
+  After adding explicit routing metadata assertions, the two affected files
+  were repeated: **6 passed**.
+- Native packaging/handshake and release-helper usage suite: **31 passed**.
+- Native adapter and shared routing fixtures: **110 passed**.
+- Routing fixtures, WebSocket terminal cancellation and virtual-time unit
+  suites: **65 passed**.
+- Initial adapter/client selection: **132 passed** (before expanded metadata
+  failure cases; the adapter suite was repeated as recorded above).
+- Full `make lint` (including architecture, cancellation safety, timing seams
+  and settings-tier checks) and full `uv run ty check` passed.
+- Strict change validation passed; **64** strict main specs passed both before
+  and after archive.
+
+## Contract evidence
+
+- Shared `websocket-routing-v1.json` cases pin lifecycle ID precedence, failed
+  model validation, Python whitespace, duplicate and escaped keys, surrogate
+  handoff, negative/huge integers and noninteger rejection in both languages.
+- `test_native_websocket_values_and_policy_match_python` compares actual native
+  and opaque wire delivery with Python parsing, including bridge multiline
+  framing, existing 1 MiB interpretation bounds and raw JSON values.
+- `test_native_websocket_routing_preserves_delivery_watermarks` covers native
+  and opaque transport crossed with downstream success/failure. Two pending
+  requests retain distinct archive and response attribution; only the delivered
+  request advances its sequence. A suppressed replay-created frame leaves the
+  watermark intact, and a later non-advancing replay raises before delivery.
+- `test_native_responses_websocket_preserves_interpretation_metadata` covers
+  missing payload/ID/sequence plus invalid ID and sequence types. Each failure
+  retires only its exchange; a peer still sends on the same helper, with exactly
+  two connection requests and no replay.
+- `test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get`
+  includes routing ID/sequence metadata in the queue byte budget and verifies
+  that draining releases the charge.
+
+No production traffic, upstream credentials or deployment were used. This
+slice does not claim throughput gains or Rust ownership of pending queues,
+request matching policy, retry, settlement or downstream acknowledgements.
+
+## Broad-suite warning
+
+The broad run emitted the Starlette deprecation warning and one aiosqlite
+worker-thread `Event loop is closed` warning attributed to
+`test_backend_responses_websocket_trusted_capability_routes_before_first_account_attempt[handshake]`.
+No test failed. The database worker and fixture lifecycle were not changed by
+this slice; this observation alone does not establish whether the warning also
+occurs on the base commit.
+
+The two variants of that test were repeated with
+`-W error::pytest.PytestUnhandledThreadExceptionWarning`: **2 passed** in 4.05
+seconds, with only the Starlette deprecation warning. The worker-thread warning
+did not reproduce in this isolated check.
+
+## PR base update
+
+Rebased without conflicts onto `d2b2e7784` (current main, including the SQLite
+invalidation rollback fix and unused Free-quota warmup change). Rust transport
+and WebSocket implementation files did not overlap those changes. Repeated
+release-helper native SSE/routed/WebSocket integration plus adapter and routing
+fixture tests on this base: **446 passed** in 36.75 seconds. Strict OpenSpec:
+**64 passed**. Full `make lint` and `uv run ty check` also passed again on
+the updated base.
+
+The full `make ci` command passed frontend lint and type checking, then its
+frontend coverage process exited with code **143** before reporting test results.
+The command had already exited when a local stop was attempted; the exact source
+of the termination was not established. The host also lacks `kind`, which the
+final Helm smoke target requires. This was not a full CI pass. Complete GitHub
+Actions checks remain a PR gate.

--- a/openspec/specs/outbound-http-clients/context.md
+++ b/openspec/specs/outbound-http-clients/context.md
@@ -156,3 +156,17 @@ permit direct JSON interpretation. Pending queues, retry, settlement and shared
 socket lifetime remain Python-owned. Sequence watermarks advance only after
 successful downstream sends, preserving suppression and replay behavior.
 Loopback compatibility tests do not establish a throughput improvement.
+
+The adapter and bundled helper must be updated together for
+`websocket_responses_routing_v1`; an incompatible helper fails closed before
+dispatch. No new deployment mechanism is introduced.
+
+Interpreted payloads admit integer tokens up to 640 digits, excluding the sign.
+This is Python's smallest configurable integer-string limit, so it protects even
+processes configured below the default 4,300 digits. Larger integers anywhere
+in an object (including nested or overwritten values) keep the entire frame
+opaque. The legacy Python parser may reject that exchange, but its integer
+conversion cannot fail the shared IPC reader or interrupt peer exchanges.
+For example, a 5,000-digit sequence is relayed as original text, while a
+640-digit negative sequence remains interpreted without precision loss.
+Strings and floating-point tokens do not use Python's integer conversion limit.

--- a/openspec/specs/outbound-http-clients/context.md
+++ b/openspec/specs/outbound-http-clients/context.md
@@ -133,3 +133,26 @@ empty-body and JSON-syntax handling follow the default Python session. Usage
 credit consumption remains a separate call, and resolved routes retain
 CodexClient ownership. Loopback probes validate these semantics; they do not
 measure production performance.
+
+## Native WebSocket routing metadata
+
+The `websocket_responses_routing_v1` capability transfers payload-only response-ID
+extraction and integer sequence recognition to the Responses crate. Python still
+validates lifecycle models. A valid completed event with nested ID ` nested `
+and top-level ID `direct` matches ` nested ` without stripping; if its
+`response.status` is invalid, validation fails and the payload ID `direct` wins.
+This preserves existing matching without duplicating Pydantic models in Rust.
+
+Rust applies Python whitespace rules (including U+001C through U+001F) and
+last-key precedence. Selected IDs that cannot decode into Rust strings use
+opaque delivery. Integer tokens, including large and negative values, cross
+IPC without numeric conversion; booleans and floats produce null metadata.
+The Python adapter validates required metadata and charges it against its queue
+byte budget. An invalid exchange is cancelled without replay or closing peers.
+
+Direct WebSocket matching and archive attribution consume the same parsed ID;
+bridge matching uses native metadata only when its existing SSE framing rules
+permit direct JSON interpretation. Pending queues, retry, settlement and shared
+socket lifetime remain Python-owned. Sequence watermarks advance only after
+successful downstream sends, preserving suppression and replay behavior.
+Loopback compatibility tests do not establish a throughput improvement.

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -1291,3 +1291,47 @@ cleanup and MUST NOT invalidate other requests sharing the helper.
 - **THEN** its exchange is retired and another query can use the same helper
 - **WHEN** the helper exits during a body read
 - **THEN** that query fails without replay and a subsequent independent query can start a fresh helper
+
+### Requirement: Rust supplies payload routing metadata for interpreted WebSocket events
+
+The native adapter MUST require `websocket_responses_routing_v1` before dispatch.
+Every interpreted Responses WebSocket event MUST include `payload_response_id`
+and `sequence_number`, each explicitly null when absent. Rust MUST select the
+first nonempty stripped string from top-level `response_id` then nested
+`response.id`, using Python whitespace and last-duplicate-key semantics.
+Sequence metadata MUST accept only JSON integer tokens, excluding booleans,
+floats and exponent notation, and MUST preserve arbitrary precision and sign.
+Unsupported selected ID strings MUST retain opaque delivery without replay.
+
+Python MUST consume native payload metadata for direct WebSocket matching,
+archive attribution, bridge matching and sequence checks. A successfully
+validated lifecycle event's nonempty nested response ID MUST retain its existing
+unstripped precedence over payload metadata. Bridge frames requiring legacy SSE
+field parsing MUST retain that parsing. Opaque frames MUST retain Python
+extraction. Malformed or missing metadata MUST fail the affected exchange
+without replay. Rust MUST NOT advance the downstream sequence watermark, mutate
+Python pending queues, settle requests, or close shared sockets on response
+terminals as part of this metadata transfer.
+
+#### Scenario: Lifecycle validation controls response-ID precedence
+
+- **WHEN** a lifecycle event has both a direct ID and a nested ID
+- **THEN** a valid nonempty lifecycle ID wins without stripping
+- **AND** failed lifecycle validation uses Rust's stripped payload ID
+
+#### Scenario: Lossless sequence metadata reaches delivery policy
+
+- **WHEN** an interpreted frame includes a negative or arbitrarily large integer sequence
+- **THEN** Python receives that exact integer for replay checks
+- **AND** only successful downstream delivery advances the watermark
+
+#### Scenario: Noninteger sequence is ignored
+
+- **WHEN** a sequence is boolean, null, float, exponent notation or a string
+- **THEN** Rust emits null sequence metadata and Python does not track that value
+
+#### Scenario: Invalid metadata does not replay an exchange
+
+- **WHEN** an interpreted event omits routing metadata or carries invalid field types
+- **THEN** the adapter fails and releases that exchange without resending the request
+- **AND** other exchanges on the helper remain usable

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -1300,7 +1300,10 @@ and `sequence_number`, each explicitly null when absent. Rust MUST select the
 first nonempty stripped string from top-level `response_id` then nested
 `response.id`, using Python whitespace and last-duplicate-key semantics.
 Sequence metadata MUST accept only JSON integer tokens, excluding booleans,
-floats and exponent notation, and MUST preserve arbitrary precision and sign.
+floats and exponent notation, and MUST preserve precision and sign.
+Objects containing any integer token over 640 digits (excluding its sign),
+including nested and overwritten values, MUST retain opaque delivery so Python
+integer conversion limits cannot interrupt unrelated helper exchanges.
 Unsupported selected ID strings MUST retain opaque delivery without replay.
 
 Python MUST consume native payload metadata for direct WebSocket matching,
@@ -1321,7 +1324,7 @@ terminals as part of this metadata transfer.
 
 #### Scenario: Lossless sequence metadata reaches delivery policy
 
-- **WHEN** an interpreted frame includes a negative or arbitrarily large integer sequence
+- **WHEN** an interpreted frame includes a negative or large integer sequence within the interpretation bound
 - **THEN** Python receives that exact integer for replay checks
 - **AND** only successful downstream delivery advances the watermark
 
@@ -1335,3 +1338,9 @@ terminals as part of this metadata transfer.
 - **WHEN** an interpreted event omits routing metadata or carries invalid field types
 - **THEN** the adapter fails and releases that exchange without resending the request
 - **AND** other exchanges on the helper remain usable
+
+#### Scenario: Oversized integers cannot fail the shared IPC decoder
+
+- **WHEN** an upstream object contains an integer over 640 digits anywhere in its payload
+- **THEN** the helper delivers the original text through the opaque path without embedding raw numeric metadata
+- **AND** other exchanges remain usable on the same helper even if Python rejects that frame

--- a/tests/integration/test_native_routed_egress.py
+++ b/tests/integration/test_native_routed_egress.py
@@ -202,6 +202,9 @@ async def test_direct_sse_and_routed_http_websocket_share_native_helper(
             assert message.responses_interpreted is True
             assert message.event_type == "response.completed"
             assert message.payload == {"type": "response.completed", "response": {"id": "resp_ws"}}
+            assert message.routing is not None
+            assert message.routing.payload_response_id == "resp_ws"
+            assert message.routing.sequence_number is None
             await websocket.close()
 
             assert native._process is helper_process

--- a/tests/integration/test_native_websocket_events.py
+++ b/tests/integration/test_native_websocket_events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,6 +24,75 @@ from app.modules.proxy._service.http_bridge import upstream_events as bridge
 from app.modules.proxy._service.websocket import mixin
 
 FIXTURES = Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/websocket-v1.json"
+
+
+@pytest.mark.asyncio
+async def test_native_websocket_oversized_integers_preserve_peer_exchanges() -> None:
+    binary = os.environ.get("CODEX_LB_NATIVE_EGRESS_TEST_BINARY")
+    if not binary:
+        pytest.skip("set CODEX_LB_NATIVE_EGRESS_TEST_BINARY to run the native wire probe")
+
+    async def echo(websocket: Any) -> None:
+        async for text in websocket:
+            await websocket.send(text)
+
+    client = SubprocessNativeEgressClient(Path(binary))
+    original_limit = sys.get_int_max_str_digits()
+    sockets: list[NativeUpstreamWebSocket] = []
+    try:
+        # The helper must also be safe with Python's smallest enabled limit.
+        sys.set_int_max_str_digits(sys.int_info.str_digits_check_threshold)
+        async with serve(echo, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            for _ in range(2):
+                sockets.append(
+                    NativeUpstreamWebSocket(
+                        await client.websocket(
+                            NativeWebSocketRequest(
+                                url=f"ws://127.0.0.1:{port}/responses",
+                                headers={},
+                                connect_timeout_seconds=5,
+                                max_message_bytes=1024 * 1024,
+                                interpret_responses=True,
+                            )
+                        )
+                    )
+                )
+            process = client._process
+            assert process is not None
+            for digits in (641, 5000):
+                token = "-" + "9" * digits
+                for fields in (
+                    f'"sequence_number":{token}',
+                    f'"response":{{"extra":[{token}]}},"sequence_number":1',
+                    f'"sequence_number":{token},"sequence_number":1',
+                ):
+                    text = '{"type":"response.output_text.delta",' + fields + "}"
+                    await sockets[0].send_text(text)
+                    message = await sockets[0].receive()
+                    assert message.kind == "text"
+                    assert message.text == text
+                    assert not message.responses_interpreted
+                    # The legacy parser may reject the affected frame, but it
+                    # must not take down the shared IPC reader or its peers.
+                    with pytest.raises(ValueError, match="integer string conversion"):
+                        mixin._parse_upstream_websocket_text_frame(text, message=message)
+                    for websocket in sockets:
+                        healthy = '{"type":"response.output_text.delta","sequence_number":' + "9" * 640 + "}"
+                        await websocket.send_text(healthy)
+                        reply = await websocket.receive()
+                        assert reply.kind == "text"
+                        assert reply.text == healthy
+                        assert reply.responses_interpreted
+                        assert reply.routing is not None
+                        assert reply.routing.sequence_number == int("9" * 640)
+                    assert client._process is process
+                    assert process.returncode is None
+            for websocket in sockets:
+                await websocket.close()
+    finally:
+        await client.aclose()
+        sys.set_int_max_str_digits(original_limit)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_native_websocket_events.py
+++ b/tests/integration/test_native_websocket_events.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
+import anyio
 import pytest
 from websockets.asyncio.server import serve
 
 from app.core.clients.native_egress import NativeWebSocketRequest, SubprocessNativeEgressClient
 from app.core.clients.proxy_websocket import NativeUpstreamWebSocket
 from app.core.clock import REAL_CLOCK, REAL_SCHEDULER
+from app.core.openai.parsing import _LIFECYCLE_EVENT_TYPES, classify_event_type, parse_sse_event_payload
 from app.core.utils.sse import parse_sse_data_json_text
+from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.http_bridge import upstream_events as bridge
 from app.modules.proxy._service.websocket import mixin
 
@@ -26,6 +31,7 @@ async def test_native_websocket_values_and_policy_match_python(monkeypatch: pyte
     if not binary:
         pytest.skip("set CODEX_LB_NATIVE_EGRESS_TEST_BINARY to run the native wire probe")
     cases = json.loads(FIXTURES.read_text())
+    cases += json.loads(FIXTURES.with_name("websocket-routing-v1.json").read_text())
     prefix = '{"type":"response.output_text.delta","delta":"'
     cases.append(
         {
@@ -81,6 +87,11 @@ async def test_native_websocket_values_and_policy_match_python(monkeypatch: pyte
                         if interpreted:
                             assert message.payload == expected.payload, case["name"]
                             assert message.event_type == case["event_type"], case["name"]
+                            assert message.routing is not None, case["name"]
+                            assert message.routing.payload_response_id == mixin._websocket_response_id(
+                                None, expected.payload
+                            ), case["name"]
+                            assert message.routing.sequence_number == expected.sequence_number, case["name"]
                         with monkeypatch.context() as patch:
                             if interpreted:
                                 patch.setattr(mixin, "json", SimpleNamespace(loads=reject_decode))
@@ -89,6 +100,8 @@ async def test_native_websocket_values_and_policy_match_python(monkeypatch: pyte
                         assert json.dumps(actual.payload) == json.dumps(expected.payload), case["name"]
                         assert actual.event_type == expected.event_type, case["name"]
                         assert actual.event == expected.event, case["name"]
+                        assert actual.response_id == expected.response_id, case["name"]
+                        assert actual.sequence_number == expected.sequence_number, case["name"]
                         process = AsyncMock()
                         harness = SimpleNamespace(_process_parsed_http_bridge_upstream_event=process)
                         expected_bridge_payload = parse_sse_data_json_text(text)
@@ -108,7 +121,151 @@ async def test_native_websocket_values_and_policy_match_python(monkeypatch: pyte
                         assert json.dumps(processed["payload"]) == json.dumps(expected_bridge_payload), case["name"]
                         assert processed["text"] == text
                         assert processed["event_block"] == f"data: {text}\n\n"
+                        bridge_type = classify_event_type(expected_bridge_payload)
+                        bridge_event = (
+                            parse_sse_event_payload(expected_bridge_payload)
+                            if bridge_type in _LIFECYCLE_EVENT_TYPES
+                            else None
+                        )
+                        assert processed["response_id"] == mixin._websocket_response_id(
+                            bridge_event, expected_bridge_payload
+                        ), case["name"]
                 finally:
                     await websocket.close()
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("interpret", [False, True], ids=["opaque", "native"])
+@pytest.mark.parametrize("send_failure", [False, True], ids=["delivered", "send-failed"])
+async def test_native_websocket_routing_preserves_delivery_watermarks(
+    monkeypatch: pytest.MonkeyPatch, interpret: bool, send_failure: bool
+) -> None:
+    binary = os.environ.get("CODEX_LB_NATIVE_EGRESS_TEST_BINARY")
+    if not binary:
+        pytest.skip("set CODEX_LB_NATIVE_EGRESS_TEST_BINARY to run the native wire probe")
+
+    async def echo(websocket: Any) -> None:
+        async for text in websocket:
+            await websocket.send(text)
+
+    service = proxy_service.ProxyService(cast(Any, None))
+    monkeypatch.setattr(service, "_touch_active_websocket_thread_affinity", AsyncMock())
+    failed = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", failed)
+    account = cast(Any, SimpleNamespace(id="account"))
+    states = [
+        proxy_service._WebSocketRequestState(
+            request_id=f"request-{i}",
+            response_id=f"r{i}",
+            archive_request_id=f"archive-{i}",
+            model="gpt-5.6-sol",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=REAL_CLOCK.monotonic(),
+        )
+        for i in (1, 2)
+    ]
+    states[1].replay_downstream_response_id = "visible-r2"
+    states[1].last_downstream_sequence_number = 5
+    pending = deque(states)
+    pending_lock = anyio.Lock()
+    control = proxy_service._WebSocketUpstreamControl()
+    sent: list[str] = []
+
+    async def send_text(text: str) -> None:
+        if send_failure and json.loads(text).get("response_id") == "visible-r2":
+            raise ConnectionError("downstream disconnected")
+        sent.append(text)
+
+    downstream = cast(Any, SimpleNamespace(send_text=send_text))
+    client = SubprocessNativeEgressClient(Path(binary))
+    try:
+        async with serve(echo, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            upstream = NativeUpstreamWebSocket(
+                await client.websocket(
+                    NativeWebSocketRequest(
+                        url=f"ws://127.0.0.1:{port}/responses",
+                        headers={},
+                        connect_timeout_seconds=5,
+                        max_message_bytes=1024 * 1024,
+                        interpret_responses=interpret,
+                    )
+                )
+            )
+            try:
+
+                async def relay(payload: dict[str, Any], archive_id: str) -> bool:
+                    text = json.dumps(payload, separators=(",", ":"))
+                    await upstream.send_text(text)
+                    message = await upstream.receive()
+                    assert message.kind == "text"
+                    assert (
+                        await mixin._websocket_archive_request_id_for_message(
+                            message, pending_requests=pending, pending_lock=pending_lock
+                        )
+                        == archive_id
+                    )
+                    return await mixin._process_and_forward_upstream_websocket_text(
+                        service,
+                        downstream,
+                        upstream,
+                        message=message,
+                        text=text,
+                        account=account,
+                        account_id_value=account.id,
+                        pending_requests=pending,
+                        pending_lock=pending_lock,
+                        client_send_lock=anyio.Lock(),
+                        api_key=None,
+                        upstream_control=control,
+                        response_create_gate=asyncio.Semaphore(1),
+                        downstream_activity=proxy_service._DownstreamWebSocketActivity(),
+                        continuity_state=None,
+                        codex_session_affinity=False,
+                        clock=REAL_CLOCK,
+                    )
+
+                assert not await relay(
+                    {
+                        "type": "response.output_text.delta",
+                        "response_id": "r1",
+                        "sequence_number": True,
+                        "delta": "one",
+                    },
+                    "archive-1",
+                )
+                assert states[0].last_downstream_sequence_number is None
+                large_sequence = 10**100 + 7
+                delta = {
+                    "type": "response.output_text.delta",
+                    "response_id": " r2 ",
+                    "sequence_number": large_sequence,
+                    "delta": "two",
+                }
+                assert await relay(delta, "archive-2") is send_failure
+                assert states[1].last_downstream_sequence_number == (5 if send_failure else large_sequence)
+                assert states[0].last_downstream_sequence_number is None
+                if send_failure:
+                    assert len(sent) == 1
+                    failed.assert_awaited_once()
+                else:
+                    assert json.loads(sent[-1])["response_id"] == "visible-r2"
+                    states[1].suppress_next_created_downstream = True
+                    assert not await relay(
+                        {"type": "response.created", "response": {"id": "r2"}, "sequence_number": 0},
+                        "archive-2",
+                    )
+                    assert len(sent) == 2
+                    assert states[1].last_downstream_sequence_number == large_sequence
+                    with pytest.raises(mixin._WebSocketReplaySequenceRegression):
+                        await relay(delta, "archive-2")
+                    assert len(sent) == 2
+                    failed.assert_not_awaited()
+            finally:
+                await upstream.close()
     finally:
         await client.aclose()

--- a/tests/unit/test_native_egress.py
+++ b/tests/unit/test_native_egress.py
@@ -19,6 +19,7 @@ from app.core.clients.native_egress import (
     NativeSseOptions,
     NativeWebSocketMessage,
     NativeWebSocketRequest,
+    NativeWebSocketRoutingMetadata,
     SubprocessNativeEgressClient,
     close_discovered_native_egress_client,
     discover_native_egress_client,
@@ -49,6 +50,7 @@ print(json.dumps({
         "http_responses_completion_v1",
         "websocket",
         "websocket_responses_events_v1",
+        "websocket_responses_routing_v1",
         "websocket_send_ack",
     ],
 }), flush=True)
@@ -584,7 +586,8 @@ for line in sys.stdin:
             "request_id": request_id,
             "text": command["text"] if request_id in interpreted else "echo:" + command["text"],
             **({"event_type": "response.text.delta",
-                "payload": json.loads(command["text"])}
+                "payload": json.loads(command["text"]),
+                "payload_response_id": "r1", "sequence_number": 17}
                if request_id in interpreted else {}),
         }), flush=True)
         print(json.dumps({
@@ -649,14 +652,40 @@ async def test_native_websocket_routes_frames_and_send_acknowledgements(tmp_path
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_metadata", [False, True], ids=["valid", "missing-payload"])
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        None,
+        ('"payload": json.loads(command["text"])', '"invalid_payload": None'),
+        ('"payload_response_id": "r1"', '"missing_response_id": None'),
+        ('"sequence_number": 17', '"missing_sequence_number": None'),
+        ('"payload_response_id": "r1"', '"payload_response_id": 17'),
+        ('"payload_response_id": "r1"', '"payload_response_id": True'),
+        ('"sequence_number": 17', '"sequence_number": True'),
+        ('"sequence_number": 17', '"sequence_number": 17.0'),
+        ('"sequence_number": 17', '"sequence_number": "17"'),
+        ('"sequence_number": 17', '"sequence_number": []'),
+    ],
+    ids=[
+        "valid",
+        "missing-payload",
+        "missing-id",
+        "missing-sequence",
+        "int-id",
+        "bool-id",
+        "bool",
+        "float",
+        "str",
+        "list",
+    ],
+)
 async def test_native_responses_websocket_preserves_interpretation_metadata(
-    tmp_path: Path, invalid_metadata: bool
+    tmp_path: Path, replacement: tuple[str, str] | None
 ) -> None:
     helper = tmp_path / "native-helper"
     source = _websocket_helper_source()
-    if invalid_metadata:
-        source = source.replace('"payload": json.loads(command["text"])', '"invalid_payload": None')
+    if replacement is not None:
+        source = source.replace(*replacement)
     _write_helper(helper, source)
     client = SubprocessNativeEgressClient(helper)
     websocket = await client.websocket(
@@ -669,10 +698,12 @@ async def test_native_responses_websocket_preserves_interpretation_metadata(
         )
     )
 
-    if invalid_metadata:
+    process = client._process
+    if replacement is not None:
         with pytest.raises(NativeEgressProtocolError, match="Responses websocket event is invalid"):
             await websocket.send_text('{"type":"response.text.delta","delta":"hi"}')
             await websocket.receive()
+        assert not client._streams
     else:
         await websocket.send_text('{"type":"response.text.delta","delta":"hi"}')
         assert await websocket.receive() == NativeWebSocketMessage(
@@ -681,8 +712,23 @@ async def test_native_responses_websocket_preserves_interpretation_metadata(
             responses_interpreted=True,
             event_type="response.text.delta",
             payload={"type": "response.text.delta", "delta": "hi"},
+            routing=NativeWebSocketRoutingMetadata("r1", 17),
         )
         await websocket.close()
+    peer = await client.websocket(
+        NativeWebSocketRequest(
+            url="wss://example.test/codex/responses",
+            headers={"user-agent": "codex-cli", "sec-websocket-protocol": "openai"},
+            connect_timeout_seconds=2,
+            max_message_bytes=1024,
+        )
+    )
+    await peer.send_text("healthy")
+    assert await peer.receive() == NativeWebSocketMessage(kind="text", text="echo:healthy")
+    await peer.close()
+    assert client._process is process
+    assert client._request_sequence == 2
+    assert not client._streams
     await client.aclose()
 
 
@@ -968,6 +1014,7 @@ async def test_native_sse_failure_releases_owned_stream(
         "http_compact_collect_v1",
         "http_responses_events_v1",
         "http_responses_completion_v1",
+        "websocket_responses_routing_v1",
     ],
 )
 async def test_native_sse_capability_is_required_before_dispatch(tmp_path: Path, capability: str) -> None:
@@ -1163,6 +1210,13 @@ def test_bounded_event_queue_trips_on_bytes_or_events_and_releases_bytes_on_get(
     with pytest.raises(asyncio.QueueFull):
         queue.put_nowait(websocket_event)
     queue.get_nowait()
+    queue.get_nowait()
+    assert queue.queued_bytes == 0
+    routed_event = {**websocket_event, "payload_response_id": "é", "sequence_number": -17}
+    queue.put_nowait(routed_event)
+    assert queue.queued_bytes == 9
+    with pytest.raises(asyncio.QueueFull):
+        queue.put_nowait(websocket_event)
     queue.get_nowait()
     assert queue.queued_bytes == 0
     # A lone event larger than the whole budget is accepted at an empty queue

--- a/tests/unit/test_native_websocket_routing_fixtures.py
+++ b/tests/unit/test_native_websocket_routing_fixtures.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.modules.proxy._service.websocket.helpers import _websocket_response_id
+from app.modules.proxy._service.websocket.mixin import _parse_upstream_websocket_text_frame
+
+FIXTURES = Path(__file__).resolve().parents[2] / "crates/codex-lb-responses/tests/fixtures/websocket-routing-v1.json"
+CASES = json.loads(FIXTURES.read_text())
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+def test_routing_fixture_matches_python(case: dict[str, Any]) -> None:
+    payload = json.loads(case["text"])
+    assert _websocket_response_id(None, payload) == case["payload_response_id"]
+    frame = _parse_upstream_websocket_text_frame(case["text"])
+    assert frame.response_id == case["response_id"]
+    assert frame.sequence_number == (json.loads(case["sequence_token"]) if case["sequence_token"] is not None else None)


### PR DESCRIPTION
## Summary

Native Responses WebSocket frames already pass through Rust, but Python still extracts their payload response IDs and sequence values. Rust now supplies this metadata through the helper protocol, and Python uses it for direct WebSocket matching, archive attribution, bridge matching and replay sequence checks.

The `websocket_responses_routing_v1` capability requires the adapter and bundled helper to be updated together. Validated lifecycle IDs retain their existing precedence, and downstream sequence watermarks still advance only after a successful send. Pending queues, retry, settlement and shared socket lifetime retain their current Python owners. No throughput improvement is claimed.

Related: #2245. No issue is closed.

## Type of change

- [x] `refactor:` — internal Rust migration with public behavior preserved

## OpenSpec

- [x] Includes an OpenSpec change, synchronized and archived after verification
- [x] Preserves upstream-equivalent WebSocket text, numeric values and lifecycle behavior

Change: `openspec/changes/archive/2026-09-10-migrate-native-websocket-routing-metadata/`.

## Changes

- Extract payload response IDs with Python whitespace and duplicate-key semantics; retain opaque delivery for unsupported selected strings.
- Recognize integer sequence tokens without narrowing precision, excluding booleans, floats and exponent notation. Objects containing any integer over 640 digits use opaque delivery to keep conversion failures out of the shared IPC reader; this includes nested and overwritten tokens.
- Validate required IPC metadata and include it in the bounded queue's byte budget. Invalid exchanges fail without replay, while the helper remains usable.
- Preserve lifecycle validation precedence: a valid nested ID ` nested ` wins unchanged over a direct ID; if lifecycle validation fails, the stripped payload ID wins instead.

No new setting, dependency, database migration, README section or dashboard surface.

## Test plan

Merged current main `ab0daae42` without conflicts, including the SQLite fixture correction in #2296. Both previously failing fixture layouts passed locally. Review corrections passed **447** release-helper/adapter/routing tests, **28** Rust tests, full lint/type checks, and **64** strict OpenSpec specs. The new real-helper probe checks 641- and 5,000-digit top-level, nested and overwritten integers at Python's minimum configurable digit limit; both sockets remain usable on the same helper.

- `make rust-check`: formatting, Clippy, 28 Rust tests and locked release helper build passed.
- Native SSE/routed/WebSocket release-helper integration: 336 passed.
- Proxy/WebSocket/HTTP bridge regression: 1,729 passed on the original base.
- Adapter/shared routing fixtures: 110 passed; cancellation/virtual-time/fixture selection: 65 passed; packaging/usage selection: 31 passed.
- Full lint/architecture/type checks and 64 strict OpenSpec specs passed.

Shared Rust/Python fixtures cover whitespace, duplicate keys, surrogate handoff, lifecycle validation and lossless integers. Actual helper probes cover request attribution, suppressed replay-created frames, sequence regression and downstream send failure. The broad run emitted one aiosqlite worker-thread cleanup warning; both attributed test variants passed when repeated with that warning treated as an error. Full commands and scope are recorded in the archived `verification.md`.

The full local `make ci` run passed frontend lint and type checking, then frontend coverage exited with code **143** before producing test results. The termination source was not established; this host also lacks `kind` for the final Helm smoke target. This is not a full CI pass; complete GitHub Actions checks remain pending.

## Checklist

- [x] Conventional Commit title
- [x] Tests and OpenSpec cover the change
- [x] Simplicity gates reviewed
- [x] CHANGELOG left to release automation
