### PR TITLE
ci(openspec): strictly validate changed active folders

### DIFF
--- a/.github/scripts/validate_changed_openspec.py
+++ b/.github/scripts/validate_changed_openspec.py
@@ -1,0 +1,57 @@
+"""Strictly validate active OpenSpec changes touched by the GitHub event."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True)
+
+
+def main() -> None:
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    event_name = os.environ["GITHUB_EVENT_NAME"]
+    if event_name == "pull_request":
+        pull_request = event["pull_request"]
+        head = pull_request["head"]["sha"]
+        base = git("merge-base", pull_request["base"]["sha"], head).strip()
+    elif event_name == "push":
+        base, head = event["before"], event["after"]
+    elif event_name == "merge_group":
+        base, head = event["merge_group"]["base_sha"], event["merge_group"]["head_sha"]
+    else:
+        raise ValueError(f"Unsupported event: {event_name}")
+    if event_name == "push" and base == "0" * 40:
+        paths = git("ls-tree", "-r", "--name-only", "-z", head, "--", "openspec/changes/")
+    else:
+        paths = git("diff", "--name-only", "-z", "--no-renames", base, head, "--", "openspec/changes/")
+    changes = set()
+    for path in paths.split("\0"):
+        parts = path.split("/")
+        if len(parts) >= 4 and parts[:2] == ["openspec", "changes"] and parts[2] != "archive":
+            if Path(*parts[:3]).is_dir():
+                changes.add(parts[2])
+    for change in sorted(changes):
+        subprocess.run(
+            [
+                "npx",
+                "--yes",
+                "@fission-ai/openspec@1.11.0",
+                "validate",
+                "--type",
+                "change",
+                "--strict",
+                "--no-interactive",
+                "--",
+                change,
+            ],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Validate canonical OpenSpec capabilities
         run: npx --yes @fission-ai/openspec@1.11.0 validate --specs
+
+      - name: Strictly validate changed OpenSpec folders
+        run: python3 .github/scripts/validate_changed_openspec.py
 
   frontend-lint:
     name: Frontend lint (eslint)

--- a/openspec/changes/archive/2026-09-10-validate-changed-openspec/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-validate-changed-openspec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-validate-changed-openspec/design.md
+++ b/openspec/changes/archive/2026-09-10-validate-changed-openspec/design.md
@@ -1,0 +1,19 @@
+## Context
+
+See proposal.md. The OpenSpec job currently checks out a shallow synthetic PR merge and validates canonical specs only.
+
+## Goals / Non-Goals
+
+Select exactly the active folders owned by the event diff. General CI cleanup and repairs to existing invalid deltas are outside this change.
+
+## Decisions
+
+Use one stdlib Python command as the CI interface. Read GitHub's event file and use pinned commit IDs. For PRs, compute the merge base with the actual PR head; target-only changes must not enter the selection. Keep the normal merge checkout so validation checks the candidate CI will merge. Fetch full history so both parents and their ancestry exist.
+
+Use a NUL-delimited Git diff with rename detection disabled. Rename sources and destinations then appear as deletion/addition paths, including moves between folders. Validate each surviving folder once, even if its proposal was deleted. Skip fully deleted folders and archive paths.
+
+Invoke the pinned OpenSpec validator with argument arrays and explicit change type. Do not run blanket change validation. Missing history fails closed. Push and merge queue use their event ranges; a zero before SHA on a new branch selects all tracked head paths.
+
+## Risks / Trade-offs
+
+Full history costs more checkout time. It avoids incomplete merge-base calculations and additional authenticated fetch logic. Local regression tests use real temporary Git repositories and an external validator stand-in; a separate proof runs the pinned validator against valid and invalid deltas.

--- a/openspec/changes/archive/2026-09-10-validate-changed-openspec/proposal.md
+++ b/openspec/changes/archive/2026-09-10-validate-changed-openspec/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+CI validates canonical capabilities but lets malformed active change deltas pass. Issue #2032 asks for strict validation of touched changes without blocking on unrelated legacy deltas.
+
+## What Changes
+
+- Validate surviving active change folders selected from the event's Git diff, using strict OpenSpec validation.
+- Preserve canonical validation and the required OpenSpec job.
+- Cover PR merge bases, push and merge queue ranges, deletions, renames and unrelated invalid changes through the CI script interface.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-automation`: Require strict validation of changed active OpenSpec folders.
+
+## Impact
+
+Only the OpenSpec CI job, its validation script and regression tests change. No runtime configuration or database changes.

--- a/openspec/changes/archive/2026-09-10-validate-changed-openspec/specs/github-automation/spec.md
+++ b/openspec/changes/archive/2026-09-10-validate-changed-openspec/specs/github-automation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: CI strictly validates changed active OpenSpec folders
+
+The required OpenSpec CI job MUST retain canonical capability validation and MUST strictly validate each surviving active change folder touched by the event diff. Pull requests MUST compare their head against its merge base with the event's target commit. Pushes MUST compare the event's before and after commits; merge queue events MUST compare their base and head commits. Missing or invalid comparison history MUST fail the job. A new branch push without a before commit MUST consider every tracked path at its head.
+
+Changed paths MUST include both sides of renames and deleted files. Each surviving immediate folder under `openspec/changes/` MUST be validated once, except `archive`. Fully deleted folders and archived changes MUST be skipped. Unrelated active changes MUST NOT affect this validation. A strict validation failure MUST fail the required job.
+
+#### Scenario: Malformed delta changes
+
+- **WHEN** a pull request adds a malformed active change delta
+- **THEN** strict validation fails the required OpenSpec job
+
+#### Scenario: Target branch advances independently
+
+- **GIVEN** an invalid active change exists only in newer target-branch history
+- **WHEN** a pull request changes a valid active change from an older merge base
+- **THEN** only the pull request's touched active folder is validated
+
+#### Scenario: Delete or rename files
+
+- **WHEN** a pull request deletes a file or moves it between active change folders
+- **THEN** every surviving source and destination folder is validated once
+- **AND** fully deleted folders and archive paths are skipped
+
+#### Scenario: Missing comparison commit
+
+- **WHEN** the event's comparison commit cannot be resolved
+- **THEN** validation fails instead of reporting no changed folders
+
+#### Scenario: Push or merge queue event
+
+- **WHEN** a push or merge queue event touches an active change
+- **THEN** the folder is strictly validated using the event's commit range

--- a/openspec/changes/archive/2026-09-10-validate-changed-openspec/tasks.md
+++ b/openspec/changes/archive/2026-09-10-validate-changed-openspec/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implement and prove the CI gate
+
+- [x] 1.1 Add a failing regression through the CI command interface.
+- [x] 1.2 Implement event-based changed-folder validation and wire the required job.
+- [x] 1.3 Cover PR merge-base isolation, deletion, rename, archive, push, merge queue and missing history.
+- [x] 1.4 Prove malformed deltas fail with OpenSpec 1.11.0 and valid deltas pass despite unrelated invalid folders.
+- [x] 1.5 Run relevant repository gates, independently review, sync and archive the verified change.

--- a/openspec/specs/github-automation/context.md
+++ b/openspec/specs/github-automation/context.md
@@ -132,3 +132,9 @@ therefore had to subscribe to `pull_request: edited`.
   runs the full suite regardless.
 - If the guards ever need the matrix result, do not fold them back into
   `ci.yml`; gate on the separate contexts instead.
+
+## Changed OpenSpec validation
+
+Issue #2032 exposed that canonical-only validation accepts malformed active deltas. The required OpenSpec job also runs `.github/scripts/validate_changed_openspec.py` against GitHub event revisions. PR selection uses the merge base and event head, while validation runs in the normal merge checkout. A target-only invalid change added after a PR branches does not enter that PR's validation set.
+
+Full history makes the merge base available. Disabling rename detection includes both old and new paths; surviving folders are validated, fully removed folders and archive paths are skipped. Strict validation is limited to touched active folders because unrelated legacy deltas can still be invalid. Validator arguments terminate options before the folder name, so a folder named `--help` cannot skip validation.

--- a/openspec/specs/github-automation/spec.md
+++ b/openspec/specs/github-automation/spec.md
@@ -172,3 +172,35 @@ body-only edit could then mint passing checks for a red or untested head.
 - **THEN** they report as `Beta release guard` and `Stable release guard`
 - **AND** the branch ruleset's required contexts are unchanged
 
+### Requirement: CI strictly validates changed active OpenSpec folders
+
+The required OpenSpec CI job MUST retain canonical capability validation and MUST strictly validate each surviving active change folder touched by the event diff. Pull requests MUST compare their head against its merge base with the event's target commit. Pushes MUST compare the event's before and after commits; merge queue events MUST compare their base and head commits. Missing or invalid comparison history MUST fail the job. A new branch push without a before commit MUST consider every tracked path at its head.
+
+Changed paths MUST include both sides of renames and deleted files. Each surviving immediate folder under `openspec/changes/` MUST be validated once, except `archive`. Fully deleted folders and archived changes MUST be skipped. Unrelated active changes MUST NOT affect this validation. A strict validation failure MUST fail the required job.
+
+#### Scenario: Malformed delta changes
+
+- **WHEN** a pull request adds a malformed active change delta
+- **THEN** strict validation fails the required OpenSpec job
+
+#### Scenario: Target branch advances independently
+
+- **GIVEN** an invalid active change exists only in newer target-branch history
+- **WHEN** a pull request changes a valid active change from an older merge base
+- **THEN** only the pull request's touched active folder is validated
+
+#### Scenario: Delete or rename files
+
+- **WHEN** a pull request deletes a file or moves it between active change folders
+- **THEN** every surviving source and destination folder is validated once
+- **AND** fully deleted folders and archive paths are skipped
+
+#### Scenario: Missing comparison commit
+
+- **WHEN** the event's comparison commit cannot be resolved
+- **THEN** validation fails instead of reporting no changed folders
+
+#### Scenario: Push or merge queue event
+
+- **WHEN** a push or merge queue event touches an active change
+- **THEN** the folder is strictly validated using the event's commit range

--- a/tests/unit/test_changed_openspec_ci.py
+++ b/tests/unit/test_changed_openspec_ci.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github/scripts/validate_changed_openspec.py"
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def commit(repo: Path) -> str:
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", "fixture")
+    return git(repo, "rev-parse", "HEAD")
+
+
+def change(repo: Path, slug: str, name: str = "proposal.md") -> Path:
+    path = repo / "openspec/changes" / slug / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{slug}\n")
+    return path
+
+
+def setup_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    change(repo, "untouched-invalid")
+    commit(repo)
+    return repo
+
+
+def run_gate(repo: Path, event_name: str, event: dict, fail: str = "") -> subprocess.CompletedProcess[str]:
+    event_file = repo.parent / "event.json"
+    event_file.write_text(json.dumps(event))
+    bin_dir = repo.parent / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    validator = bin_dir / "npx"
+    validator.write_text(
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "print('VALIDATE ' + ' '.join(sys.argv[1:]))\n"
+        "sys.exit(1 if os.environ.get('FAIL_CHANGE') in sys.argv[1:] else 0)\n"
+    )
+    validator.chmod(0o755)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "GITHUB_EVENT_NAME": event_name,
+            "GITHUB_EVENT_PATH": str(event_file),
+            "FAIL_CHANGE": fail,
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_pr_uses_merge_base_and_event_head_in_merge_checkout(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    ancestor = git(repo, "rev-parse", "HEAD")
+    change(repo, "target-only-invalid")
+    base = commit(repo)
+    git(repo, "checkout", "-qb", "pr", ancestor)
+    change(repo, "touched")
+    change(repo, "touched", "notes with spaces.md")
+    head = commit(repo)
+    git(repo, "merge", "--no-edit", base)
+
+    result = run_gate(repo, "pull_request", {"pull_request": {"base": {"sha": base}, "head": {"sha": head}}})
+
+    assert result.returncode == 0, result.stderr
+    validations = [line for line in result.stdout.splitlines() if line.startswith("VALIDATE ")]
+    assert validations == [
+        "VALIDATE --yes @fission-ai/openspec@1.11.0 validate --type change --strict --no-interactive -- touched"
+    ]
+
+
+def test_push_and_merge_queue_validate_the_event_range(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    base = git(repo, "rev-parse", "HEAD")
+    change(repo, "new-change")
+    head = commit(repo)
+    for event_name, event in (
+        ("push", {"before": base, "after": head}),
+        ("merge_group", {"merge_group": {"base_sha": base, "head_sha": head}}),
+    ):
+        result = run_gate(repo, event_name, event, fail="new-change")
+        assert "--type change --strict --no-interactive -- new-change" in result.stdout
+        assert result.returncode != 0
+        assert "untouched-invalid" not in result.stdout
+
+
+def test_new_branch_push_validates_all_tracked_active_changes(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    result = run_gate(repo, "push", {"before": "0" * 40, "after": git(repo, "rev-parse", "HEAD")})
+    assert result.returncode == 0, result.stderr
+    assert "--type change --strict --no-interactive -- untouched-invalid" in result.stdout
+
+
+def test_renames_deletions_and_archives_select_surviving_folders(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    deleted = change(repo, "deleted")
+    archived = change(repo, "archived")
+    proposal = change(repo, "partial")
+    change(repo, "partial", "tasks.md")
+    moved = change(repo, "source", "delta.md")
+    change(repo, "source")
+    base = commit(repo)
+    deleted.unlink()
+    archived.rename(change(repo, "archive/2026-09-10-archived"))
+    proposal.unlink()
+    moved.rename(change(repo, "destination", "delta.md"))
+    head = commit(repo)
+    git(repo, "clean", "-fd")  # Match a fresh Actions checkout: Git does not retain empty directories.
+
+    result = run_gate(repo, "push", {"before": base, "after": head})
+
+    assert result.returncode == 0, result.stderr
+    validations = [line.split(" -- ")[1] for line in result.stdout.splitlines() if "VALIDATE " in line]
+    assert validations == ["destination", "partial", "source"]
+
+
+def test_missing_history_fails_without_validating_unrelated_changes(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    result = run_gate(repo, "push", {"before": "a" * 40, "after": git(repo, "rev-parse", "HEAD")})
+    assert result.returncode != 0
+    assert "VALIDATE " not in result.stdout
+
+
+def test_no_changed_active_folders_succeeds(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    base = git(repo, "rev-parse", "HEAD")
+    (repo / "README.md").write_text("unrelated")
+    head = commit(repo)
+    result = run_gate(repo, "push", {"before": base, "after": head})
+    assert result.returncode == 0, result.stderr
+    assert "VALIDATE " not in result.stdout
+
+
+def test_option_like_folder_is_a_positional_change_name(tmp_path: Path) -> None:
+    repo = setup_repo(tmp_path)
+    base = git(repo, "rev-parse", "HEAD")
+    change(repo, "--help")
+    head = commit(repo)
+    result = run_gate(repo, "push", {"before": base, "after": head})
+    assert result.returncode == 0, result.stderr
+    assert "--type change --strict --no-interactive -- --help" in result.stdout

--- a/tests/unit/test_ci_workflow_required_checks.py
+++ b/tests/unit/test_ci_workflow_required_checks.py
@@ -90,7 +90,8 @@ def test_openspec_validation_is_required_for_spec_only_changes() -> None:
     assert "\n    needs:" not in openspec_job
     assert "\n    if:" not in openspec_job
     assert "npx --yes @fission-ai/openspec@1.11.0 validate --specs" in openspec_job
-    assert "--strict" not in openspec_job
+    assert "fetch-depth: 0" in openspec_job
+    assert "python3 .github/scripts/validate_changed_openspec.py" in openspec_job
     assert "- openspec" in required_job
 
 


### PR DESCRIPTION
## Summary

CI now strictly validates active OpenSpec folders touched by the event diff, closing the canonical-only validation gap. PR selection uses the merge base and event head so newer target-only deltas cannot block unrelated work.

## Type of change

- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging

Fixes #2032

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/archive/2026-09-10-validate-changed-openspec/`. Verified and synced to `github-automation`.

## Changes

- Keep canonical validation in the required OpenSpec job; fetch full history and invoke a stdlib changed-folder validator.
- Use event revisions for PR, push and merge queue ranges. Include rename sources and destinations, validate surviving folders after partial deletion, and skip archives and fully deleted folders.
- Pass folder names after `--` so option-like names cannot bypass validation. Missing history and validator errors fail the job.

## Test plan

- `uv run pytest -q tests/unit/test_changed_openspec_ci.py tests/unit/test_ci_workflow_required_checks.py tests/unit/test_github_ci_scripts.py`: 28 passed.
- `make lint` and `make typecheck`: passed.
- OpenSpec 1.11.0 strict change validation: passed before archive. Canonical validation after sync: 65 passed.
- Real temporary Git repository and pinned OpenSpec 1.11.0: canonical-only command passed a malformed delta; new script failed it; repaired touched delta passed beside an unchanged invalid delta. A malformed `--help` folder also failed.
- Both database environment variables pointed to the same dedicated disposable SQLite database throughout local tests and checks. No runtime changes.

## Checklist

- [x] Title uses Conventional Commits.
- [x] Linked the related issue.
- [x] Added regression coverage.
- [x] Ran the relevant local checks.
- [x] Specs validate and implementation verification is complete.
- [x] Reviewed simplicity gates; no settings or UI changes.
- [x] CHANGELOG is unchanged.

Prepared with GPT-6 Astra and an independent bounded review. Hosted CI and maintainer acceptance remain separate gates.
