### PR TITLE
feat(cli): bound whole-home retag planning and report progress

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -11,7 +11,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from app.codex_sessions_retag import RetagResult, default_codex_home, retag_codex_sessions
+from app.codex_sessions_retag import RetagProgress, RetagResult, default_codex_home, retag_codex_sessions
 from app.core.ingress_limits import MAX_DECOMPRESSED_RESPONSES_BODY_BYTES
 
 if TYPE_CHECKING:
@@ -221,6 +221,18 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
     if not args.dry_run:
         _confirm_retag_write(args.yes, progress_json=args.progress_json)
 
+    progress_enabled = args.progress_json
+
+    def report_progress(event: RetagProgress) -> None:
+        nonlocal progress_enabled
+        if progress_enabled:
+            try:
+                print(json.dumps(asdict(event)), file=sys.stderr, flush=True)
+            except BrokenPipeError:
+                progress_enabled = False
+                # Python flushes stderr again at shutdown, including a failed buffered write.
+                sys.stderr = open(os.devnull, "w")
+
     try:
         result = retag_codex_sessions(
             codex_home=codex_home,
@@ -228,9 +240,7 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
             target_provider=args.target_provider,
             dry_run=args.dry_run,
             progress_logger=lambda message: print(message, flush=True),
-            progress_callback=(lambda event: print(json.dumps(asdict(event)), file=sys.stderr, flush=True))
-            if args.progress_json
-            else None,
+            progress_callback=report_progress if args.progress_json else None,
         )
     except sqlite3.OperationalError as exc:
         message = str(exc)

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sqlite3
 import sys
 from collections.abc import Sequence
+from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +52,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Codex data directory. Defaults to CODEX_HOME, /codex-home in Docker, or ~/.codex.",
     )
