### PR TITLE
feat(db): explain guarded migration recovery stamping

### DIFF
--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -673,7 +673,12 @@ def _schema_ahead_error(state: MigrationState) -> MigrationBootstrapError:
     return MigrationBootstrapError(
         f"Database schema revision(s) {','.join(state.unknown_revisions)} are not known to this build "
         f"(head={state.head_revision}); the schema was likely migrated by a newer version. "
-        "Deploy a matching or newer image, or run an Alembic downgrade to a revision this build knows."
+        "Deploy a matching or newer image, or use a build containing the required migrations for a reviewed "
+        "Alembic downgrade. For an image rollback only after verifying schema and data compatibility with the "
+        "rollback image, ensuring migration transactions have ended, and preserving a recoverable database backup "
+        "and encryption key: run `python -m app.db.migrate stamp <revision>` from a build containing both the "
+        "recorded and target revisions, against the same database. Stamping only changes migration metadata; "
+        "it does not roll back schema or data. See docs/database.md for recovery preconditions and verification."
     )
 
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -42,6 +42,23 @@ Compose volume. If that guard fires, run the `postgres-upgrade` profile above be
 It also refuses nested `/var/lib/postgresql/data` directories that still report a pre-18 major version, because those
 layouts need an explicit pg_upgrade before the Postgres 18 container can safely open them.
 
