### PR TITLE
fix(warmup): preserve live reset evidence across skipped polls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ INTEGRATION_CORE_SHARD_COUNT := 3
 POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_cost_backfill.py \
 	tests/integration/test_atomic_quota_warmup_claims.py \
+	tests/integration/test_live_reset_warmup.py \
 	tests/integration/test_report_rollup.py \
 	tests/integration/test_reports_performance_api.py \
 	tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match \

--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -21,6 +21,7 @@ from app.db.session import detach_session_objects, get_background_session
 from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.limit_warmup.repository import LimitWarmupRepository
+from app.modules.limit_warmup.reset_evidence import recover_current_reset_evidence
 from app.modules.limit_warmup.service import (
     LimitWarmupService,
     StreamingLimitWarmupSender,
@@ -212,40 +213,55 @@ class UsageRefreshScheduler:
                 updater = build_background_usage_updater()
                 refresh_started_at = usage_updater_module.utcnow()
                 usage_written = await updater.refresh_accounts([selected_account], before_primary)
-                if usage_written:
-                    async with get_background_session() as session:
-                        usage_repo = UsageRepository(session)
-                        accounts_repo = AccountsRepository(session)
-                        settings_repo = SettingsRepository(session)
-                        after_primary = await usage_repo.latest_by_account(
-                            window="primary",
-                            account_ids=selected_account_ids,
-                        )
-                        after_secondary = await usage_repo.latest_by_account(
-                            window="secondary",
-                            account_ids=selected_account_ids,
-                        )
-                        after_monthly = await usage_repo.latest_by_account(
-                            window="monthly",
-                            account_ids=selected_account_ids,
-                        )
-                        dashboard_settings = await settings_repo.get_or_create()
-                        refreshed_accounts = await accounts_repo.list_accounts(refresh_existing=True)
-                        refreshed_selected_accounts = [
-                            account for account in refreshed_accounts if account.id == selected_account.id
-                        ]
+                async with get_background_session() as session:
+                    usage_repo = UsageRepository(session)
+                    accounts_repo = AccountsRepository(session)
+                    settings_repo = SettingsRepository(session)
+                    after_primary = await usage_repo.latest_by_account(
+                        window="primary",
+                        account_ids=selected_account_ids,
+                    )
+                    after_secondary = await usage_repo.latest_by_account(
+                        window="secondary",
+                        account_ids=selected_account_ids,
+                    )
+                    after_monthly = await usage_repo.latest_by_account(
+                        window="monthly",
+                        account_ids=selected_account_ids,
+                    )
+                    dashboard_settings = await settings_repo.get_or_create()
+                    refreshed_accounts = await accounts_repo.list_accounts(refresh_existing=True)
+                    refreshed_selected_accounts = [
+                        account for account in refreshed_accounts if account.id == selected_account.id
+                    ]
+                    monthly_reset_evidence = {}
+                    if usage_written:
                         monthly_reset_evidence = await _resolve_monthly_reset_evidence(
                             accounts=refreshed_selected_accounts,
                             usage_repo=usage_repo,
                             before_monthly=before_monthly,
                             after_monthly=after_monthly,
                         )
-                        detach_session_objects(session)
-                    warmup_before_monthly = dict(before_monthly)
-                    warmup_after_monthly = dict(after_monthly)
-                    for account_id, reset_evidence in monthly_reset_evidence.items():
-                        warmup_before_monthly[account_id] = reset_evidence.before
-                        warmup_after_monthly[account_id] = reset_evidence.after
+                    persisted_reset_evidence = await recover_current_reset_evidence(
+                        accounts=refreshed_selected_accounts,
+                        settings=dashboard_settings,
+                        primary=after_primary,
+                        secondary=_select_long_window_entries(
+                            accounts=refreshed_selected_accounts,
+                            monthly_entries=after_monthly,
+                            secondary_entries=after_secondary,
+                        ),
+                        usage_repo=usage_repo,
+                        warmup_repo=LimitWarmupRepository(session),
+                        now=usage_updater_module.utcnow(),
+                    )
+                    detach_session_objects(session)
+                warmup_before_monthly = dict(before_monthly)
+                warmup_after_monthly = dict(after_monthly)
+                for account_id, reset_evidence in monthly_reset_evidence.items():
+                    warmup_before_monthly[account_id] = reset_evidence.before
+                    warmup_after_monthly[account_id] = reset_evidence.after
+                if usage_written:
                     async with get_background_session() as session:
                         await reconcile_recoverable_account_statuses(
                             accounts_repo=AccountsRepository(session),
@@ -254,34 +270,36 @@ class UsageRefreshScheduler:
                             monthly_reset_evidence=monthly_reset_evidence,
                             dashboard_settings=dashboard_settings,
                         )
-                    warmup_service = LimitWarmupService(
-                        cast(Any, _BackgroundLimitWarmupRepository()),
-                        cast(Any, _BackgroundRequestLogsRepository()),
-                        sender=StreamingLimitWarmupSender(
-                            cast(AccountsRepository, BackgroundAccountsRepository()),
-                            accounts_repo_factory=_background_accounts_repo,
-                        ),
-                    )
-                    await warmup_service.run_after_usage_refresh(
+                warmup_service = LimitWarmupService(
+                    cast(Any, _BackgroundLimitWarmupRepository()),
+                    cast(Any, _BackgroundRequestLogsRepository()),
+                    sender=StreamingLimitWarmupSender(
+                        cast(AccountsRepository, BackgroundAccountsRepository()),
+                        accounts_repo_factory=_background_accounts_repo,
+                    ),
+                )
+                await warmup_service.run_after_usage_refresh(
+                    accounts=refreshed_selected_accounts,
+                    stagger_accounts=refreshed_accounts,
+                    settings=dashboard_settings,
+                    before_primary=before_primary,
+                    before_secondary=_select_long_window_entries(
                         accounts=refreshed_selected_accounts,
-                        stagger_accounts=refreshed_accounts,
-                        settings=dashboard_settings,
-                        before_primary=before_primary,
-                        before_secondary=_select_long_window_entries(
-                            accounts=refreshed_selected_accounts,
-                            monthly_entries=warmup_before_monthly,
-                            secondary_entries=before_secondary,
-                        ),
-                        after_primary=after_primary,
-                        after_secondary=_select_long_window_entries(
-                            accounts=refreshed_selected_accounts,
-                            monthly_entries=warmup_after_monthly,
-                            secondary_entries=after_secondary,
-                        ),
-                        previous_plan_types=previous_plan_types,
-                        refresh_started_at=refresh_started_at,
-                        usage_refresh_interval_seconds=self.interval_seconds,
-                    )
+                        monthly_entries=warmup_before_monthly,
+                        secondary_entries=before_secondary,
+                    ),
+                    after_primary=after_primary,
+                    after_secondary=_select_long_window_entries(
+                        accounts=refreshed_selected_accounts,
+                        monthly_entries=warmup_after_monthly,
+                        secondary_entries=after_secondary,
+                    ),
+                    previous_plan_types=previous_plan_types,
+                    refresh_started_at=refresh_started_at,
+                    usage_refresh_interval_seconds=self.interval_seconds,
+                    reset_evidence=persisted_reset_evidence,
+                    usage_written=usage_written,
+                )
                 if cycle_complete:
                     await _invalidate_usage_refresh_caches()
             except Exception:

--- a/app/modules/limit_warmup/repository.py
+++ b/app/modules/limit_warmup/repository.py
@@ -42,6 +42,21 @@ class LimitWarmupRepository:
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 
+    async def has_attempt(self, account_id: str, window: str, reset_at: int, *, tolerance_seconds: int) -> bool:
+        return bool(
+            await self._session.scalar(
+                select(
+                    select(AccountLimitWarmup.id)
+                    .where(
+                        AccountLimitWarmup.account_id == account_id,
+                        AccountLimitWarmup.window == window,
+                        AccountLimitWarmup.reset_at.between(reset_at - tolerance_seconds, reset_at + tolerance_seconds),
+                    )
+                    .exists()
+                )
+            )
+        )
+
     async def try_create_attempt(
         self,
         *,

--- a/app/modules/limit_warmup/reset_evidence.py
+++ b/app/modules/limit_warmup/reset_evidence.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.db.models import Account, DashboardSettings, UsageHistory
+from app.modules.limit_warmup.repository import LimitWarmupRepository
+from app.modules.limit_warmup.service import (
+    RESET_AT_JITTER_TOLERANCE_SECONDS,
+    UsageResetEvidence,
+    effective_warmup_usage_entry,
+    selected_warmup_windows,
+    usage_reset_confirmed,
+)
+from app.modules.usage.repository import UsageRepository
+
+
+async def recover_current_reset_evidence(
+    *,
+    accounts: list[Account],
+    settings: DashboardSettings,
+    primary: dict[str, UsageHistory],
+    secondary: dict[str, UsageHistory],
+    usage_repo: UsageRepository,
+    warmup_repo: LimitWarmupRepository,
+    now: datetime,
+) -> dict[tuple[str, str], UsageResetEvidence]:
+    """Recover unconsumed reset pairs without changing the current usage snapshot."""
+    evidence: dict[tuple[str, str], UsageResetEvidence] = {}
+    if not settings.limit_warmup_enabled:
+        return evidence
+    now_epoch = now.replace(tzinfo=timezone.utc).timestamp()
+    for account in accounts:
+        if not account.limit_warmup_enabled:
+            continue
+        for selected_window in selected_warmup_windows(settings.limit_warmup_windows):
+            latest = effective_warmup_usage_entry(
+                account.id, window=selected_window, primary=primary, secondary=secondary
+            )
+            if latest is None or latest.reset_at is None or latest.reset_at <= now_epoch:
+                continue
+            window = latest.window or "primary"
+            claim_window = "monthly" if window == "monthly" else selected_window
+            if await warmup_repo.has_attempt(
+                account.id, claim_window, latest.reset_at, tolerance_seconds=RESET_AT_JITTER_TOLERANCE_SECONDS
+            ):
+                continue
+            since = await usage_repo.first_reset_observed_at(
+                account.id, window, latest.reset_at, tolerance_seconds=RESET_AT_JITTER_TOLERANCE_SECONDS
+            )
+            if since is None:
+                continue
+            history = await usage_repo.history_since(account.id, window, since, include_predecessor=True)
+            for before, after in zip(history, history[1:]):
+                if (after.recorded_at, after.id) > (latest.recorded_at, latest.id):
+                    break
+                if (
+                    after.reset_at is not None
+                    and abs(after.reset_at - latest.reset_at) <= RESET_AT_JITTER_TOLERANCE_SECONDS
+                    and usage_reset_confirmed(before=before, after=after)
+                ):
+                    evidence[account.id, window] = UsageResetEvidence(before=before, after=after)
+    return evidence

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -44,7 +44,13 @@ _IDLE_PRIMARY_WINDOW = "primary_idle"
 _RESET_CONFIRMED_MIN_JUMP_SECONDS = 60
 # Persist the upstream value, but treat nearby values as the same reset. This
 # avoids duplicate attempts when reset_at jitters between refresh cycles.
-_RESET_AT_JITTER_TOLERANCE_SECONDS = 5
+RESET_AT_JITTER_TOLERANCE_SECONDS = 5
+
+
+@dataclass(frozen=True, slots=True)
+class UsageResetEvidence:
+    before: UsageHistory
+    after: UsageHistory
 
 
 @dataclass(frozen=True, slots=True)
@@ -347,13 +353,15 @@ class LimitWarmupService:
         previous_plan_types: dict[str, str | None] | None = None,
         refresh_started_at: datetime | None = None,
         usage_refresh_interval_seconds: int = _STAGGER_SLOT_GRACE_SECONDS,
+        reset_evidence: dict[tuple[str, str], UsageResetEvidence] | None = None,
+        usage_written: bool = True,
     ) -> None:
         if not settings.limit_warmup_enabled:
             return
         # C2-3 resilience toggles: bound before the warmup fan-out so the
         # upstream probes gate their breaker on the dashboard value.
         bind_resilience_toggles(settings)
-        selected_windows = _selected_windows(settings.limit_warmup_windows)
+        selected_windows = selected_warmup_windows(settings.limit_warmup_windows)
         if not selected_windows:
             return
 
@@ -380,7 +388,7 @@ class LimitWarmupService:
             latest_attempt = latest_attempts.get(account.id)
 
             windows_to_evaluate = list(selected_windows)
-            if settings.limit_warmup_staggered_idle_enabled and "primary" not in windows_to_evaluate:
+            if usage_written and settings.limit_warmup_staggered_idle_enabled and "primary" not in windows_to_evaluate:
                 windows_to_evaluate.append("primary")
             for window in windows_to_evaluate:
                 candidate = None
@@ -393,8 +401,9 @@ class LimitWarmupService:
                         after_primary=after_primary,
                         after_secondary=after_secondary,
                         min_available_percent=settings.limit_warmup_min_available_percent,
+                        reset_evidence=reset_evidence,
                     )
