### PR TITLE
fix(proxy): project pooled quotas into Codex rate-limit events

### DIFF
--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -502,6 +502,7 @@ from app.modules.proxy.http_bridge_forwarding import (
     OwnerForwardRelayFailure as OwnerForwardRelayFailure,
 )
 from app.modules.proxy.load_balancer import AccountLease, effective_account_concurrency_caps
+from app.modules.proxy.rate_limit_events import project_codex_rate_limit_event, rate_limit_headers_for_client
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     apply_enforced_service_tier_model_fallback,
@@ -1081,6 +1082,19 @@ async def _process_and_forward_upstream_websocket_text(
         codex_session_affinity=codex_session_affinity,
         clock=clock,
     )
+    if parsed_frame.event_type == "codex.rate_limits":
+        # Raw account telemetry has already been processed/archived. Only the
+        # client projection changes; quota lookups must not fail inference.
+        try:
+            quota_headers = await rate_limit_headers_for_client(api_key, proxy.rate_limit_headers)
+        except Exception as exc:
+            _facade().logger.warning("Unable to load pooled websocket quota metadata: %s", type(exc).__name__)
+            quota_headers = {}
+        pooled_event = project_codex_rate_limit_event(parsed_frame.payload or {}, quota_headers)
+        if pooled_event is None:
+            upstream_control.suppress_downstream_event = True
+        else:
+            downstream_text = json.dumps(pooled_event, ensure_ascii=True, separators=(",", ":"))
     suppress_downstream_event = upstream_control.suppress_downstream_event
     downstream_texts = upstream_control.downstream_texts
     downstream_sequence_request_state = upstream_control.downstream_sequence_request_state

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
 from app.core.clock import Clock, Scheduler
@@ -72,3 +73,6 @@ class _WebSocketServiceProtocol(Protocol):
     _write_request_log: Any
     _write_websocket_connect_failure: Any
     proxy_responses_websocket: Any
+
+    @property
+    def rate_limit_headers(self) -> Callable[[], Awaitable[dict[str, str]]]: ...

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -295,6 +295,13 @@ from app.modules.proxy.overflow import (
     resolve_subscription_overflow,
     restore_client_store,
 )
+from app.modules.proxy.rate_limit_events import (
+    hide_upstream_quota_for_api_key_clients as _hide_upstream_quota_for_api_key_clients,
+)
+from app.modules.proxy.rate_limit_events import (
+    project_codex_rate_limit_event,
+    rate_limit_headers_for_client,
+)
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     apply_api_key_enforcement_to_chat_payload,
@@ -2309,13 +2316,6 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
     )
 
 
