### PR TITLE
fix(proxy): bound aggregate detached retirement lock waits

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -2849,12 +2849,18 @@ async def _release_http_bridge_unanchored_handoffs_for_request(
         # sweep runs. Reconsider every detached generation so marker ordering
         # cannot leave a fully drained predecessor owning a socket and cap slot.
         detached_sessions = tuple(service._http_bridge_detached_sessions.values())
-    for session in detached_sessions:
-        # Bounded: this sweep is on every request's path, so one detached
-        # session whose lock stays busy (or wedged) must not stall the fleet.
+    deadline = clock_for(service).monotonic() + _HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS
+    for index, session in enumerate(detached_sessions):
+        remaining = deadline - clock_for(service).monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "Detached HTTP bridge retire sweep deadline exhausted: skipped_sessions=%d",
+                len(detached_sessions) - index,
+            )
+            break
         await service._retire_http_bridge_after_drain_if_ready(
             session,
-            lock_wait_timeout_seconds=_HTTP_BRIDGE_DETACHED_RETIRE_LOCK_WAIT_SECONDS,
+            lock_wait_timeout_seconds=remaining,
         )
 
 

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/design.md
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/design.md
@@ -1,0 +1,17 @@
+## Context
+
+The maintainer confirmed #2149 on main. The request-finalization sweep grants each detached session a fresh five-second lock wait. ERR #1905 owns separate admission guards and has cleared this scope.
+
+## Goals / Non-Goals
+
+Bound aggregate lock waiting during request finalization. Preserve handoff release, session tracking, cancellation and lifecycle cleanup. Socket-close completion and registry-lock waiting retain their existing contracts.
+
+## Decisions
+
+Use the service's monotonic clock and one deadline before the detached-session loop. Each attempt receives the remaining time; stop with a skipped-count warning when none remains. This avoids cancelling a retirement owner midway through resource cleanup. Keep the existing retirement interface and sequential order.
+
+The accepted #2149 helper regression seam proves exact virtual elapsed time and deferred cleanup. The public response stream proves finalization uses that deadline during completion and cancellation.
+
+## Risks / Trade-offs
+
+A busy first session can defer later ready sessions. They remain tracked for later sweeps and lifecycle owners. Existing bounded socket-close work may outlast the lock-wait budget; this change does not impose cancellation on resource owners.

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/proposal.md
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #2149 identifies request finalization waiting up to five seconds for each detached session lock. Several busy sessions multiply that delay.
+
+## What Changes
+
+- Give each request's detached retirement sweep one five-second monotonic deadline.
+- Pass only remaining time to each lock wait and stop starting attempts after expiry.
+- Retain deferred sessions for existing lifecycle cleanup and report the skipped count.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: bound detached retirement lock waits across the sweep.
+
+## Impact
+
+HTTP bridge request finalization, its regression tests, and the owning spec. No configuration or dependency changes.

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/specs/responses-api-compat/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Per-request detached-session retire sweep bounds its lock wait
+
+The fail-safe sweep that reconsiders detached HTTP-bridge generations on every bridge request MUST use one five-second monotonic deadline for its aggregate detached-session lock waits. Each retirement attempt MUST receive only the remaining time. Once the deadline expires, the sweep MUST stop starting attempts and emit one warning naming the number of unattempted sessions, if any. Timed-out and unattempted sessions MUST remain tracked with their lock state untouched for later sweeps and lifecycle cleanup. Session lifecycle owners (drain, close, cooldown-suppression retirement) MUST keep waiting for the lock without a bound so retirement decisions stay authoritative. Request cancellation MUST NOT bypass the shielded finalization sweep or transfer resource cleanup ownership.
+
+#### Scenario: Busy detached lock does not park the request path
+
+- **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is held by another task for longer than the bound
+- **WHEN** a request runs the fail-safe sweep
+- **THEN** the sweep returns after the bound without closing the session
+- **AND** a warning names the skipped session
+- **AND** the lock remains owned by its holder with no stranded waiter
+
+#### Scenario: Free detached lock still retires
+
+- **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is free and which no turn owns
+- **WHEN** a request runs the fail-safe sweep
+- **THEN** the session is retired exactly as before
+
+#### Scenario: Lifecycle owners keep the unbounded wait
+
+- **GIVEN** a drain or close path calls the retire check without a bound while another task briefly holds the lock
+- **WHEN** the holder releases
+- **THEN** the retire check proceeds and retires the session
+
+#### Scenario: Several busy sessions share one deadline
+
+- **GIVEN** three detached sessions and a five-second sweep budget
+- **WHEN** the first retirement attempt consumes three seconds and the second consumes its remaining two seconds
+- **THEN** no third attempt starts and aggregate lock waiting is five seconds
+- **AND** the deferred sessions remain tracked and a later sweep can retire them
+
+#### Scenario: Cancelled request finalization uses the same deadline
+
+- **WHEN** a bridge request is cancelled while several detached sessions have busy locks
+- **THEN** shielded finalization uses one aggregate lock-wait deadline before cancellation propagates
+- **AND** deferred sessions retain their existing cleanup owners

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/specs/responses-api-compat/spec.md
@@ -9,7 +9,8 @@ The fail-safe sweep that reconsiders detached HTTP-bridge generations on every b
 - **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is held by another task for longer than the bound
 - **WHEN** a request runs the fail-safe sweep
 - **THEN** the sweep returns after the bound without closing the session
