### PR TITLE
fix(proxy): contain post-terminal health write failures

### DIFF
--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -788,6 +788,26 @@ class _StreamingRetryMixin:
                 return settled
             return True
 
+        async def _write_post_terminal_health(
+            account: Account,
+            error: UpstreamError,
+            code: str,
+            *,
+            http_status: int | None = None,
+        ) -> None:
+            try:
+                if http_status is None:
+                    await proxy._handle_stream_error(account, error, code)
+                else:
+                    await proxy._handle_stream_error(account, error, code, http_status=http_status)
+            except Exception:
+                logger.warning(
+                    "Failed to write post-terminal stream health account_id=%s request_id=%s",
+                    account.id,
+                    request_id,
+                    exc_info=True,
+                )
+
         async def _finalize_terminal_settlement_after_downstream_close(
             current_settlement: _StreamSettlement,
             account: Account,
@@ -806,7 +826,7 @@ class _StreamingRetryMixin:
                 if not settled:
                     return
                 if current_settlement.account_health_error:
-                    await proxy._handle_stream_error(
+                    await _write_post_terminal_health(
                         account,
                         _stream_settlement_error_payload(current_settlement),
                         current_settlement.error_code or "upstream_error",
@@ -2372,7 +2392,7 @@ class _StreamingRetryMixin:
                                         raise
                                 settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 if settled and settlement.account_health_error:
-                                    await proxy._handle_stream_error(
+                                    await _write_post_terminal_health(
                                         account,
                                         _stream_settlement_error_payload(settlement),
                                         settlement.error_code or "upstream_error",
@@ -2744,7 +2764,7 @@ class _StreamingRetryMixin:
                         else:
                             settled = await _settle_stream_usage_before_pending_penalty(settlement)
                             if settled and settlement.account_health_error:
-                                await proxy._handle_stream_error(
+                                await _write_post_terminal_health(
                                     account,
                                     _stream_settlement_error_payload(settlement),
                                     settlement.error_code or "upstream_error",
@@ -2812,7 +2832,7 @@ class _StreamingRetryMixin:
                     else:
                         health_write_allowed = await _settle_stream_usage_before_pending_penalty(settlement)
                         if health_write_allowed and settlement.account_health_error:
-                            await proxy._handle_stream_error(
+                            await _write_post_terminal_health(
                                 account,
                                 _stream_settlement_error_payload(settlement),
                                 settlement.error_code or "upstream_error",
@@ -3149,7 +3169,7 @@ class _StreamingRetryMixin:
                                 settlement.account_health_error = _facade()._should_penalize_stream_error(error_code)
                                 settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 if settled and settlement.account_health_error:
-                                    await proxy._handle_stream_error(
+                                    await _write_post_terminal_health(
                                         account,
                                         _stream_settlement_error_payload(settlement),
                                         settlement.error_code or "upstream_error",
@@ -3404,7 +3424,7 @@ class _StreamingRetryMixin:
                                 and settlement.account_health_error
                                 and not current_account_penalty_queued
                             ):
-                                await proxy._handle_stream_error(
+                                await _write_post_terminal_health(
                                     account,
                                     _stream_settlement_error_payload(settlement),
                                     settlement.error_code or "upstream_error",

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/context.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/context.md
@@ -1,0 +1,11 @@
+# Reproduction and scope
+
+Confirmed product defect on upstream main `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`, matching issue #2033. The direct streaming path uses `stream: true`; HTTP session bridging is disabled in the existing test fixture. No new setting or special client setup is required. The existing terminal-settlement immutability requirement and the maintainer's September 8 issue analysis require preserving the delivered terminal outcome.
+
+The route-handler regression injects an ordinary account-health persistence failure after a successful reservation settlement. Keyed owner continuations reproduce an abrupt completion error for a first-event failure and two terminal events for later-event or raised upstream failures. An unkeyed stream with visible text followed by a raised quota error also produces two terminals. All four fail on the pinned base and pass with the fix.
+
+The integration regression imports a synthetic account through `/api/accounts/import`, then posts `{"model":"gpt-5.1","instructions":"hi","input":"hello","stream":true}` to `/v1/responses` through the real ASGI app. Upstream yields `response.created`, a text delta, then raises a quota error. The injected health exception produces two terminal events on main and one original `usage_limit_reached` terminal with the fix. It also verifies the exception is logged.
+
+The attempted unkeyed owner-rewrite matrix is not evidence for this post-terminal bug: its health write occurs before terminal delivery. An unkeyed native later-event failure in the tested setup forwards without attempting a health penalty. Those paths are excluded from the regression matrix and unchanged.
+
+The fix wraps six existing post-terminal error-health calls only. It leaves pre-terminal retry/admission decisions, settlement errors, success writes, and cancellation propagation unchanged. No dependency on PR #1905 or another unmerged change is introduced.

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/design.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/design.md
@@ -1,0 +1,15 @@
+## Context
+
+The retry loop has a cancellation-deferring terminal finalizer plus inline post-terminal error-health writes. An ordinary health exception can enter the attempt's broad exception handler or escape an exception branch. See proposal.md for the reproduced symptom.
+
+## Goals / Non-Goals
+
+Contain account-error health exceptions after a terminal response. Keep existing settlement and cancellation ownership. Settlement failures, pre-terminal health decisions, and success-recording policy are outside this change.
+
+## Decisions
+
+Use one local helper around post-terminal `_handle_stream_error` calls. Catch `Exception`, log with exception information, and return. Do not catch `BaseException`, move health before settlement, or suppress errors across the entire attempt. The local helper retains access to request logging context without expanding the service interface. Keep this narrow edit in the existing retry module; splitting the attempt state machine is unrelated work.
+
+## Risks / Trade-offs
+
+The failed health update remains unpersisted. Logging exposes the failure while preserving the already delivered response. Existing cancellation and settlement-order regressions protect cleanup behavior.

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/proposal.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #2033 reports a second terminal Responses frame or abrupt stream close when an account-health write fails after the terminal frame. Current main still reproduces the keyed cases.
+
+## What Changes
+
+- Catch and log ordinary post-terminal account-health write failures without changing the delivered response.
+- Preserve reservation settlement before health writes and cancellation propagation.
+- Cover first-event, later-event, and raised upstream errors through the Responses route.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: keep a terminal stream complete when its subsequent account-health write fails.
+
+## Impact
+
+Backend streaming retry finalization and Responses route regression tests. No settings, schema, frontend, or unmerged dependency.

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/specs/responses-api-compat/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Post-terminal health failures preserve stream completion
+After publishing a terminal Responses event, the proxy MUST log ordinary failures from subsequent account-error health writes without emitting another terminal event or aborting stream completion. This MUST apply to first-event, later-event, and raised upstream errors, with and without an API-key reservation. Required reservation settlement MUST precede the health write. Cancellation MUST retain its existing propagation and cleanup behavior.
+
+#### Scenario: Account health persistence fails after a terminal response
+- **WHEN** an upstream failure produces a terminal response and the subsequent account-error health write raises an ordinary exception
+- **THEN** the client receives exactly one terminal event with the original response error and the stream completes normally
+- **AND** the health-write failure is logged with exception information
+
+#### Scenario: Keyed health persistence fails after ordered settlement
+- **WHEN** a keyed continuation fails and its account-error health write raises after reservation settlement
+- **THEN** settlement completes before the health write is attempted
+- **AND** the client receives only the intended owner-unavailable terminal response

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/tasks.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/tasks.md
@@ -1,0 +1,8 @@
+## 1. Reproduction and fix
+
+- [x] 1.1 Reproduce health-write failure through the public Responses route and stream handler for applicable keyed/unkeyed inputs; record exact failing behavior and excluded pre-terminal setups.
+- [x] 1.2 Contain post-terminal account-error health exceptions and prove one terminal response, clean completion, and logged exception in the route regression.
+
+## 2. Verification
+
+- [x] 2.1 Run related settlement/disconnect regressions, lint, typing, and strict OpenSpec validation; review the pinned diff and archive only after verification.

--- a/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/verification.md
+++ b/openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/verification.md
@@ -1,0 +1,11 @@
+# Verification
+
+Base: `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`.
+
+All three tasks are complete. The four stream-handler cases fail on the base and pass with the fix. The real ASGI `/v1/responses` regression fails with two terminal events on the base and passes with one terminal event on the candidate.
+
+The related stream health, settlement, terminal, and owner-rewrite selection passes all 72 tests. `make lint typecheck` passes, including proxy architecture, cancellation safety, timing, settings-tier checks, Ruff, and ty. The added integration test passes separately. Strict OpenSpec validation passes all 65 main specs and this change.
+
+The implementation matches both requirement scenarios. The helper catches only ordinary health-write exceptions; all existing settlement gates and cancellation propagation remain in place. Independent review of the retry and stream-handler test diff found no actionable defects. Pre-terminal admission and whole-body continuation logic are unchanged.
+
+No critical findings or warnings remain for the implementation. Hosted CI, upstream review, merge, and deployment are separate follow-up states.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -297,3 +297,7 @@ stream. Predispatch failures and cancellation release origin-owned reservations;
 accepted or delivery-ambiguous owner forwards retain their settlement owner.
 Context bindings do not span yields because startup probes and consumers may
 advance the stream from different tasks.
+
+## Health persistence after a terminal response
+
+A failed account-error health write must not replace a Responses terminal that the client already received. For example, a quota failure followed by a database error must retain the original quota terminal and log the health failure. The retry loop contains ordinary post-terminal health exceptions after reservation settlement; it preserves cancellation and pre-terminal retry decisions. Issue #2033 has both a public `/v1/responses` regression and stream-handler coverage for keyed owner continuations. The implementation and excluded pre-terminal setups are recorded in `openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/context.md`.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Define Responses API compatibility contracts so Codex, OpenCode, and OpenAI-style clients preserve expected behavior.
+
 ## Requirements
+
 ### Requirement: Use prompt_cache_key as OpenAI cache affinity
 For OpenAI-style `/v1/responses`, `/v1/responses/compact`, and chat-completions requests mapped onto Responses, the service MUST treat a non-empty `prompt_cache_key` as the bounded upstream account affinity key for prompt-cache correctness even when a `session_id` header is present. OpenAI-style route wiring MUST NOT upgrade those requests to durable `CODEX_SESSION` affinity by default. This affinity MUST apply even when dashboard `sticky_threads_enabled` is disabled, the service MUST continue forwarding the same `prompt_cache_key` upstream unchanged, and the stored affinity MUST expire after the configured freshness window so older keys can rebalance. The freshness window MUST come from dashboard settings so operators can adjust it without restart.
 
@@ -10831,3 +10833,15 @@ still awaiting I/O.
 - **THEN** the key is quarantined and the probe is planned without the dead anchor
 - **AND** the probe resends full history rather than the dead anchor
 
+### Requirement: Post-terminal health failures preserve stream completion
+After publishing a terminal Responses event, the proxy MUST log ordinary failures from subsequent account-error health writes without emitting another terminal event or aborting stream completion. This MUST apply to first-event, later-event, and raised upstream errors, with and without an API-key reservation. Required reservation settlement MUST precede the health write. Cancellation MUST retain its existing propagation and cleanup behavior.
+
+#### Scenario: Account health persistence fails after a terminal response
+- **WHEN** an upstream failure produces a terminal response and the subsequent account-error health write raises an ordinary exception
+- **THEN** the client receives exactly one terminal event with the original response error and the stream completes normally
+- **AND** the health-write failure is logged with exception information
+
+#### Scenario: Keyed health persistence fails after ordered settlement
+- **WHEN** a keyed continuation fails and its account-error health write raises after reservation settlement
+- **THEN** settlement completes before the health write is attempted
+- **AND** the client receives only the intended owner-unavailable terminal response

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -161,6 +161,53 @@ def _disable_http_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_health_write_failure_keeps_one_terminal(async_client, monkeypatch, caplog):
+    auth_json = _make_auth_json("acc_post_terminal_health", "post-terminal-health@example.com")
+    imported = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert imported.status_code == 200
+    health_attempts = []
+
+    async def fake_stream(*args, **kwargs):
+        yield 'data: {"type":"response.created","response":{"id":"resp_health_failure"}}\n\n'
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+        raise proxy_client_module.ProxyResponseError(
+            429,
+            {"error": {"code": "usage_limit_reached", "message": "quota exhausted", "type": "rate_limit_error"}},
+        )
+
+    async def fail_health(self, account, error, code, **kwargs):
+        health_attempts.append(code)
+        raise RuntimeError("injected post-terminal health write failure")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", fail_health)
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={"model": "gpt-5.1", "instructions": "hi", "input": "hello", "stream": True},
+    )
+
+    assert response.status_code == 200
+    events = list(_iter_sse_events(response.text.splitlines()))
+    terminals = [
+        event
+        for event in events
+        if event.get("type") in {"response.failed", "response.completed", "response.incomplete", "error"}
+    ]
+    assert len(terminals) == 1
+    assert terminals[0]["response"]["error"]["code"] == "usage_limit_reached"
+    assert health_attempts == ["usage_limit_reached"]
+    health_logs = [
+        record for record in caplog.records if "Failed to write post-terminal stream health" in record.message
+    ]
+    assert len(health_logs) == 1
+    assert health_logs[0].exc_info is not None
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_no_accounts(async_client):
     payload = {"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True}
     request_id = "req_stream_123"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -18033,6 +18033,128 @@ async def test_stream_responses_route_keyed_owner_rewrite_settles_before_origina
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("keyed", "upstream_path"),
+    [(True, "first_event"), (True, "later_event"), (True, "proxy_response_error"), (False, "proxy_response_error")],
+)
+async def test_stream_responses_route_health_failure_keeps_one_terminal(
+    monkeypatch,
+    caplog,
+    upstream_path: str,
+    keyed: bool,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account(f"acc_keyed_owner_rewrite_{upstream_path}")
+    api_key = _make_api_key_data(f"key_keyed_owner_rewrite_{upstream_path}")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id=f"resv_keyed_owner_rewrite_{upstream_path}",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    order: list[str] = []
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> proxy_service.ApiKeyUsageReservationData | None:
+        return reservation if keyed else None
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        *_args: object,
+        **kwargs: object,
+    ) -> bool:
+        assert settled_api_key is (api_key if keyed else None)
+        assert settled_reservation is (reservation if keyed else None)
+        if keyed:
+            assert kwargs.get("wait_for_settlement") is True
+        settlement.usage_settlement_transferred = True
+        if keyed:
+            order.append("settle")
+        return True
+
+    async def handle_stream_error(
+        failed_account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        del error, http_status
+        assert failed_account is account
+        order.append(f"health:{code}")
+        raise RuntimeError("injected post-terminal health write failure")
+
+    async def core_stream(*_args: object, **_kwargs: object):
+        if not keyed:
+            yield 'data: {"type":"response.created","response":{"id":"resp_owner_rewrite"}}\n\n'
+            yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+        if upstream_path == "proxy_response_error":
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error("usage_limit_reached", "owner quota exhausted"),
+            )
+        if keyed and upstream_path == "later_event":
+            yield 'data: {"type":"response.created","response":{"id":"resp_owner_rewrite"}}\n\n'
+        yield (
+            'data: {"type":"response.failed","response":{"id":"resp_owner_rewrite","status":"failed",'
+            '"error":{"code":"usage_limit_reached","message":"owner quota exhausted"}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", core_stream)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_resolve_websocket_previous_response_owner",
+        AsyncMock(return_value=account.id),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp_owner_anchor" if keyed else None,
+            "stream": True,
+        }
+    )
+    response = await proxy_api._stream_responses(
+        request,
+        payload,
+        context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+        api_key=api_key if keyed else None,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    chunks = [chunk async for chunk in response.body_iterator]
+    body = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
+    expected_code = "previous_response_owner_unavailable" if keyed else "usage_limit_reached"
+    assert f'"code":"{expected_code}"' in body
+    assert request_logs.calls[-1]["error_code"] == expected_code
+    assert body.count('"type":"response.failed"') == 1
+    assert order == (["settle"] if keyed else []) + ["health:usage_limit_reached"]
+    service._load_balancer.record_success.assert_not_awaited()
+    health_logs = [
+        record for record in caplog.records if "Failed to write post-terminal stream health" in record.message
+    ]
+    assert len(health_logs) == 1
+    assert health_logs[0].exc_info is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "upstream_path",
     ["first_event", "later_event", "proxy_response_error"],
 )


### PR DESCRIPTION
## Summary

A failing account-health write after a Responses terminal can emit a second `response.failed` event or abort stream completion. Catch and log ordinary post-terminal health exceptions while preserving the original response, reservation settlement order, and cancellation propagation.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Fixes #2033

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-09-10-fix-post-terminal-health-failures/`

## Changes

- Use one exception-logging helper at the six post-terminal error-health writes. Existing settlement gates, queued-account deduplication, and HTTP status forwarding stay intact.
- Add a real ASGI `/v1/responses` regression and four stream-handler cases covering keyed owner continuations and an unkeyed stream with visible text followed by a quota error.

Pre-terminal health writes, settlement failures, and success recording keep their existing behavior. This is independent of unmerged PRs, including #1905.

## Test plan

Both database environment variables pointed to the same dedicated disposable SQLite database before app imports and tests.

```bash
uv run pytest tests/unit/test_proxy_utils.py \
  -k 'stream and (health or settlement or terminal or owner_rewrite)' -q
# 72 passed
uv run pytest tests/integration/test_proxy_responses.py \
  -k test_v1_responses_health_write_failure_keeps_one_terminal -q
# 1 passed
make lint typecheck
# Passed, including architecture and cancellation checks
pnpm dlx @fission-ai/openspec validate --specs --strict
# 65 passed
```

The four new stream-handler cases and the public HTTP test fail against pinned main `0f6a31c56` and pass with this patch. The active change passed strict validation before archive; main specs passed again after sync. Independent review found no actionable defects. Hosted CI and maintainer review remain pending.

## Screenshots / output

Public request: `POST /v1/responses` with `{"model":"gpt-5.1","instructions":"hi","input":"hello","stream":true}`. A synthetic upstream emits text and then raises a quota error; the injected health write raises `RuntimeError`.

- Before: `response.failed/usage_limit_reached`, then `response.failed/upstream_error`.
- After: one `response.failed/usage_limit_reached`; the health failure is logged with exception information.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added tests covering the change.
- [x] Ran the relevant `make` subset locally.
- [x] Strict OpenSpec validation and implementation verification pass.
- [x] Simplicity gates reviewed; no settings, defaults, setup steps, README sections, or dashboard changes.
- [x] CHANGELOG is not edited by hand.