-                if candidate is None and window == "secondary":
+                if usage_written and candidate is None and window == "secondary":
                     candidate = _build_paid_to_free_transition_candidate(
                         account=account,
                         previous_plan_type=(previous_plan_types or {}).get(account.id),
@@ -402,7 +411,7 @@ class LimitWarmupService:
                         refresh_started_at=refresh_started_at,
                         min_available_percent=settings.limit_warmup_min_available_percent,
                     )
-                if candidate is None and window == "secondary":
+                if usage_written and candidate is None and window == "secondary":
                     candidate = _build_initial_free_quota_candidate(
                         account=account,
                         previous_plan_type=(previous_plan_types or {}).get(account.id),
@@ -411,7 +420,8 @@ class LimitWarmupService:
                         refresh_started_at=refresh_started_at,
                     )
                 if (
-                    candidate is None
+                    usage_written
+                    and candidate is None
                     and _account_is_safe_candidate(account)
                     and settings.limit_warmup_staggered_idle_enabled
                     and window == "primary"
@@ -695,7 +705,7 @@ class _WarmupCandidate:
     require_no_prior_attempt: bool = False
 
 
-def _selected_windows(value: str) -> tuple[str, ...]:
+def selected_warmup_windows(value: str) -> tuple[str, ...]:
     normalized = value.strip().lower()
     if normalized == "both":
         return ("primary", "secondary")
@@ -723,24 +733,34 @@ def _build_candidate(
     after_primary: dict[str, UsageHistory],
     after_secondary: dict[str, UsageHistory],
     min_available_percent: float,
+    reset_evidence: dict[tuple[str, str], UsageResetEvidence] | None = None,
 ) -> _WarmupCandidate | None:
-    before = _effective_usage_entry(
+    before = effective_warmup_usage_entry(
         account.id,
         window=window,
         primary=before_primary,
         secondary=before_secondary,
     )
-    after = _effective_usage_entry(
+    after = effective_warmup_usage_entry(
         account.id,
         window=window,
         primary=after_primary,
         secondary=after_secondary,
     )
-    if before is None or after is None:
+    if after is None:
         return None
     available_percent = 100.0 - after.used_percent
     if min_available_percent < 100.0 and available_percent < min_available_percent:
         return None
+    evidence = (reset_evidence or {}).get((account.id, after.window or "primary"))
+    if (
+        evidence is not None
+        and after.used_percent < 100.0
+        and after.reset_at is not None
+        and evidence.after.reset_at is not None
+        and abs(after.reset_at - evidence.after.reset_at) <= RESET_AT_JITTER_TOLERANCE_SECONDS
+    ):
+        before, after = evidence.before, evidence.after
     if not usage_reset_confirmed(before=before, after=after):
         return None
     assert after.reset_at is not None
@@ -952,7 +972,7 @@ def _usage_entry_refreshed_for_cycle(
     return entry.recorded_at >= refresh_started_at
 
 
-def _effective_usage_entry(
+def effective_warmup_usage_entry(
     account_id: str,
     *,
     window: str,
@@ -998,4 +1018,4 @@ def _truncate(value: str | None, limit: int = 1000) -> str | None:
 
 
 def _attempt_reset_at_tolerance(candidate: _WarmupCandidate) -> int:
-    return _RESET_AT_JITTER_TOLERANCE_SECONDS
+    return RESET_AT_JITTER_TOLERANCE_SECONDS

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -908,11 +908,28 @@ class UsageRepository:
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 
+    async def first_reset_observed_at(
+        self, account_id: str, window: str, reset_at: int, *, tolerance_seconds: int
+    ) -> datetime | None:
+        stmt = (
+            select(UsageHistory.recorded_at)
+            .where(
+                UsageHistory.account_id == account_id,
+                _window_clause(window),
+                UsageHistory.reset_at.between(reset_at - tolerance_seconds, reset_at + tolerance_seconds),
+            )
+            .order_by(UsageHistory.recorded_at.asc(), UsageHistory.id.asc())
+            .limit(1)
+        )
+        return await self._session.scalar(stmt)
+
     async def history_since(
         self,
         account_id: str,
         window: str,
         since: datetime,
+        *,
+        include_predecessor: bool = False,
     ) -> list[UsageHistory]:
         stmt = (
             select(UsageHistory)
@@ -924,7 +941,21 @@ class UsageRepository:
             .order_by(UsageHistory.recorded_at.asc(), UsageHistory.id.asc())
         )
         result = await self._session.execute(stmt)
-        return list(result.scalars().all())
+        history = list(result.scalars().all())
+        if include_predecessor:
+            predecessor = await self._session.scalar(
+                select(UsageHistory)
+                .where(
+                    UsageHistory.account_id == account_id,
+                    _window_clause(window),
+                    UsageHistory.recorded_at < since,
+                )
+                .order_by(UsageHistory.recorded_at.desc(), UsageHistory.id.desc())
+                .limit(1)
+            )
+            if predecessor is not None:
+                history.insert(0, predecessor)
+        return history
 
     async def bulk_history_since(
         self,

--- a/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/design.md
+++ b/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/design.md
@@ -1,0 +1,27 @@
+## Context
+
+See proposal.md for the missed trigger. Both writers persist UsageHistory. The scheduler currently evaluates warm-up only after a poll writes. The existing account/window/reset claim already provides durable consumption, including failed or pending attempts.
+
+## Goals / Non-Goals
+
+Recover current reset evidence through ordinary warm-up admission. Keep sender preflight, reset detection, plan selection and bootstrap freshness unchanged. General warm-up redesign and token-floor changes are outside this fix.
+
+## Decisions
+
+Read current snapshots and settings after every selected-account poll. Keep existing blocked-account reconciliation tied to successful polling, and retain its special anchored Free monthly recovery.
+
+For opted-in accounts, find the earliest retained observation of the current reset identity, then search that span plus its immediate predecessor for a confirmed pair. Check the durable claim first to avoid rescanning consumed windows. The reset identity anchors the lookup across restarts and delayed deadlines; a moving duration cutoff would discard still-current evidence. No new database table or migration is needed.
+
+Pass recovered pairs separately from current snapshots. The warm-up service uses the pair to prove the reset and identify the durable claim, while current snapshots govern availability. Initial-Free, paid-to-Free and staggered-idle paths remain gated on an actual poll write. A concurrent live snapshot cannot satisfy that gate merely by arriving after refresh starts.
+
+An in-memory baseline would fail on restart or leader change. A separate event queue would duplicate the attempt ledger and require changes to both writers and schema. Retained history already contains the evidence needed for this bounded repair.
+
+## Risks / Trade-offs
+
+Busy unconsumed windows can contain many rows. Locating the first matching reset can scan retained history for the selected account/window; the subsequent read starts at that reset observation. Reads stop recurring after the durable claim. Retention that removes the predecessor leaves insufficient proof, so recovery fails closed.
+
+Historical deadlines that drift beyond five seconds of the current identity are not replayed. Existing anchored monthly recovery remains unchanged. A claimed attempt is best effort; a crash after claim does not authorize a duplicate send.
+
+## Migration Plan
+
+Source-only rollout with existing schema and defaults. Reverting the code restores the previous scheduler behavior without changing stored claims or usage history. This task does not deploy the change.

--- a/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/proposal.md
+++ b/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #1975 documents a missed warm-up when live ingestion persists a confirmed reset before the scheduler reads its baseline. A freshness-skipped poll loses the transition even though the database retains the evidence.
+
+## What Changes
+
+- Evaluate persisted reset evidence for the selected account even when polling writes nothing.
+- Reuse durable attempt claims to consume each reset at most once across scheduler restarts and duplicate snapshots.
+- Keep current quota availability, plan/window selection, opt-in and reset confirmation rules.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Recover reset-confirmed warm-up from persisted usage evidence independently of the poll writer.
+
+## Impact
+
+Backend scheduler and usage-history reads, with integration tests through live ingestion and scheduler lifecycle. No frontend, new setting, upstream dependency or runtime deployment.

--- a/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Persisted current reset evidence survives a skipped poll
+
+For the account selected by a background refresh slice, reset-confirmed warm-up SHALL evaluate retained authoritative usage evidence even when the poll writes no new usage. A confirmed reset pair belonging to the latest quota window SHALL remain eligible after additional same-window snapshots or scheduler restart. Recovery MUST require an unexpired reset deadline matching the latest snapshot within the existing five-second deduplication tolerance, and MUST apply current usage availability, current account state, global opt-in, per-account opt-in and plan-applicable window selection. Missing evidence MUST NOT be replaced with an inferred reset.
+
+The durable account/window/reset attempt claim SHALL consume recovered evidence across workers and restarts. Pending, succeeded, failed and skipped attempts MUST all prevent another attempt for the same reset identity. A skipped poll MUST NOT admit initial-Free, paid-to-Free or staggered-idle warm-up, including when a concurrent live snapshot arrives after refresh starts.
+
+#### Scenario: Live ingestion wins the write race
+
+- **GIVEN** an eligible account has a retained confirmed reset pair written through live usage ingestion
+- **WHEN** the next scheduled poll skips the fresh account
+- **THEN** the scheduler attempts one reset-confirmed warm-up for that current window
+
+#### Scenario: Duplicate observations and restart preserve consumption
+
+- **GIVEN** a reset-confirmed attempt already exists
+- **WHEN** duplicate live snapshots, a restarted scheduler or a later poll observes the same reset
+- **THEN** no second warm-up attempt or send occurs
+
+#### Scenario: Further live observations preserve the reset pair
+
+- **GIVEN** additional same-window usage snapshots arrive before the scheduler evaluates a confirmed reset
+- **WHEN** the scheduler evaluates the current window
+- **THEN** it can recover the earlier consecutive pair without relying on a fixed count of newest rows
+
+#### Scenario: Historical evidence does not override current eligibility
+
+- **GIVEN** a retained reset pair exists
+- **WHEN** the latest window supersedes that reset, its deadline has expired, current quota is exhausted or below the configured availability gate, or the account opts out
+- **THEN** no warm-up is sent from that historical pair
+
+#### Scenario: No transition is invented from incomplete history
+
+- **GIVEN** only an available snapshot or a jitter-only pair remains
+- **WHEN** the scheduler evaluates a freshness-skipped account
+- **THEN** no reset-confirmed warm-up is sent
+
+#### Scenario: Scheduled resets tolerate missing duration metadata
+
+- **GIVEN** consecutive retained snapshots cross the previous reset deadline and confirm a new available window
+- **WHEN** the new snapshot omits duration metadata or its deadline exceeds one nominal window from observation
+- **THEN** recovery still evaluates the confirmed pair using the ordinary reset rules
+
+#### Scenario: A delayed deadline stays recoverable after a late restart
+
+- **GIVEN** a confirmed weekly reset has a next deadline one week and 120 seconds after observation
+- **AND** subsequent same-window snapshots preserve that identity
+- **WHEN** the scheduler restarts one week and 10 seconds after the reset and skips a fresh poll
+- **THEN** it still recovers the retained reset pair and attempts one warm-up before the deadline expires
+
+#### Scenario: A live write during a skipped poll does not bootstrap or idle-warm
+
+- **GIVEN** a fresh account has no confirmed reset evidence
+- **AND** its scheduled poll skips without writing usage
+- **WHEN** a live snapshot arrives after that refresh starts
+- **THEN** the snapshot does not trigger initial-Free or staggered-idle warm-up

--- a/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/tasks.md
+++ b/openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/tasks.md
@@ -1,0 +1,11 @@
+## 1. Reproduce and repair
+
+- [x] 1.1 Reproduce live ingestion followed by a freshness-skipped scheduler tick through public lifecycle methods; observe the missing send.
+- [x] 1.2 Recover current reset evidence and reuse atomic claims; make the regression pass across scheduler restart.
+- [x] 1.3 Cover duplicate snapshots, later polling, current eligibility and incomplete history through scheduler/ingestion integration tests.
+- [x] 1.4 Reproduce and fix late-restart cutoff loss and non-reset trigger admission; verify their scheduler regressions pass.
+
+## 2. Verify and deliver
+
+- [x] 2.1 Run affected warm-up, ingestion and scheduler checks, lint, typing and OpenSpec validation with a dedicated disposable database.
+- [x] 2.2 Review the fixed base/candidate diff and verify requirement coverage.

--- a/openspec/specs/usage-refresh-policy/context.md
+++ b/openspec/specs/usage-refresh-policy/context.md
@@ -126,3 +126,13 @@ does not count as evidence that the account is healthy.
 
 - [#676 - initial bug report on `/wham/usage` vs. Settings UI divergence](https://github.com/Soju06/codex-lb/issues/676)
 - [#677 - dashboard per-account force-probe action](https://github.com/Soju06/codex-lb/issues/677)
+
+## Reset evidence after live ingestion
+
+[Issue #1975](https://github.com/Soju06/codex-lb/issues/1975) exposed a missed warm-up when live usage recorded a reset before a freshness-skipped poll. The [reset-evidence requirement](spec.md#requirement-persisted-current-reset-evidence-survives-a-skipped-poll) covers that path.
+
+The scheduler locates the first retained observation of the current reset identity and reads that history span plus its predecessor. This survives restart and delayed deadlines without another consumption table. Existing warm-up claims consume pending, succeeded, failed and skipped attempts; a crash after claiming does not authorize another send. Current snapshots govern availability, while the historical pair proves the reset. Other warm-up triggers still require a poll write.
+
+For example, live ingestion can record weekly usage falling from 51% to 0%, then receive more snapshots before the scheduler runs. The earlier pair remains usable even though the latest two rows show the same reset deadline. An expired or superseded identity is not replayed, and a missing predecessor supplies no proof.
+
+The first-reset lookup can scan retained history for the selected account/window, and the following span is not row-capped. Already-claimed windows skip this lookup. This cost avoids discarding evidence at an arbitrary time or row limit; no new setting or migration is required.

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -2207,3 +2207,58 @@ with zero configuration and MUST NOT require an operator setting.
 - **WHEN** two refreshes of that account observe `plan_type` `free` concurrently
 - **THEN** the recorded observation count reflects both observations rather than one
 
+### Requirement: Persisted current reset evidence survives a skipped poll
+
+For the account selected by a background refresh slice, reset-confirmed warm-up SHALL evaluate retained authoritative usage evidence even when the poll writes no new usage. A confirmed reset pair belonging to the latest quota window SHALL remain eligible after additional same-window snapshots or scheduler restart. Recovery MUST require an unexpired reset deadline matching the latest snapshot within the existing five-second deduplication tolerance, and MUST apply current usage availability, current account state, global opt-in, per-account opt-in and plan-applicable window selection. Missing evidence MUST NOT be replaced with an inferred reset.
+
+The durable account/window/reset attempt claim SHALL consume recovered evidence across workers and restarts. Pending, succeeded, failed and skipped attempts MUST all prevent another attempt for the same reset identity. A skipped poll MUST NOT admit initial-Free, paid-to-Free or staggered-idle warm-up, including when a concurrent live snapshot arrives after refresh starts.
+
+#### Scenario: Live ingestion wins the write race
+
+- **GIVEN** an eligible account has a retained confirmed reset pair written through live usage ingestion
+- **WHEN** the next scheduled poll skips the fresh account
+- **THEN** the scheduler attempts one reset-confirmed warm-up for that current window
+
+#### Scenario: Duplicate observations and restart preserve consumption
+
+- **GIVEN** a reset-confirmed attempt already exists
+- **WHEN** duplicate live snapshots, a restarted scheduler or a later poll observes the same reset
+- **THEN** no second warm-up attempt or send occurs
+
+#### Scenario: Further live observations preserve the reset pair
+
+- **GIVEN** additional same-window usage snapshots arrive before the scheduler evaluates a confirmed reset
+- **WHEN** the scheduler evaluates the current window
+- **THEN** it can recover the earlier consecutive pair without relying on a fixed count of newest rows
+
+#### Scenario: Historical evidence does not override current eligibility
+
+- **GIVEN** a retained reset pair exists
+- **WHEN** the latest window supersedes that reset, its deadline has expired, current quota is exhausted or below the configured availability gate, or the account opts out
+- **THEN** no warm-up is sent from that historical pair
+
+#### Scenario: No transition is invented from incomplete history
+
+- **GIVEN** only an available snapshot or a jitter-only pair remains
+- **WHEN** the scheduler evaluates a freshness-skipped account
+- **THEN** no reset-confirmed warm-up is sent
+
+#### Scenario: Scheduled resets tolerate missing duration metadata
+
+- **GIVEN** consecutive retained snapshots cross the previous reset deadline and confirm a new available window
+- **WHEN** the new snapshot omits duration metadata or its deadline exceeds one nominal window from observation
+- **THEN** recovery still evaluates the confirmed pair using the ordinary reset rules
+
+#### Scenario: A delayed deadline stays recoverable after a late restart
+
+- **GIVEN** a confirmed weekly reset has a next deadline one week and 120 seconds after observation
+- **AND** subsequent same-window snapshots preserve that identity
+- **WHEN** the scheduler restarts one week and 10 seconds after the reset and skips a fresh poll
+- **THEN** it still recovers the retained reset pair and attempts one warm-up before the deadline expires
+
+#### Scenario: A live write during a skipped poll does not bootstrap or idle-warm
+
+- **GIVEN** a fresh account has no confirmed reset evidence
+- **AND** its scheduled poll skips without writing usage
+- **WHEN** a live snapshot arrives after that refresh starts
+- **THEN** the snapshot does not trigger initial-Free or staggered-idle warm-up

--- a/tests/integration/live_reset_helpers.py
+++ b/tests/integration/live_reset_helpers.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.usage import refresh_scheduler
+from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
+from app.core.usage.models import RateLimitPayload, UsagePayload, UsageWindow
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.limit_warmup.repository import LimitWarmupRepository
+from app.modules.limit_warmup.service import LimitWarmupSendResult
+from app.modules.settings.repository import SettingsRepository
+from app.modules.usage.live_ingest import LiveUsageIngestor
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+
+
+async def run_scheduler_ticks(monkeypatch: pytest.MonkeyPatch, *, workers: int = 1) -> None:
+    finished: asyncio.Queue[None] = asyncio.Queue()
+
+    class Leader:
+        async def run_if_leader(self, fn: Callable[[], Awaitable[float]]) -> float:
+            try:
+                return await fn()
+            finally:
+                finished.put_nowait(None)
+
+    monkeypatch.setattr(refresh_scheduler, "_get_leader_election", Leader)
+    schedulers = [refresh_scheduler.UsageRefreshScheduler(interval_seconds=60, enabled=True) for _ in range(workers)]
+    for scheduler in schedulers:
+        await scheduler.start()
+    try:
+        async with asyncio.timeout(5):
+            for _ in schedulers:
+                await finished.get()
+    finally:
+        await asyncio.gather(*(scheduler.stop() for scheduler in schedulers))
+
+
+async def publish_and_wait(
+    ingestor: LiveUsageIngestor, snapshot: LiveRateLimitSnapshot, account_id: str, window: str
+) -> None:
+    async with SessionLocal() as session:
+        previous = (await UsageRepository(session).latest_by_account(window)).get(account_id)
+    ingestor.publish(snapshot, account_id=account_id)
+    async with asyncio.timeout(5):
+        while True:
+            async with SessionLocal() as session:
+                latest = (await UsageRepository(session).latest_by_account(window)).get(account_id)
+            if latest is not None and (previous is None or latest.id != previous.id):
+                return
+            await asyncio.sleep(0.001)
+
+
+async def prepare_live_reset(
+    window: str, *, prior_status: str | None = None, baseline: str = "reset"
+) -> tuple[Account, LiveRateLimitSnapshot, int]:
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="live-reset",
+        chatgpt_account_id="workspace-live-reset",
+        email="live-reset@example.com",
+        plan_type="free" if window == "monthly" else "plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        limit_warmup_enabled=True,
+    )
+    now = int(time.time())
+    window_minutes = {"primary": 300, "secondary": 10_080, "monthly": 43_200}[window]
+    reset_at = now + window_minutes * 60
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(account)
+        if baseline != "missing":
+            await UsageRepository(session).add_entry(
+                account.id,
+                51.0,
+                window=window,
+                recorded_at=utcnow() - timedelta(minutes=2),
+                reset_at=reset_at - 5 if baseline == "jitter" else now - 1,
+                window_minutes=window_minutes,
+            )
+        await AdditionalUsageRepository(session).add_entry(
+            account.id,
+            "codex",
+            "codex",
+            "secondary",
+            0.0,
+            reset_at=now + 604_800,
+            window_minutes=10_080,
+            recorded_at=utcnow(),
+            quota_key="codex",
+        )
+        await SettingsRepository(session).update(
+            limit_warmup_enabled=True,
+            limit_warmup_windows="primary" if window == "primary" else "secondary",
+            limit_warmup_model="gpt-5.1-codex-mini",
+            limit_warmup_staggered_idle_enabled=False,
+        )
+        if prior_status is not None:
+            await LimitWarmupRepository(session).try_create_attempt(
+                account_id=account.id,
+                window=window,
+                reset_at=reset_at,
+                model="gpt-5.1-codex-mini",
+                attempted_at=utcnow(),
+                status=prior_status,
+            )
+
+    snapshot = LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(
+            0.0, window_minutes if window == "monthly" else 300, reset_at if window != "secondary" else now + 18_000
+        ),
+        secondary=None
+        if window == "monthly"
+        else LiveUsageWindow(0.0, 10_080, reset_at if window == "secondary" else now + 604_800),
+        credits_has=None,
+        credits_unlimited=None,
+        credits_balance=None,
+    )
+    return account, snapshot, reset_at
+
+
+def usage_payload(snapshot: LiveRateLimitSnapshot, plan_type: str) -> UsagePayload:
+    primary = snapshot.primary
+    secondary = snapshot.secondary
+    return UsagePayload(
+        plan_type=plan_type,
+        rate_limit=RateLimitPayload(
+            primary_window=UsageWindow(
+                used_percent=primary.used_percent,
+                reset_at=primary.reset_at,
+                limit_window_seconds=(primary.window_minutes or 300) * 60,
+            )
+            if primary
+            else None,
+            secondary_window=UsageWindow(
+                used_percent=secondary.used_percent,
+                reset_at=secondary.reset_at,
+                limit_window_seconds=(secondary.window_minutes or 10_080) * 60,
+            )
+            if secondary
+            else None,
+        ),
+    )
+
+
+def record_warmup_sends(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    sends: list[str] = []
+
+    class Sender:
+        async def send(self, target: Account, *, model: str, prompt: str) -> LimitWarmupSendResult:
+            sends.append(target.id)
+            return LimitWarmupSendResult(request_id="reset-probe", success=True, latency_ms=1)
+
+    monkeypatch.setattr(refresh_scheduler, "StreamingLimitWarmupSender", lambda *args, **kwargs: Sender())
+    return sends

--- a/tests/integration/test_live_reset_warmup.py
+++ b/tests/integration/test_live_reset_warmup.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+
+from app.core.usage.live_snapshots import LiveUsageWindow
+from app.core.usage.models import UsagePayload
+from app.core.utils.time import naive_utc_to_epoch, utcnow
+from app.db.models import Account, UsageHistory
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.limit_warmup.repository import LimitWarmupRepository
+from app.modules.settings.repository import SettingsRepository
+from app.modules.usage import repository as usage_repository
+from app.modules.usage import updater
+from app.modules.usage.live_ingest import LiveUsageIngestor
+from app.modules.usage.repository import AdditionalUsageRepository
+from tests.integration.live_reset_helpers import (
+    prepare_live_reset,
+    publish_and_wait,
+    record_warmup_sends,
+    run_scheduler_ticks,
+    usage_payload,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.usage_refresh_request_path]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window", ["primary", "secondary", "monthly"])
+@pytest.mark.parametrize("prior_status", [None, "pending", "succeeded", "failed", "skipped"])
+async def test_live_reset_survives_freshness_skip_and_scheduler_restart(
+    db_setup: bool, monkeypatch: pytest.MonkeyPatch, window: str, prior_status: str | None
+) -> None:
+    account, snapshot, reset_at = await prepare_live_reset(window, prior_status=prior_status)
+
+    sends = record_warmup_sends(monkeypatch)
+    polls: list[str] = []
+
+    async def fetch_usage(**kwargs: object) -> UsagePayload:
+        polls.append("poll")
+        return usage_payload(snapshot, account.plan_type)
+
+    monkeypatch.setattr(updater, "fetch_usage", fetch_usage)
+    ingestor = LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0)
+    ingestor.start()
+    try:
+        await publish_and_wait(ingestor, snapshot, account.id, window)
+        # More writes must not erase the earlier consecutive reset pair.
+        count = 240 if window == "secondary" and prior_status is None else 2
+        for index in range(count):
+            target = snapshot.secondary if window == "secondary" else snapshot.primary
+            assert target is not None
+            updated = replace(target, used_percent=(index + 1) / 100)
+            snapshot = replace(snapshot, **{"secondary" if window == "secondary" else "primary": updated})
+            await publish_and_wait(ingestor, snapshot, account.id, window)
+        await run_scheduler_ticks(monkeypatch, workers=2)
+        expected_sends = [account.id] if prior_status is None else []
+        assert polls == []
+        assert sends == expected_sends
+
+        await publish_and_wait(ingestor, snapshot, account.id, window)
+        await run_scheduler_ticks(monkeypatch)
+        assert sends == expected_sends
+        async with SessionLocal() as session:
+            original_attempt = (await LimitWarmupRepository(session).latest_by_account([account.id]))[account.id]
+
+        # Expire only the updater's freshness clock, then exercise a real poll.
+        poll_time = utcnow() + timedelta(seconds=61)
+        monkeypatch.setattr(updater, "utcnow", lambda: poll_time)
+        await run_scheduler_ticks(monkeypatch)
+        assert polls == ["poll"]
+        assert sends == expected_sends
+        async with SessionLocal() as session:
+            attempt = (await LimitWarmupRepository(session).latest_by_account([account.id]))[account.id]
+        assert attempt.id == original_attempt.id
+        assert (attempt.window, attempt.reset_at, attempt.status) == (window, reset_at, prior_status or "succeeded")
+    finally:
+        await ingestor.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "missing",
+        "jitter",
+        "superseded",
+        "exhausted",
+        "below_availability",
+        "opted_out",
+        "disabled",
+        "other_window",
+        "expired",
+    ],
+)
+async def test_live_reset_recovery_respects_current_eligibility(
+    db_setup: bool, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, condition: str
+) -> None:
+    account, snapshot, reset_at = await prepare_live_reset("secondary", baseline=condition)
+    sends = record_warmup_sends(monkeypatch)
+
+    async def fetch_usage(**kwargs: object) -> UsagePayload:
+        return usage_payload(snapshot, account.plan_type)
+
+    monkeypatch.setattr(updater, "fetch_usage", fetch_usage)
+    ingestor = LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0)
+    ingestor.start()
+    try:
+        await publish_and_wait(ingestor, snapshot, account.id, "secondary")
+        secondary = snapshot.secondary
+        assert secondary is not None
+        if condition == "superseded":
+            secondary = replace(secondary, reset_at=reset_at + 3600, used_percent=2.0)
+        elif condition in {"exhausted", "below_availability"}:
+            secondary = replace(secondary, used_percent=100.0 if condition == "exhausted" else 21.0)
+        snapshot = replace(snapshot, secondary=secondary)
+        await publish_and_wait(ingestor, snapshot, account.id, "secondary")
+        async with SessionLocal() as session:
+            await SettingsRepository(session).update(
+                limit_warmup_enabled=condition != "disabled",
+                limit_warmup_windows="primary" if condition == "other_window" else "secondary",
+                limit_warmup_min_available_percent=80.0,
+            )
+            if condition == "opted_out":
+                await AccountsRepository(session).update_limit_warmup_enabled(account.id, False)
+        if condition == "expired":
+            expired_now = utcnow() + timedelta(days=8)
+            monkeypatch.setattr(updater, "utcnow", lambda: expired_now)
+        await run_scheduler_ticks(monkeypatch)
+        assert sends == []
+        async with SessionLocal() as session:
+            assert await LimitWarmupRepository(session).latest_by_account([account.id]) == {}
+        assert "Usage refresh loop failed" not in caplog.text
+    finally:
+        await ingestor.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window_minutes,deadline_offset", [(None, 0), (10_080, 120)])
+async def test_live_scheduled_reset_does_not_require_an_exact_new_window_start(
+    db_setup: bool, monkeypatch: pytest.MonkeyPatch, window_minutes: int | None, deadline_offset: int
+) -> None:
+    account, snapshot, reset_at = await prepare_live_reset("secondary")
+    secondary = snapshot.secondary
+    assert secondary is not None
+    snapshot = replace(
+        snapshot, secondary=replace(secondary, window_minutes=window_minutes, reset_at=reset_at + deadline_offset)
+    )
+    sends = record_warmup_sends(monkeypatch)
+
+    async def fetch_usage(**kwargs: object) -> UsagePayload:
+        pytest.fail("Fresh live quota must skip polling")
+
+    monkeypatch.setattr(updater, "fetch_usage", fetch_usage)
+    ingestor = LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0)
+    ingestor.start()
+    try:
+        await publish_and_wait(ingestor, snapshot, account.id, "secondary")
+        await run_scheduler_ticks(monkeypatch)
+        assert sends == [account.id]
+        async with SessionLocal() as session:
+            attempt = (await LimitWarmupRepository(session).latest_by_account([account.id]))[account.id]
+        assert attempt.reset_at == reset_at + deadline_offset
+    finally:
+        await ingestor.stop()
+
+
+@pytest.mark.asyncio
+async def test_live_reset_survives_a_late_restart_before_its_delayed_deadline(
+    db_setup: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account, snapshot, reset_at = await prepare_live_reset("secondary")
+    secondary = snapshot.secondary
+    assert secondary is not None
+    snapshot = replace(snapshot, secondary=replace(secondary, reset_at=reset_at + 120))
+    sends = record_warmup_sends(monkeypatch)
+
+    async def fetch_usage(**kwargs: object) -> UsagePayload:
+        pytest.fail("The newly ingested snapshot must keep the restarted scheduler's poll fresh")
+
+    monkeypatch.setattr(updater, "fetch_usage", fetch_usage)
+    ingestor = LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0)
+    ingestor.start()
+    try:
+        await publish_and_wait(ingestor, snapshot, account.id, "secondary")
+        late_now = utcnow() + timedelta(seconds=604_810)
+        monkeypatch.setattr(updater, "utcnow", lambda: late_now)
+        # Advance the persistence clock as well, so this is an actual fresh live write.
+        monkeypatch.setattr(usage_repository, "utcnow", lambda: late_now)
+        snapshot = replace(snapshot, primary=LiveUsageWindow(0.0, 300, int(naive_utc_to_epoch(late_now)) + 18_000))
+        await publish_and_wait(ingestor, snapshot, account.id, "secondary")
+        async with SessionLocal() as session:
+            await AdditionalUsageRepository(session).add_entry(
+                account.id,
+                "codex",
+                "codex",
+                "secondary",
+                0.0,
+                reset_at=reset_at + 120,
+                window_minutes=10_080,
+                recorded_at=late_now,
+                quota_key="codex",
+            )
+        await run_scheduler_ticks(monkeypatch)
+        assert sends == [account.id]
+        async with SessionLocal() as session:
+            attempt = (await LimitWarmupRepository(session).latest_by_account([account.id]))[account.id]
+        assert attempt.reset_at == reset_at + 120
+    finally:
+        await ingestor.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window", ["primary", "monthly"])
+async def test_live_snapshot_during_skipped_poll_does_not_enable_non_reset_triggers(
+    db_setup: bool, monkeypatch: pytest.MonkeyPatch, window: str
+) -> None:
+    account, snapshot, _ = await prepare_live_reset(window, baseline="missing")
+    sends = record_warmup_sends(monkeypatch)
+
+    async def fetch_usage(**kwargs: object) -> UsagePayload:
+        pytest.fail("The real updater must skip fresh live usage")
+
+    monkeypatch.setattr(updater, "fetch_usage", fetch_usage)
+    ingestor = LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0)
+    original_refresh = updater.UsageUpdater.refresh_accounts
+
+    async def refresh_then_ingest(
+        self: updater.UsageUpdater, accounts: list[Account], latest_usage: Mapping[str, UsageHistory]
+    ) -> bool:
+        written = await original_refresh(self, accounts, latest_usage)
+        assert written is False
+        await publish_and_wait(ingestor, snapshot, account.id, window)
+        return written
+
+    monkeypatch.setattr(updater.UsageUpdater, "refresh_accounts", refresh_then_ingest)
+    async with SessionLocal() as session:
+        await SettingsRepository(session).update(
+            limit_warmup_windows="secondary", limit_warmup_staggered_idle_enabled=window == "primary"
+        )
+    ingestor.start()
+    try:
+        await publish_and_wait(ingestor, snapshot, account.id, window)
+        await run_scheduler_ticks(monkeypatch)
+        assert sends == []
+        async with SessionLocal() as session:
+            assert await LimitWarmupRepository(session).latest_by_account([account.id]) == {}
+    finally:
+        await ingestor.stop()

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.core.resilience.toggles import resolve_resilience_toggles
 from app.core.usage import refresh_scheduler as refresh_scheduler_module
-from app.db.models import Account, AccountStatus, UsageHistory
+from app.db.models import Account, AccountStatus, DashboardSettings, UsageHistory
 from app.modules.proxy.load_balancer import effective_routing_tunables
 
 pytestmark = pytest.mark.unit
@@ -1503,8 +1503,8 @@ async def test_refresh_slices_scope_queries_and_followups_to_selected_account(
         def __init__(self, _session: object) -> None:
             pass
 
-        async def get_or_create(self) -> object:
-            return object()
+        async def get_or_create(self) -> DashboardSettings:
+            return DashboardSettings(limit_warmup_enabled=False)
 
     class _Updater:
         async def refresh_accounts(
@@ -1561,8 +1561,12 @@ async def test_refresh_slices_scope_queries_and_followups_to_selected_account(
         ("primary", ("acc_a",)),
         ("secondary", ("acc_a",)),
         ("monthly", ("acc_a",)),
+        ("primary", ("acc_a",)),
+        ("secondary", ("acc_a",)),
+        ("monthly", ("acc_a",)),
     ]
-    assert warmup_calls == []
+    assert len(warmup_calls) == 1
+    assert [account.id for account in cast("list[Account]", warmup_calls[0]["accounts"])] == ["acc_a"]
     assert invalidations == 0
 
     assert await scheduler._refresh_once() == 30.0
@@ -1575,14 +1579,14 @@ async def test_refresh_slices_scope_queries_and_followups_to_selected_account(
         ("secondary", ("acc_b",)),
         ("monthly", ("acc_b",)),
     ]
-    assert len(warmup_calls) == 1
-    assert [account.id for account in cast("list[Account]", warmup_calls[0]["accounts"])] == ["acc_b"]
-    assert [account.id for account in cast("list[Account]", warmup_calls[0]["stagger_accounts"])] == [
+    assert len(warmup_calls) == 2
+    assert [account.id for account in cast("list[Account]", warmup_calls[1]["accounts"])] == ["acc_b"]
+    assert [account.id for account in cast("list[Account]", warmup_calls[1]["stagger_accounts"])] == [
         "acc_a",
         "acc_b",
     ]
-    assert set(cast("dict[str, UsageHistory]", warmup_calls[0]["before_primary"])) == {"acc_b"}
-    assert set(cast("dict[str, UsageHistory]", warmup_calls[0]["after_primary"])) == {"acc_b"}
+    assert set(cast("dict[str, UsageHistory]", warmup_calls[1]["before_primary"])) == {"acc_b"}
+    assert set(cast("dict[str, UsageHistory]", warmup_calls[1]["after_primary"])) == {"acc_b"}
     assert invalidations == 1
     assert open_sessions == 0
 


### PR DESCRIPTION
## Summary

Live usage can persist a confirmed reset before the scheduler polls. A freshness skip then loses the warm-up trigger. This change recovers the retained reset pair and consumes it through the existing durable attempt claim.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1975

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-09-10-preserve-live-reset-evidence/`

## Changes

- Evaluate selected-account reset evidence even when polling writes nothing.
- Anchor history at the first retained observation of the current reset identity, including its predecessor. This survives restart and delayed deadlines.
- Apply current quota availability and opt-in state to historical reset proof. Keep bootstrap, paid-to-Free and idle triggers gated on actual poll writes.
- Add the ingestion/scheduler regression suite to hosted PostgreSQL coverage.

The existing atomic claim prevents duplicate attempts after repeated ingestion, scheduler restarts and concurrent workers. Already-claimed windows skip history lookup. The first-reset lookup can scan retained account/window history, and the following span is not row-capped. No new ledger, migration, setting or deployment is included.

## Test plan

All local tests used equal main/test URLs pointing to a dedicated disposable SQLite database.

```text
uv run pytest tests/unit tests/simulation tests/test_request_logs_options_api.py -q --tb=short --maxfail=3
9680 passed, 101 skipped, 1 known xfailed

Affected ingestion, scheduler, warm-up, atomic-claim and usage-repository suite:
171 passed, 19 PostgreSQL-only checks skipped

make lint typecheck: passed
OpenSpec change validation --strict: passed
OpenSpec canonical validation --specs --strict after sync/archive: 65 passed
```

The reported path was red on the pinned base using real ingestion, the real updater freshness decision and scheduler lifecycle. Current tests cover duplicate snapshots, later polling, restart, concurrent schedulers, all prior-attempt states and current eligibility. Independent standards and correctness review found no remaining actionable findings on the final source tree. PostgreSQL execution remains a hosted check.

## Screenshots / output

```text
Live 51% -> 0% reset, freshness-skipped poll:
  before: no warm-up send
  after: one warm-up send
Duplicate ingestion + restart + later normal poll:
  still one warm-up send
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local make targets and affected test subset.
- [x] Strict OpenSpec validation passes and verification is complete.
- [x] Simplicity gates reviewed: no new setup, setting, README or dashboard surface.
- [x] CHANGELOG is not edited by hand.