-- **AND** a warning names the skipped session
+- **AND** if sessions remain unattempted when the deadline expires, one warning reports their count
+- **AND** the timed-out session remains tracked for later sweeps and lifecycle cleanup
 - **AND** the lock remains owned by its holder with no stranded waiter
 
 #### Scenario: Free detached lock still retires

--- a/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/tasks.md
+++ b/openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/tasks.md
@@ -1,0 +1,10 @@
+## 1. Regression and implementation
+
+- [x] 1.1 Reproduce aggregate waiting through the accepted sweep seam with virtual time.
+- [x] 1.2 Apply one deadline and preserve deferred session tracking.
+- [x] 1.3 Verify public stream finalization and cancellation with several busy sessions.
+
+## 2. Verification and delivery
+
+- [x] 2.1 Run focused lifecycle controls, lint and strict OpenSpec validation.
+- [x] 2.2 Review the candidate and sync the verified requirement into the main spec.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -297,3 +297,7 @@ stream. Predispatch failures and cancellation release origin-owned reservations;
 accepted or delivery-ambiguous owner forwards retain their settlement owner.
 Context bindings do not span yields because startup probes and consumers may
 advance the stream from different tasks.
+
+## Detached retirement sweep deadline
+
+Issue #2149 bounds aggregate detached-session lock waiting during request finalization. A sweep shares five seconds: if its first attempt consumes three seconds, the next receives two, and later attempts stop at expiry. Deferred generations remain tracked for later requests and their lifecycle owners. The deadline does not cancel resource-close owners or replace their existing close timeout.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -9954,7 +9954,7 @@ rewritten payload.
 
 ### Requirement: Per-request detached-session retire sweep bounds its lock wait
 
-The fail-safe sweep that reconsiders detached HTTP-bridge generations on every bridge request MUST bound how long it waits for any single detached session's `pending_lock`. When the bound elapses the sweep MUST skip that session for the current pass, emit a warning, leave the session tracked and its lock state untouched, and continue. Session lifecycle owners (drain, close, cooldown-suppression retirement) MUST keep waiting for the lock without a bound so retirement decisions stay authoritative.
+The fail-safe sweep that reconsiders detached HTTP-bridge generations on every bridge request MUST use one five-second monotonic deadline for its aggregate detached-session lock waits. Each retirement attempt MUST receive only the remaining time. Once the deadline expires, the sweep MUST stop starting attempts and emit one warning naming the number of unattempted sessions, if any. Timed-out and unattempted sessions MUST remain tracked with their lock state untouched for later sweeps and lifecycle cleanup. Session lifecycle owners (drain, close, cooldown-suppression retirement) MUST keep waiting for the lock without a bound so retirement decisions stay authoritative. Request cancellation MUST NOT bypass the shielded finalization sweep or transfer resource cleanup ownership.
 
 #### Scenario: Busy detached lock does not park the request path
 
@@ -9975,6 +9975,19 @@ The fail-safe sweep that reconsiders detached HTTP-bridge generations on every b
 - **GIVEN** a drain or close path calls the retire check without a bound while another task briefly holds the lock
 - **WHEN** the holder releases
 - **THEN** the retire check proceeds and retires the session
+
+#### Scenario: Several busy sessions share one deadline
+
+- **GIVEN** three detached sessions and a five-second sweep budget
+- **WHEN** the first retirement attempt consumes three seconds and the second consumes its remaining two seconds
+- **THEN** no third attempt starts and aggregate lock waiting is five seconds
+- **AND** the deferred sessions remain tracked and a later sweep can retire them
+
+#### Scenario: Cancelled request finalization uses the same deadline
+
+- **WHEN** a bridge request is cancelled while several detached sessions have busy locks
+- **THEN** shielded finalization uses one aggregate lock-wait deadline before cancellation propagates
+- **AND** deferred sessions retain their existing cleanup owners
 
 ### Requirement: Cancelled streamed responses do not re-cancel deferred startup work every loop iteration
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -9961,7 +9961,8 @@ The fail-safe sweep that reconsiders detached HTTP-bridge generations on every b
 - **GIVEN** a detached session flagged `retire_after_drain` whose `pending_lock` is held by another task for longer than the bound
 - **WHEN** a request runs the fail-safe sweep
 - **THEN** the sweep returns after the bound without closing the session