+## Recovering an image rollback with an unknown revision
+
+If startup reports a revision unknown to the image, first deploy a matching or newer image. An older image cannot infer compatibility from the revision label.
+
+Stamping changes migration metadata only. It does not undo schema changes, restore data or cancel database transactions. Even additive changes can break old readers or writes through new constraints and defaults.
+
+Use a metadata-only stamp for an image rollback only after these checks:
+
+1. Stop application writers and migration jobs. Confirm their database transactions have ended, including server-side queries from an interrupted deployment. Stopping a container alone is not proof.
+2. Preserve a consistent, recoverable backup of the current database, its encryption key and required data files. Record the current image, database target and recorded revisions. Do not replace newer writes with an old backup.
+3. On a disposable copy, verify that the rollback image can read and write the existing schema and data. Review every intervening schema and data migration, including incomplete backfills. If compatibility is unknown or incompatible, keep the matching image or plan a reviewed downgrade using the required migration scripts.
+4. Select the exact revision expected by the rollback image. Use a build containing both the recorded and target revisions. The old build cannot stamp an unknown current revision; do not delete or purge migration metadata to bypass that error.
+5. Only after those checks, run `python -m app.db.migrate stamp <revision>` in that migration-capable build, replacing `<revision>` with the verified target. Keep the same explicit database configuration. Do not use the newer build's `head`, which can name a different revision.
+6. Switch to the rollback image while writers remain stopped. Run `python -m app.db.migrate current` and `python -m app.db.migrate check` against the same database. Retain the encryption key, verify startup and the rehearsed read/write behavior, then resume traffic. A successful stamp or schema check alone does not prove application compatibility.
+
+For example, a new release might add an optional column that the previous release ignores. Stamping back can be considered only after the previous release's reads and writes pass on a copy, including constraints and data semantics. A removed column or an unfinished backfill required by that release rules out this shortcut.
+
 ---
 
 *Specs: [database-backends](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/database-backends) · [database-migrations](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/database-migrations)*

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/design.md
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/design.md
@@ -1,0 +1,21 @@
+## Context
+
+The schema-ahead guard already rejects an upgrade before Alembic execution. Its error mentions deploying a newer image or downgrading, but omits the separately requested hint from #1470.
+
+## Goals / Non-Goals
+
+Provide accurate conditional guidance through the existing migration CLI and startup error. Do not change stamping, locks, startup readiness, migration transactions or background data phases.
+
+## Decisions
+
+Extend the existing error text, keeping the check in place. The migration module is already large, but extracting a separate module for this single diagnostic would add an interface without a separate responsibility.
+
+Use CLI subprocess tests against a disposable SQLite fixture to verify the accepted public command/error contract. Preserve fixture contents before and after the rejected commands. No live PostgreSQL or Docker access is required for a text-only change.
+
+## Risks / Trade-offs
+
+An unknown revision cannot be traversed by the old build's Alembic stamp command. Guidance must require the migration-capable build that contains both revisions. Do not introduce purge or automatically infer compatibility from additive DDL. Defaults, constraints and data readers can still be incompatible.
+
+## Migration Plan
+
+No database migration is introduced. Deploying or reverting this change only changes guidance.

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/proposal.md
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Issue #1470 requests a standalone recovery hint for an image rollback encountering an unknown migration revision. The current error omits metadata-only stamping and the conditions that make it safe.
+
+## What Changes
+
+- Explain guarded stamping in the schema-ahead error and operator documentation.
+- Preserve fail-closed upgrade behavior and all migration execution semantics.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-migrations`: schema-ahead recovery guidance and its safety preconditions.
+
+## Impact
+
+Only migration error text, documentation and CLI regression coverage. This is partial #1470 work; background data phases and progress reporting remain separate.

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/specs/database-migrations/spec.md
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/specs/database-migrations/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Guarded recovery guidance for unknown revisions
+
+When an upgrade rejects revisions unknown to the running build, its diagnostic SHALL retain the matching-or-newer-image option and describe `python -m app.db.migrate stamp <revision>` as a conditional metadata-only operation. It MUST state that stamping does not roll back schema or data, requires verified schema and data compatibility with the rollback image, and must run from a build containing both the recorded and target revisions after migration transactions have ended and a recoverable database backup and encryption key have been preserved. The failed upgrade MUST NOT automatically stamp or alter application data. Operator documentation SHALL explain selecting an explicit target revision, preserving the database target and encryption key, verifying compatibility on a disposable copy, and checking the rollback image before resuming traffic.
+
+#### Scenario: Upgrade against a newer revision
+
+- **GIVEN** a database records a revision unknown to the running build
+- **WHEN** the operator runs the migration upgrade CLI
+- **THEN** the command fails with the unknown-revision diagnostic and guarded stamp guidance
+- **AND** the recorded revision, schema and application data remain unchanged
+
+#### Scenario: Unknown revision cannot be stamped by the old build
+
+- **GIVEN** the current revision is absent from the running build
+- **WHEN** the operator runs the existing stamp CLI to a locally known revision
+- **THEN** the command fails without changing the revision
+- **AND** documentation directs the operator to a build containing both revisions instead of deleting or purging migration metadata

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/tasks.md
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/tasks.md
@@ -1,0 +1,8 @@
+## 1. Guidance
+
+- [x] 1.1 Prove missing guidance with a failing CLI regression, then add conditional text and verify the test passes without database changes.
+- [x] 1.2 Document compatibility, transaction, backup and key preconditions; verify existing stamp behavior on an unknown revision.
+
+## 2. Verification
+
+- [x] 2.1 Run focused migration checks, review the exact diff, and validate OpenSpec before archive.

--- a/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/verification.md
+++ b/openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/verification.md
@@ -1,0 +1,13 @@
+# Verification
+
+Base: `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`. The implementation changes only the existing schema-ahead diagnostic.
+
+- Completeness: all implementation tasks complete; one added requirement covered.
+- Correctness: CLI regression failed on absent stamp guidance before the change and passed afterward. Both scenarios pass; failed commands preserve SQLite fixture bytes.
+- Coherence: no migration execution, locking, stamping or readiness logic changes. Read-only independent review found no actionable findings.
+
+`pytest tests/integration/test_migration_recovery_hints.py tests/unit/test_db_migrate.py -q`: 61 passed. Dedicated disposable SQLite upgrade to head and check: `migration_policy=ok`, `schema_drift=none`. Ruff check, format check and targeted ty check passed. Strict change validation passed.
+
+Both database environment variables selected the same dedicated disposable SQLite database; main and background engine targets were checked. No live database, Docker or routing operation occurred. PostgreSQL execution and hosted CI are not claimed.
+
+No critical issues, warnings or suggestions remain within this change. The broader #1470 data-phase contract remains outside scope.

--- a/openspec/specs/database-migrations/context.md
+++ b/openspec/specs/database-migrations/context.md
@@ -72,3 +72,11 @@ branch. See the [repair context](../../changes/merge-overflow-transport-migratio
 ## Example
 
 Branch A and B each create migration revisions in parallel. After merge, CI detects multiple heads and fails. The resolver adds a merge revision, reruns CI, and proceeds. During deployment, a DB still storing old `013_add_dashboard_settings_routing_strategy` in `alembic_version` is auto-remapped to `20260225_000000_add_dashboard_settings_routing_strategy` before upgrade.
+
+## Guarded image rollback guidance
+
+Issue #1470 separates recovery hints from the general data-phase runner. The unknown-revision error explains metadata-only stamping without changing the fail-closed upgrade guard. The stamp command must run in a build containing both revisions because Alembic resolves the current revision before changing it.
+
+An optional added column is a possible compatible example, after testing old-image reads and writes on a disposable copy. Added constraints, changed data meanings or incomplete backfills can still invalidate that route. Stamping cannot reverse those changes or end an interrupted database transaction. Preserve current data and encryption keys before recovery.
+
+The [operator sequence](../../../docs/database.md#recovering-an-image-rollback-with-an-unknown-revision) covers transaction completion, backup, compatibility proof, exact revision selection and verification before traffic resumes. See [the requirement](spec.md#requirement-guarded-recovery-guidance-for-unknown-revisions).

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Define migration, drift detection, and Alembic governance contracts so deployments fail closed on schema mismatch.
+
 ## Requirements
+
 ### Requirement: Alembic as migration source of truth
 
 The system SHALL use Alembic as the only runtime migration mechanism and SHALL NOT execute custom migration runners. Dashboard settings schema changes, including weekly pace working days, MUST be represented by Alembic revisions and ORM metadata so startup drift detection can verify them.
@@ -511,3 +513,20 @@ remain for operator recovery.
 - **THEN** recovery MUST fail before deleting sidecars, writing output, or
   moving the source
 
+### Requirement: Guarded recovery guidance for unknown revisions
+
+When an upgrade rejects revisions unknown to the running build, its diagnostic SHALL retain the matching-or-newer-image option and describe `python -m app.db.migrate stamp <revision>` as a conditional metadata-only operation. It MUST state that stamping does not roll back schema or data, requires verified schema and data compatibility with the rollback image, and must run from a build containing both the recorded and target revisions after migration transactions have ended and a recoverable database backup and encryption key have been preserved. The failed upgrade MUST NOT automatically stamp or alter application data. Operator documentation SHALL explain selecting an explicit target revision, preserving the database target and encryption key, verifying compatibility on a disposable copy, and checking the rollback image before resuming traffic.
+
+#### Scenario: Upgrade against a newer revision
+
+- **GIVEN** a database records a revision unknown to the running build
+- **WHEN** the operator runs the migration upgrade CLI
+- **THEN** the command fails with the unknown-revision diagnostic and guarded stamp guidance
+- **AND** the recorded revision, schema and application data remain unchanged
+
+#### Scenario: Unknown revision cannot be stamped by the old build
+
+- **GIVEN** the current revision is absent from the running build
+- **WHEN** the operator runs the existing stamp CLI to a locally known revision
+- **THEN** the command fails without changing the revision
+- **AND** documentation directs the operator to a build containing both revisions instead of deleting or purging migration metadata

--- a/tests/integration/test_migration_recovery_hints.py
+++ b/tests/integration/test_migration_recovery_hints.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_upgrade_unknown_revision_reports_guarded_recovery_without_changes(tmp_path: Path) -> None:
+    database = tmp_path / "future.db"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            "CREATE TABLE alembic_version (version_num VARCHAR(255) PRIMARY KEY);"
+            "INSERT INTO alembic_version VALUES ('20990101_000000_future');"
+            "CREATE TABLE preserved_data (value TEXT);"
+            "INSERT INTO preserved_data VALUES ('synthetic-sentinel');"
+        )
+    before = database.read_bytes()
+    url = f"sqlite+aiosqlite:///{database}"
+    result = subprocess.run(
+        [sys.executable, "-m", "app.db.migrate", "upgrade", "head"],
+        env={**os.environ, "CODEX_LB_DATABASE_URL": url, "CODEX_LB_TEST_DATABASE_URL": url},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "MigrationBootstrapError" in result.stderr
+    assert "20990101_000000_future" in result.stderr
+    assert "Deploy a matching or newer image" in result.stderr
+    assert database.read_bytes() == before
+    assert "python -m app.db.migrate stamp <revision>" in result.stderr
+    assert "schema and data compatibility" in result.stderr
+    assert "both the recorded and target revisions" in result.stderr
+    assert "migration transactions have ended" in result.stderr
+    assert "database backup and encryption key" in result.stderr
+    assert "does not roll back schema or data" in result.stderr
+    assert "synthetic-sentinel" not in result.stderr
+
+
+def test_old_build_cannot_stamp_unknown_revision(tmp_path: Path) -> None:
+    database = tmp_path / "future.db"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            "CREATE TABLE alembic_version (version_num VARCHAR(255) PRIMARY KEY);"
+            "INSERT INTO alembic_version VALUES ('20990101_000000_future');"
+        )
+    before = database.read_bytes()
+    url = f"sqlite+aiosqlite:///{database}"
+    result = subprocess.run(
+        [sys.executable, "-m", "app.db.migrate", "stamp", "head"],
+        env={**os.environ, "CODEX_LB_DATABASE_URL": url, "CODEX_LB_TEST_DATABASE_URL": url},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Can't locate revision identified by '20990101_000000_future'" in result.stderr
+    assert database.read_bytes() == before


### PR DESCRIPTION
## Summary

Explain guarded metadata-only stamping when an image rollback encounters an unknown migration revision. The hint requires schema and data compatibility, ended migration transactions, a recoverable backup and encryption key, and a build containing both revisions.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: Partial #1470, recovery guidance only. Data phases and progress reporting remain separate; this does not close the issue.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/archive/2026-09-10-guarded-migration-recovery-hints/`, verified and synced to `database-migrations`.

