### PR TITLE
feat(db): log per-revision migration progress

### DIFF
--- a/app/db/alembic/env.py
+++ b/app/db/alembic/env.py
@@ -6,6 +6,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 from app.core.config.settings import get_settings
+from app.db.migration_progress import revision_progress
 from app.db.migration_url import to_sync_database_url
 from app.db.models import Base
 
@@ -60,8 +61,9 @@ def run_migrations_online() -> None:
             render_as_batch=connection.dialect.name == "sqlite",
         )
 
-        with context.begin_transaction():
-            context.run_migrations()
+        with revision_progress(context.get_context()):
+            with context.begin_transaction():
+                context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -928,6 +928,7 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
+    logging.basicConfig(level=logging.INFO)
     database_url = get_settings().database_url if args.db_url is None else args.db_url
 
     if args.command == "upgrade":

--- a/app/db/migration_progress.py
+++ b/app/db/migration_progress.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from time import monotonic
+
+from alembic.runtime.migration import MigrationContext, RevisionStep
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def revision_progress(context: MigrationContext) -> Iterator[None]:
+    """Report online revision execution while Alembic retains transaction control."""
+    # Alembic exposes only an after-apply callback. Keep the iterator adapter
+    # here so starts and failures can be reported without replacing its runner.
+    original = context._migrations_fn
+    assert original is not None
+    active: RevisionStep | None = None
+    started = 0.0
+
+    def steps(heads: tuple[str, ...], migration_context: MigrationContext) -> Iterator[RevisionStep]:
+        nonlocal active, started
+        for step in original(heads, migration_context):
+            if not isinstance(step, RevisionStep):
+                yield step
+                continue
+            active = step
+            started = monotonic()
+            direction = "upgrade" if step.is_upgrade else "downgrade"
+            logger.info("Migration started revision=%s direction=%s", step.revision.revision, direction)
+            yield step
+            logger.info(
+                "Migration executed revision=%s direction=%s elapsed_seconds=%.3f",
+                step.revision.revision,
+                direction,
+                monotonic() - started,
+            )
+            active = None
+
+    context._migrations_fn = steps
+    try:
+        yield
+    except BaseException:
+        if active is not None:
+            logger.error(
+                "Migration failed revision=%s direction=%s elapsed_seconds=%.3f",
+                active.revision.revision,
+                "upgrade" if active.is_upgrade else "downgrade",
+                monotonic() - started,
+            )
+        raise
+    finally:
+        context._migrations_fn = original

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/design.md
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/design.md
@@ -1,0 +1,17 @@
+## Context
+
+Alembic owns revision selection, execution, version bookkeeping and transactions. Its completion callback alone cannot report a revision before it begins or identify a failed revision.
+
+## Decisions
+
+Wrap the Alembic migration-step iterator in the online environment. Yield each original step unchanged so Alembic retains execution and transaction control. Keep this compatibility adapter in one small module. Measure monotonic elapsed time around each yielded step. A surrounding exception handler reports the active revision and rethrows the original exception.
+
+Use INFO for start and executed events, ERROR for failure. The CLI configures logging only when invoked as a command. No global logging setup during imports. Completed execution can still be rolled back by a later failure; use `executed`, not `committed`.
+
+## Risks
+
+The iterator integration depends on Alembic's migration callback. Real runner tests must protect compatibility with the pinned Alembic version, including multi-revision execution, failure and no-op upgrades.
+
+## Non-goals
+
+No background work, resumability framework, affected-row estimates, SQL logging, periodic heartbeat, or benchmark threshold.

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/proposal.md
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Issue #1470 reports startup migrations that look hung. Operators need revision identity and elapsed execution time before deciding whether to interrupt deployment.
+
+## What Changes
+
+- Log revision start, execution completion, and failure without database contents.
+- Preserve Alembic ordering, transactions, and exception propagation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-migrations`: online revision execution progress.
+
+## Impact
+
+Alembic online environment and migration CLI logging. Partial coverage of #1470. Background data phases, row counts, batch percentages, recovery guidance, and #1471 benchmark policy remain separate.

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/specs/database-migrations/spec.md
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/specs/database-migrations/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Online migration revision progress
+
+Online upgrades SHALL log each revision identifier and direction before execution and SHALL log elapsed seconds when execution completes or fails. Progress SHALL NOT include SQL, parameters, database URLs, revision descriptions, or exception messages. Execution completion SHALL NOT claim transaction commit. Failures SHALL propagate without executing later revisions. An upgrade with no pending revisions SHALL NOT emit revision execution events.
+
+#### Scenario: Pending revisions execute
+
+- **WHEN** an online upgrade executes pending revisions
+- **THEN** each revision has an ordered start and execution-complete event with nonnegative elapsed seconds
+- **AND** the start event is available before the revision runs
+
+#### Scenario: A revision fails
+
+- **WHEN** revision execution raises an exception
+- **THEN** a failure event identifies the revision and elapsed seconds without the exception text
+- **AND** the original failure propagates and no later revision starts
+
+#### Scenario: Database is current
+
+- **WHEN** an upgrade has no pending revisions
+- **THEN** no revision start or completion events are emitted

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/tasks.md
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/tasks.md
@@ -1,0 +1,7 @@
+## 1. Prove and implement
+
+- [x] 1.1 Reproduce missing progress through the real upgrade runner.
+- [x] 1.2 Implement revision start and elapsed completion events.
+- [x] 1.3 Prove failure propagation, privacy, and no-op behavior.
+- [x] 1.4 Verify migration checks, lint, types, and strict specs.
+- [x] 1.5 Review implementation against the spec and pinned Alembic runner.

--- a/openspec/changes/archive/2026-09-10-log-migration-revision-progress/verification.md
+++ b/openspec/changes/archive/2026-09-10-log-migration-revision-progress/verification.md
@@ -1,0 +1,21 @@
+# Verification
+
+Base: `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`.
+
+All five implementation tasks are complete. The added requirement and all three
+scenarios have regression coverage through `run_upgrade` and the migration CLI.
+An executing fixture reads its start record from a file before doing work. The
+failure fixture proves later revisions do not run and private exception text is
+excluded from progress records. No-op execution produces no progress events.
+
+The original runner failed the missing-events assertion. The original CLI failed
+the stderr assertion. Migration suites passed 118 tests, with 10 PostgreSQL-only
+skips. The strengthened progress tests passed separately. Upgrade to head and
+policy/schema checks passed on a dedicated disposable SQLite database. Lint,
+types, and strict OpenSpec checks passed. PostgreSQL execution remains a hosted
+CI check; no live database or runtime was changed.
+
+Independent source review found no concrete defect. Alembic still owns revision
+execution, version bookkeeping and transactions. The adapter restores its
+callback on exit and propagates failures. No critical or warning findings remain
+for this bounded revision-progress contract.

--- a/openspec/specs/database-migrations/context.md
+++ b/openspec/specs/database-migrations/context.md
@@ -72,3 +72,22 @@ branch. See the [repair context](../../changes/merge-overflow-transport-migratio
 ## Example
 
 Branch A and B each create migration revisions in parallel. After merge, CI detects multiple heads and fails. The resolver adds a merge revision, reruns CI, and proceeds. During deployment, a DB still storing old `013_add_dashboard_settings_routing_strategy` in `alembic_version` is auto-remapped to `20260225_000000_add_dashboard_settings_routing_strategy` before upgrade.
+
+## Revision progress
+
+Online Alembic execution emits `Migration started`, `Migration executed`, and
+`Migration failed` records with revision identity and direction. Terminal events
+include monotonic elapsed seconds. The migration CLI writes these logs to stderr
+and keeps its current-revision result on stdout. Startup uses application logging.
+
+For example, a start record followed by no terminal event identifies the revision
+still running or interrupted without cleanup. An executed event means Alembic
+finished that step; a later transaction failure can still roll it back. No event
+claims commit, row counts, or percent completion. These records exclude SQL,
+parameters, URLs, revision descriptions, and exception text. They do not redact
+existing exception handling elsewhere in the application.
+
+The small iterator adapter exists because Alembic's after-apply callback cannot
+report starts or failures. Real runner tests protect the integration with the
+pinned Alembic version. Background data phases and the benchmark policy in #1471
+remain separate from this partial implementation of #1470.

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -511,3 +511,24 @@ remain for operator recovery.
 - **THEN** recovery MUST fail before deleting sidecars, writing output, or
   moving the source
 
+
+### Requirement: Online migration revision progress
+
+Online upgrades SHALL log each revision identifier and direction before execution and SHALL log elapsed seconds when execution completes or fails. Progress SHALL NOT include SQL, parameters, database URLs, revision descriptions, or exception messages. Execution completion SHALL NOT claim transaction commit. Failures SHALL propagate without executing later revisions. An upgrade with no pending revisions SHALL NOT emit revision execution events.
+
+#### Scenario: Pending revisions execute
+
+- **WHEN** an online upgrade executes pending revisions
+- **THEN** each revision has an ordered start and execution-complete event with nonnegative elapsed seconds
+- **AND** the start event is available before the revision runs
+
+#### Scenario: A revision fails
+
+- **WHEN** revision execution raises an exception
+- **THEN** a failure event identifies the revision and elapsed seconds without the exception text
+- **AND** the original failure propagates and no later revision starts
+
+#### Scenario: Database is current
+
+- **WHEN** an upgrade has no pending revisions
+- **THEN** no revision start or completion events are emitted

--- a/tests/unit/test_migration_progress.py
+++ b/tests/unit/test_migration_progress.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from app.db.migrate import run_upgrade
+
+
+def test_upgrade_reports_revision_execution_and_noop(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    url = f"sqlite+aiosqlite:///{tmp_path / 'progress.db'}"
+    revision = "20260213_000000_base_schema"
+    with caplog.at_level(logging.INFO, logger="app.db.migration_progress"):
+        run_upgrade(url, revision, bootstrap_legacy=False)
+    records = [record for record in caplog.records if record.name == "app.db.migration_progress"]
+    assert [record.getMessage().split()[1] for record in records] == ["started", "executed"]
+    assert all(f"revision={revision}" in record.getMessage() for record in records)
+    assert "elapsed_seconds=" in records[-1].getMessage()
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="app.db.migration_progress"):
+        run_upgrade(url, revision, bootstrap_legacy=False)
+    assert not [record for record in caplog.records if record.name == "app.db.migration_progress"]
+
+
+def test_failed_upgrade_reports_active_revision_without_private_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import app.db.migrate as migrate
+
+    scripts = tmp_path / "scripts"
+    versions = scripts / "versions"
+    versions.mkdir(parents=True)
+    progress_log = tmp_path / "progress.log"
+    scripts.joinpath("env.py").write_text(Path("app/db/alembic/env.py").read_text())
+    versions.joinpath("first.py").write_text(
+        "from pathlib import Path\nrevision = 'first'\ndown_revision = None\n"
+        "def upgrade():\n"
+        f"    assert 'Migration started revision=first' in Path({str(progress_log)!r}).read_text()\n"
+    )
+    versions.joinpath("broken.py").write_text(
+        "revision = 'broken'\ndown_revision = 'first'\n"
+        "def upgrade():\n    raise RuntimeError('private-sql-parameter')\n"
+    )
+    versions.joinpath("last.py").write_text("revision = 'last'\ndown_revision = 'broken'\ndef upgrade():\n    pass\n")
+    monkeypatch.setattr(migrate, "_script_location", lambda: str(scripts))
+    progress_logger = logging.getLogger("app.db.migration_progress")
+    with closing(logging.FileHandler(progress_log)) as handler:
+        progress_logger.addHandler(handler)
+        try:
+            with caplog.at_level(logging.INFO, logger="app.db.migration_progress"):
+                with pytest.raises(RuntimeError, match="private-sql-parameter"):
+                    run_upgrade(f"sqlite+aiosqlite:///{tmp_path / 'failure.db'}", "head", bootstrap_legacy=False)
+        finally:
+            progress_logger.removeHandler(handler)
+    messages = [record.getMessage() for record in caplog.records if record.name == "app.db.migration_progress"]
+    assert [message.split()[1:3] for message in messages] == [
+        ["started", "revision=first"],
+        ["executed", "revision=first"],
+        ["started", "revision=broken"],
+        ["failed", "revision=broken"],
+    ]
+    assert "private-sql-parameter" not in "\n".join(messages)
+    assert float(messages[-1].split("elapsed_seconds=")[1]) >= 0
+
+
+def test_cli_upgrade_prints_progress_to_stderr(tmp_path: Path) -> None:
+    import os
+    import subprocess
+    import sys
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'cli.db'}"
+    result = subprocess.run(
+        [sys.executable, "-m", "app.db.migrate", "upgrade", "20260213_000000_base_schema"],
+        env={**os.environ, "CODEX_LB_DATABASE_URL": url, "CODEX_LB_TEST_DATABASE_URL": url},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Migration started revision=20260213_000000_base_schema" in result.stderr
+    assert "Migration executed revision=20260213_000000_base_schema" in result.stderr
+    assert result.stdout.strip() == "current_revision=20260213_000000_base_schema"


### PR DESCRIPTION
## Summary

Startup migrations currently give operators no per-revision elapsed or failure progress. Online Alembic runs now log each revision before execution, then its elapsed time on completion or failure. The migration CLI enables stderr logging while preserving its stdout result.

Refs #1470, partial implementation of runner progress only. Background data phases, resumability, affected-row counts, batch percentages, recovery guidance, and #1471 benchmark policy remain separate.

## Type of change

- [x] `feat:` new operator-visible capability

## OpenSpec

- [x] Includes a verified, archived OpenSpec change

Change: `openspec/changes/archive/2026-09-10-log-migration-revision-progress/`. Main database-migrations spec and context are synced.

## Changes

A small adapter wraps Alembic's migration-step iterator because its after-apply callback cannot report starts or failures. Alembic retains revision selection, execution, version bookkeeping, and transactions. The adapter restores the callback on exit and propagates the original failure.

`executed` means the step finished, not that the upgrade committed. Progress records contain only revision identity, direction, and elapsed time. They omit SQL, parameters, database URLs, revision descriptions, and exception messages. Existing exception handling outside these records is unchanged.

## Test plan

- Regression failed on the original runner's absent progress records; the CLI stderr regression also failed before logging was enabled.
- Migration suites: 118 passed, 10 PostgreSQL-only skips. Strengthened progress suite: 3 passed, including a revision reading its own start record before executing, failure privacy, no later revision after failure, and no-op behavior.
- Dedicated disposable SQLite: `codex-lb-db upgrade head` and `codex-lb-db check` passed.
- `make lint`, `make typecheck`, strict OpenSpec validation, and simplicity budgets passed.
- Independent source review found no concrete defect. PostgreSQL execution awaits hosted CI. No live runtime changes.

## Screenshots / output

```text
Migration started revision=20260213_000000_base_schema direction=upgrade
Migration executed revision=20260213_000000_base_schema direction=upgrade elapsed_seconds=0.016
```

Elapsed time varies. A failing step emits `Migration failed` and rethrows.

## Checklist

- [x] Conventional Commits title; related issue linked as partial coverage.
- [x] Regression coverage and relevant local checks complete.
- [x] Strict specs validated; implementation verified and archived.
- [x] Simplicity gates reviewed. Zero configuration; no new settings or dashboard changes.
- [x] CHANGELOG untouched.