-- **AND** a warning names the skipped session
+- **AND** if sessions remain unattempted when the deadline expires, one warning reports their count
+- **AND** the timed-out session remains tracked for later sweeps and lifecycle cleanup
 - **AND** the lock remains owned by its holder with no stranded waiter
 
 #### Scenario: Free detached lock still retires

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2529,7 +2529,7 @@ async def test_submit_http_bridge_request_keeps_reserved_detached_lane_after_rep
 async def test_release_handoffs_retires_ready_detached_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), clock=VirtualClock())
     session = _make_bridge_session(key_value="detached-released-handoff")
     session.unanchored_reservation_id = "scope-detached-release"
     session.upstream_control.reconnect_requested = True
@@ -2545,6 +2545,47 @@ async def test_release_handoffs_retires_ready_detached_generation(
 
     assert session.unanchored_reservation_id is None
     retire.assert_awaited_once_with(session, lock_wait_timeout_seconds=5.0)
+
+
+@pytest.mark.asyncio
+async def test_release_handoffs_shares_deadline_and_revisits_deferred_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    clock = VirtualClock()
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), clock=clock)
+    sessions = [_make_bridge_session(key_value=f"deadline-{index}") for index in range(3)]
+    for session in sessions:
+        session.unanchored_reservation_id = "deadline-scope"
+        service._http_bridge_detached_sessions[id(session)] = session
+    waits: list[float] = []
+
+    async def busy_retire(session: Any, *, lock_wait_timeout_seconds: float) -> bool:
+        waits.append(lock_wait_timeout_seconds)
+        clock.advance(min(3.0, lock_wait_timeout_seconds))
+        return False
+
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", busy_retire)
+    await http_bridge_helpers_module._release_http_bridge_unanchored_handoffs_for_request(
+        service, request_scope_id="deadline-scope"
+    )
+
+    assert clock.monotonic() == 5.0
+    assert waits == [5.0, 2.0]
+    assert list(service._http_bridge_detached_sessions.values()) == sessions
+    assert all(session.unanchored_reservation_id is None for session in sessions)
+    assert "skipped_sessions=1" in caplog.text
+
+    async def ready_retire(session: Any, *, lock_wait_timeout_seconds: float) -> bool:
+        assert lock_wait_timeout_seconds == 5.0
+        service._http_bridge_detached_sessions.pop(id(session))
+        return True
+
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", ready_retire)
+    await http_bridge_helpers_module._release_http_bridge_unanchored_handoffs_for_request(
+        service, request_scope_id="next-scope"
+    )
+    assert not service._http_bridge_detached_sessions
 
 
 @pytest.mark.asyncio