## Changes

- Preserve the failed upgrade and all existing migration execution and stamp behavior.
- Document recovery preconditions and checks before resuming traffic. Stamping does not undo schema or data. The older build cannot stamp a current revision absent from its migration scripts.

## Test plan

- CLI regression failed on the missing hint before the change and passed afterward. Failed upgrade and stamp commands leave disposable SQLite fixtures byte-for-byte unchanged.
- `uv run pytest tests/integration/test_migration_recovery_hints.py tests/unit/test_db_migrate.py -q`: 61 passed.
- Disposable SQLite `python -m app.db.migrate upgrade head` then `check`: `migration_policy=ok`, `schema_drift=none`.
- `make lint typecheck`: passed.
- Strict OpenSpec change validation and `openspec validate --specs --strict`: passed, 65 specs.

Both database environment variables used dedicated disposable SQLite targets. No PostgreSQL execution or live rollout is claimed. Independent read-only review found no actionable findings.

## Screenshots / output

The existing unknown-revision error now includes this conditional guidance:

```text
For an image rollback only after verifying schema and data compatibility with the rollback image, ensuring migration transactions have ended, and preserving a recoverable database backup and encryption key: run `python -m app.db.migrate stamp <revision>` from a build containing both the recorded and target revisions, against the same database. Stamping only changes migration metadata; it does not roll back schema or data.
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