-async def _hide_upstream_quota_for_api_key_clients(api_key: ApiKeyData | None) -> bool:
-    if api_key is None:
-        return False
-    settings = await get_settings_cache().get()
-    return bool(getattr(settings, "hide_upstream_quota_from_api_keys", False))
-
-
 async def _apply_api_key_enforcement_with_fast_mode_policy(
     payload: ResponsesRequest | ResponsesCompactRequest,
     api_key: ApiKeyData | None,
@@ -2346,9 +2346,7 @@ async def _rate_limit_headers_for_request(
     context: ProxyContext,
     api_key: ApiKeyData | None,
 ) -> dict[str, str]:
-    if await _hide_upstream_quota_for_api_key_clients(api_key):
-        return {}
-    return await context.service.rate_limit_headers()
+    return await rate_limit_headers_for_client(api_key, context.service.rate_limit_headers)
 
 
 async def _release_reservation_deferring_cancellation(
@@ -5345,6 +5343,7 @@ async def _source_responses_response(
                     enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     native_codex_heartbeat=native_codex_heartbeat,
                     preserve_native_failure_lifecycle=preserve_native_failure_lifecycle,
+                    codex_rate_limit_headers=rate_limit_headers,
                 ),
             )
             return SourceStreamingResponse(
@@ -6260,6 +6259,7 @@ async def _wrap_source_responses_public_stream(
     enforce_openai_sdk_contract: bool = True,
     native_codex_heartbeat: bool = False,
     preserve_native_failure_lifecycle: bool = False,
+    codex_rate_limit_headers: Mapping[str, str] | None = None,
 ) -> AsyncIterator[str]:
     """Normalize and keep source-routed Responses SSE proxy-timeout friendly.
 
@@ -6280,6 +6280,7 @@ async def _wrap_source_responses_public_stream(
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         forward_unparseable_data=True,
         preserve_native_failure_lifecycle=preserve_native_failure_lifecycle,
+        codex_rate_limit_headers=codex_rate_limit_headers,
     )
     keepalive_stream = (
         normalized
@@ -6952,6 +6953,7 @@ async def _stream_responses(
         ),
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         preserve_native_failure_lifecycle=preserve_native_failure_lifecycle,
+        codex_rate_limit_headers=rate_limit_headers,
     )
     service_stream = stream
     use_codex_keepalive = native_codex_heartbeat or not enforce_openai_sdk_contract
@@ -9393,6 +9395,7 @@ async def _normalize_public_responses_stream(
     enforce_openai_sdk_contract: bool = True,
     forward_unparseable_data: bool = False,
     preserve_native_failure_lifecycle: bool = False,
+    codex_rate_limit_headers: Mapping[str, str] | None = None,
 ) -> AsyncIterator[str]:
     stream = _normalize_reasoning_summary_stream(stream)
     """Normalize the upstream SSE event stream for the public /v1 surface.
@@ -9405,9 +9408,8 @@ async def _normalize_public_responses_stream(
             item events, and synthesize a leading response.created event
             when the upstream stream's first standard event is not
             response.created. When False (used for /backend-api/codex/*,
-            which feeds the Codex CLI), all events including vendor events are
-            forwarded verbatim and no synthesis happens — the Codex CLI
-            relies on the upstream's native event shape.
+            which feeds the Codex CLI), preserve native events without synthesis,
+            except account quota events, which use the pooled header snapshot.
     """
     terminal_seen = False
     done_seen = False
@@ -9527,6 +9529,13 @@ async def _normalize_public_responses_stream(
                     failure_phase="upstream",
                 )
         raw_event_type = payload.get("type")
+        if raw_event_type == "codex.rate_limits":
+            if enforce_openai_sdk_contract:
+                continue
+            pooled_event = project_codex_rate_limit_event(payload, codex_rate_limit_headers or {})
+            if pooled_event is not None:
+                yield format_sse_event(pooled_event)
+            continue
         if (
             enforce_openai_sdk_contract
             and isinstance(raw_event_type, str)

--- a/app/modules/proxy/rate_limit_events.py
+++ b/app/modules/proxy/rate_limit_events.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+
+from app.core.config.settings_cache import get_settings_cache
+from app.core.types import JsonValue
+from app.core.usage.live_snapshots import LiveUsageWindow, parse_rate_limit_headers
+from app.modules.api_keys.service import ApiKeyData
+
+
+async def hide_upstream_quota_for_api_key_clients(api_key: ApiKeyData | None) -> bool:
+    if api_key is None:
+        return False
+    settings = await get_settings_cache().get()
+    return settings.hide_upstream_quota_from_api_keys
+
+
+async def rate_limit_headers_for_client(
+    api_key: ApiKeyData | None,
+    load_headers: Callable[[], Awaitable[dict[str, str]]],
+) -> dict[str, str]:
+    if await hide_upstream_quota_for_api_key_clients(api_key):
+        return {}
+    return await load_headers()
+
+
+def project_codex_rate_limit_event(
+    payload: Mapping[str, JsonValue],
+    headers: Mapping[str, str],
+) -> dict[str, JsonValue] | None:
+    """Replace account telemetry with the downstream pool snapshot, never merge it."""
+    for discriminator in ("limit_id", "metered_limit_name", "limit_name"):
+        if payload.get(discriminator) not in (None, "codex"):
+            return None
+    snapshot = parse_rate_limit_headers(headers)
+    if snapshot is None or not snapshot.has_windows:
+        return None
+    event: dict[str, JsonValue] = {
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "primary": _event_window(snapshot.primary),
+            "secondary": _event_window(snapshot.secondary),
+        },
+    }
+    if snapshot.credits_has is not None and snapshot.credits_unlimited is not None:
+        event["credits"] = {
+            "has_credits": snapshot.credits_has,
+            "unlimited": snapshot.credits_unlimited,
+            "balance": headers.get("x-codex-credits-balance"),
+        }
+    return event
+
+
+def _event_window(window: LiveUsageWindow | None) -> dict[str, JsonValue] | None:
+    if window is None:
+        return None
+    return {
+        "used_percent": window.used_percent,
+        "window_minutes": window.window_minutes,
+        "reset_at": window.reset_at,
+    }

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/context.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/context.md
@@ -1,0 +1,17 @@
+The reported warning originated in the Codex CLI's threshold logic, which
+accepts default `codex.rate_limits` events as its current account usage. A
+selected account at 97% used could overwrite a pool at 66.5% used. The upstream
+privacy switch made this more confusing by hiding pooled headers while raw
+account events remained visible.
+
+Projection uses pooled headers as the existing aggregate contract. HTTP keeps
+one snapshot consistent with its response headers; long-lived WebSockets read
+the cached aggregate on quota events only. No upstream refresh is introduced
+on each event. Original ingestion remains upstream of projection, so routing
+still sees account-specific usage. Unrepresented limit families are omitted
+instead of presenting global usage as model-specific capacity.
+
+With privacy enabled, this fix removes misleading account warnings; it does
+not publish previously hidden pool data. Operators who want pool percentages
+in Codex must use the existing upstream-quota visibility setting. API-key
+self-usage remains a distinct key-budget surface.

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/proposal.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Native Codex receives account-specific `codex.rate_limits` events even when
+codex-lb supplies pooled quota headers or hides upstream quotas. The CLI then
+warns that the selected account's weekly limit is nearly exhausted while the
+pool still has capacity. The privacy setting currently covers headers but not
+these stream events.
+
+## What Changes
+
+- Project default Codex rate-limit events from the same aggregate snapshot as
+  downstream quota headers on HTTP SSE and WebSocket Responses transports.
+- Suppress account-specific quota events when upstream quotas are hidden, no
+  aggregate is known, or the event belongs to an unaggregated limit family.
+- Preserve original upstream usage ingestion and ordinary response events.
+- Reuse the existing quota cache and visibility setting; add no configuration.
+
+## Impact
+
+- Affected specs: `responses-api-compat`, `api-keys`.
+- Affected code: downstream Responses SSE normalization and WebSocket relay.
+- API-key self-usage and its configured limits keep their existing semantics.

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/specs/api-keys/spec.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/specs/api-keys/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: API-key quota privacy covers native Codex stream events
+
+When `hide_upstream_quota_from_api_keys` is enabled, API-key-authenticated
+Responses SSE and WebSocket streams MUST omit upstream `codex.rate_limits`
+events, including model-specific families. Owner requests without API-key
+authentication MUST continue to receive pooled quota events when available.
+The API key's own self-usage endpoint and limits MUST remain unchanged.
+
+#### Scenario: Hidden headers cannot be bypassed through streaming metadata
+
+- **GIVEN** upstream quotas are hidden from API keys
+- **WHEN** upstream emits a quota event on a native Codex SSE or WebSocket stream
+- **THEN** the API-key client receives neither pooled quota headers nor upstream quota events
+- **AND** normal response events remain available

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/specs/responses-api-compat/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Native Codex stream quotas describe the pool
+
+Native Codex Responses SSE and WebSocket egress MUST NOT forward an account's
+raw `codex.rate_limits` payload. Default-family events MUST be rebuilt using
+the pooled downstream quota-header snapshot, including its normalized window
+durations, reset timestamps, and credits. HTTP SSE MUST use its response's
+quota-header snapshot; WebSocket egress MUST use the existing aggregate cache.
+Source-routed SSE MUST follow the same rule. The service MUST suppress quota
+events when no aggregate window is available and MUST NOT substitute a global
+aggregate for model-specific or otherwise unrepresented limit families.
+Projection MUST happen after original upstream usage ingestion and MUST NOT
+change normal response lifecycle events or account attribution. Failure to
+read quota metadata on an established WebSocket MUST suppress the quota event
+without interrupting inference; cancellation MUST still propagate.
+
+#### Scenario: A nearly exhausted account serves a pool with capacity
+
+- **GIVEN** the selected account reports 97% weekly usage and pooled downstream headers report 66.5%
+- **WHEN** native Codex receives the Responses stream
+- **THEN** its default quota event reports 66.5% weekly usage and the pooled reset timestamp
+- **AND** the event contains no account-specific plan, credits, or quota metadata
+
+#### Scenario: Unrepresented quota events cannot overwrite the pool
+
+- **WHEN** an upstream quota event belongs to a model-specific family or no pooled window is known
+- **THEN** the downstream stream omits that quota event
+- **AND** response deltas and terminal events remain deliverable
+
+#### Scenario: A quota cache read fails on an established WebSocket
+
+- **WHEN** pooled quota metadata cannot be loaded while handling a quota event
+- **THEN** the event is omitted without forwarding account-specific values
+- **AND** the next response event can still be delivered
+
+## MODIFIED Requirements
+
+### Requirement: Public /v1 responses SSE stream emits only OpenAI Responses contract events
+
+When serving streaming `POST /v1/responses`, the service MUST forward a
+string-valued event type only when it is exactly `error` or begins with
+`response.`. Other string-valued event types MUST be dropped before they reach
+the public stream. OpenAI-shaped backend requests with public contract
+enforcement enabled MUST follow the same filtering rule. Native Codex requests
+with public contract enforcement disabled MUST retain upstream vendor events,
+except `codex.rate_limits`, which MUST follow the pooled quota projection and
+API-key quota privacy requirements.
+
+#### Scenario: Codex-internal rate-limit event is dropped before response.created
+
+- **WHEN** upstream emits `codex.rate_limits` before `response.created` for a streaming `/v1/responses` request
+- **THEN** the public stream MUST NOT contain `codex.rate_limits`
+- **AND** its first event MUST be `response.created`
+
+#### Scenario: Timing diagnostics are filtered without losing text or completion
+
+- **WHEN** upstream emits `responsesapi.websocket_timing` before, between, or after standard response events
+- **THEN** a public-contract stream MUST NOT contain that diagnostic
+- **AND** standard text deltas and completion events MUST remain in order
+
+#### Scenario: OpenAI-shaped backend request filters vendor events
+
+- **WHEN** an OpenAI-shaped `/backend-api/codex/responses` request enables public contract enforcement
+- **THEN** its response stream MUST apply the public event-family filtering rule
+
+#### Scenario: Codex-internal events on the Codex CLI route are preserved
+
+- **WHEN** a native `/backend-api/codex/responses` request disables public contract enforcement
+- **THEN** the response stream MUST retain `responsesapi.websocket_timing` in upstream order
+- **AND** default `codex.rate_limits` events MUST contain the visible pooled quota snapshot or be omitted when no snapshot is available

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/tasks.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [x] 1.1 Share the client quota-header visibility policy across HTTP and WebSocket paths.
+- [x] 1.2 Project native Codex rate-limit events from pooled headers and suppress unrepresented quotas.
+- [x] 1.3 Apply projection after upstream ingestion on SSE, HTTP bridge, source SSE, and direct WebSocket egress.
+
+## 2. Verification
+
+- [x] 2.1 Cover divergent account/pool usage, hidden quotas, unknown/model-specific quotas, and cache failures.
+- [x] 2.2 Verify response lifecycle, account usage ingestion, and source/bridge behavior remain intact.
+- [x] 2.3 Run focused regression suites, lint, type and architecture checks, and strict OpenSpec validation.
+- [x] 2.4 Sync the specs and archive the verified change.

--- a/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/verification.md
+++ b/openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/verification.md
@@ -1,0 +1,23 @@
+Validated against base `0f6a31c56` using Python 3.14.6.
+
+- Responses regression suites: 293 passed (normalization, native/public HTTP,
+  source forwarding, keepalives, and stream ownership).
+- Quota/privacy and ingestion suites: 67 passed; four existing PostgreSQL-only
+  transaction/row-lock tests skipped in the isolated SQLite environment.
+- Additional transport and projection checks: 20 passed, including unit tests
+  also present in the Responses regression run.
+- Full repository Ruff lint, formatting, and `ty check`: passed.
+- Proxy architecture, cancellation safety, timing seams, and settings-tier
+  checks: passed.
+- Strict OpenSpec validation: all 65 capability specs and this change passed.
+
+New external-path tests cover HTTP direct and HTTP-to-WebSocket bridge routes,
+canonical and trailing-slash HTTP URLs, both WebSocket Responses URLs, real
+API-key privacy settings, real two-account aggregation, unknown quota families,
+original bridge ingestion attribution, and quota-cache read failures while
+normal completion remains deliverable. Unit tests also cover cancellation,
+owner visibility, malformed/unknown metadata, and split source SSE frames.
+
+Production settings and deployment have not been changed. With upstream quota
+privacy enabled, deployment will suppress account quota events; publishing
+pool percentages still requires the existing visibility setting to allow them.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -1943,3 +1943,17 @@ The database SHALL provide an index that supports filtering request logs by API 
 - **THEN** the `request_logs` table includes an index whose leading key columns are `api_key_id` and descending `requested_at`
 - **AND** the 7-day account-cost breakdown query for an API key is satisfiable by that index for its filter phase
 
+### Requirement: API-key quota privacy covers native Codex stream events
+
+When `hide_upstream_quota_from_api_keys` is enabled, API-key-authenticated
+Responses SSE and WebSocket streams MUST omit upstream `codex.rate_limits`
+events, including model-specific families. Owner requests without API-key
+authentication MUST continue to receive pooled quota events when available.
+The API key's own self-usage endpoint and limits MUST remain unchanged.
+
+#### Scenario: Hidden headers cannot be bypassed through streaming metadata
+
+- **GIVEN** upstream quotas are hidden from API keys
+- **WHEN** upstream emits a quota event on a native Codex SSE or WebSocket stream
+- **THEN** the API-key client receives neither pooled quota headers nor upstream quota events
+- **AND** normal response events remain available

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -297,3 +297,23 @@ stream. Predispatch failures and cancellation release origin-owned reservations;
 accepted or delivery-ambiguous owner forwards retain their settlement owner.
 Context bindings do not span yields because startup probes and consumers may
 advance the stream from different tasks.
+
+## Native Codex quota display
+
+Codex turns default `codex.rate_limits` stream events into usage warnings and
+status percentages. An account-specific event could therefore overwrite the
+LB's pooled headers: for example, an account at 97% used displayed 3% left
+while the pool at 66.5% used still had 33.5% left.
+
+Downstream native Responses streams now project the default event from pooled
+quota headers. HTTP uses the response-header snapshot; WebSockets use the
+existing quota cache on each quota event. Original upstream usage ingestion
+keeps its account attribution. No upstream refresh runs on the display path.
+
+When `hide_upstream_quota_from_api_keys` is enabled, quota events are omitted
+for API-key callers, just like quota headers. Publishing pool percentages
+requires the existing visibility setting to allow them. The Codex usage API
+still describes an API key's own configured budget. Unknown or model-specific
+quota families are omitted because global pool usage does not describe them.
+If the WebSocket quota lookup fails, quota telemetry is omitted and inference
+continues; cancellation still propagates.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1276,7 +1276,9 @@ string-valued event type only when it is exactly `error` or begins with
 `response.`. Other string-valued event types MUST be dropped before they reach
 the public stream. OpenAI-shaped backend requests with public contract
 enforcement enabled MUST follow the same filtering rule. Native Codex requests
-with public contract enforcement disabled MUST retain upstream vendor events.
+with public contract enforcement disabled MUST retain upstream vendor events,
+except `codex.rate_limits`, which MUST follow the pooled quota projection and
+API-key quota privacy requirements.
 
 #### Scenario: Codex-internal rate-limit event is dropped before response.created
 
@@ -1298,7 +1300,8 @@ with public contract enforcement disabled MUST retain upstream vendor events.
 #### Scenario: Codex-internal events on the Codex CLI route are preserved
 
 - **WHEN** a native `/backend-api/codex/responses` request disables public contract enforcement
-- **THEN** the response stream MUST retain `codex.rate_limits` and `responsesapi.websocket_timing` in upstream order
+- **THEN** the response stream MUST retain `responsesapi.websocket_timing` in upstream order
+- **AND** default `codex.rate_limits` events MUST contain the visible pooled quota snapshot or be omitted when no snapshot is available
 
 ### Requirement: Streamed /v1 responses terminal output is backfilled from item events
 When serving streaming `POST /v1/responses`, if the upstream's terminal `response.completed` or `response.incomplete` event carries `output` as missing or as an empty list, the service MUST reconstruct `output` from the `response.output_item.done` events emitted earlier in the same stream before yielding the terminal SSE event. The reconstructed `output` MUST preserve the `output_index` ordering and the raw item payloads. When the terminal `response.completed` / `response.incomplete` already carries a non-empty `output`, the service MUST forward it unchanged.
@@ -10831,3 +10834,36 @@ still awaiting I/O.
 - **THEN** the key is quarantined and the probe is planned without the dead anchor
 - **AND** the probe resends full history rather than the dead anchor
 
+### Requirement: Native Codex stream quotas describe the pool
+
+Native Codex Responses SSE and WebSocket egress MUST NOT forward an account's
+raw `codex.rate_limits` payload. Default-family events MUST be rebuilt using
+the pooled downstream quota-header snapshot, including its normalized window
+durations, reset timestamps, and credits. HTTP SSE MUST use its response's
+quota-header snapshot; WebSocket egress MUST use the existing aggregate cache.
+Source-routed SSE MUST follow the same rule. The service MUST suppress quota
+events when no aggregate window is available and MUST NOT substitute a global
+aggregate for model-specific or otherwise unrepresented limit families.
+Projection MUST happen after original upstream usage ingestion and MUST NOT
+change normal response lifecycle events or account attribution. Failure to
+read quota metadata on an established WebSocket MUST suppress the quota event
+without interrupting inference; cancellation MUST still propagate.
+
+#### Scenario: A nearly exhausted account serves a pool with capacity
+
+- **GIVEN** the selected account reports 97% weekly usage and pooled downstream headers report 66.5%
+- **WHEN** native Codex receives the Responses stream
+- **THEN** its default quota event reports 66.5% weekly usage and the pooled reset timestamp
+- **AND** the event contains no account-specific plan, credits, or quota metadata
+
+#### Scenario: Unrepresented quota events cannot overwrite the pool
+
+- **WHEN** an upstream quota event belongs to a model-specific family or no pooled window is known
+- **THEN** the downstream stream omits that quota event
+- **AND** response deltas and terminal events remain deliverable
+
+#### Scenario: A quota cache read fails on an established WebSocket
+
+- **WHEN** pooled quota metadata cannot be loaded while handling a quota event
+- **THEN** the event is omitted without forwarding account-specific values
+- **AND** the next response event can still be delivered

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3267,7 +3267,7 @@ async def test_wrap_source_responses_native_codex_preserves_codex_events_and_kee
     release_upstream.set()
     remaining = [chunk async for chunk in iterator]
     joined = "".join(remaining)
-    assert "codex.rate_limits" in joined
+    assert "codex.rate_limits" not in joined
     assert "response.created" not in joined
     assert "resp_codex_src" in joined
 
@@ -3665,7 +3665,7 @@ async def test_backend_desktop_openai_shape_preserves_native_event_order(
     )
 
     event_types = [event.get("type") for event in _sse_data_events(lines)]
-    assert event_types[0] == "codex.rate_limits"
+    assert "codex.rate_limits" not in event_types
     assert "codex.keepalive" not in event_types
     assert "response.created" not in event_types
     assert "response.completed" in event_types

--- a/tests/integration/test_proxy_rate_limit_events.py
+++ b/tests/integration/test_proxy_rate_limit_events.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+import app.modules.proxy.api as proxy_api
+import app.modules.proxy.service as proxy_service
+from app.core.clients.proxy_websocket import UpstreamWebSocketMessage
+from app.core.config.dashboard_overrides import with_dashboard_overrides
+from app.core.crypto import TokenEncryptor
+from app.core.usage.live_hub import register_live_usage_publisher
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.db.session import SessionLocal
+from app.dependencies import get_proxy_service_for_app
+from app.modules.proxy.load_balancer import AccountSelection
+
+pytestmark = pytest.mark.integration
+
+
+@dataclass
+class QuotaPool:
+    account: Account
+    key: str
+    reset_at: int
+
+
+@pytest_asyncio.fixture
+async def quota_pool(async_client):
+    now = utcnow()
+    reset_at = int((now + timedelta(days=3)).timestamp())
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        accounts = []
+        for index, used in enumerate((97, 36)):
+            account = Account(
+                id=f"quota-pool-{index}",
+                chatgpt_account_id=f"upstream-quota-{index}",
+                email=f"quota-{index}@example.com",
+                plan_type="pro",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=now,
+                status=AccountStatus.ACTIVE,
+            )
+            session.add(account)
+            accounts.append(account)
+            session.add(
+                UsageHistory(
+                    account_id=account.id,
+                    recorded_at=now,
+                    window="primary",
+                    used_percent=used,
+                    window_minutes=10080,
+                    reset_at=reset_at + index * 3600,
+                    credits_has=False,
+                    credits_unlimited=False,
+                    credits_balance=0,
+                )
+            )
+        await session.commit()
+        for account in accounts:
+            session.expunge(account)
+    response = await async_client.post("/api/api-keys", json={"name": "pool-quota-test"})
+    assert response.status_code == 200, response.text
+    return QuotaPool(accounts[0], response.json()["key"], reset_at)
+
+
+def _upstream_events():
+    quota = {
+        "type": "codex.rate_limits",
+        "plan_type": "pro",
+        "account_id": "must-not-leak",
+        "rate_limits": {"primary": {"used_percent": 97, "window_minutes": 10080, "reset_at": 1900000000}},
+        "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+    }
+    return [
+        quota,
+        {**quota, "metered_limit_name": "codex_other"},
+        {"type": "response.created", "response": {"id": "resp_quota", "status": "in_progress"}},
+        {"type": "response.output_text.delta", "response_id": "resp_quota", "delta": "OK"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_quota",
+                "status": "completed",
+                "output": [],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            },
+        },
+    ]
+
+
+class QuotaUpstream:
+    def __init__(self):
+        self.messages = asyncio.Queue()
+        self.closed = False
+
+    async def send_text(self, text):
+        for event in _upstream_events():
+            self.messages.put_nowait(UpstreamWebSocketMessage(kind="text", text=json.dumps(event)))
+
+    async def receive(self):
+        return await self.messages.get()
+
+    async def close(self):
+        self.closed = True
+
+
+def _assert_downstream(events, *, hidden, reset_at):
+    quotas = [event for event in events if event["type"] == "codex.rate_limits"]
+    if hidden:
+        assert quotas == []
+    else:
+        assert len(quotas) == 1
+        assert quotas[0]["rate_limits"] == {
+            "primary": None,
+            "secondary": {"used_percent": 66.5, "window_minutes": 10080, "reset_at": reset_at},
+        }
+        assert "plan_type" not in quotas[0]
+        assert "account_id" not in quotas[0]
+    assert [event["type"] for event in events if event["type"] != "codex.rate_limits"] == [
+        "response.created",
+        "response.output_text.delta",
+        "response.completed",
+    ]
+    assert next(event for event in events if event["type"] == "response.output_text.delta")["delta"] == "OK"
+
+
+@pytest.mark.parametrize("transport", ["http", "bridge"])
+@pytest.mark.parametrize("hidden", [False, True])
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses", "/backend-api/codex/responses/"])
+async def test_native_sse_projects_pool_and_honors_privacy(
+    async_client,
+    app_instance,
+    monkeypatch,
+    quota_pool,
+    transport,
+    hidden,
+    path,
+):
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "hideUpstreamQuotaFromApiKeys": hidden,
+            "apiKeyAuthEnabled": True,
+            "httpDownstreamTransportPolicy": "always_websocket" if transport == "bridge" else "always_http",
+        },
+    )
+    assert settings.status_code == 200, settings.text
+    app_settings = proxy_api.get_settings().model_copy(
+        update={"http_responses_session_bridge_enabled": transport == "bridge"}
+    )
+    monkeypatch.setattr(proxy_api, "get_settings", lambda: with_dashboard_overrides(app_settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: with_dashboard_overrides(app_settings))
+    upstream = QuotaUpstream()
+    ingested = []
+    register_live_usage_publisher(lambda snapshot, **identity: ingested.append((snapshot, identity)))
+
+    async def select_account(self, *args, **kwargs):
+        return AccountSelection(account=quota_pool.account, error_message=None, error_code=None)
+
+    async def fresh(self, account, **kwargs):
+        return account
+
+    async def connect(*args, **kwargs):
+        assert transport == "bridge"
+        return upstream
+
+    async def stream(*args, **kwargs):
+        assert transport == "http"
+        for event in _upstream_events():
+            yield "data: " + json.dumps(event) + "\n\n"
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_select_account_with_budget", select_account)
+    monkeypatch.setattr(proxy_service.ProxyService, "_ensure_fresh_with_budget", fresh)
+    monkeypatch.setattr(proxy_service, "connect_responses_websocket", connect)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", stream)
+    service = get_proxy_service_for_app(app_instance)
+    try:
+        response = await async_client.post(
+            path,
+            headers={
+                "Authorization": f"Bearer {quota_pool.key}",
+                "user-agent": "codex-cli/0.154.0",
+            },
+            json={"model": "gpt-5.6-sol", "instructions": "", "input": "hi", "stream": True},
+        )
+        assert response.status_code == 200, response.text
+        events = [
+            json.loads(line[6:])
+            for line in response.text.splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        events = [event for event in events if event["type"] != "codex.keepalive"]
+        _assert_downstream(events, hidden=hidden, reset_at=quota_pool.reset_at)
+        if hidden:
+            assert not any(name.startswith("x-codex-secondary-") for name in response.headers)
+        else:
+            assert float(response.headers["x-codex-secondary-used-percent"]) == 66.5
+        if transport == "bridge":
+            assert any(
+                snapshot.primary.used_percent == 97 and identity["account_id"] == quota_pool.account.id
+                for snapshot, identity in ingested
+            )
+        async with SessionLocal() as session:
+            usage = (
+                (await session.execute(select(UsageHistory).where(UsageHistory.account_id == quota_pool.account.id)))
+                .scalars()
+                .all()
+            )
+            assert all(row.used_percent == 97 for row in usage)
+    finally:
+        register_live_usage_publisher(None)
+        for session in list(service._http_bridge_sessions.values()):
+            await service._close_http_bridge_session(session)
+
+
+@pytest.mark.parametrize("path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.parametrize("mode", ["visible", "hidden", "unavailable"])
+async def test_websocket_projects_pool_without_interrupting_responses(
+    async_client,
+    app_instance,
+    monkeypatch,
+    quota_pool,
+    path,
+    mode,
+):
+    settings = await async_client.put(
+        "/api/settings", json={"hideUpstreamQuotaFromApiKeys": mode == "hidden", "apiKeyAuthEnabled": True}
+    )
+    assert settings.status_code == 200, settings.text
+    upstream = QuotaUpstream()
+
+    async def connect(self, *args, **kwargs):
+        return quota_pool.account, upstream
+
+    async def unavailable(self):
+        raise RuntimeError("quota cache unavailable")
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", connect)
+    if mode == "unavailable":
+        monkeypatch.setattr(proxy_service.ProxyService, "rate_limit_headers", unavailable)
+
+    def run_client():
+        with TestClient(app_instance) as client:
+            with client.websocket_connect(path, headers={"Authorization": f"Bearer {quota_pool.key}"}) as socket:
+                socket.send_json({"type": "response.create", "model": "gpt-5.6-sol", "input": "hi"})
+                events = []
+                while not events or events[-1]["type"] != "response.completed":
+                    events.append(socket.receive_json())
+                return events
+
+    events = await asyncio.to_thread(run_client)
+    _assert_downstream(events, hidden=mode != "visible", reset_at=quota_pool.reset_at)

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -1195,7 +1195,6 @@ async def test_responses_routes_filter_vendor_events_only_for_public_contract(as
     event_types = [event["type"] for event in events]
     if native:
         assert event_types == [
-            "codex.rate_limits",
             "response.created",
             "response.output_text.delta",
             "responsesapi.websocket_timing",
@@ -1315,7 +1314,8 @@ async def test_proxy_responses_native_string_input_with_instructions_preserves_v
         lines = [line async for line in resp.aiter_lines() if line]
 
     event_types = [event["type"] for event in _iter_sse_events(lines)]
-    assert event_types[0] == "codex.rate_limits"
+    assert "codex.rate_limits" not in event_types
+    assert event_types[0] == "response.completed"
     assert "response.created" not in event_types
     assert "response.completed" in event_types
 
@@ -1355,7 +1355,8 @@ async def test_proxy_responses_native_conversation_preserves_vendor_events(async
         lines = [line async for line in resp.aiter_lines() if line]
 
     event_types = [event["type"] for event in _iter_sse_events(lines)]
-    assert event_types[0] == "codex.rate_limits"
+    assert "codex.rate_limits" not in event_types
+    assert event_types[0] == "response.completed"
     assert "response.created" not in event_types
     assert "response.completed" in event_types
 
@@ -1395,7 +1396,8 @@ async def test_proxy_responses_native_openai_routing_headers_preserve_vendor_eve
         lines = [line async for line in resp.aiter_lines() if line]
 
     event_types = [event["type"] for event in _iter_sse_events(lines)]
-    assert event_types[0] == "codex.rate_limits"
+    assert "codex.rate_limits" not in event_types
+    assert event_types[0] == "response.completed"
     assert "response.created" not in event_types
     assert "response.completed" in event_types
 
@@ -1434,7 +1436,8 @@ async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_
         lines = [line async for line in resp.aiter_lines() if line]
 
     event_types = [event["type"] for event in _iter_sse_events(lines)]
-    assert event_types[0] == "codex.rate_limits"
+    assert "codex.rate_limits" not in event_types
+    assert event_types[0] == "response.completed"
     assert "response.created" not in event_types
     assert "response.completed" in event_types
 

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1726,11 +1726,8 @@ async def test_normalize_public_responses_stream_does_not_double_emit_response_c
 
 
 @pytest.mark.asyncio
-async def test_normalize_public_responses_stream_codex_route_preserves_codex_events() -> None:
-    """`enforce_openai_sdk_contract=False` (used by /backend-api/codex/*) MUST
-    forward `codex.*` vendor events verbatim, MUST NOT backfill terminal
-    output, and MUST NOT synthesize a leading `response.created`. The Codex
-    CLI consumes the upstream stream natively."""
+async def test_normalize_public_responses_stream_codex_route_omits_unknown_quota_without_synthesis() -> None:
+    """Unknown pool quotas are omitted without changing native failures."""
     blocks = [
         block
         async for block in proxy_api_module._normalize_public_responses_stream(
@@ -1748,12 +1745,12 @@ async def test_normalize_public_responses_stream_codex_route_preserves_codex_eve
 
     payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
     event_types = [p["type"] for p in payloads if p is not None]
-    # codex.rate_limits MUST be preserved
-    assert "codex.rate_limits" in event_types
+    # No aggregate is available to publish.
+    assert "codex.rate_limits" not in event_types
     # response.created MUST NOT be synthesized
     assert "response.created" not in event_types
     # Original sequence order preserved
-    assert event_types == ["codex.rate_limits", "response.failed"]
+    assert event_types == ["response.failed"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_rate_limit_events.py
+++ b/tests/unit/test_proxy_rate_limit_events.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from collections import deque
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from app.db.models import Account
+from app.modules.proxy import api as proxy_api
+from app.modules.proxy import rate_limit_events
+from app.modules.proxy._service.support import _DownstreamWebSocketActivity, _WebSocketUpstreamControl
+from app.modules.proxy._service.websocket.mixin import _process_and_forward_upstream_websocket_text
+from app.modules.proxy.rate_limit_events import project_codex_rate_limit_event
+
+pytestmark = pytest.mark.unit
+
+
+def test_rate_limit_event_replaces_all_account_metadata_with_pool_snapshot():
+    upstream = {
+        "type": "codex.rate_limits",
+        "plan_type": "pro",
+        "rate_limits": {
+            "primary": {"used_percent": 97, "window_minutes": 10080, "reset_at": 1900000000},
+            "allowed": False,
+        },
+        "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+        "account_id": "upstream-account",
+    }
+    original = copy.deepcopy(upstream)
+    event = project_codex_rate_limit_event(
+        upstream,
+        {
+            "x-codex-secondary-used-percent": "66.5",
+            "x-codex-secondary-window-minutes": "10080",
+            "x-codex-secondary-reset-at": "1800000000",
+            "x-codex-credits-has-credits": "true",
+            "x-codex-credits-unlimited": "false",
+            "x-codex-credits-balance": "15.25",
+        },
+    )
+    assert event == {
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "primary": None,
+            "secondary": {"used_percent": 66.5, "window_minutes": 10080, "reset_at": 1800000000},
+        },
+        "credits": {"has_credits": True, "unlimited": False, "balance": "15.25"},
+    }
+    assert upstream == original
+
+
+@pytest.mark.parametrize("headers", [{}, {"x-codex-primary-used-percent": "NaN"}])
+def test_unknown_pool_does_not_leak_account_usage(headers):
+    assert project_codex_rate_limit_event({"type": "codex.rate_limits"}, headers) is None
+
+
+@pytest.mark.parametrize("discriminator", ["limit_id", "metered_limit_name", "limit_name"])
+def test_model_specific_quota_is_not_relabelled_as_global_usage(discriminator):
+    assert (
+        project_codex_rate_limit_event(
+            {"type": "codex.rate_limits", discriminator: "codex_other"},
+            {"x-codex-primary-used-percent": "66.5", "x-codex-primary-window-minutes": "300"},
+        )
+        is None
+    )
+
+
+def test_reset_windows_do_not_reuse_upstream_reset_or_credits():
+    event = project_codex_rate_limit_event(
+        {"type": "codex.rate_limits", "credits": {"balance": "999"}},
+        {"x-codex-primary-used-percent": "0", "x-codex-primary-window-minutes": "300"},
+    )
+    assert event == {
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "primary": {"used_percent": 0.0, "window_minutes": 300, "reset_at": None},
+            "secondary": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("visible", [False, True])
+async def test_source_sse_projects_split_quota_events_and_preserves_terminal(visible):
+    raw = (
+        b'event: codex.rate_limits\r\ndata: {"type":"codex.rate_limits","plan_type":"pro",'
+        b'"rate_limits":{"primary":{"used_percent":97,"window_minutes":10080}}}\r\n\r\n'
+        b'data: {"type":"response.completed","response":{"id":"resp_source","output":[]}}\n\n'
+    )
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            yield raw[:61]
+            yield raw[61:]
+        finally:
+            closed = True
+
+    chunks = [
+        chunk
+        async for chunk in proxy_api._wrap_source_responses_public_stream(
+            source(),
+            enforce_openai_sdk_contract=False,
+            codex_rate_limit_headers={
+                "x-codex-secondary-used-percent": "66.5",
+                "x-codex-secondary-window-minutes": "10080",
+            }
+            if visible
+            else {},
+        )
+    ]
+    events = [proxy_api._parse_sse_payload(chunk) for chunk in chunks]
+    events = [event for event in events if event and event["type"] != "codex.keepalive"]
+    assert events[-1]["type"] == "response.completed"
+    assert "plan_type" not in "".join(chunks)
+    assert "97" not in "".join(chunks)
+    assert closed
+    if visible:
+        assert len(events) == 2
+        assert events[0]["rate_limits"] == {
+            "primary": None,
+            "secondary": {"used_percent": 66.5, "window_minutes": 10080, "reset_at": None},
+        }
+    else:
+        assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_websocket_quota_projection_does_not_swallow_cancellation():
+    text = json.dumps({"type": "codex.rate_limits", "rate_limits": {}})
+    proxy = SimpleNamespace(
+        _process_upstream_websocket_text=AsyncMock(return_value=text),
+        rate_limit_headers=AsyncMock(side_effect=asyncio.CancelledError),
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await _process_and_forward_upstream_websocket_text(
+            proxy,
+            cast(Any, SimpleNamespace()),
+            cast(Any, SimpleNamespace()),
+            message=SimpleNamespace(kind="text", text=text),
+            text=text,
+            account=Account(id="quota-account"),
+            account_id_value="quota-account",
+            pending_requests=deque(),
+            pending_lock=anyio.Lock(),
+            client_send_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=_WebSocketUpstreamControl(),
+            response_create_gate=asyncio.Semaphore(1),
+            downstream_activity=_DownstreamWebSocketActivity(),
+            continuity_state=None,
+            codex_session_affinity=False,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("hidden", "is_api_key"), [(True, True), (True, False), (False, True)])
+async def test_quota_visibility_hides_key_metadata_but_preserves_owner_access(monkeypatch, hidden, is_api_key):
+    settings = AsyncMock(return_value=SimpleNamespace(hide_upstream_quota_from_api_keys=hidden))
+    monkeypatch.setattr(rate_limit_events, "get_settings_cache", lambda: SimpleNamespace(get=settings))
+    pooled = {"x-codex-secondary-used-percent": "66.5"}
+    load = AsyncMock(return_value=pooled)
+    headers = await rate_limit_events.rate_limit_headers_for_client(cast(Any, object()) if is_api_key else None, load)
+    if hidden and is_api_key:
+        assert headers == {}
+        load.assert_not_awaited()
+    else:
+        assert headers == pooled
+        load.assert_awaited_once()
+    if not is_api_key:
+        settings.assert_not_awaited()


### PR DESCRIPTION
## Summary

Codex CLI can warn that less than 25% of its weekly quota remains when the selected account is nearly exhausted but the pool still has capacity. Native SSE and WebSocket streams currently forward that account's `codex.rate_limits` event, including when API-key quota privacy hides the HTTP headers.

Rebuild these events from the visible pooled quota snapshot so stream-driven warnings and status use the same quota scope as downstream headers.

## Type of change

- [x] `fix:` — bug fix

## OpenSpec

- [x] Includes an OpenSpec change, verified, synced, and archived.

Change: [project-pooled-codex-rate-limits](openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/).

Intentional upstream divergence: account-specific `codex.rate_limits` events are projected or omitted, as recorded in [Native Codex stream quotas describe the pool](openspec/specs/responses-api-compat/spec.md#requirement-native-codex-stream-quotas-describe-the-pool). Other native response events retain their existing behavior.

## Changes

- Share the existing quota visibility policy across HTTP, source SSE, HTTP-to-WebSocket bridges, and direct WebSockets.
- Build fresh quota events from pooled windows, resets, and credits; retain original account telemetry for ingestion and attribution.
- Omit events when quota privacy is enabled, no pooled window is known, or the limit family is unrepresented. WebSocket quota-cache failures omit telemetry without interrupting inference; cancellation still propagates.
- Keep public SSE filtering and `/api/codex/usage` API-key budget semantics unchanged. No new configuration or default changes.

With `hide_upstream_quota_from_api_keys=true`, this suppresses account warnings; showing pooled percentages requires the existing visibility setting to allow them.

## Test plan

```text
make lint typecheck
  Architecture, cancellation, timing, settings tiers, Ruff, formatting, ty: passed
openspec validate --specs --strict
  65 capability specs passed; change also passed strict validation before archival
```

Isolated pytest runs covered:

- Responses normalization and API regression suites: 293 passed.
- Quota/privacy, API-key usage, and raw ingestion suites: 67 passed, 4 existing PostgreSQL-only transaction/row-lock tests skipped under SQLite.
- Additional transport and projection checks: 20 passed (includes unit tests from the first run).

New tests exercise real two-account aggregation and API-key privacy, direct/bridged HTTP including trailing slashes, both WebSocket routes, split source SSE, unknown quota families, cache failure, and cancellation. [Verification details](openspec/changes/archive/2026-09-10-project-pooled-codex-rate-limits/verification.md).

## Example output

For native `POST /backend-api/codex/responses`, two equal-capacity Pro accounts with 97% and 36% weekly usage produce 66.5% pooled usage. Previously the selected account's 97% triggered the low-quota warning. With quota visibility enabled, the downstream event instead contains the pooled value (illustrative snapshot without a known reset):

```text
data: {"type":"codex.rate_limits","rate_limits":{"primary":null,"secondary":{"used_percent":66.5,"window_minutes":10080,"reset_at":null}}}
```

With privacy enabled, the quota event is omitted while response deltas and completion continue.

## Checklist

- [x] Conventional Commits title.
- [x] Tests added and existing expectations updated.
- [x] Relevant `make` targets and focused regression suites passed locally.
- [x] Strict OpenSpec validation passed and implementation verified against the archived change.
- [x] Simplicity gates reviewed; no new setup, settings, or dashboard surface.
- [x] CHANGELOG not edited by hand.
