### PR TITLE
test(request-logs): align facet index setup with the ORM schema from #2246

### DIFF
--- a/tests/integration/test_request_log_facet_sqlite.py
+++ b/tests/integration/test_request_log_facet_sqlite.py
@@ -14,6 +14,12 @@ from app.db.session import SessionLocal, engine
 
 pytestmark = [pytest.mark.integration, pytest.mark.skipif(engine.dialect.name != "sqlite", reason="SQLite query plans")]
 
+_LIVE_FACET_INDEXES = {
+    "idx_logs_live_api_key",
+    "idx_logs_live_model_effort",
+    "idx_logs_live_status_error",
+}
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("live_facet_indexes", [False, True])
@@ -85,17 +91,14 @@ async def test_options_avoid_repeated_live_cohort_scans(
             ],
         )
         await session.commit()
-        if live_facet_indexes:
-            # The independently proposed partial indexes must remain compatible.
-            for name, columns in (
-                ("api_key", "api_key_id"),
-                ("model_effort", "model, reasoning_effort"),
-                ("status_error", "status, error_code"),
-            ):
-                await session.execute(
-                    text(f"CREATE INDEX idx_logs_live_{name} ON request_logs ({columns}) WHERE deleted_at IS NULL")
-                )
+        if not live_facet_indexes:
+            # db_setup creates the live facet indexes from ORM metadata.
+            # Remove them only for the case exercising the standard indexes alone.
+            for index_name in sorted(_LIVE_FACET_INDEXES):
+                await session.execute(text(f"DROP INDEX {index_name}"))
             await session.commit()
+        index_names = {row[1] for row in await session.execute(text("PRAGMA index_list('request_logs')"))}
+        assert index_names & _LIVE_FACET_INDEXES == (_LIVE_FACET_INDEXES if live_facet_indexes else set())
         assert not (await session.execute(text("SELECT name FROM sqlite_master WHERE name = 'sqlite_stat1'"))).all()
 
     # Count SQLite VM work for the real HTTP endpoint, including its actual


### PR DESCRIPTION
## Summary

`main` is red on `Tests (pytest, integration-core-2)` since #2246 merged: `test_options_avoid_repeated_live_cohort_scans[True]` fails with `sqlite3.OperationalError: index idx_logs_live_api_key already exists`. This aligns the test's index setup with the ORM schema #2246 introduced. Test-only change; no production behavior, contract, or schema is touched.

## Type of change

- [x] `test:` — test-only change

Linked issue: none (main-red follow-up to #2246)

## OpenSpec

- [x] Not applicable — test stabilization; restores coverage of the existing `openspec/specs/query-caching/spec.md` live-facet requirement without changing it

## Root cause

1. #2246 added the three live facet partial indexes (`idx_logs_live_api_key`, `idx_logs_live_model_effort`, `idx_logs_live_status_error`) to `app/db/models.py` as ORM `Index` objects.
2. The integration fixture `_recreate_test_schema` runs `Base.metadata.create_all`, so every test now starts with those indexes already present.
3. `test_options_avoid_repeated_live_cohort_scans[True]` still assumed they were absent and issued an unconditional `CREATE INDEX` → duplicate-index error.
4. `[False]` kept passing but was silently running against a database that *had* all three indexes, so the "standard indexes only" case was not exercising what its name claims.

The migration itself (`20260909_130000_add_request_logs_live_facet_indexes`) already uses `CREATE INDEX IF NOT EXISTS` and is not the duplicate creator. Reproduced on a clean detached worktree at `d2b2e7784` and on main's own push CI for that commit.

## Changes

- `tests/integration/test_request_log_facet_sqlite.py`: `[True]` keeps the fixture-created production indexes; `[False]` explicitly drops the three live facet indexes from the freshly recreated schema. Both parameters now assert the actual index set via `PRAGMA index_list('request_logs')` before hitting the endpoint. The response, visibility/NULL/status, no-`sqlite_stat1`, and `0 < operations < 20_000` VM-work assertions are unchanged.

## Test plan

Regression evidence (assertion added first, then the setup fix):

```
# before fix, with the new index-state assertion:
FAILED ...[False]  AssertionError: extra items {'idx_logs_live_api_key', 'idx_logs_live_model_effort', 'idx_logs_live_status_error'}
FAILED ...[True]   sqlite3.OperationalError: index idx_logs_live_api_key already exists
# after fix:
2 passed
```

Gates run on `cf7497155`:

```
uv run pytest tests/integration/test_request_log_facet_sqlite.py -q   # 2 passed
uv run pytest tests/integration/test_migrations.py -q                 # 42 passed, 8 skipped (PostgreSQL-only)
uv run pytest tests/test_request_logs_options_api.py -q               # 13 passed, 1 skipped (PostgreSQL-only)
make lint && make typecheck && make migration-check                   # pass; schema_drift=none
openspec validate --specs --strict                                    # 64 passed
```

## Notes for reviewers

- #2294 (telemetry v2) is currently red on the same job for this reason only; it needs no change and should go green once this lands.
- One concern, one file, 13 lines.

## Checklist

- [x] Title is in Conventional Commits format
- [x] Added or updated tests covering the change
- [x] Ran the relevant `make <target>` subset locally
- [x] CHANGELOG is **not** edited by hand