@@ -2654,6 +2695,119 @@ async def test_http_bridge_request_cleanup_releases_pre_submit_handoff(
         reset_request_scope_id(request_scope_token)
 
     assert session.unanchored_reservation_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_request", [False, True])
+async def test_http_response_finalization_shares_detached_lock_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    cancel_request: bool,
+) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), clock=clock, scheduler=scheduler)
+    sessions = [_make_bridge_session(key_value=f"stream-deadline-{index}") for index in range(3)]
+    for session in sessions:
+        session.upstream_control.reconnect_requested = True
+        session.upstream_control.retire_after_drain = True
+        service._http_bridge_detached_sessions[id(session)] = session
+    sessions[0].unanchored_reservation_id = "stream-deadline"
+    sessions[2].unanchored_reservation_id = "other-request"
+    runtime_config = SimpleNamespace(
+        enabled=True,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=1800.0,
+        max_sessions=8,
+        queue_limit=4,
+        prompt_cache_idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=SimpleNamespace())),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_service_get_settings", _make_app_settings)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    started = asyncio.Event()
+    release_holders = asyncio.Event()
+    scope = anyio.CancelScope()
+
+    async def upstream_stream(*args: object, **kwargs: object):
+        yield "data: completed\n\n"
+        first_request = not started.is_set()
+        started.set()
+        if cancel_request and first_request:
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(service, "_stream_via_http_bridge", upstream_stream)
+
+    async def hold(session: Any) -> None:
+        async with session.pending_lock:
+            await release_holders.wait()
+
+    async def consume() -> list[str]:
+        chunks: list[str] = []
+        token = set_request_scope_id("stream-deadline")
+        try:
+            with scope:
+                payload = proxy_service.ResponsesRequest.model_validate(
+                    {"model": "gpt-5.6-sol", "instructions": "test", "input": "hello"}
+                )
+                async for chunk in service.stream_http_responses(payload, {}, codex_session_affinity=True):
+                    chunks.append(chunk)
+        finally:
+            reset_request_scope_id(token)
+        return chunks
+
+    holders = [asyncio.create_task(hold(session)) for session in sessions]
+    await scheduler.drain()
+    consumer = asyncio.create_task(consume())
+    try:
+        await scheduler.drain()
+        assert started.is_set()
+        if cancel_request:
+            scope.cancel()
+            await scheduler.drain()
+        assert not consumer.done()
+        await scheduler.advance(5.0)
+        assert consumer.done(), "request finalization restarted the lock budget for another session"
+        assert await consumer == ["data: completed\n\n"]
+        assert scope.cancelled_caught is cancel_request
+        assert list(service._http_bridge_detached_sessions.values()) == sessions
+        assert sessions[0].unanchored_reservation_id is None
+        assert sessions[2].unanchored_reservation_id == "other-request"
+        for session in sessions:
+            assert session.pending_lock.locked()
+            assert session.pending_lock.statistics().tasks_waiting == 0
+            assert not session.upstream_close_attempted
+            cast(AsyncMock, session.upstream.close).assert_not_awaited()
+
+        release_holders.set()
+        await asyncio.gather(*holders)
+        # A later public request can retire drained generations; a foreign
+        # handoff still belongs to its request.
+        followup = asyncio.create_task(consume_followup(service))
+        await asyncio.wait_for(followup, timeout=1.0)
+        assert list(service._http_bridge_detached_sessions.values()) == [sessions[2]]
+        for session in sessions[:2]:
+            cast(AsyncMock, session.upstream.close).assert_awaited_once()
+        cast(AsyncMock, sessions[2].upstream.close).assert_not_awaited()
+    finally:
+        release_holders.set()
+        await asyncio.gather(*holders)
+        if not consumer.done():
+            consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        await scheduler.cancel_owned_tasks()
+
+
+async def consume_followup(service: proxy_service.ProxyService) -> None:
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "test", "input": "hello"}
+    )
+    async for _ in service.stream_http_responses(payload, {}, codex_session_affinity=True):
+        pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Detached sessions currently each receive a fresh five-second lock wait during request finalization. Share one monotonic deadline across the sweep so several busy locks cannot multiply that delay.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #2149

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-09-10-bound-detached-retire-sweep-deadline/`. Verified and synced into `responses-api-compat`.

## Changes

- Pass only remaining time to each retirement lock wait; stop at expiry with a skipped-count warning.
- Preserve deferred generations, foreign handoffs, and existing resource-close ownership. Socket-close completion retains its separate timeout.
- Cover exact budget reduction, public HTTP stream completion/cancellation, and later cleanup of deferred sessions.

## Test plan

Using the existing Python 3.13 environment, with both database variables set to the same disposable SQLite database:

```text
pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_http_bridge_idle_leases.py \
  -k 'release_handoffs or finalization_shares_detached or retire or close_http_bridge_session or request_cleanup_releases or terminal_lifecycle or settlement_ownership' -q
92 passed
ruff check . / ruff format --check .: pass
ty check: pass
check_proxy_architecture.py / check_cancellation_safety.py / check_proxy_timing_seams.py / check_settings_tiers.py: pass
openspec validate bound-detached-retire-sweep-deadline --strict: pass before archive
```

The helper regression fails on unchanged main at 9 virtual seconds versus 5. Both public completion/cancellation variants also fail on main and pass on this fix. Independent review found no actionable issues.

CI-pinned OpenSpec 1.11.0 validates all 65 capabilities. Local `pnpm dlx @fission-ai/openspec@1.11.0 validate --specs --strict` also passes 65/65. The warning scenario in the archive and main spec requires the unattempted-session count and preserves timed-out sessions for later cleanup. No live runtime changes or production measurement.

## Screenshots / output

```text
Detached HTTP bridge retire sweep deadline exhausted: skipped_sessions=2
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local check subset.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. Change verification passed before archive; strict full-spec validation passes with OpenSpec 1.11.0.
- [x] Simplicity gates reviewed: no settings, setup, UI, or documentation-budget additions.
- [x] CHANGELOG is not edited by hand.