+    retag.add_argument("--progress-json", action="store_true", help="Emit JSONL phase progress on stderr.")
     retag.add_argument("--dry-run", action="store_true", help="Show what would change without writing files.")
     retag.add_argument(
         "--yes",
@@ -216,7 +219,7 @@ def _parse_server_ws_max_size(raw_ws_max_size: str) -> int:
 def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
     codex_home = args.codex_home or default_codex_home()
     if not args.dry_run:
-        _confirm_retag_write(args.yes)
+        _confirm_retag_write(args.yes, progress_json=args.progress_json)
 
     try:
         result = retag_codex_sessions(
@@ -225,6 +228,9 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
             target_provider=args.target_provider,
             dry_run=args.dry_run,
             progress_logger=lambda message: print(message, flush=True),
+            progress_callback=(lambda event: print(json.dumps(asdict(event)), file=sys.stderr, flush=True))
+            if args.progress_json
+            else None,
         )
     except sqlite3.OperationalError as exc:
         message = str(exc)
@@ -242,12 +248,12 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
     _print_retag_summary(result)
 
 
-def _confirm_retag_write(yes: bool) -> None:
+def _confirm_retag_write(yes: bool, *, progress_json: bool = False) -> None:
     warning = (
         "This command rewrites Codex session metadata, including state_*.sqlite when present.\n"
         "Close Codex/Codex CLI before continuing to avoid SQLite locks or stale writes."
     )
-    print(warning, file=sys.stderr)
+    print(warning, file=sys.stdout if progress_json else sys.stderr)
     if yes:
         return
     if not sys.stdin.isatty():

--- a/app/codex_retag_metadata.py
+++ b/app/codex_retag_metadata.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+METADATA_BYTE_LIMIT = 64 * 1024
+
+
+@dataclass(frozen=True)
+class Metadata:
+    records: tuple[dict[str, object], ...]
+    end: int
+
+    def counts(self) -> Counter[str]:
+        return Counter(provider for record in self.records if (provider := record_provider(record)) is not None)
+
+
+def record_provider(record: dict[str, object]) -> str | None:
+    provider = record.get("model_provider")
+    if isinstance(provider, str):
+        return provider
+    payload = record.get("payload")
+    if record.get("type") == "session_meta" and isinstance(payload, dict):
+        provider = payload.get("model_provider")
+        if isinstance(provider, str):
+            return provider
+    return None
+
+
+def read_metadata(path: Path) -> Metadata:
+    records: list[dict[str, object]] = []
+    end = 0
+    with path.open("rb") as source:
+        prefix = source.read(METADATA_BYTE_LIMIT)
+    with BytesIO(prefix) as handle:
+        while handle.tell() < METADATA_BYTE_LIMIT:
+            remaining = METADATA_BYTE_LIMIT - handle.tell()
+            raw = handle.readline(remaining)
+            if not raw:
+                break
+            if not raw.endswith(b"\n") and len(raw) == remaining:
+                if records:
+                    break
+                raise ValueError(f"Session metadata exceeds {METADATA_BYTE_LIMIT} bytes: {path}")
+            try:
+                record = json.loads(raw)
+            except (ValueError, UnicodeError) as exc:
+                if records:
+                    break
+                raise ValueError(f"Invalid initial session metadata: {path}") from exc
+            if not isinstance(record, dict) or record_provider(record) is None:
+                break
+            records.append(record)
+            end = handle.tell()
+            if record.get("type") == "session_meta":
+                break
+    return Metadata(tuple(records), end)

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import sqlite3
+from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -13,12 +14,29 @@ from tempfile import NamedTemporaryFile
 from typing import cast
 from urllib.parse import quote
 
+from app.codex_retag_metadata import read_metadata
+
 JsonObject = dict[str, object]
 ProgressLogger = Callable[[str], None]
 
 PROVIDER_RETAG_BACKUP_DIR = "provider-retag"
 _SUPPORTED_PROVIDERS = {"openai", "codex-lb"}
 _STATE_DB_PATTERN = "state_*.sqlite"
+
+
+@dataclass(frozen=True)
+class RetagProgress:
+    phase: str
+    completed: int
+    total: int | None = None
+
+
+ProgressCallback = Callable[[RetagProgress], None]
+
+
+def _progress(callback: ProgressCallback | None, phase: str, completed: int, total: int | None = None) -> None:
+    if callback is not None:
+        callback(RetagProgress(phase, completed, total))
 
 
 @dataclass(frozen=True)
@@ -68,6 +86,7 @@ def retag_codex_sessions(
     target_provider: str,
     dry_run: bool = False,
     progress_logger: ProgressLogger | None = None,
+    progress_callback: ProgressCallback | None = None,
 ) -> RetagResult:
     logs: list[str] = []
 
@@ -87,12 +106,22 @@ def retag_codex_sessions(
 
     # Build the full write set before taking a backup so dry-runs and real
     # retags report the same targets.
+    _progress(progress_callback, "discovery", 0)
     jsonl_files = tuple(_find_jsonl_session_files(sessions_dir))
     state_dbs = tuple(_find_state_dbs(codex_home))
-    provider_counts_before = _provider_counts(codex_home)
-    jsonl_files_to_update = tuple(path for path in jsonl_files if _jsonl_contains_provider(path, source_provider))
-    sqlite_dbs_to_update = tuple(db for db in state_dbs if _sqlite_count_provider_rows(db, source_provider) > 0)
-    sqlite_rows_matched = sum(_sqlite_count_provider_rows(db, source_provider) for db in sqlite_dbs_to_update)
+    counts_by_path: dict[Path, Counter[str]] = {}
+    total = len(jsonl_files) + len(state_dbs)
+    for path in jsonl_files:
+        counts_by_path[path] = read_metadata(path).counts()
+        _progress(progress_callback, "discovery", len(counts_by_path), total)
+    for db in state_dbs:
+        counts_by_path[db] = _sqlite_provider_counts(db)
+        _progress(progress_callback, "discovery", len(counts_by_path), total)
+    _progress(progress_callback, "discovery", total, total)
+    provider_counts_before = _sum_counts(counts_by_path.values())
+    jsonl_files_to_update = tuple(path for path in jsonl_files if counts_by_path[path][source_provider])
+    sqlite_dbs_to_update = tuple(db for db in state_dbs if counts_by_path[db][source_provider])
+    sqlite_rows_matched = sum(counts_by_path[db][source_provider] for db in sqlite_dbs_to_update)
 
     methods_used = _methods_used(jsonl_files_to_update, sqlite_dbs_to_update)
     log(f"JSONL sessions method scanned {len(jsonl_files)} files under {sessions_dir}")
@@ -102,27 +131,50 @@ def retag_codex_sessions(
     jsonl_files_updated = 0
     sqlite_rows_updated = 0
 
-    if dry_run:
-        log("Dry run enabled; no files will be changed")
-    elif jsonl_files_to_update or sqlite_dbs_to_update:
-        backup_path = _create_backup(codex_home, jsonl_files_to_update, sqlite_dbs_to_update)
-        log(f"Created backup at {backup_path}")
+    try:
+        if dry_run:
+            log("Dry run enabled; no files will be changed")
+        elif jsonl_files_to_update or sqlite_dbs_to_update:
+            backup_path = _create_backup(codex_home, jsonl_files_to_update, sqlite_dbs_to_update, progress_callback)
+            log(f"Created backup at {backup_path}")
 
-        for path in jsonl_files_to_update:
-            if _retag_jsonl_file(path, source_provider, target_provider):
-                jsonl_files_updated += 1
-        if jsonl_files_to_update:
-            log(f"Updated {jsonl_files_updated} JSONL session file(s)")
+            total_targets = len(jsonl_files_to_update) + len(sqlite_dbs_to_update)
+            _progress(progress_callback, "rewrite", 0, total_targets)
+            for index, path in enumerate(jsonl_files_to_update, 1):
+                if _retag_jsonl_file(path, source_provider, target_provider):
+                    jsonl_files_updated += 1
+                _progress(progress_callback, "rewrite", index, total_targets)
+            if jsonl_files_to_update:
+                log(f"Updated {jsonl_files_updated} JSONL session file(s)")
 
-        for db_path in sqlite_dbs_to_update:
-            sqlite_rows_updated += _update_sqlite_provider(db_path, source_provider, target_provider)
-        if sqlite_dbs_to_update:
-            log(f"Updated {sqlite_rows_updated} SQLite thread row(s)")
-    else:
-        log(f"No {source_provider} Codex session tags were found")
+            for index, db_path in enumerate(sqlite_dbs_to_update, len(jsonl_files_to_update) + 1):
+                sqlite_rows_updated += _update_sqlite_provider(db_path, source_provider, target_provider)
+                _progress(progress_callback, "rewrite", index, total_targets)
+            if sqlite_dbs_to_update:
+                log(f"Updated {sqlite_rows_updated} SQLite thread row(s)")
+        else:
+            log(f"No {source_provider} Codex session tags were found")
 
-    provider_counts_after = provider_counts_before if dry_run else _provider_counts(codex_home)
+        if not dry_run:
+            total_targets = len(jsonl_files_to_update) + len(sqlite_dbs_to_update)
+            _progress(progress_callback, "verification", 0, total_targets)
+            for index, path in enumerate(jsonl_files_to_update, 1):
+                verified = read_metadata(path).counts()
+                _verify_counts(counts_by_path[path], verified, source_provider, target_provider, path)
+                counts_by_path[path] = verified
+                _progress(progress_callback, "verification", index, total_targets)
+            for index, db in enumerate(sqlite_dbs_to_update, len(jsonl_files_to_update) + 1):
+                verified = _sqlite_provider_counts(db)
+                _verify_counts(counts_by_path[db], verified, source_provider, target_provider, db)
+                counts_by_path[db] = verified
+                _progress(progress_callback, "verification", index, total_targets)
+    except Exception as exc:
+        if backup_path is not None:
+            raise ValueError(f"{exc}. Backup retained at {backup_path}; changes may be partial.") from exc
+        raise
+    provider_counts_after = _sum_counts(counts_by_path.values())
 
+    _progress(progress_callback, "complete", total, total)
     return RetagResult(
         codex_home=codex_home,
         source_provider=source_provider,
@@ -224,41 +276,31 @@ def _jsonl_contains_provider(path: Path, provider: str) -> bool:
 
 
 def _retag_jsonl_file(path: Path, source_provider: str, target_provider: str) -> bool:
-    changed = False
+    metadata = read_metadata(path)
+    if not metadata.counts()[source_provider]:
+        return False
     temp_path: Path | None = None
     try:
         with (
-            path.open("r", encoding="utf-8") as input_handle,
-            NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as output_handle,
+            path.open("rb") as input_handle,
+            NamedTemporaryFile("w", encoding="utf-8", newline="", dir=path.parent, delete=False) as output_handle,
         ):
             temp_path = Path(output_handle.name)
-            for raw_line in input_handle:
-                line = raw_line.rstrip("\n")
-                if not line:
-                    output_handle.write(raw_line)
-                    continue
-                try:
-                    record = json.loads(line)
-                except json.JSONDecodeError:
-                    output_handle.write(raw_line)
-                    continue
-                if isinstance(record, dict) and _retag_jsonl_record_provider(record, source_provider, target_provider):
-                    # Preserve invalid or unrelated JSONL lines verbatim; only
-                    # matched session records are normalized through json.dumps.
-                    changed = True
+            while input_handle.tell() < metadata.end:
+                raw_line = input_handle.readline(metadata.end - input_handle.tell())
+                record = json.loads(raw_line)
+                if _retag_jsonl_record_provider(record, source_provider, target_provider):
                     output_handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
                 else:
-                    output_handle.write(raw_line)
+                    output_handle.write(raw_line.decode("utf-8"))
+            output_handle.flush()
+            shutil.copyfileobj(input_handle, output_handle.buffer)
+        shutil.copymode(path, temp_path)
+        temp_path.replace(path)
     except Exception:
         if temp_path is not None:
             temp_path.unlink(missing_ok=True)
         raise
-    if not changed:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
-        return False
-    assert temp_path is not None
-    temp_path.replace(path)
     return True
 
 
@@ -403,30 +445,45 @@ def _sqlite_has_model_provider_column(conn: sqlite3.Connection) -> bool:
     return any(row[1] == "model_provider" for row in rows)
 
 
-def _provider_counts(codex_home: Path) -> tuple[ProviderCount, ...]:
-    counts: dict[str, int] = {}
-    for path in _find_jsonl_session_files(codex_home / "sessions"):
-        for record in _read_jsonl_records(path):
-            provider = _jsonl_record_provider(record)
-            if isinstance(provider, str):
-                counts[provider] = counts.get(provider, 0) + 1
-    for db_path in _find_state_dbs(codex_home):
+def _verify_counts(
+    before: Counter[str],
+    after: Counter[str],
+    source: str,
+    target: str,
+    path: Path,
+) -> None:
+    expected = before.copy()
+    expected[target] += expected.pop(source, 0)
+    if after != expected:
+        raise ValueError(f"Retag verification failed: {path}")
+
+
+def _sum_counts(counts: Iterable[Counter[str]]) -> tuple[ProviderCount, ...]:
+    total: Counter[str] = Counter()
+    for count in counts:
+        total.update(count)
+    return tuple(ProviderCount(provider, count) for provider, count in sorted(total.items()) if count)
+
+
+def _sqlite_provider_counts(db_path: Path) -> Counter[str]:
+    try:
+        with _connect_sqlite(db_path, read_only=True) as conn:
+            if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
+                return Counter()
+            rows = conn.execute("SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider").fetchall()
+            return Counter({provider: int(count) for provider, count in rows if isinstance(provider, str)})
+    except sqlite3.OperationalError as exc:
+        if "unable to open database file" not in str(exc).casefold():
+            raise
+        temp_path = _copy_sqlite_to_temp(db_path)
         try:
-            with _connect_sqlite(db_path, read_only=True) as conn:
-                if not _sqlite_has_threads_table(conn):
-                    continue
-                if not _sqlite_has_model_provider_column(conn):
-                    continue
-                rows = conn.execute(
-                    "SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider",
-                ).fetchall()
-                for provider, count in rows:
-                    if isinstance(provider, str):
-                        counts[provider] = counts.get(provider, 0) + int(count)
-        except sqlite3.OperationalError as exc:
-            if "unable to open database file" not in str(exc).casefold():
-                raise
-    return tuple(ProviderCount(provider, count) for provider, count in sorted(counts.items()))
+            with _connect_sqlite(temp_path, read_only=True) as conn:
+                if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
+                    return Counter()
+                rows = conn.execute("SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider").fetchall()
+                return Counter({provider: int(count) for provider, count in rows if isinstance(provider, str)})
+        finally:
+            temp_path.unlink(missing_ok=True)
 
 
 def _methods_used(jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> tuple[str, ...]:
@@ -438,21 +495,37 @@ def _methods_used(jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> tup
     return tuple(methods)
 
 
-def _create_backup(codex_home: Path, jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> Path:
+def _create_backup(
+    codex_home: Path,
+    jsonl_files: Sequence[Path],
+    state_dbs: Sequence[Path],
+    progress_callback: ProgressCallback | None = None,
+) -> Path:
     backup_dir = _next_backup_dir(codex_home / "backups" / PROVIDER_RETAG_BACKUP_DIR)
     backup_dir.mkdir(parents=True)
 
-    for db_path in state_dbs:
-        _backup_sqlite_db(db_path, backup_dir / db_path.name)
+    try:
+        total = len(state_dbs) + len(jsonl_files)
+        _progress(progress_callback, "backup", 0, total)
+        for index, db_path in enumerate(state_dbs, 1):
+            _backup_sqlite_db(db_path, backup_dir / db_path.name)
+            _progress(progress_callback, "backup", index, total)
 
-    session_index = codex_home / "session_index.jsonl"
-    if session_index.is_file():
-        shutil.copy2(session_index, backup_dir / session_index.name)
+        session_index = codex_home / "session_index.jsonl"
+        if session_index.is_file():
+            shutil.copy2(session_index, backup_dir / session_index.name)
 
-    for path in jsonl_files:
-        destination = backup_dir / path.relative_to(codex_home)
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
+        for index, path in enumerate(jsonl_files, len(state_dbs) + 1):
+            destination = backup_dir / path.relative_to(codex_home)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.link(path, destination)
+            except OSError:
+                shutil.copy2(path, destination)
+            _progress(progress_callback, "backup", index, total)
+
+    except Exception as exc:
+        raise ValueError(f"Backup failed before mutation: {exc}. Partial backup retained at {backup_dir}") from exc
 
     return backup_dir
 

--- a/docs/session-retag.md
+++ b/docs/session-retag.md
@@ -1,7 +1,7 @@
 # Whole-home session retag
 
 This command changes provider tags in local Codex session metadata. Its contract
-is defined in [runtime portability](../openspec/specs/runtime-portability/spec.md).
+is defined in [runtime portability](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/runtime-portability).
 
 Preview first:
 

--- a/docs/session-retag.md
+++ b/docs/session-retag.md
@@ -1,0 +1,46 @@
+# Whole-home session retag
+
+This command changes provider tags in local Codex session metadata. Its contract
+is defined in [runtime portability](../openspec/specs/runtime-portability/spec.md).
+
+Preview first:
+
+```bash
+codex-lb codex-sessions retag --from openai --to codex-lb \
+  --codex-home /path/to/.codex --dry-run --progress-json
+```
+
+Stop Codex and Codex CLI before applying the same command with `--yes` instead of
+`--dry-run`. Keep them stopped until verification finishes. The command leaves
+`config.toml` and provider selection unchanged.
+
+Discovery reads at most 64 KiB per JSONL file under `sessions/` and runs one
+grouped provider-count query per eligible `state_*.sqlite` database. It recognizes
+a leading `session_meta` record or consecutive leading legacy records with a
+string `model_provider`. Transcript content is not searched for provider tags.
+Malformed initial JSON or an oversized initial metadata record fails before writes.
+After recognized legacy metadata, an incomplete record at the byte limit begins
+the opaque tail and is left unchanged.
+Files without recognized leading provider metadata do not become targets.
+Archived sessions remain outside this command's existing scope.
+
+Matched JSONL files are backed up with hard links, falling back to copies when
+links are unavailable. Rewriting replaces the working file and preserves the
+backup. SQLite backups use SQLite's snapshot API, including committed WAL data.
+The existing SQLite copy-based write fallback is retained. Verification reads
+only planned targets; unrelated files and databases are not rescanned.
+
+`--progress-json` sends JSONL phase events to stderr while keeping the existing
+human summary on stdout. Each event has `phase`, `completed`, and `total` fields.
+The total is null until discovery enumerates the files. Phases are `discovery`,
+`backup`, `rewrite`, `verification`, and `complete`. Counts refer to files and
+databases, not bytes or rows. A phase emits a start event and per-item updates.
+A single large file copy or database operation can take time between events.
+Dry runs omit write phases. Errors produce a nonzero exit and a diagnostic;
+consumers must not interpret missing `complete` as success.
+
+Backups live under `backups/provider-retag/` in the selected home. A failure after
+backup creation reports the retained path. Changes may be partial across files
+and databases. There is no automatic rollback or cross-file transaction. Keep
+the client stopped and use the retained originals for recovery. Hard links do
+not protect against another process writing the old inode in place.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Remote Access: deployment/remote.md
   - Reference:
       - Settings: reference/settings.md
+      - Session Retagging: session-retag.md
   - Traffic Parity: traffic-parity.md
   - Development:
       - Rust Migration Architecture: rust-architecture.md

--- a/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/design.md
+++ b/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/design.md
@@ -1,0 +1,23 @@
+## Context
+
+See proposal.md. Current main scans transcript JSON repeatedly and repeats SQLite source counts. The existing tests also cover multiple leading legacy provider records, WAL backups and copy-based writes.
+
+## Goals / Non-Goals
+
+Keep the existing public retag command and its session scope. No targeted preview/repair commands, live-client support, automatic rollback or transaction across files and databases.
+
+## Decisions
+
+Cache counts per discovered file/database. Use one grouped SQLite query to derive source matches and aggregate counts. After writes, replace only target contributions with verified counts. Preserve the current SQLite backup and replacement helpers.
+
+Bound JSONL metadata at 64 KiB. A canonical session_meta header ends discovery immediately. Legacy leading records continue until a non-provider record. Reject invalid or oversized initial metadata. After recognized legacy metadata, an incomplete next record at the byte bound belongs to the opaque tail; complete leading legacy metadata records remain supported. Copy the transcript tail without decoding. Metadata parsing belongs in a small separate module; orchestration stays in the retag module.
+
+Use an opt-in progress callback and CLI flag, keeping existing human output. Emit per-item counts and phase starts. Back up through hard links with copy fallback; replacement leaves the backup inode unchanged.
+
+## Risks / Trade-offs
+
+Retag requires stopped clients. Hard links are not independent snapshots if another process writes in place, so that precondition stays explicit. Nonstandard files without supported leading metadata fail before mutation. Verification is scoped to the plan, not a second discovery of a changing home. Failure preserves backups and reports partial work; it does not roll back automatically.
+
+## Verification
+
+Use the accepted public CLI and temporary home artifacts, plus filesystem byte-read and real SQLite trace observation for the explicit performance contract. Both application database environment variables point at one worker-owned disposable file before imports. No live home, account, Docker or routing use.

--- a/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/proposal.md
+++ b/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #1636 accepts bounded whole-home retag planning and progress. Current retag repeatedly scans transcripts and counts SQLite rows, with no structured progress. Targeted repair is covered separately by PR #2323.
+
+## What Changes
+
+- Discover JSONL metadata within a bounded prefix and query each state database once for grouped provider counts.
+- Cache the plan, back up before writes using hard links with copy fallback, and verify only planned targets.
+- Add optional JSON progress on stderr while preserving the existing human summary and confirmation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-portability`: bounded whole-home retag planning, backup, verification and progress.
+
+## Impact
+
+Standalone retag CLI, fixture tests and operator docs. No runtime settings or dependencies. No live home operation. This is partial #1636 coverage without the targeted commands from #2323.

--- a/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/specs/runtime-portability/spec.md
+++ b/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/specs/runtime-portability/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Bounded whole-home retag plan
+
+The whole-home retag CLI SHALL build one plan from JSONL metadata and one grouped provider-count query per eligible state database. JSONL discovery SHALL read at most 64 KiB per file, SHALL recognize consecutive leading legacy provider records or a leading `session_meta` record, and SHALL leave transcript contents outside that metadata unchanged. Invalid or oversized initial metadata SHALL fail before backup or mutation. After recognized legacy metadata, an incomplete record at the byte limit SHALL remain part of the unchanged transcript tail. Discovery SHALL retain the existing `sessions` directory scope. Dry runs SHALL reuse plan counts without rescanning. Confirmed writes SHALL back up before mutation and verify only planned targets. JSONL backups SHALL prefer hard links and fall back to copies, with atomic replacement of rewritten files. SQLite backups and write fallbacks SHALL retain their WAL-aware behavior. Configuration and unrelated sessions SHALL remain unchanged.
+
+#### Scenario: Large transcript dry run
+
+- **WHEN** retag previews a home containing supported leading metadata followed by large transcripts
+- **THEN** discovery reads at most 64 KiB from each JSONL file and one grouped count query from each eligible state database
+- **AND** the summary reports matching files and rows without a second scan or backup
+
+#### Scenario: Confirmed planned mutation
+
+- **WHEN** an operator stops Codex and confirms retag
+- **THEN** the command creates recoverable JSONL and SQLite backups before writing
+- **AND** only planned metadata is rewritten and verified
+- **AND** transcript bytes, configuration and unrelated sessions remain unchanged
+
+### Requirement: Whole-home retag structured progress
+
+The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr during discovery, backup, rewrite and verification. Each event SHALL identify its phase and completed item count, and SHALL include a total when known. Events SHALL be emitted before each phase and after each processed item. The CLI SHALL retain its human-readable stdout summary. A failure after backup creation SHALL report the retained backup path and SHALL NOT claim successful completion or automatic rollback.
+
+#### Scenario: Supervised retag
+
+- **WHEN** an operator runs retag with `--progress-json`
+- **THEN** stderr contains machine-readable phase progress without transcript contents
+- **AND** stdout retains the existing summary
+
+#### Scenario: Write failure after backup
+
+- **WHEN** a planned write fails after backups exist
+- **THEN** the command fails and reports the backup path for recovery

--- a/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/tasks.md
+++ b/openspec/changes/archive/2026-09-10-optimize-whole-home-retag/tasks.md
@@ -1,0 +1,10 @@
+## 1. Plan and execute
+
+- [x] 1.1 Prove bounded discovery and grouped queries through public CLI fixtures, then implement cached plans.
+- [x] 1.2 Prove opaque transcript preservation, planned-only verification and hard-link/copy backups through retag fixtures.
+- [x] 1.3 Prove JSON progress and retained-backup failures through the CLI.
+
+## 2. Deliver
+
+- [x] 2.1 Run affected tests, lint, typing and strict OpenSpec validation; retain measured query/discovery evidence.
+- [x] 2.2 Independently review the exact candidate and record resolved findings for delivery.

--- a/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/design.md
+++ b/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/design.md
@@ -1,0 +1,11 @@
+## Context
+
+The optional stderr callback currently propagates BrokenPipeError into retag. See proposal.md for the failing CLI contract.
+
+## Decisions
+
+Handle only BrokenPipeError in the CLI callback and disable subsequent events for that invocation. File errors and other output failures keep their existing behavior. Redirect the closed stderr stream to the null device so Python cannot retry buffered output at shutdown and exit with code 120. Keep the service callback contract unchanged.
+
+## Risks / Trade-offs
+
+Progress is unavailable once its reader closes. The stdout summary still reports the verified result. Tests cover closure in every phase and preserved backup and transcript bytes.

--- a/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/proposal.md
+++ b/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+PR #2325 adds optional progress for #1636. A closed stderr reader currently aborts retag, including after backup or mutation.
+
+## What Changes
+
+- Disable progress after BrokenPipeError and finish the confirmed retag.
+- Preserve all file, backup, verification and summary behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-portability`: tolerate a closed structured-progress reader.
+
+## Impact
+
+CLI progress callback and public CLI regression tests. No settings, runtime changes or SQLite access changes.

--- a/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/specs/runtime-portability/spec.md
+++ b/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/specs/runtime-portability/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Whole-home retag structured progress
+
+The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr during discovery, backup, rewrite and verification. Each event SHALL identify its phase and completed item count, and SHALL include a total when known. Events SHALL be emitted before each phase and after each processed item. If the stderr progress reader closes, the CLI SHALL stop progress writes and continue the retag through verification. The CLI SHALL retain its human-readable stdout summary. A failure after backup creation SHALL report the retained backup path and SHALL NOT claim successful completion or automatic rollback.
+
+#### Scenario: Supervised retag
+
+- **WHEN** an operator runs retag with `--progress-json`
+- **THEN** stderr contains machine-readable phase progress without transcript contents
+- **AND** stdout retains the existing summary
+
+#### Scenario: Write failure after backup
+
+- **WHEN** a planned write fails after backups exist
+- **THEN** the command fails and reports the backup path for recovery
+
+#### Scenario: Progress reader closes
+
+- **WHEN** the structured-progress reader closes during a confirmed retag
+- **THEN** retag completes its planned writes and verification, preserves backups and prints its stdout summary
+- **AND** no further progress writes are attempted

--- a/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/tasks.md
+++ b/openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/tasks.md
@@ -1,0 +1,5 @@
+## 1. Repair progress output
+
+- [x] 1.1 Reproduce a closed progress reader through the public CLI in each phase.
+- [x] 1.2 Disable progress writes after BrokenPipeError without interrupting retag.
+- [x] 1.3 Run affected tests, lint, type checks and strict spec validation; independently review the repair.

--- a/openspec/specs/runtime-portability/context.md
+++ b/openspec/specs/runtime-portability/context.md
@@ -51,3 +51,18 @@ docker run --rm \
   codex-lb codex-sessions retag --from openai --to codex-lb \
     --codex-home /codex-home --yes
 ```
+
+## Whole-home retag planning
+
+See [the operator guide](../../../docs/session-retag.md) for `--progress-json`,
+metadata bounds and recovery behavior. Whole-home retag caches one metadata plan
+and grouped database counts, then verifies only matched targets. JSONL discovery
+is capped at 64 KiB and recognizes leading canonical or legacy metadata; it does
+not search transcript content. For example, a dry run against a 2 MiB transcript
+reads the same bounded prefix as one against a 100 KiB transcript.
+
+Clients must remain stopped during writes. Hard-link backups are preserved by
+replacing the working file, but an external in-place writer can still change the
+backup inode. Failure reports retained backups without promising automatic
+rollback across files and databases. Targeted repair remains a separate command
+proposal in PR #2323.

--- a/openspec/specs/runtime-portability/context.md
+++ b/openspec/specs/runtime-portability/context.md
@@ -66,3 +66,5 @@ replacing the working file, but an external in-place writer can still change the
 backup inode. Failure reports retained backups without promising automatic
 rollback across files and databases. Targeted repair remains a separate command
 proposal in PR #2323.
+
+If a progress reader exits early, retag disables progress output and finishes the confirmed operation. For example, a supervisor can stop reading stderr without interrupting file writes. The CLI replaces the closed stderr stream to prevent Python from failing a second flush at shutdown. Stdout still reports the verified result.

--- a/openspec/specs/runtime-portability/spec.md
+++ b/openspec/specs/runtime-portability/spec.md
@@ -112,7 +112,7 @@ The whole-home retag CLI SHALL build one plan from JSONL metadata and one groupe
 
 ### Requirement: Whole-home retag structured progress
 
-The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr during discovery, backup, rewrite and verification. Each event SHALL identify its phase and completed item count, and SHALL include a total when known. Events SHALL be emitted before each phase and after each processed item. The CLI SHALL retain its human-readable stdout summary. A failure after backup creation SHALL report the retained backup path and SHALL NOT claim successful completion or automatic rollback.
+The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr during discovery, backup, rewrite and verification. Each event SHALL identify its phase and completed item count, and SHALL include a total when known. Events SHALL be emitted before each phase and after each processed item. If the stderr progress reader closes, the CLI SHALL stop progress writes and continue the retag through verification. The CLI SHALL retain its human-readable stdout summary. A failure after backup creation SHALL report the retained backup path and SHALL NOT claim successful completion or automatic rollback.
 
 #### Scenario: Supervised retag
 
@@ -124,3 +124,9 @@ The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr duri
 
 - **WHEN** a planned write fails after backups exist
 - **THEN** the command fails and reports the backup path for recovery
+
+#### Scenario: Progress reader closes
+
+- **WHEN** the structured-progress reader closes during a confirmed retag
+- **THEN** retag completes its planned writes and verification, preserves backups and prints its stdout summary
+- **AND** no further progress writes are attempted

--- a/openspec/specs/runtime-portability/spec.md
+++ b/openspec/specs/runtime-portability/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Define runtime portability contracts so resilience features degrade safely across supported operating systems.
+
 ## Requirements
+
 ### Requirement: Memory monitor startup remains portable across supported platforms
 
 The resilience memory monitor MUST NOT prevent application startup on platforms where Unix-specific standard-library modules are unavailable. The system MUST resolve RSS measurement through a platform-appropriate provider when one exists, and MUST fall back to treating memory pressure telemetry as unavailable instead of crashing when no provider is available.
@@ -91,3 +93,34 @@ The `codex-lb` server CLI SHALL accept integer main-listener ports in the inclus
 - **THEN** the CLI validates and forwards the flag value
 - **AND** the environment value does not replace it
 
+### Requirement: Bounded whole-home retag plan
+
+The whole-home retag CLI SHALL build one plan from JSONL metadata and one grouped provider-count query per eligible state database. JSONL discovery SHALL read at most 64 KiB per file, SHALL recognize consecutive leading legacy provider records or a leading `session_meta` record, and SHALL leave transcript contents outside that metadata unchanged. Invalid or oversized initial metadata SHALL fail before backup or mutation. After recognized legacy metadata, an incomplete record at the byte limit SHALL remain part of the unchanged transcript tail. Discovery SHALL retain the existing `sessions` directory scope. Dry runs SHALL reuse plan counts without rescanning. Confirmed writes SHALL back up before mutation and verify only planned targets. JSONL backups SHALL prefer hard links and fall back to copies, with atomic replacement of rewritten files. SQLite backups and write fallbacks SHALL retain their WAL-aware behavior. Configuration and unrelated sessions SHALL remain unchanged.
+
+#### Scenario: Large transcript dry run
+
+- **WHEN** retag previews a home containing supported leading metadata followed by large transcripts
+- **THEN** discovery reads at most 64 KiB from each JSONL file and one grouped count query from each eligible state database
+- **AND** the summary reports matching files and rows without a second scan or backup
+
+#### Scenario: Confirmed planned mutation
+
+- **WHEN** an operator stops Codex and confirms retag
+- **THEN** the command creates recoverable JSONL and SQLite backups before writing
+- **AND** only planned metadata is rewritten and verified
+- **AND** transcript bytes, configuration and unrelated sessions remain unchanged
+
+### Requirement: Whole-home retag structured progress
+
+The retag CLI SHALL accept `--progress-json` to emit JSONL events on stderr during discovery, backup, rewrite and verification. Each event SHALL identify its phase and completed item count, and SHALL include a total when known. Events SHALL be emitted before each phase and after each processed item. The CLI SHALL retain its human-readable stdout summary. A failure after backup creation SHALL report the retained backup path and SHALL NOT claim successful completion or automatic rollback.
+
+#### Scenario: Supervised retag
+
+- **WHEN** an operator runs retag with `--progress-json`
+- **THEN** stderr contains machine-readable phase progress without transcript contents
+- **AND** stdout retains the existing summary
+
+#### Scenario: Write failure after backup
+
+- **WHEN** a planned write fails after backups exist
+- **THEN** the command fails and reports the backup path for recovery

--- a/tests/unit/test_codex_retag_plan.py
+++ b/tests/unit/test_codex_retag_plan.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app import cli
+
+pytestmark = pytest.mark.unit
+
+
+def _run(home: Path, *flags: str) -> None:
+    cli.main(
+        [
+            "codex-sessions",
+            "retag",
+            "--from",
+            "openai",
+            "--to",
+            "codex-lb",
+            "--codex-home",
+            str(home),
+            *flags,
+        ]
+    )
+
+
+def _session(home: Path, name: str, provider: str = "openai") -> Path:
+    path = home / "sessions" / f"{name}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        json.dumps({"type": "session_meta", "payload": {"id": name, "model_provider": provider}}).encode()
+        + b"\n"
+        + b"\xff" * 100_000
+    )
+    return path
+
+
+def test_cli_plan_reads_metadata_only_and_groups_each_database_once(tmp_path, monkeypatch, capsys):
+    path = _session(tmp_path, "selected")
+    original = path.read_bytes()
+    db = tmp_path / "state_5.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.executemany("INSERT INTO threads VALUES (?, ?)", [("one", "openai"), ("two", "codex-lb")])
+    statements = []
+    connect = sqlite3.connect
+
+    def traced_connect(*args, **kwargs):
+        conn = connect(*args, **kwargs)
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", traced_connect)
+    _run(tmp_path, "--dry-run")
+    output = capsys.readouterr().out
+    assert "Would update JSONL files: 1" in output
+    assert "Would update SQLite rows: 1" in output
+    assert [sql for sql in statements if "FROM threads" in sql] == [
+        "SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider"
+    ]
+    assert path.read_bytes() == original
+    assert not (tmp_path / "backups").exists()
+
+
+def test_cli_write_keeps_transcript_and_hardlink_backup(tmp_path, capsys):
+    path = _session(tmp_path, "selected")
+    untouched = _session(tmp_path, "untouched", "codex-lb")
+    original = path.read_bytes()
+    untouched_original = untouched.read_bytes()
+    original_inode = path.stat().st_ino
+    config = tmp_path / "config.toml"
+    config.write_text('model_provider = "openai"\n')
+    _run(tmp_path, "--yes")
+    backup = next((tmp_path / "backups" / "provider-retag").glob("*/sessions/selected.jsonl"))
+    assert backup.read_bytes() == original
+    assert backup.stat().st_ino == original_inode
+    assert path.stat().st_ino != original_inode
+    header, tail = path.read_bytes().split(b"\n", 1)
+    assert json.loads(header)["payload"]["model_provider"] == "codex-lb"
+    assert tail == original.split(b"\n", 1)[1]
+    assert untouched.read_bytes() == untouched_original
+    assert config.read_text() == 'model_provider = "openai"\n'
+    assert "Updated JSONL files: 1" in capsys.readouterr().out
+
+
+def test_cli_json_progress_reports_all_write_phases(tmp_path, capsys):
+    _session(tmp_path, "selected")
+    _run(tmp_path, "--yes", "--progress-json")
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines()]
+    for phase in ("discovery", "backup", "rewrite", "verification"):
+        phase_events = [event for event in events if event["phase"] == phase]
+        assert phase_events[0]["completed"] == 0
+        assert phase_events[-1]["completed"] == phase_events[-1]["total"] == 1
+    assert events[-1]["phase"] == "complete"
+    assert "Updated JSONL files: 1" in captured.out
+
+
+def test_cli_failure_reports_retained_backup(tmp_path, monkeypatch, capsys):
+    path = _session(tmp_path, "selected")
+    original = path.read_bytes()
+    replace = Path.replace
+
+    def deny_replacement(self, target):
+        if Path(target) == path:
+            raise PermissionError("fixture replacement denied")
+        return replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", deny_replacement)
+    with pytest.raises(SystemExit, match="Backup retained at"):
+        _run(tmp_path, "--yes", "--progress-json")
+    events = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert not any(event["phase"] == "complete" for event in events)
+    assert path.read_bytes() == original
+    backup = next((tmp_path / "backups" / "provider-retag").glob("*/sessions/selected.jsonl"))
+    assert backup.read_bytes() == original
+
+
+def test_cli_discovery_bytes_do_not_grow_with_transcript(tmp_path, monkeypatch, capsys):
+    paths = [_session(tmp_path, "small"), _session(tmp_path, "large")]
+    with paths[1].open("ab") as handle:
+        handle.write(b"x" * 2_000_000)
+    byte_counts = {path: 0 for path in paths}
+    open_path = Path.open
+
+    class MeteredRead:
+        def __init__(self, handle, path):
+            self.handle = handle
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return self.handle.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self.handle, name)
+
+        def read(self, size=-1):
+            data = self.handle.read(size)
+            byte_counts[self.path] += len(data)
+            return data
+
+    def metered_open(self, *args, **kwargs):
+        handle = open_path(self, *args, **kwargs)
+        return MeteredRead(handle, self) if self in byte_counts else handle
+
+    monkeypatch.setattr(Path, "open", metered_open)
+    _run(tmp_path, "--dry-run")
+    assert byte_counts[paths[0]] == byte_counts[paths[1]] == 65536
+    assert "Would update JSONL files: 2" in capsys.readouterr().out
+
+
+def test_cli_hardlink_failure_uses_independent_copy(tmp_path, monkeypatch):
+    import os
+
+    path = _session(tmp_path, "selected")
+    original = path.read_bytes()
+    inode = path.stat().st_ino
+
+    def denied_link(*args, **kwargs):
+        raise OSError("fixture does not support hard links")
+
+    monkeypatch.setattr(os, "link", denied_link)
+    _run(tmp_path, "--yes")
+    backup = next((tmp_path / "backups" / "provider-retag").glob("*/sessions/selected.jsonl"))
+    assert backup.read_bytes() == original
+    assert backup.stat().st_ino != inode
+
+
+def test_cli_failed_backup_never_mutates_sessions(tmp_path, monkeypatch):
+    import os
+    import shutil
+
+    path = _session(tmp_path, "selected")
+    original = path.read_bytes()
+
+    def denied(*args, **kwargs):
+        raise PermissionError("fixture backup denied")
+
+    monkeypatch.setattr(os, "link", denied)
+    monkeypatch.setattr(shutil, "copy2", denied)
+    with pytest.raises(SystemExit, match="Backup failed before mutation"):
+        _run(tmp_path, "--yes")
+    assert path.read_bytes() == original
+
+
+def test_cli_rejects_oversized_initial_metadata_before_backup(tmp_path):
+    path = _session(tmp_path, "selected")
+    original = b'{"model_provider":"openai","long":"' + b"x" * 70_000 + b'"}\n'
+    path.write_bytes(original)
+    with pytest.raises(SystemExit, match="metadata exceeds 65536 bytes"):
+        _run(tmp_path, "--yes")
+    assert path.read_bytes() == original
+    assert not (tmp_path / "backups").exists()
+
+
+def test_cli_verifies_database_changes_instead_of_assuming_success(tmp_path):
+    db = tmp_path / "state_5.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.execute("INSERT INTO threads VALUES ('one', 'openai')")
+        conn.execute("CREATE TRIGGER ignore_update BEFORE UPDATE ON threads BEGIN SELECT RAISE(IGNORE); END")
+    with pytest.raises(SystemExit, match="Retag verification failed.*Backup retained at"):
+        _run(tmp_path, "--yes")
+
+
+def test_cli_verifies_only_planned_files_and_databases(tmp_path, monkeypatch):
+    _session(tmp_path, "selected")
+    unrelated = _session(tmp_path, "unrelated", "codex-lb")
+    for name, provider in (("state_5.sqlite", "openai"), ("state_6.sqlite", "codex-lb")):
+        with sqlite3.connect(tmp_path / name) as conn:
+            conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+            conn.execute("INSERT INTO threads VALUES ('one', ?)", (provider,))
+    unrelated_reads = []
+    grouped_queries = []
+    open_path = Path.open
+    connect = sqlite3.connect
+
+    def capture_open(self, *args, **kwargs):
+        if self == unrelated:
+            unrelated_reads.append(self)
+        return open_path(self, *args, **kwargs)
+
+    def capture_connect(target, *args, **kwargs):
+        conn = connect(target, *args, **kwargs)
+        conn.set_trace_callback(
+            lambda sql: grouped_queries.append(str(target)) if "GROUP BY model_provider" in sql else None
+        )
+        return conn
+
+    monkeypatch.setattr(Path, "open", capture_open)
+    monkeypatch.setattr(sqlite3, "connect", capture_connect)
+    _run(tmp_path, "--yes")
+    assert len(unrelated_reads) == 1
+    assert sum("state_5.sqlite" in query for query in grouped_queries) == 2
+    assert sum("state_6.sqlite" in query for query in grouped_queries) == 1
+
+
+def test_cli_legacy_metadata_with_large_transcript_tail(tmp_path):
+    path = tmp_path / "sessions" / "legacy.jsonl"
+    path.parent.mkdir()
+    transcript = json.dumps({"type": "turn_context", "text": "x" * 100_000}).encode() + b"\n"
+    path.write_bytes(b'{"model_provider":"openai","id":"legacy"}\n' + transcript)
+    _run(tmp_path, "--dry-run")
+    _run(tmp_path, "--yes")
+    header, tail = path.read_bytes().split(b"\n", 1)
+    assert json.loads(header)["model_provider"] == "codex-lb"
+    assert tail == transcript

--- a/tests/unit/test_codex_retag_plan.py
+++ b/tests/unit/test_codex_retag_plan.py
@@ -251,3 +251,69 @@ def test_cli_legacy_metadata_with_large_transcript_tail(tmp_path):
     header, tail = path.read_bytes().split(b"\n", 1)
     assert json.loads(header)["model_provider"] == "codex-lb"
     assert tail == transcript
+
+
+@pytest.mark.parametrize("phase", ["discovery", "backup", "rewrite", "verification"])
+def test_cli_closed_progress_pipe_does_not_interrupt_retag(tmp_path, monkeypatch, capsys, phase):
+    path = _session(tmp_path, "selected")
+    original = path.read_bytes()
+
+    class ClosingProgressReader:
+        failed = False
+
+        def write(self, text):
+            if self.failed:
+                pytest.fail("Progress was written after the reader closed")
+            if text.startswith("{") and json.loads(text)["phase"] == phase:
+                self.failed = True
+                raise BrokenPipeError("progress reader closed")
+            return len(text)
+
+        def flush(self):
+            pass
+
+    reader = ClosingProgressReader()
+    monkeypatch.setattr("sys.stderr", reader)
+    _run(tmp_path, "--yes", "--progress-json")
+    assert reader.failed
+    assert "Updated JSONL files: 1" in capsys.readouterr().out
+    header, tail = path.read_bytes().split(b"\n", 1)
+    assert json.loads(header)["payload"]["model_provider"] == "codex-lb"
+    assert tail == original.split(b"\n", 1)[1]
+    backup = next((tmp_path / "backups" / "provider-retag").glob("*/sessions/selected.jsonl"))
+    assert backup.read_bytes() == original
+
+
+def test_cli_closed_progress_pipe_exits_successfully(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    path = _session(tmp_path, "selected")
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    try:
+        result = subprocess.run(
+            [
+                str(Path(sys.executable).with_name("codex-lb")),
+                "codex-sessions",
+                "retag",
+                "--from",
+                "openai",
+                "--to",
+                "codex-lb",
+                "--codex-home",
+                str(tmp_path),
+                "--yes",
+                "--progress-json",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=write_fd,
+            text=True,
+            check=False,
+        )
+    finally:
+        os.close(write_fd)
+    assert result.returncode == 0
+    assert "Updated JSONL files: 1" in result.stdout
+    assert json.loads(path.read_bytes().split(b"\n", 1)[0])["payload"]["model_provider"] == "codex-lb"


### PR DESCRIPTION
## Summary

Whole-home retag now builds a bounded metadata plan, reuses grouped SQLite counts, and verifies only planned targets. This implements the accepted optimization/progress portion of #1636 without depending on the targeted commands in #2323.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: Refs #1636. Partial coverage; targeted mismatch preview and confirmed repair remain separate in #2323.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directories: `openspec/changes/archive/2026-09-10-optimize-whole-home-retag/` and `openspec/changes/archive/2026-09-10-tolerate-closed-retag-progress/`. Two requirements synced to `runtime-portability`.

## Changes

- Read at most 64 KiB per session file and run one grouped provider-count query per eligible state database during planning. Cache counts instead of rescanning the home after writes.
- Recognize a leading canonical `session_meta` record or consecutive leading legacy provider records. Only that metadata is rewritten; transcript bytes stay opaque. Malformed or oversized initial metadata is rejected. An incomplete record after recognized legacy metadata at the byte limit stays unchanged. Arbitrary provider fields later in a transcript are no longer searched or rewritten.
- Prefer hard-link JSONL backups with copy fallback and replace working files atomically. Preserve SQLite snapshot backups, write fallback, configuration and existing `sessions/` scope. Clients must remain stopped. Failures retain backups and report their location; no automatic rollback is claimed.
- A closed progress reader disables stderr progress and lets retag finish, including a successful process exit.
- Add opt-in `--progress-json` phase counts on stderr, retaining the human summary on stdout. Counts are per file/database, so one large copy or query can take time between events.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- New settings: none. The progress flag is opt-in; bounds are fixed defaults.
- Setting tiers: not applicable.
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

Repair verification reran affected tests, lint, full type checks and strict specs. Original publication evidence covers the docs build and measurements below. Both database environment variables pointed to the same worker-owned disposable SQLite file before imports/tests. Main/background engines and session-factory bind were verified.

- `pytest -q tests/unit/test_codex_retag_plan.py tests/unit/test_codex_sessions_retag.py tests/unit/test_cli.py`: 69 passed, including phase-by-phase broken-pipe coverage and an installed CLI subprocess with a closed stderr pipe.
- `make lint`: passed, including repository architecture/settings guards.
- `ty check`: passed across the repository.
- `mkdocs build --strict`: passed with the new guide registered in navigation and its spec link verified.
- OpenSpec 1.11.0 strict change validation before archive and `validate --specs --strict` afterward: 65 main specs passed.
- Actual installed CLI retagged one JSONL and one SQLite row in a disposable home, retained config/backups and emitted parseable JSONL progress.
- Independent read-only review completed; its legacy-large-tail finding has a red/green CLI regression and correction review.

Measured through the public CLI with a baseline implementation adapter against `0f6a31c56ac30804ca1c0fac27ca02c6f59bf2b0`:

| Two transcript bodies | Before bytes returned by file reads | After | Planning thread-count queries |
| --- | ---: | ---: | --- |
| 100,000 bytes each | 300,426 | 131,072 | 3 → 1 |
| 2,000,000 bytes each | 6,000,426 | 131,072 | 3 → 1 |

This proves bounded read/query behavior, not wall-clock or live-home performance. No full suite, Windows or live-home run was performed.

## Screenshots / output

Representative stderr events from the executable fixture:

```json
{"phase": "discovery", "completed": 0, "total": null}
{"phase": "backup", "completed": 2, "total": 2}
{"phase": "rewrite", "completed": 2, "total": 2}
{"phase": "verification", "completed": 2, "total": 2}
{"phase": "complete", "completed": 2, "total": 2}
```

Stdout reports `Updated JSONL files: 1` and `Updated SQLite rows: 1` with the retained backup path.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make` subset locally.
- [x] `openspec validate --specs` passes and change verification is clean.
- [x] Simplicity gates reviewed against P1-P6.
- [x] CHANGELOG is not edited by hand.
