### PR TITLE
feat(proxy): forward explicit compact requests to model sources

### DIFF
--- a/app/modules/model_sources/forwarding.py
+++ b/app/modules/model_sources/forwarding.py
@@ -387,13 +387,40 @@ async def forward_responses(
     encryptor: TokenEncryptor | None = None,
     recode_credential_failures: bool = True,
 ) -> SourceResponsesCompletion:
+    return await _forward_responses_json(
+        source,
+        payload,
+        path="/responses",
+        encryptor=encryptor,
+        recode_credential_failures=recode_credential_failures,
+    )
+
+
+async def forward_compact_responses(
+    source: ModelSource,
+    payload: dict[str, JsonValue],
+    *,
+    encryptor: TokenEncryptor | None = None,
+) -> SourceResponsesCompletion:
+    """Compact at the selected source using the shared authenticated JSON transport."""
+    return await _forward_responses_json(source, payload, path="/responses/compact", encryptor=encryptor)
+
+
+async def _forward_responses_json(
+    source: ModelSource,
+    payload: dict[str, JsonValue],
+    *,
+    path: Literal["/responses", "/responses/compact"],
+    encryptor: TokenEncryptor | None = None,
+    recode_credential_failures: bool = True,
+) -> SourceResponsesCompletion:
     try:
         async with lease_model_source_session() as session:
             # Non-stream generations legitimately spend minutes before the
             # first byte, so only connect establishment and the source's total
             # budget are bounded here (no header/first-frame deadline).
             async with session.post(
-                _source_url(source, "/responses"),
+                _source_url(source, path),
                 headers=_source_headers(source, encryptor=encryptor),
                 json=payload,
                 timeout=_source_client_timeout(source),

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -157,6 +157,7 @@ from app.core.openai.parsing import classify_event_type, parse_response_payload
 from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesRequest,
+    extract_input_file_ids,
     normalize_tool_type,
     responses_request_has_explicit_prompt_cache_controls,
     strip_replayed_tool_call_namespaces_from_payload,
@@ -226,6 +227,7 @@ from app.modules.model_sources.forwarding import (
     SourceUsage,
     SourceUsageHolder,
     forward_chat_completion,
+    forward_compact_responses,
 )
 from app.modules.model_sources.forwarding import (
     empty_stream_error as source_empty_stream_error,
@@ -4843,6 +4845,43 @@ async def _select_responses_model_source_with_continuity(
     return source_selection, False
 
 
+async def _select_compact_model_source_with_continuity(
+    request: Request,
+    payload: ResponsesCompactRequest,
+    context: ProxyContext,
+    api_key: ApiKeyData | None,
+    *,
+    raw_model: str | None,
+) -> tuple[tuple[ModelSource, str] | None, bool]:
+    selection = await _select_responses_model_source(payload.model, api_key, raw_model=raw_model)
+    if selection is None:
+        disabled = await _select_responses_model_source(payload.model, api_key, raw_model=raw_model, only_disabled=True)
+        if disabled is None:
+            return None, False
+    # A disabled source cannot veto an existing native owner. Returning to the
+    # compact service keeps complete owner-conflict reconciliation in one place.
+    previous_response_id = getattr(payload, "previous_response_id", None)
+    if isinstance(previous_response_id, str) and previous_response_id.strip():
+        owner = await context.service._resolve_websocket_previous_response_owner(
+            previous_response_id=previous_response_id,
+            api_key=api_key,
+            session_id=proxy_affinity_module._owner_lookup_session_id_from_headers(request.headers),
+            surface="compact_source_route",
+        )
+        if owner is not None:
+            return None, True
+    turn_state = proxy_affinity_module._sticky_key_from_turn_state_header(request.headers)
+    if turn_state is not None:
+        owner = await context.service._resolve_compact_turn_state_owner(
+            turn_state=turn_state,
+            api_key=api_key,
+            fail_on_missing=not proxy_affinity_module._is_synthesized_turn_state(turn_state),
+        )
+        if owner is not None:
+            return None, True
+    return selection, False
+
+
 async def _disabled_model_source_denial(
     request: Request,
     model: str,
@@ -5245,7 +5284,7 @@ async def _overflow_source_response(
 
 async def _source_responses_response(
     request: Request,
-    payload: ResponsesRequest,
+    payload: ResponsesRequest | ResponsesCompactRequest,
     *,
     source: ModelSource,
     api_key: ApiKeyData | None,
@@ -5289,11 +5328,18 @@ async def _source_responses_response(
             _model_source_busy_error(),
             headers={**rate_limit_headers, "Retry-After": "1"},
         )
+    compact_source_payload: dict[str, JsonValue] | None = None
     try:
         # Inside the route-helper latch (I13): the budget serializer can raise
         # (a lone surrogate in the body) and a claimed slot must never outlive
         # the request that claimed it.
-        admission_budget = estimate_api_key_request_usage(payload)
+        if isinstance(payload, ResponsesCompactRequest):
+            compact_source_payload = strip_source_telemetry(payload.model_dump(mode="json", exclude_none=True))
+            compact_source_payload.pop("store", None)
+            compact_source_payload.pop("stream", None)
+            if api_key is not None and api_key.enforced_reasoning_effort is not None:
+                normalize_source_reasoning_aliases(compact_source_payload)
+        admission_budget = estimate_api_key_request_usage(payload, upstream_payload=compact_source_payload)
         reservation = await _enforce_request_limits(
             api_key,
             request_model=payload.model,
@@ -5321,6 +5367,40 @@ async def _source_responses_response(
         claims.release_if_unowned()
         raise
     try:
+        if isinstance(payload, ResponsesCompactRequest):
+            assert compact_source_payload is not None
+            result = await open_with_disconnect_watch(
+                request, owner, forward_compact_responses(source, compact_source_payload)
+            )
+            try:
+                compact_result = CompactResponsePayload.model_validate(result.payload)
+            except ValidationError:
+                await owner.finish(
+                    status="error",
+                    error_code="invalid_upstream_response",
+                    error_message="model source returned an invalid compact response",
+                    usage=result.usage,
+                    timings=result.timings,
+                    upstream_status_code=result.upstream_status_code,
+                )
+                return _logged_error_json_response(
+                    request,
+                    502,
+                    openai_error(
+                        "invalid_upstream_response",
+                        "OpenAI-compatible model source returned an invalid compact response",
+                        error_type="server_error",
+                    ),
+                    headers=rate_limit_headers,
+                )
+            if not enforce_openai_sdk_contract:
+                result = replace(
+                    result,
+                    payload=_normalize_codex_remote_compaction_v2_result(compact_result, result.payload),
+                )
+            return await _finish_non_stream_source_dispatch(
+                request, owner, result, rate_limit_headers=rate_limit_headers
+            )
         source_payload = _shape_source_responses_payload(
             payload,
             source,
@@ -7222,7 +7302,7 @@ async def responses_compact(
     _raw_trigger_validation: None = Depends(_capture_raw_compaction_trigger_error),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
-) -> JSONResponse:
+) -> Response:
     capability_transport_denial = await _required_capability_http_transport_denial(request, api_key, payload=payload)
     if capability_transport_denial is not None:
         return capability_transport_denial
@@ -7249,7 +7329,7 @@ async def v1_responses_compact(
     payload: V1ResponsesCompactRequest = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
-) -> JSONResponse:
+) -> Response:
     capability_transport_denial = await _required_capability_http_transport_denial(request, api_key, payload=payload)
     if capability_transport_denial is not None:
         return capability_transport_denial
@@ -7280,22 +7360,52 @@ async def _compact_responses(
     codex_session_affinity: bool = False,
     openai_cache_affinity: bool = False,
     prohibit_fast_mode: bool = False,
-) -> JSONResponse:
-    # The replaced effort is discarded: this path is subscription-only, so the
-    # rewrite that works around the backend hang must stick.
-    service_tier_was_enforced = apply_api_key_enforcement(
+) -> Response:
+    raw_source_model = _effective_optional_model_for_api_key(api_key, payload.model)
+    enforcement = apply_api_key_enforcement(
         payload,
         api_key,
         prohibit_fast_mode=prohibit_fast_mode,
-    ).service_tier_was_enforced
+    )
+    if prohibit_fast_mode and _is_fast_mode_model_alias(raw_source_model):
+        raw_source_model = payload.model
     apply_enforced_service_tier_model_fallback(
         payload,
-        service_tier_was_enforced=service_tier_was_enforced,
+        service_tier_was_enforced=enforcement.service_tier_was_enforced,
     )
     validate_model_access(api_key, payload.model)
     pin_denial = await compact_pin_denial(request, payload, context=context)
     if pin_denial is not None:
         return pin_denial
+    source_route_excluded = bool(extract_input_file_ids(payload.input))
+    try:
+        source_selection, continuity_suppressed = (
+            (None, False)
+            if source_route_excluded
+            else await _select_compact_model_source_with_continuity(
+                request, payload, context, api_key, raw_model=raw_source_model
+            )
+        )
+    except ProxyResponseError as exc:
+        return _logged_error_json_response(request, exc.status_code, exc.payload)
+    if source_selection is not None:
+        source, payload.model = source_selection
+        return await _source_responses_response(
+            request,
+            payload,
+            source=source,
+            api_key=api_key,
+            rate_limit_headers=await _rate_limit_headers_for_request(context, api_key),
+            pre_normalization_effort=enforcement.pre_normalization_reasoning_effort,
+            enforce_openai_sdk_contract=not codex_session_affinity,
+            context=context,
+        )
+    if not source_route_excluded and not continuity_suppressed:
+        disabled_denial = await _disabled_model_source_denial(
+            request, payload.model, api_key, route="responses", raw_model=raw_source_model
+        )
+        if disabled_denial is not None:
+            return disabled_denial
     try:
         request_usage_budget = estimate_api_key_request_usage(payload)
     except ClientPayloadError as exc:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -7369,10 +7369,6 @@ async def _compact_responses(
     )
     if prohibit_fast_mode and _is_fast_mode_model_alias(raw_source_model):
         raw_source_model = payload.model
-    apply_enforced_service_tier_model_fallback(
-        payload,
-        service_tier_was_enforced=enforcement.service_tier_was_enforced,
-    )
     validate_model_access(api_key, payload.model)
     pin_denial = await compact_pin_denial(request, payload, context=context)
     if pin_denial is not None:
@@ -7406,6 +7402,10 @@ async def _compact_responses(
         )
         if disabled_denial is not None:
             return disabled_denial
+    apply_enforced_service_tier_model_fallback(
+        payload,
+        service_tier_was_enforced=enforcement.service_tier_was_enforced,
+    )
     try:
         request_usage_budget = estimate_api_key_request_usage(payload)
     except ClientPayloadError as exc:

--- a/app/modules/proxy/api_key_usage.py
+++ b/app/modules/proxy/api_key_usage.py
@@ -43,10 +43,11 @@ def estimate_api_key_request_usage(
     ``None`` means the proxy cannot size that side of the request locally, so
     API-key enforcement should use its conservative default for that dimension.
 
-    ``upstream_payload`` lets callers that already hold ``payload.to_payload()``
-    share it instead of paying for another full dump. It must be the pristine
-    ``to_payload()`` result for ``payload`` (``to_payload`` is deterministic, so
-    the budget is identical either way).
+    ``upstream_payload`` must be the exact payload the selected transport will
+    send. Native callers can share their pristine ``payload.to_payload()``
+    result instead of serializing twice. Source compact callers supply their
+    source projection because native serialization removes tool definitions
+    and can trim history that the source still receives.
     """
 
     if upstream_payload is None:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -56,6 +56,17 @@ Each signal needs at least eight samples on at least three accounts (per model, 
 
 Limit warm-up sends **one small real request** (using the configured warm-up model and prompt) to an opted-in account when one of its quota windows is confirmed to have newly reset, verifying that the account responds. It consumes a small amount of quota. The optional staggered idle mode additionally pre-starts the 5h window of idle opted-in accounts before traffic arrives; the configured cooldown applies to these staggered idle probes, while ordinary reset-confirmed probes fire once per confirmed reset. Accounts opt in individually (`Enable warm-up` in account actions); the last attempt's result, model, and time are shown on the account list entry.
 
+## Direct model-source compaction
+
+For an external model served by a Responses-compatible source, explicit requests to
+`/v1/responses/compact` and `/backend-api/codex/responses/compact` forward to that
+source's `/responses/compact` endpoint. No subscription account is required. Native
+continuation and uploaded-file ownership still take precedence. The source must
+support compaction; its errors are returned without switching models or falling
+back to subscription accounts. This does not enable terminal `compaction_trigger`
+requests or compaction for overflow-pinned conversations. Owning spec:
+[responses-api-compat](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat).
+
 ## Subscription-exhaustion overflow to a model source
 
 > **Status: shipped, ship-dark.** Overflow routing is in this release and inactive until a source is designated: with the control **Off** (both settings columns `null`) the request path performs no probe, pin lookup, source selection or body walk and an exhausted pool answers exactly as before, byte for byte. **Production flip gate:** do not designate a source in production before every replica runs the release that contains the wired anchors and the WebSocket parity (this one); rehearse on a canary first (see [Canary and drills](#canary-and-drills)). Owning spec: [model-source-routing](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/model-source-routing); design: issue [#2123](https://github.com/Soju06/codex-lb/issues/2123), which supersedes the earlier proposals in #428 and #1664.

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/design.md
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The explicit compact route is currently subscription-only. A prior loopback diagnostic registered a Responses source through the public API, then received `503 no_accounts` from both compact paths while the source received no traffic. This is an accepted feature gap in the single-provider bridge, not evidence that the current subscription-only contract is implemented incorrectly. Refresh the route proof against the pinned base before changing code.
+
+## Goals / Non-Goals
+
+Support explicit compact requests for configured Responses sources with the same source scope, native precedence, admission and usage behavior as ordinary Responses. Preserve complete source history and opaque compact output.
+
+Provider translation, history storage, catalog discovery and implicit terminal-trigger compaction are separate work. This change does not claim actual CPA/provider compatibility or introduce an unmerged PR dependency.
+
+## Decisions
+
+Resolve sources before subscription admission. Preserve native file pins and resolve subscription previous-response and turn-state owners before source dispatch. If an owner requires subscription routing, let the existing compact service perform its complete reconciliation and cleanup. Source resolution failures remain errors.
+
+Use the existing source dispatch owner for concurrency claims, API-key reservations, disconnect detection, settlement and logging. Extend the source HTTP transport with a separate compact entry point that shares the existing non-stream request implementation. Do not duplicate settlement or retry code.
+
+Forward external compact payloads without the subscription-specific history trimming or tool removal. Retain API-key enforcement and strip LB telemetry. Do not infer that Responses support proves compact support; an unsupported source endpoint returns its explicit upstream error, without fallback or another model.
+
+## Risks / Trade-offs
+
+Native continuity can overlap a source model. Public route tests must prove those owners never dispatch externally. The native compact service remains unchanged.
+
+The two public compact contracts differ: SDK output retains the source envelope, while the Codex path uses the existing compact result normalization. Preserve opaque content rather than translating it.
+
+Source timeouts and cancellation must release admission and reservation ownership. Reuse the source dispatcher and verify recovery through subsequent public requests.
+
+No migration or configuration change is needed. Rolling back removes external compact support while preserving source records. Real provider authorization and deployed-host acceptance remain external decisions.

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/proposal.md
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Explicit compact requests for a registered external Responses model enter subscription account selection. With no subscription accounts they return `503 no_accounts`, although the configured source can serve `/responses/compact`.
+
+## What Changes
+
+- Route explicit compact requests to their configured Responses source when no subscription continuity or uploaded-file owner requires native routing.
+- Preserve source authentication, payload history, admission, usage settlement, cancellation and error reporting.
+- Keep native compact ownership and serialization unchanged. Unsupported source compaction returns the source's error without native fallback.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: explicit compact routing for external Responses sources.
+
+## Impact
+
+Both `/v1/responses/compact` and `/backend-api/codex/responses/compact`, the shared source dispatcher and the source HTTP transport. No catalog discovery dependency, provider translation, schema migration, setting or frontend change.

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/specs/responses-api-compat/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Explicit compact requests route to Responses model sources
+
+The system MUST route explicit compact requests on `/v1/responses/compact` and `/backend-api/codex/responses/compact` to the selected Responses model source's `/responses/compact` endpoint when subscription continuity or uploaded-file ownership does not require native routing. Source selection MUST preserve API-key source scope, model enforcement and native registry precedence. Disabled source ownership MUST produce the existing disabled-source error rather than subscription fallback.
+
+#### Scenario: External compact works without subscription accounts
+- **GIVEN** an enabled Responses source serves an external model and no subscription accounts exist
+- **WHEN** the client posts a compact request for that model on either explicit compact route
+- **THEN** the source receives the compact request authenticated with its configured source credential
+- **AND** the client receives its compact result without a subscription account lookup failure
+
+#### Scenario: Native continuity remains native
+- **GIVEN** a compact request includes a subscription-owned previous response, turn-state alias or uploaded file
+- **WHEN** a Responses source also claims the requested model
+- **THEN** the source receives no request
+- **AND** the existing subscription compact reconciliation determines the result
+
+#### Scenario: A disabled source does not fall through
+- **WHEN** a compact request selects an external source or source model that is disabled
+- **THEN** the client receives `503 model_source_disabled`
+- **AND** neither source nor subscription upstream receives the request
+
+### Requirement: External compact preserves source protocol and dispatch ownership
+
+External compact forwarding MUST retain the supplied history and opaque source compaction state without subscription-specific trimming or tool removal. It MUST apply API-key policy and source telemetry filtering, use the source's configured authentication and bounded transport, and retain the existing source admission, usage settlement and cancellation guarantees. Admission MUST estimate usage from the actual source-bound payload, including retained tool definitions. Source failures MUST remain explicit without subscription or model fallback. The SDK route MUST retain the source compact envelope; the Codex route MUST apply its existing compact output normalization.
+
+#### Scenario: Source compact history is retained
+- **WHEN** external compact input contains messages, completed tool pairs and opaque source compaction state
+- **THEN** the source receives that history without silent removal
+- **AND** source compaction content is returned unchanged within the applicable public envelope
+
+#### Scenario: Limited-key compact usage settles
+- **WHEN** a source compact response reports usage for a limited API key
+- **THEN** the source dispatch settles the reservation using that usage before reporting success
+- **AND** a later request can acquire the released source admission capacity
+
+#### Scenario: Preserved definitions count toward admission
+- **WHEN** a compact request's retained tool definitions fill the key's remaining bounded reservation budget
+- **THEN** that budget remains reserved until the request settles
+- **AND** a concurrent request cannot consume the same remaining quota
+
+#### Scenario: Unsupported compact remains an explicit source failure
+- **WHEN** the selected source rejects `/responses/compact`
+- **THEN** the client receives the source error with credential redaction and applicable retry metadata
+- **AND** no subscription fallback occurs
+
+#### Scenario: Cancellation releases source ownership
+- **WHEN** the client disconnects or compact dispatch is cancelled
+- **THEN** the source dispatcher releases its connection, admission claim and reservation through its existing cleanup lifecycle

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/tasks.md
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/tasks.md
@@ -1,0 +1,16 @@
+## 1. Confirm the contract
+
+- [x] 1.1 Reproduce both explicit compact routes against the pinned upstream base using a registered loopback source and an isolated database.
+- [x] 1.2 Record current subscription-only behavior as an accepted feature gap and file a focused issue, #2318.
+
+## 2. Implement and prove forwarding
+
+- [x] 2.1 Make the first public compact route regression pass through the existing source dispatch lifecycle.
+- [x] 2.2 Prove source scope, disabled ownership, native continuity and payload/output preservation through the public routes.
+- [x] 2.3 Prove limited-key usage, upstream errors and cancellation cleanup; fix any failures without weakening the assertions.
+
+## 3. Verify and hand off
+
+- [x] 3.1 Run affected source/compact regressions, lint, typing and strict OpenSpec validation.
+- [x] 3.2 Review the exact candidate against the pinned base and prepare verified spec synchronization.
+- [x] 3.3 Prepare the issue-linked PR and operational handoff with hosted monitoring ownership and remaining CPA decisions.

--- a/openspec/changes/archive/2026-09-10-forward-external-source-compaction/verification.md
+++ b/openspec/changes/archive/2026-09-10-forward-external-source-compaction/verification.md
@@ -1,0 +1,41 @@
+## Local verification
+
+Base: upstream/main `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`, fetched again before publication.
+
+The public setup uses an enabled, manually registered Responses source and a
+loopback HTTP provider. Both explicit compact routes initially returned
+`503 no_accounts` with no native accounts. This confirms an accepted feature gap
+in the existing subscription-only contract, rather than incorrect source setup.
+
+The final focused run passed 58 cases: 30 new public compact checks and 28
+request-budget checks. They cover both routes, disabled source/model ownership,
+source assignment and model enforcement, history/tool preservation, output shape,
+invalid responses, native registry/previous-response/file/turn-state ownership,
+usage settlement, concurrent admission, errors, redaction and cancellation.
+
+A broader run passed 394 source-forwarding, dispatch, deadline, native compact,
+trigger and transport cases before the final compact-budget correction. That
+correction only changes the compact source projection used for admission; the
+58-case final run verifies it. Unchanged broad results are retained.
+
+`make lint typecheck` and strict change validation pass. Foreground, background
+and fixture engines were checked against one dedicated SQLite test database
+before the final runs. No live database, container or provider was used.
+
+## Requirement coverage
+
+- Source routing and native ownership: `test_model_source_compact.py` and
+  `test_model_source_compact_ownership.py` through the two public compact routes.
+- Payload/output preservation and malformed responses: `test_model_source_compact.py`.
+- Usage, concurrent reservation, upstream errors and departure cleanup:
+  `test_model_source_compact_lifecycle.py` through HTTP and ASGI disconnect input.
+
+## Limits
+
+Synthetic HTTP proof does not establish actual CPA/provider compatibility.
+Provider authorization, deployed-host acceptance, CPA deferred discovery and
+HTTP response-history storage remain separate. Terminal-trigger and
+overflow-pinned compaction are outside this explicit-endpoint change.
+Hosted CI and independent review remain PR gates. An independent local reviewer
+could not start because its model request returned `503 no_accounts`; no
+independent-review pass is claimed.

--- a/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/context.md
+++ b/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/context.md
@@ -1,0 +1,3 @@
+The reproduction uses an explicitly assigned Responses source whose model also exists in an authoritative native catalog with only the default tier. An enforced priority request succeeds but its request log loses priority. Unknown external model identities do not reproduce this problem.
+
+The existing fallback helper is subscription-only. Source selection must finish first. Native continuity, source wire serialization and configured local HTTP remain outside this repair. Both public compact routes and the request-log API are the accepted test boundaries.

--- a/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/proposal.md
+++ b/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/proposal.md
@@ -1,0 +1,13 @@
+## Why
+
+PR #2324 applies subscription tier fallback before selecting a compact source. An assigned source sharing a known native model loses its enforced tier in request accounting.
+
+## What Changes
+
+- Run subscription tier fallback only after the compact source branch.
+- Verify both compact endpoints through the public request-log API.
+- Repair two existing budget-failure test doubles for the new optional payload argument.
+
+## Impact
+
+Source compact accounting retains the enforced tier. Native fallback and configured HTTP transport stay unchanged. Closes #2318 remains the owning PR issue.

--- a/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/specs/responses-api-compat/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Source compact retains enforced tier attribution
+
+Explicit compact requests selected for a Responses model source MUST retain their enforced service tier for source admission and requested-tier attribution. Subscription model tier fallback MUST run only when the request follows subscription-account routing.
+
+#### Scenario: Assigned source shares a native model without the enforced tier
+- **GIVEN** an API key assigns a Responses source and enforces priority
+- **AND** the source model also exists in an authoritative subscription catalog that advertises only default
+- **WHEN** either explicit compact endpoint selects that source
+- **THEN** the request log records requested service tier priority
+- **AND** the subscription fallback does not clear that tier

--- a/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/tasks.md
+++ b/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/tasks.md
@@ -1,0 +1,5 @@
+## 1. Repair and verify
+
+- [x] Reproduce missing requested tier on both public compact routes.
+- [x] Move fallback to the native branch and verify regression coverage.
+- [x] Validate specs.

--- a/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/verification.md
+++ b/openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/verification.md
@@ -1,0 +1,3 @@
+Both public routes reproduced requestedServiceTier null instead of priority on the original candidate. After moving the fallback, 60 compact and budget cases pass. Native compact tier tests and make lint typecheck pass. Both hosted-failure tests pass after correcting their test-double signatures. The original independent review found only the reproduced fallback ordering defect; final candidate review and hosted verification are recorded separately by the PR owner.
+
+No design.md was required for moving one existing call. No new policy, setting, transport restriction or module boundary is introduced.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -297,3 +297,23 @@ stream. Predispatch failures and cancellation release origin-owned reservations;
 accepted or delivery-ambiguous owner forwards retain their settlement owner.
 Context bindings do not span yields because startup probes and consumers may
 advance the stream from different tasks.
+
+## Direct external compact forwarding
+
+Explicit compact requests use the configured Responses source when native
+continuity or an uploaded file does not pin the request to subscription accounts.
+For example, `/v1/responses/compact` for an external model can succeed with no
+subscription accounts when the source implements `/responses/compact`.
+
+The source receives retained history and tool definitions. Its exact outgoing
+payload determines reservation admission, so definitions removed only by native
+compact serialization cannot escape the source's usage budget. The existing
+source dispatcher owns concurrency, disconnect handling, settlement and redaction.
+Native compact ownership and serialization stay in the native service.
+
+Responses capability does not guarantee provider compact support. An unsupported
+endpoint returns its source error without fallback. This feature covers explicit
+compact endpoints; terminal-trigger and overflow-pinned compaction retain their
+existing behavior. It supplies no provider history store or tool translator.
+See issue [#2318](https://github.com/Soju06/codex-lb/issues/2318) and the requirements
+in [spec.md](spec.md).

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Define Responses API compatibility contracts so Codex, OpenCode, and OpenAI-style clients preserve expected behavior.
+
 ## Requirements
+
 ### Requirement: Use prompt_cache_key as OpenAI cache affinity
 For OpenAI-style `/v1/responses`, `/v1/responses/compact`, and chat-completions requests mapped onto Responses, the service MUST treat a non-empty `prompt_cache_key` as the bounded upstream account affinity key for prompt-cache correctness even when a `session_id` header is present. OpenAI-style route wiring MUST NOT upgrade those requests to durable `CODEX_SESSION` affinity by default. This affinity MUST apply even when dashboard `sticky_threads_enabled` is disabled, the service MUST continue forwarding the same `prompt_cache_key` upstream unchanged, and the stored affinity MUST expire after the configured freshness window so older keys can rebalance. The freshness window MUST come from dashboard settings so operators can adjust it without restart.
 
@@ -10831,3 +10833,51 @@ still awaiting I/O.
 - **THEN** the key is quarantined and the probe is planned without the dead anchor
 - **AND** the probe resends full history rather than the dead anchor
 
+### Requirement: Explicit compact requests route to Responses model sources
+
+The system MUST route explicit compact requests on `/v1/responses/compact` and `/backend-api/codex/responses/compact` to the selected Responses model source's `/responses/compact` endpoint when subscription continuity or uploaded-file ownership does not require native routing. Source selection MUST preserve API-key source scope, model enforcement and native registry precedence. Disabled source ownership MUST produce the existing disabled-source error rather than subscription fallback.
+
+#### Scenario: External compact works without subscription accounts
+- **GIVEN** an enabled Responses source serves an external model and no subscription accounts exist
+- **WHEN** the client posts a compact request for that model on either explicit compact route
+- **THEN** the source receives the compact request authenticated with its configured source credential
+- **AND** the client receives its compact result without a subscription account lookup failure
+
+#### Scenario: Native continuity remains native
+- **GIVEN** a compact request includes a subscription-owned previous response, turn-state alias or uploaded file
+- **WHEN** a Responses source also claims the requested model
+- **THEN** the source receives no request
+- **AND** the existing subscription compact reconciliation determines the result
+
+#### Scenario: A disabled source does not fall through
+- **WHEN** a compact request selects an external source or source model that is disabled
+- **THEN** the client receives `503 model_source_disabled`
+- **AND** neither source nor subscription upstream receives the request
+
+### Requirement: External compact preserves source protocol and dispatch ownership
+
+External compact forwarding MUST retain the supplied history and opaque source compaction state without subscription-specific trimming or tool removal. It MUST apply API-key policy and source telemetry filtering, use the source's configured authentication and bounded transport, and retain the existing source admission, usage settlement and cancellation guarantees. Admission MUST estimate usage from the actual source-bound payload, including retained tool definitions. Source failures MUST remain explicit without subscription or model fallback. The SDK route MUST retain the source compact envelope; the Codex route MUST apply its existing compact output normalization.
+
+#### Scenario: Source compact history is retained
+- **WHEN** external compact input contains messages, completed tool pairs and opaque source compaction state
+- **THEN** the source receives that history without silent removal
+- **AND** source compaction content is returned unchanged within the applicable public envelope
+
+#### Scenario: Limited-key compact usage settles
+- **WHEN** a source compact response reports usage for a limited API key
+- **THEN** the source dispatch settles the reservation using that usage before reporting success
+- **AND** a later request can acquire the released source admission capacity
+
+#### Scenario: Preserved definitions count toward admission
+- **WHEN** a compact request's retained tool definitions fill the key's remaining bounded reservation budget
+- **THEN** that budget remains reserved until the request settles
+- **AND** a concurrent request cannot consume the same remaining quota
+
+#### Scenario: Unsupported compact remains an explicit source failure
+- **WHEN** the selected source rejects `/responses/compact`
+- **THEN** the client receives the source error with credential redaction and applicable retry metadata
+- **AND** no subscription fallback occurs
+
+#### Scenario: Cancellation releases source ownership
+- **WHEN** the client disconnects or compact dispatch is cancelled
+- **THEN** the source dispatcher releases its connection, admission claim and reservation through its existing cleanup lifecycle

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -10881,3 +10881,14 @@ External compact forwarding MUST retain the supplied history and opaque source c
 #### Scenario: Cancellation releases source ownership
 - **WHEN** the client disconnects or compact dispatch is cancelled
 - **THEN** the source dispatcher releases its connection, admission claim and reservation through its existing cleanup lifecycle
+
+### Requirement: Source compact retains enforced tier attribution
+
+Explicit compact requests selected for a Responses model source MUST retain their enforced service tier for source admission and requested-tier attribution. Subscription model tier fallback MUST run only when the request follows subscription-account routing.
+
+#### Scenario: Assigned source shares a native model without the enforced tier
+- **GIVEN** an API key assigns a Responses source and enforces priority
+- **AND** the source model also exists in an authoritative subscription catalog that advertises only default
+- **WHEN** either explicit compact endpoint selects that source
+- **THEN** the request log records requested service tier priority
+- **AND** the subscription fallback does not clear that tier

--- a/tests/integration/test_model_source_compact.py
+++ b/tests/integration/test_model_source_compact.py
@@ -1,0 +1,190 @@
+"""Explicit compact routing through the public API and a loopback source."""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+
+from tests.integration.model_source_helpers import _create_model_source, _enable_api_key_auth, stub_source_upstreams
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_routes_to_registered_source_without_subscription_accounts(async_client, route):
+    received = []
+
+    async def compact(request):
+        received.append((request.path, request.headers.get("Authorization"), await request.json()))
+        return web.json_response(
+            {
+                "id": "cmp_source",
+                "object": "response.compaction",
+                "output": [{"type": "compaction", "encrypted_content": "source-opaque-state"}],
+                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            }
+        )
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        await _create_model_source(
+            async_client,
+            name="compact-fixture",
+            model="external-compact-model",
+            base_url=base,
+            supports_responses=True,
+            supports_streaming=False,
+        )
+        response = await async_client.post(
+            route,
+            json={
+                "model": "external-compact-model",
+                "instructions": "Compact this conversation",
+                "input": [{"role": "user", "content": "Remember the number 42"}],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert len(received) == 1
+    assert received[0][0] == "/v1/responses/compact"
+    assert received[0][1] == "Bearer token-compact-fixture"
+    assert received[0][2]["model"] == "external-compact-model"
+    assert "Remember the number 42" in str(received[0][2]["input"])
+    assert response.json()["output"][0]["encrypted_content"] == "source-opaque-state"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_rejects_non_compact_source_response(async_client, route):
+    async def invalid_compact(_request):
+        return web.json_response({"id": "resp_wrong", "object": "response", "output": []})
+
+    async with stub_source_upstreams() as start:
+        base = await start(invalid_compact)
+        await _create_model_source(
+            async_client,
+            name="invalid-compact-fixture",
+            model="external-compact-model",
+            base_url=base,
+            supports_responses=True,
+        )
+        response = await async_client.post(
+            route,
+            json={"model": "external-compact-model", "instructions": "Compact", "input": []},
+        )
+
+    assert response.status_code == 502, response.text
+    assert response.json()["error"]["code"] == "invalid_upstream_response"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_preserves_source_history_and_public_output_contract(async_client, route):
+    received = []
+    history = [
+        {"type": "compaction", "id": "cmp_prior", "encrypted_content": "prior-source-state"},
+        {"type": "function_call", "call_id": "call_1", "name": "lookup", "namespace": "tools", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_1", "output": "42"},
+    ]
+    definitions = [{"type": "function", "name": "lookup", "parameters": {"type": "object"}}]
+    source_output = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Retained input"}]},
+        {"type": "compaction", "id": "cmp_next", "encrypted_content": "next-source-state"},
+    ]
+
+    async def compact(request):
+        received.append(await request.json())
+        return web.json_response({"id": "cmp_result", "object": "response.compaction", "output": source_output})
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        await _create_model_source(
+            async_client, name="history", model="external-compact-model", base_url=base, supports_responses=True
+        )
+        response = await async_client.post(
+            route,
+            json={
+                "model": "external-compact-model",
+                "instructions": "Compact",
+                "input": history,
+                "tools": definitions,
+                "client_metadata": {"private": "client-telemetry"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert received[0]["input"] == history
+    assert received[0]["tools"] == definitions
+    assert "client_metadata" not in received[0]
+    assert "store" not in received[0]
+    assert "stream" not in received[0]
+    expected_output = source_output if route.startswith("/v1/") else [source_output[1]]
+    assert response.json()["output"] == expected_output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disabled", ["source", "model"])
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_refuses_disabled_source_ownership(async_client, route, disabled):
+    received = []
+
+    async def unexpected_source(request):
+        received.append(request.path)
+        return web.json_response({"object": "response.compaction", "output": []})
+
+    async with stub_source_upstreams() as start:
+        base = await start(unexpected_source)
+        source_id = await _create_model_source(
+            async_client, name="disabled", model="external-compact-model", base_url=base, supports_responses=True
+        )
+        change = (
+            {"isEnabled": False}
+            if disabled == "source"
+            else {"models": [{"model": "external-compact-model", "isEnabled": False}]}
+        )
+        updated = await async_client.patch(f"/api/model-sources/{source_id}", json=change)
+        assert updated.status_code == 200, updated.text
+        response = await async_client.post(
+            route, json={"model": "external-compact-model", "instructions": "Compact", "input": []}
+        )
+
+    assert response.status_code == 503, response.text
+    assert response.json()["error"]["code"] == "model_source_disabled"
+    assert received == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_uses_enforced_model_and_assigned_source(async_client, route):
+    received = []
+
+    async def compact(request):
+        received.append((request.headers["Authorization"], await request.json()))
+        return web.json_response(
+            {"object": "response.compaction", "output": [{"type": "compaction", "encrypted_content": "state"}]}
+        )
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        await _create_model_source(
+            async_client, name="unassigned", model="external-compact-model", base_url=base, supports_responses=True
+        )
+        assigned_id = await _create_model_source(
+            async_client, name="assigned", model="external-compact-model", base_url=base, supports_responses=True
+        )
+        await _enable_api_key_auth(async_client)
+        created = await async_client.post(
+            "/api/api-keys/",
+            json={"name": "scoped", "assignedSourceIds": [assigned_id], "enforcedModel": "external-compact-model"},
+        )
+        assert created.status_code == 200, created.text
+        response = await async_client.post(
+            route,
+            headers={"Authorization": f"Bearer {created.json()['key']}"},
+            json={"model": "client-model", "instructions": "Compact", "input": []},
+        )
+
+    assert response.status_code == 200, response.text
+    assert received[0][0] == "Bearer token-assigned"
+    assert received[0][1]["model"] == "external-compact-model"

--- a/tests/integration/test_model_source_compact.py
+++ b/tests/integration/test_model_source_compact.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from aiohttp import web
 
+from app.core.openai.model_registry import get_model_registry
 from tests.integration.model_source_helpers import _create_model_source, _enable_api_key_auth, stub_source_upstreams
 
 pytestmark = pytest.mark.integration
@@ -188,3 +191,51 @@ async def test_compact_uses_enforced_model_and_assigned_source(async_client, rou
     assert response.status_code == 200, response.text
     assert received[0][0] == "Bearer token-assigned"
     assert received[0][1]["model"] == "external-compact-model"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_retains_enforced_tier_in_source_request_log(async_client, route):
+    registry = get_model_registry()
+    model = replace(registry.get_models_for_metadata()["gpt-5.6-sol"], raw={"service_tiers": [{"slug": "default"}]})
+    await registry.update(
+        {"pro": [model]},
+        per_account_results={"fixture-account": ("pro", [model])},
+        active_account_plans={"fixture-account": "pro"},
+    )
+    received = []
+
+    async def compact(request):
+        received.append(await request.json())
+        return web.json_response(
+            {
+                "id": "cmp_tier",
+                "object": "response.compaction",
+                "output": [{"type": "compaction", "encrypted_content": "state"}],
+                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            }
+        )
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        source_id = await _create_model_source(
+            async_client, name="tier", model="gpt-5.6-sol", base_url=base, supports_responses=True
+        )
+        await _enable_api_key_auth(async_client)
+        created = await async_client.post(
+            "/api/api-keys/",
+            json={"name": "tier", "assignedSourceIds": [source_id], "enforcedServiceTier": "priority"},
+        )
+        assert created.status_code == 200, created.text
+        response = await async_client.post(
+            route,
+            headers={"Authorization": f"Bearer {created.json()['key']}"},
+            json={"model": "gpt-5.6-sol", "instructions": "Compact", "input": []},
+        )
+
+    assert response.status_code == 200, response.text
+    logs = await async_client.get("/api/request-logs")
+    assert logs.status_code == 200, logs.text
+    row = next(row for row in logs.json()["requests"] if row["requestId"] == "cmp_tier")
+    assert row["requestedServiceTier"] == "priority"
+    assert row["serviceTier"] is None

--- a/tests/integration/test_model_source_compact_lifecycle.py
+++ b/tests/integration/test_model_source_compact_lifecycle.py
@@ -1,0 +1,196 @@
+"""Source compact accounting and disconnect behavior at the HTTP boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from aiohttp import web
+
+from tests.integration.model_source_helpers import (
+    _AsgiStream,
+    _create_model_source,
+    _enable_api_key_auth,
+    stub_source_upstreams,
+)
+
+pytestmark = pytest.mark.integration
+
+_BODY = {"model": "source-compact", "instructions": "Compact", "input": []}
+_RESULT = {
+    "id": "cmp_source",
+    "object": "response.compaction",
+    "output": [{"type": "compaction", "encrypted_content": "source-state"}],
+    "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+}
+
+
+async def _limited_key(async_client, source_id, *, max_value=100_000):
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "compact-limit",
+            "assignedSourceIds": [source_id],
+            "limits": [{"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": max_value}],
+        },
+    )
+    assert created.status_code == 200, created.text
+    return created.json()["id"], {"Authorization": f"Bearer {created.json()['key']}"}
+
+
+async def _limit_value(async_client, key_id):
+    response = await async_client.get("/api/api-keys/")
+    assert response.status_code == 200, response.text
+    key = next(item for item in response.json() if item["id"] == key_id)
+    return key["limits"][0]["currentValue"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_settles_reported_usage_and_releases_source_capacity(async_client, route):
+    async def compact(_request):
+        return web.json_response(_RESULT)
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        source_id = await _create_model_source(
+            async_client, name="usage", model="source-compact", base_url=base, supports_responses=True
+        )
+        updated = await async_client.patch(f"/api/model-sources/{source_id}", json={"maxConcurrency": 1})
+        assert updated.status_code == 200
+        key_id, headers = await _limited_key(async_client, source_id)
+        first = await async_client.post(route, headers=headers, json=_BODY)
+        assert first.status_code == 200, first.text
+        assert await _limit_value(async_client, key_id) == 15
+        second = await async_client.post(route, headers=headers, json=_BODY)
+        assert second.status_code == 200, second.text
+        assert await _limit_value(async_client, key_id) == 30
+
+
+@pytest.mark.asyncio
+async def test_compact_admission_counts_preserved_source_tool_definitions(async_client):
+    received = []
+    entered = asyncio.Event()
+    hold = asyncio.Event()
+
+    async def compact(request):
+        received.append(await request.json())
+        entered.set()
+        await hold.wait()
+        return web.json_response(_RESULT)
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        source_id = await _create_model_source(
+            async_client, name="budget", model="source-compact", base_url=base, supports_responses=True
+        )
+        key_id, headers = await _limited_key(async_client, source_id, max_value=3_000)
+        first = asyncio.create_task(
+            async_client.post(
+                "/v1/responses/compact",
+                headers=headers,
+                json={
+                    **_BODY,
+                    "tools": [{"type": "function", "name": "lookup", "description": "x" * 10_000}],
+                },
+            )
+        )
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            assert await _limit_value(async_client, key_id) == 3_000
+            second = await async_client.post("/v1/responses/compact", headers=headers, json=_BODY)
+            assert second.status_code == 429, second.text
+            assert len(received) == 1
+        finally:
+            hold.set()
+            response = await asyncio.wait_for(first, timeout=5)
+        assert response.status_code == 200, response.text
+        assert await _limit_value(async_client, key_id) == 15
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [404, 429, 500])
+async def test_compact_source_error_is_explicit_redacted_and_releases_usage(async_client, status):
+    requests = 0
+
+    async def compact(_request):
+        nonlocal requests
+        requests += 1
+        if requests == 1:
+            return web.json_response(
+                {"error": {"code": "source_error", "message": "Rejected token-errors", "type": "server_error"}},
+                status=status,
+                headers={"Retry-After": "9"},
+            )
+        return web.json_response(_RESULT)
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact)
+        source_id = await _create_model_source(
+            async_client, name="errors", model="source-compact", base_url=base, supports_responses=True
+        )
+        updated = await async_client.patch(f"/api/model-sources/{source_id}", json={"maxConcurrency": 1})
+        assert updated.status_code == 200
+        key_id, headers = await _limited_key(async_client, source_id)
+        first = await async_client.post("/v1/responses/compact", headers=headers, json=_BODY)
+        assert first.status_code == status, first.text
+        assert first.json()["error"]["code"] == "source_error"
+        assert "token-errors" not in first.text
+        assert first.headers["Retry-After"] == "9"
+        assert await _limit_value(async_client, key_id) == 0
+        second = await async_client.post("/v1/responses/compact", headers=headers, json=_BODY)
+        assert second.status_code == 200, second.text
+        assert requests == 2
+        assert await _limit_value(async_client, key_id) == 15
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True], ids=["disconnect", "cancel"])
+async def test_compact_departure_releases_limited_key_and_source_capacity(async_client, app_instance, cancel):
+    entered = asyncio.Event()
+    hold = asyncio.Event()
+    requests = 0
+
+    async def compact(_request):
+        nonlocal requests
+        requests += 1
+        if requests == 1:
+            entered.set()
+            await hold.wait()
+        return web.json_response(_RESULT)
+
+    async with stub_source_upstreams() as start:
+        base = await start(compact, handler_cancellation=True, shutdown_timeout=0.1)
+        source_id = await _create_model_source(
+            async_client, name="departure", model="source-compact", base_url=base, supports_responses=True
+        )
+        updated = await async_client.patch(f"/api/model-sources/{source_id}", json={"maxConcurrency": 1})
+        assert updated.status_code == 200
+        key_id, headers = await _limited_key(async_client, source_id)
+        stream = _AsgiStream(
+            app=app_instance,
+            path="/v1/responses/compact",
+            headers={"authorization": headers["Authorization"]},
+            body=json.dumps(_BODY).encode(),
+        )
+        runner = asyncio.create_task(stream.run())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            if cancel:
+                runner.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await runner
+            else:
+                stream.disconnect()
+                await asyncio.wait_for(runner, timeout=5)
+            assert await _limit_value(async_client, key_id) == 0
+            second = await async_client.post("/v1/responses/compact", headers=headers, json=_BODY)
+            assert second.status_code == 200, second.text
+            assert await _limit_value(async_client, key_id) == 15
+        finally:
+            hold.set()
+            if not runner.done():
+                runner.cancel()
+                await asyncio.gather(runner, return_exceptions=True)

--- a/tests/integration/test_model_source_compact_ownership.py
+++ b/tests/integration/test_model_source_compact_ownership.py
@@ -1,0 +1,202 @@
+"""Native compact ownership survives a competing external model source."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aiohttp import web
+
+import app.modules.proxy.service as proxy_module
+from app.core.openai.models import CompactResponsePayload
+from app.db.session import SessionLocal
+from app.modules.proxy.durable_bridge_repository import DurableBridgeRepository, durable_bridge_api_key_scope
+from tests.integration.compact_test_helpers import _make_auth_json
+from tests.integration.model_source_helpers import _create_model_source, _enable_api_key_auth, stub_source_upstreams
+
+pytestmark = pytest.mark.integration
+
+
+async def _import_native_account(async_client):
+    auth = _make_auth_json("native-compact-account", "compact@example.com")
+    response = await async_client.post(
+        "/api/accounts/import", files={"auth_json": ("auth.json", json.dumps(auth), "application/json")}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["accountId"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_native_model_keeps_registry_precedence(async_client, monkeypatch, route):
+    await _import_native_account(async_client)
+    native_accounts = []
+    source_requests = []
+
+    async def native_compact(payload, headers, access_token, account_id):
+        native_accounts.append(account_id)
+        return CompactResponsePayload.model_validate(
+            {"object": "response.compaction", "output": [{"type": "compaction", "encrypted_content": "native"}]}
+        )
+
+    async def source(request):
+        source_requests.append(request.path)
+        return web.json_response({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", native_compact)
+    async with stub_source_upstreams() as start:
+        base = await start(source)
+        await _create_model_source(
+            async_client, name="native-collision", model="gpt-5.6-sol", base_url=base, supports_responses=True
+        )
+        response = await async_client.post(route, json={"model": "gpt-5.6-sol", "instructions": "Compact", "input": []})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["output"][0]["encrypted_content"] == "native"
+    assert native_accounts == ["native-compact-account"]
+    assert source_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pin", ["file", "turn-state"])
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_native_file_and_durable_turn_owners_precede_source(async_client, monkeypatch, route, pin):
+    account_id = await _import_native_account(async_client)
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post("/api/api-keys/", json={"name": "pinned-compact-key"})
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+    headers = {"Authorization": f"Bearer {created.json()['key']}"}
+    native_accounts = []
+    source_requests = []
+    body = {"model": "gpt-5.6-sol", "instructions": "Compact", "input": []}
+
+    async def native_compact(payload, headers, access_token, account_id):
+        native_accounts.append(account_id)
+        return CompactResponsePayload.model_validate(
+            {"object": "response.compaction", "output": [{"type": "compaction", "encrypted_content": "native"}]}
+        )
+
+    async def native_file(**kwargs):
+        return {"file_id": "file_native_compact", "upload_url": "https://example.invalid/upload"}
+
+    async def source(request):
+        source_requests.append(request.path)
+        return web.json_response({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", native_compact)
+    monkeypatch.setattr(proxy_module, "core_create_file", native_file)
+    if pin == "file":
+        uploaded = await async_client.post(
+            "/backend-api/files", headers=headers, json={"file_name": "note.txt", "file_size": 42}
+        )
+        assert uploaded.status_code == 200, uploaded.text
+        body["input"] = [{"role": "user", "content": [{"type": "input_file", "file_id": uploaded.json()["file_id"]}]}]
+    else:
+        # Seed the durable session a different replica wrote. The request still
+        # resolves it through the real compact route and repository lookup.
+        async with SessionLocal() as session:
+            repository = DurableBridgeRepository(session)
+            snapshot = await repository.claim_session(
+                session_key_kind="codex_session",
+                session_key_value="fixture-session",
+                api_key_scope=durable_bridge_api_key_scope(key_id),
+                instance_id="fixture-replica",
+                lease_ttl_seconds=60,
+                account_id=account_id,
+                model="gpt-5.6-sol",
+                service_tier=None,
+                latest_turn_state="opaque-native-turn",
+                latest_response_id=None,
+                allow_takeover=False,
+                owner_process_epoch="fixture-epoch",
+            )
+            await repository.upsert_alias(
+                session_id=snapshot.id,
+                alias_kind="turn_state",
+                alias_value="opaque-native-turn",
+                api_key_scope=durable_bridge_api_key_scope(key_id),
+            )
+        headers["x-codex-turn-state"] = "opaque-native-turn"
+
+    async with stub_source_upstreams() as start:
+        base = await start(source)
+        source_id = await _create_model_source(
+            async_client, name="pinned-collision", model="gpt-5.6-sol", base_url=base, supports_responses=True
+        )
+        assigned = await async_client.patch(f"/api/api-keys/{key_id}", json={"assignedSourceIds": [source_id]})
+        assert assigned.status_code == 200
+        response = await async_client.post(route, headers=headers, json=body)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["output"][0]["encrypted_content"] == "native"
+    assert native_accounts == ["native-compact-account"]
+    assert source_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [True, False], ids=["enabled-source", "disabled-source"])
+@pytest.mark.parametrize("route", ["/v1/responses/compact", "/backend-api/codex/responses/compact"])
+async def test_compact_previous_response_owner_precedes_assigned_source(async_client, monkeypatch, route, enabled):
+    await _import_native_account(async_client)
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post("/api/api-keys/", json={"name": "continuity-key"})
+    assert created.status_code == 200, created.text
+    key_id = created.json()["id"]
+    headers = {"Authorization": f"Bearer {created.json()['key']}"}
+    native_accounts = []
+    source_requests = []
+
+    async def native_response(payload, headers, access_token, account_id, **kwargs):
+        yield (
+            'data: {"type":"response.created","response":{"id":"resp_native_compact",'
+            '"object":"response","status":"in_progress","output":[]}}\n\n'
+        )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_native_compact",'
+            '"object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    async def native_compact(payload, headers, access_token, account_id):
+        native_accounts.append(account_id)
+        return CompactResponsePayload.model_validate(
+            {"object": "response.compaction", "output": [{"type": "compaction", "encrypted_content": "native"}]}
+        )
+
+    async def source(request):
+        source_requests.append(request.path)
+        return web.json_response({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", native_response)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", native_compact)
+    first = await async_client.post(
+        "/v1/responses", headers=headers, json={"model": "gpt-5.6-sol", "input": "Initial native turn", "stream": False}
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["id"] == "resp_native_compact"
+
+    async with stub_source_upstreams() as start:
+        base = await start(source)
+        source_id = await _create_model_source(
+            async_client, name="later-source", model="gpt-5.6-sol", base_url=base, supports_responses=True
+        )
+        assigned = await async_client.patch(f"/api/api-keys/{key_id}", json={"assignedSourceIds": [source_id]})
+        assert assigned.status_code == 200, assigned.text
+        if not enabled:
+            disabled = await async_client.patch(f"/api/model-sources/{source_id}", json={"isEnabled": False})
+            assert disabled.status_code == 200
+        response = await async_client.post(
+            route,
+            headers=headers,
+            json={
+                "model": "gpt-5.6-sol",
+                "instructions": "Compact",
+                "input": [],
+                "previous_response_id": first.json()["id"],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["output"][0]["encrypted_content"] == "native"
+    assert native_accounts == ["native-compact-account"]
+    assert source_requests == []

--- a/tests/integration/test_model_source_dispatch.py
+++ b/tests/integration/test_model_source_dispatch.py
@@ -1075,7 +1075,7 @@ async def test_admission_estimate_exception_is_covered_by_the_route_helper_latch
         max_concurrency=1,
     )
 
-    def exploding_estimate(_payload: object) -> object:
+    def exploding_estimate(_payload: object, *, upstream_payload: object = None) -> object:
         raise RuntimeError("estimate exploded")
 
     async def never_opened(*_args: object, **_kwargs: object) -> object:

--- a/tests/integration/test_subscription_overflow_routing.py
+++ b/tests/integration/test_subscription_overflow_routing.py
@@ -791,7 +791,7 @@ async def test_overflow_route_helper_releases_the_decisions_claims_when_admissio
     dispatch = _dispatch_double(source, model="overflow-latch-model", route=ROUTE_V1_RESPONSES)
     assert get_source_bulkhead().in_flight(source_id) == 1
 
-    def exploding_estimate(_payload: object) -> object:
+    def exploding_estimate(_payload: object, *, upstream_payload: object = None) -> object:
         raise RuntimeError("estimate exploded")
 
     async def never_opened(*_args: object, **_kwargs: object) -> object:

--- a/tests/unit/test_proxy_api_key_usage.py
+++ b/tests/unit/test_proxy_api_key_usage.py
@@ -22,6 +22,21 @@ from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from tests.unit.hypothesis_strategies import json_arrays, json_objects
 
 
+def test_compact_source_projection_counts_retained_tool_definitions() -> None:
+    source_payload: JsonObject = {
+        "model": "external-compact-model",
+        "instructions": "Compact",
+        "input": [],
+        "tools": [{"type": "function", "name": "lookup", "description": "x" * 10_000}],
+    }
+    request = ResponsesCompactRequest.model_validate(source_payload)
+
+    budget = estimate_api_key_request_usage(request, upstream_payload=source_payload)
+
+    assert budget.input_tokens == 8_192
+    assert budget.output_tokens is None
+
+
 @pytest.mark.parametrize(
     ("budget", "expected"),
     [


### PR DESCRIPTION
## Summary

Explicit compact requests for external Responses models currently enter subscription account selection and return `503 no_accounts` when no native accounts exist. Forward them to the selected source's `/responses/compact` endpoint while preserving native continuation and uploaded-file ownership.

Closes #2318.

## Type of change

- [x] `feat:` new capability extending the existing subscription-only compact contract.

## OpenSpec

- [x] Includes verified change artifacts and synced `responses-api-compat` requirements.
- [x] Preserves the existing SDK and Codex compact output contracts.

Changes: `openspec/changes/archive/2026-09-10-forward-external-source-compaction/` and `openspec/changes/archive/2026-09-10-retain-source-compact-enforced-tier/`.

## Changes

- Reuse source authentication, admission, disconnect handling, settlement and error redaction. Retained source tools/history also count toward reservation admission.
- Keep recorded native owners authoritative, including when a competing source is disabled. Native compact service logic is unchanged.
- Preserve enforced-tier source attribution when an assigned source shares a native model. Subscription tier fallback runs only on the native path.
- Return unsupported-source errors explicitly. This covers the two explicit compact endpoints; terminal-trigger and overflow-pinned compaction retain their current behavior.

No catalog-PR dependency, provider translation, schema migration, new setting or frontend change. Existing Responses source configuration enables forwarding without another setup step. Actual provider compact support remains provider-dependent.

## Test plan

60 compact/budget tests, six native compact tier cases, and both source admission failure regressions pass on the repair. The original candidate's broader 394-case source/native compact run is retained as earlier evidence.

`make lint typecheck` and all 65 canonical specs pass with strict OpenSpec validation. Test runs verified foreground, background and fixture engines against dedicated disposable SQLite databases. Independent candidate and standards reviews found no remaining substantive issues. Hosted CI passed on `7a39bb742`. Current head incorporates the upstream beta.7 version metadata; its feature diff is identical. Hosted checks for the updated head and live CPA/provider acceptance are separate gates.

## Screenshots / output

Both `POST /v1/responses/compact` and `POST /backend-api/codex/responses/compact`, with an enabled Responses source and no subscription accounts, now return its `response.compaction` result instead of `503 no_accounts`.

## Checklist

- [x] Conventional title and exact issue link.
- [x] Public-path regression coverage and relevant local checks.
- [x] OpenSpec requirements and context updated.
- [x] Simplicity gates reviewed; no new configuration or surface budget.
- [x] No manual changelog edit.
