### PR TITLE
refactor(bridge): resolve admission and reconnect settings before the prewarm lock

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -48,6 +48,7 @@ from app.core.metrics.prometheus import (
 from app.core.utils.locks import fast_lock
 from app.core.utils.request_id import ensure_request_scope_id
 from app.db.models import (
+    DashboardSettings,
     StickySessionKind,
 )
 from app.modules.api_keys.service import (
@@ -1981,6 +1982,7 @@ class _HTTPBridgeMixin(
         require_preferred_account: bool = False,
         owner_rebind_affinity: _AffinityPolicy | None = None,
         selection_affinity: _AffinityPolicy | None = None,
+        dashboard_settings: DashboardSettings | None = None,
     ) -> None:
         request_state.response_create_sent_at = None
         goal_restart = request_state.affinity_policy.abandon_unavailable_legacy_owner
@@ -2023,7 +2025,15 @@ class _HTTPBridgeMixin(
             now=clock_for(self).monotonic(),
         )
         try:
-            settings = await _service_get_settings_cache().get()
+            # Callers that reconnect while holding a lock resolve this row
+            # before taking it and pass it in. The prewarm timeout recovery is
+            # one: it reconnects under ``prewarm_lock``, and a refresh behind
+            # this read runs a DB query under a process-global lock, so
+            # awaiting it there would suspend the critical section (issues
+            # #1971/#1972).
+            settings = (
+                dashboard_settings if dashboard_settings is not None else await _service_get_settings_cache().get()
+            )
             session.api_key = request_state.api_key
             forced_refresh_account_id = request_state.force_refresh_account_id
             excluded_account_ids: set[str] = set(request_state.excluded_account_ids)

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2570,7 +2570,24 @@ class _HTTPBridgeRequestSubmitMixin:
         # behind that read runs a DB query under a process-global lock; one
         # stalled query would then hold this session's prewarm lock and stall
         # every later turn on it (issues #1971 and #1972).
-        dashboard_settings = await _service_get_settings_cache().get()
+        settings_cache = _service_get_settings_cache()
+        try:
+            dashboard_settings = await settings_cache.get()
+        except Exception:  # noqa: BLE001 - a prewarm must never fail a servable request
+            # The same fallback the request entry point's dashboard-overrides
+            # middleware applies to this row: prefer the last one this replica
+            # loaded. With no row at all the prewarm is skipped rather than run
+            # without a snapshot, which would put the read back under the lock.
+            dashboard_settings = settings_cache.cached_row()
+            logger.warning(
+                "HTTP bridge prewarm settings snapshot unavailable; %s",
+                "using the last loaded dashboard values" if dashboard_settings is not None else "skipping the prewarm",
+                exc_info=True,
+            )
+            if dashboard_settings is None:
+                request_state.prewarm_status = "skipped"
+                _record_http_bridge_prewarm_outcome(outcome="skipped")
+                return
         async with prewarm_lock:
             if session.prewarmed:
                 request_state.prewarm_status = "skipped"

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2563,6 +2563,14 @@ class _HTTPBridgeRequestSubmitMixin:
             request_state.prewarm_status = "skipped"
             _record_http_bridge_prewarm_outcome(outcome="skipped")
             return
+        # The two settings readers the locked body reaches -- the admission
+        # gate's account caps/tunables and the reconnect the timeout path takes
+        # -- get this one row instead of reading it themselves, so nothing
+        # awaits the settings cache while ``prewarm_lock`` is held. A refresh
+        # behind that read runs a DB query under a process-global lock; one
+        # stalled query would then hold this session's prewarm lock and stall
+        # every later turn on it (issues #1971 and #1972).
+        dashboard_settings = await _service_get_settings_cache().get()
         async with prewarm_lock:
             if session.prewarmed:
                 request_state.prewarm_status = "skipped"
@@ -2605,6 +2613,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     account_id=session.account.id,
                     surface="http_bridge_prewarm",
                     bridge_session=session,
+                    dashboard_settings=dashboard_settings,
                 )
                 gate_acquired = True
                 async with session.lifecycle_lock:
@@ -2677,6 +2686,7 @@ class _HTTPBridgeRequestSubmitMixin:
                                     kind=session.key.affinity_kind,
                                     key=session.key.affinity_key,
                                 ),
+                                dashboard_settings=dashboard_settings,
                             )
                         except Exception:
                             session.closed = True

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1286,6 +1286,7 @@ class ProxyService(
         account_id: str | None = None,
         surface: str = "websocket",
         routing_tunables: RoutingTunables | None = None,
+        dashboard_settings: DashboardSettings | None = None,
     ) -> None:
         scheduler = self._scheduler
         timeout_seconds = _proxy_admission_wait_timeout_seconds()
@@ -1296,9 +1297,16 @@ class ProxyService(
         request_state.response_create_gate = response_create_gate
         request_state.response_create_gate_wait_started_at = self._clock.monotonic()
         if account_id is not None:
-            # One cached snapshot for this lease operation; a caller that already
-            # resolved the tunables for the same turn (bridge submit) passes them.
-            settings = await get_settings_cache().get()
+            # One cached snapshot for this lease operation. A caller that
+            # already resolved the row for the same turn passes it in, and then
+            # this helper awaits nothing here at all -- which the prewarm path
+            # needs: it admits its warm-up while holding the session's
+            # ``prewarm_lock``, and a cache refresh behind this read runs a DB
+            # query under a process-global lock, so one stalled refresh would
+            # suspend that critical section (issues #1971/#1972 wedged every
+            # keyed submit on exactly this pattern). Tunables resolved by the
+            # caller (bridge submit) still override the snapshot's.
+            settings = dashboard_settings if dashboard_settings is not None else await get_settings_cache().get()
             request_state.account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
                 account_id=account_id,
                 request_id=request_state.request_id,

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/proposal.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/proposal.md
@@ -21,11 +21,16 @@ invariant can be the true one: no settings read at all while the lock is held.
 - Give both helpers an optional snapshot parameter that defaults to today's
   behaviour (read the cache), so every other caller is unaffected.
 - Upgrade the deployment-installation prewarm wording from "MUST NOT add a
-  settings read under that lock" to "MUST NOT read settings while that lock is
-  held", with a scenario covering a full prewarm body.
+  settings read under that lock" to "the prewarm's own helpers MUST NOT read
+  the dashboard row for themselves while that lock is held", naming the
+  residual work the timeout recovery still reaches (account selection, token
+  refresh, upstream route resolution) as out of scope.
+- Apply the request entry point's snapshot-failure fallback to that pre-lock
+  read (last loaded row, else skip the prewarm) so moving the read cannot fail
+  a request the bridge can otherwise serve.
 - Assert the invariant directly: a prewarm that builds its warm-up, takes
-  admission and sends upstream records exactly one settings read, before the
-  lock, and opens no database session.
+  admission, sends upstream and completes records exactly one settings read,
+  attributed to the pre-lock snapshot, and opens no database session.
 
 No dashboard value changes meaning; only where it is read changes.
 
@@ -39,6 +44,15 @@ None.
 
 - `deployment-installation`: The Codex prewarm switch requirement now forbids
   any settings read while the prewarm lock is held, not just newly added ones.
+
+## Out of scope
+
+The prewarm timeout path reconnects while holding the lock, and the reconnect
+reaches account selection, token refresh and upstream route resolution, each
+of which has its own settings read or database session. Threading the snapshot
+through those would be a much larger change (route resolution has its own
+cache), so this change removes the two reads the prewarm's own helpers take
+and states the invariant at exactly that scope.
 
 ## Impact
 

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/proposal.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The Codex HTTP-bridge prewarm holds a per-session `prewarm_lock` across its
+whole body. Two helpers it calls under that lock read the dashboard settings
+row for themselves: the response-create admission gate (account concurrency
+caps and routing tunables) and the reconnect the prewarm-timeout recovery
+takes. A settings-cache read refreshes behind a process-global lock and runs a
+database query, so one stalled refresh suspends the critical section and
+stalls every later turn on that session -- the pattern that wedged every keyed
+submit in issues #1971 and #1972.
+
+`dashboard-managed-codex-prewarm` could only require that the bridge add no
+new settings read under that lock, because those two reads already existed.
+With both of them threaded from a snapshot taken before the lock, the
+invariant can be the true one: no settings read at all while the lock is held.
+
+## What Changes
+
+- Resolve the dashboard settings row once in the prewarm path, before taking
+  `prewarm_lock`, and pass it into the admission gate and the reconnect.
+- Give both helpers an optional snapshot parameter that defaults to today's
+  behaviour (read the cache), so every other caller is unaffected.
+- Upgrade the deployment-installation prewarm wording from "MUST NOT add a
+  settings read under that lock" to "MUST NOT read settings while that lock is
+  held", with a scenario covering a full prewarm body.
+- Assert the invariant directly: a prewarm that builds its warm-up, takes
+  admission and sends upstream records exactly one settings read, before the
+  lock, and opens no database session.
+
+No dashboard value changes meaning; only where it is read changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: The Codex prewarm switch requirement now forbids
+  any settings read while the prewarm lock is held, not just newly added ones.
+
+## Impact
+
+- Affected code: HTTP-bridge prewarm/reconnect helpers and the proxy
+  response-create admission gate.
+- Affected tests: HTTP-bridge prewarm and reconnect unit coverage.
+- No schema, API, or configuration surface change.

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/specs/deployment-installation/spec.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/specs/deployment-installation/spec.md
@@ -86,12 +86,19 @@ environment) whose
 deprecated alias that applies only while the column is NULL and that joins the
 removed-settings warning list in the next minor release. The bridge MUST
 resolve the switch before it takes a session's prewarm lock, from the dashboard
-overrides the request entry point already bound, and MUST NOT read settings
-while that lock is held. Every dashboard value the locked body needs -- the
-response-create admission gate's account concurrency caps and routing
-tunables, and the reconnect the prewarm timeout path takes -- MUST come from
-one snapshot resolved before the lock and passed in, so no code path under
-that lock can await a settings-cache refresh or open a database session.
+overrides the request entry point already bound. The prewarm's own helpers
+MUST NOT read the dashboard row for themselves while that lock is held: the
+values the response-create admission gate needs (account concurrency caps and
+routing tunables) and the row the reconnect on the prewarm timeout path
+resolves MUST come from one snapshot taken before the lock and passed in. If
+that snapshot cannot be loaded, the bridge MUST fall back to the last
+dashboard row the replica loaded, exactly as the request entry point does, and
+where no row has ever been loaded it MUST skip the prewarm rather than serve
+it without a snapshot; a prewarm MUST NOT fail a request the bridge can
+otherwise serve. Work the recovery path reaches beyond those two helpers --
+account selection, token refresh, and upstream route resolution, each with its
+own settings read or database session -- is out of scope for this requirement
+and keeps its existing behaviour.
 `database_pool_size` and `database_max_overflow` MUST remain
 operator-configurable settings, and `soft_drain_enabled` and
 `deterministic_failover_enabled` MUST remain the failover subsystem's only
@@ -227,15 +234,25 @@ warning list in the next minor release.
 - **THEN** the session prewarm is attempted for that request
 - **AND** no request is excluded by canary sampling or an allow/deny cohort
 
-#### Scenario: A prewarm holds its lock without reading settings
+#### Scenario: A prewarm's own helpers read no settings under its lock
 
 - **GIVEN** the Codex session prewarm switch is on in the dashboard
-- **WHEN** a session prewarm runs its full body under the prewarm lock -- the
+- **WHEN** a session prewarm runs its body under the prewarm lock -- the
   warm-up request built, response-create admission taken for it, and the
-  warm-up sent upstream
-- **THEN** the dashboard settings row is read once before the lock is taken
-- **AND** no settings-cache read and no database session occur between
-  acquiring and releasing that lock
+  warm-up sent upstream to a stream that completes
+- **THEN** the dashboard settings row is read once, before the lock is taken
+- **AND** the admission gate takes no settings read of its own while the lock
+  is held, and that path opens no database session
+
+#### Scenario: An unreadable settings row does not fail the request
+
+- **GIVEN** the Codex session prewarm switch is on and the settings row cannot
+  be loaded when a first-turn Codex bridge request arrives
+- **WHEN** the bridge resolves its pre-lock snapshot
+- **THEN** the last dashboard row this replica loaded is used and the prewarm
+  proceeds
+- **AND** where no row has ever been loaded, the prewarm records
+  `prewarm_status=skipped` and the request is still served
 
 #### Scenario: Prewarm env alias applies only until the dashboard sets a value
 

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/specs/deployment-installation/spec.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/specs/deployment-installation/spec.md
@@ -1,0 +1,260 @@
+## MODIFIED Requirements
+
+### Requirement: Removed tunables are fixed constants, derived values, or dashboard settings
+
+Values that are protocol constants or internal tuning details SHALL NOT be
+operator-configurable, and values the dashboard runtime settings own SHALL NOT
+also be operator-configurable through the environment. When a previously
+supported `CODEX_LB_*` setting is removed from the configuration surface, its
+environment variable MUST be ignored without failing startup, and for at
+least one release after removal, startup MUST emit a single warning log
+listing every removed setting name found in the process environment or the
+loaded env files (never the values), referencing the simplicity principle
+that motivated the removal. Once a removed name has had its warning release,
+it MUST be pruned from the warning list while staying inert (`extra="ignore"`);
+the warning list therefore covers only the most recent removal batch. Each
+subsystem affected by a removal MUST retain at most one enable/disable
+setting, and the Helm chart MUST NOT render environment variables for removed
+settings.
+
+The following values MUST be fixed at their previously documented defaults:
+
+- The OAuth protocol identity values (authorization base URL, client id,
+  originator, scope, redirect URI, and callback port): they identify
+  codex-lb to OpenAI exactly like the Codex CLI, and changing any of them
+  breaks login.
+- Background scheduler cadences (quota planner tick, automations poll,
+  model registry refresh, sticky-session cleanup).
+- The Codex client fingerprint (OS, architecture, terminal).
+- Live-usage write coalescing (minimum write interval and queue size).
+- The request-log count-cache TTL.
+- Circuit-breaker tuning (failure threshold and recovery timeout).
+- The images-route internals (internal host model and partial-images cap).
+- The PostgreSQL pool checkout timeout (30 seconds) and pooled-connection
+  recycle window (1800 seconds).
+- The soft-drain/probe thresholds (primary drain threshold 85%, secondary
+  drain threshold 90%, error window 60 seconds, error count 2, probe quiet
+  window 60 seconds, probe success streak 3), fixed in
+  `app/core/balancer/logic.py`.
+- The never-tuned core tunables constantized by `constantize-core-tunables`:
+  the upstream SSE event / websocket frame budget (16 MiB) and the derived
+  serialized `response.create` budget (15 MiB); the OAuth exchange timeout
+  (30 s), token-refresh exchange timeout (8 s), refresh-failure negative
+  cache (5 s) and the token-refresh claim TTL (`max(30 s, admission wait +
+  2 x refresh timeout)`, all in code); the admission wait (10 s) and the
+  token-refresh (64), upstream websocket connect (128) and compact
+  response-create (64) gates; the usage / reset-credits fetch timeout (10 s)
+  and retry budget (2), the usage refresh interval (60 s) with its derived
+  freshness horizon, the usage auth-failure cooldown (300 s) and the
+  reset-credits polling interval (60 s); the always-on switches for usage
+  refresh, live usage ingestion, sticky-session cleanup, the model registry
+  and the quota planner scheduler (the dashboard `quota_planner_settings.mode
+  = "off"` remains the only planner switch); the HTTP ingress body budgets
+  (32 MiB general, 128 MiB Responses); inline image fetching (always on, no
+  host allowlist); the public default image model (`gpt-image-2`); and
+  proxy-generated prompt-cache-key derivation (always on). There is no
+  separate upstream compact timeout: the dashboard compact request budget is
+  the only cap.
+
+The following values MUST be derived rather than configured:
+
+- The memory-pressure warning threshold: 80% of the configurable reject
+  threshold (`CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`), with both disabled
+  when the reject threshold is 0.
+- The background-task database engine's pool size and max overflow: always
+  taken from `database_pool_size` and `database_max_overflow`.
+
+The following values MUST be owned by the dashboard runtime settings alone,
+with the first-created settings row taking the column defaults (`smart`,
+`1800`, `gpt-5.4-mini`, `false`) instead of an environment seed:
+`http_downstream_transport_policy`, `openai_cache_affinity_max_age_seconds`,
+`warmup_model`, and `http_responses_session_bridge_gateway_safe_mode`. The
+retention windows (`request_log_retention_days`,
+`usage_history_retention_days`) MUST be dashboard runtime settings with no
+environment alias (see `data-retention`).
+
+Incident-debugging trace logging SHALL be controlled by the single
+`CODEX_LB_TRACE` comma-separated channel list, whose empty default disables
+all trace channels. The Codex HTTP-bridge prewarm rollout scoping SHALL NOT
+be operator-configurable: prewarm eligibility MUST be the single
+`http_responses_session_bridge_codex_prewarm_enabled` switch alone, with no
+canary sampling percent and no API-key allow/deny cohort lists. That switch
+MUST be a dashboard runtime setting (a nullable `dashboard_settings` column of
+the same name, NULL on the first-created row and never seeded from the
+environment) whose
+`CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED` variable is a
+deprecated alias that applies only while the column is NULL and that joins the
+removed-settings warning list in the next minor release. The bridge MUST
+resolve the switch before it takes a session's prewarm lock, from the dashboard
+overrides the request entry point already bound, and MUST NOT read settings
+while that lock is held. Every dashboard value the locked body needs -- the
+response-create admission gate's account concurrency caps and routing
+tunables, and the reconnect the prewarm timeout path takes -- MUST come from
+one snapshot resolved before the lock and passed in, so no code path under
+that lock can await a settings-cache refresh or open a database session.
+`database_pool_size` and `database_max_overflow` MUST remain
+operator-configurable settings, and `soft_drain_enabled` and
+`deterministic_failover_enabled` MUST remain the failover subsystem's only
+enable switches. Those two switches and `circuit_breaker_enabled` MUST be
+dashboard runtime settings (`dashboard_settings` columns of the same name,
+NULL on the first-created row; see `account-routing` and
+`outbound-http-clients`) whose `CODEX_LB_*` variables are deprecated aliases
+that apply only while the column is NULL and that join the removed-settings
+warning list in the next minor release.
+
+#### Scenario: Removed env vars are ignored with one startup warning
+
+- **GIVEN** a deployment whose environment still sets removed settings such
+  as `CODEX_LB_REQUEST_LOG_RETENTION_DAYS` and
+  `CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS`
+- **WHEN** the application starts
+- **THEN** startup succeeds and the dashboard runtime values are used
+- **AND** exactly one warning log lists both removed names without their
+  values
+
+#### Scenario: Clean environment starts without removal warnings
+
+- **GIVEN** a deployment that sets no removed setting names
+- **WHEN** the application starts
+- **THEN** no removed-settings warning is logged
+
+#### Scenario: Names past their warning release are silently inert
+
+- **GIVEN** a deployment whose environment still sets names removed in an
+  earlier batch, such as `CODEX_LB_AUTH_BASE_URL`,
+  `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS`, or
+  `CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS`
+- **WHEN** the application starts
+- **THEN** startup succeeds, the fixed built-in values are used
+- **AND** no removed-settings warning is logged for those names
+
+#### Scenario: Trace channels default to off
+
+- **GIVEN** a default install with `CODEX_LB_TRACE` unset
+- **WHEN** the proxy serves requests
+- **THEN** no request-shape, payload, service-tier, or upstream trace logs
+  are emitted
+
+#### Scenario: A trace channel can be enabled for an incident
+
+- **GIVEN** `CODEX_LB_TRACE=shape,upstream_payload`
+- **WHEN** the proxy serves requests
+- **THEN** request-shape and upstream-payload trace logs are emitted while
+  all other trace channels stay off
+
+#### Scenario: Memory warning threshold derives from the reject threshold
+
+- **GIVEN** `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB=100`
+- **WHEN** process RSS reaches 80 MiB
+- **THEN** a memory warning is logged while requests continue to be served
+- **AND** requests are rejected with 503 only once RSS reaches 100 MiB
+
+#### Scenario: Memory guard stays fully disabled by default
+
+- **GIVEN** a default install with `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`
+  unset (0)
+- **WHEN** the proxy serves requests under any memory usage
+- **THEN** no memory warning is logged and no request is rejected for
+  memory pressure
+
+#### Scenario: Helm chart renders no removed settings
+
+- **GIVEN** a Helm install using the chart's default values
+- **WHEN** the config map is rendered
+- **THEN** it contains no `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS`,
+  `CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD`, or
+  `CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS` entries
+- **AND** startup emits no removed-settings warning
+
+#### Scenario: Dashboard-owned columns seed from their defaults
+
+- **GIVEN** a fresh database and `CODEX_LB_WARMUP_MODEL=gpt-5.4-nano` still
+  set in the environment
+- **WHEN** the dashboard settings row is created for the first time
+- **THEN** `warmup_model` is `gpt-5.4-mini`, `http_downstream_transport_policy`
+  is `smart`, and `openai_cache_affinity_max_age_seconds` is `1800`
+- **AND** the startup warning names `CODEX_LB_WARMUP_MODEL`
+
+#### Scenario: Fresh database bootstrap ignores a removed variable
+
+- **GIVEN** an empty database and
+  `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS=64` still set in the
+  environment
+- **WHEN** the Alembic chain is upgraded to head
+- **THEN** the seeded `dashboard_settings` row has
+  `openai_cache_affinity_max_age_seconds` `1800`
+- **AND** no migration reads the removed variable
+
+#### Scenario: Removed names are matched case-insensitively
+
+- **GIVEN** a deployment whose environment sets `codex_lb_warmup_model`
+  in lowercase (which the former field honoured)
+- **WHEN** the application starts
+- **THEN** the startup warning lists `CODEX_LB_WARMUP_MODEL`
+
+#### Scenario: Background pool sizing derives from the main pool settings
+
+- **GIVEN** `CODEX_LB_DATABASE_POOL_SIZE=12` and
+  `CODEX_LB_DATABASE_MAX_OVERFLOW=4` on a PostgreSQL deployment
+- **WHEN** the application creates the background-task database engine
+- **THEN** the background engine uses pool size 12 and max overflow 4
+- **AND** no separate background pool sizing can be configured
+
+#### Scenario: Drain and probe thresholds are fixed constants
+
+- **GIVEN** a deployment with `soft_drain_enabled` left at its default
+- **WHEN** an account's primary window usage reaches 85%
+- **THEN** the account enters the draining health tier
+- **AND** a drained account enters the probing tier only after the fixed
+  60-second quiet window, regardless of any `CODEX_LB_PROBE_QUIET_SECONDS`
+  value still present in the environment
+
+#### Scenario: Prewarm stays off by default
+
+- **GIVEN** a default install with no prewarm variables set and the dashboard
+  prewarm switch unset (NULL)
+- **WHEN** Codex bridge requests are served
+- **THEN** no session prewarm is attempted and visible requests record
+  `prewarm_status=not_applicable`
+
+#### Scenario: Prewarm eligibility is the enabled flag alone
+
+- **GIVEN** the Codex session prewarm switch is on, either in the dashboard or
+  through `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED=true`
+  while the dashboard value is unset
+- **WHEN** a first-turn Codex bridge request arrives on a session that has
+  not been prewarmed
+- **THEN** the session prewarm is attempted for that request
+- **AND** no request is excluded by canary sampling or an allow/deny cohort
+
+#### Scenario: A prewarm holds its lock without reading settings
+
+- **GIVEN** the Codex session prewarm switch is on in the dashboard
+- **WHEN** a session prewarm runs its full body under the prewarm lock -- the
+  warm-up request built, response-create admission taken for it, and the
+  warm-up sent upstream
+- **THEN** the dashboard settings row is read once before the lock is taken
+- **AND** no settings-cache read and no database session occur between
+  acquiring and releasing that lock
+
+#### Scenario: Prewarm env alias applies only until the dashboard sets a value
+
+- **GIVEN** `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED=true`
+  and a `dashboard_settings` row whose
+  `http_responses_session_bridge_codex_prewarm_enabled` column is NULL
+- **WHEN** an operator turns the Codex session prewarm off in the dashboard
+- **THEN** the next new Codex bridge session on every replica is served
+  without a prewarm and without a restart, and the settings API reports
+  `source: "dashboard"`
+- **AND** clearing the dashboard value returns to the environment alias
+  (`source: "env"`) until that alias is removed in the next minor release
+
+#### Scenario: Resilience toggle env aliases apply only until the dashboard sets a value
+
+- **GIVEN** `CODEX_LB_CIRCUIT_BREAKER_ENABLED=true` and a `dashboard_settings`
+  row whose `circuit_breaker_enabled` column is NULL
+- **WHEN** an operator sets the circuit breaker off in the dashboard
+- **THEN** the next request runs with the breaker off on every replica without
+  a restart, and the settings API reports `source: "dashboard"`
+- **AND** clearing the dashboard value returns to the environment alias
+  (`source: "env"`) until that alias is removed in the next minor release

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/tasks.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/tasks.md
@@ -1,0 +1,29 @@
+## 1. Lock critical-section audit
+
+- [x] 1.1 Enumerate every call the `prewarm_lock` body can reach that arrives
+  at a settings-cache `get()` or a database session, and confirm the two real
+  ones (admission gate, reconnect) against the near-miss call sites that are
+  outside the lock.
+
+## 2. Regression coverage
+
+- [x] 2.1 Prove a full prewarm body (warm-up built, admission acquired, sent
+  to a fake upstream) records exactly one settings read, attributed to the
+  prewarm helper before the lock, and none while the lock is held.
+- [x] 2.2 Prove the prewarm timeout path hands its pre-lock snapshot to the
+  reconnect.
+- [x] 2.3 Prove the reconnect completes on a caller-supplied snapshot without
+  awaiting the settings cache.
+
+## 3. Implementation
+
+- [x] 3.1 Resolve the dashboard snapshot before `prewarm_lock` and thread it
+  into the admission gate and the reconnect.
+- [x] 3.2 Keep both new parameters optional so the unchanged callers keep
+  reading the cache exactly as before.
+
+## 4. Verification
+
+- [x] 4.1 Run the HTTP-bridge and proxy-utils unit suites plus the bridge and
+  settings-API integration suites.
+- [x] 4.2 Run Ruff, Ty, the full unit suite, and strict OpenSpec validation.

--- a/openspec/changes/no-settings-reads-under-prewarm-lock/tasks.md
+++ b/openspec/changes/no-settings-reads-under-prewarm-lock/tasks.md
@@ -14,6 +14,8 @@
   reconnect.
 - [x] 2.3 Prove the reconnect completes on a caller-supplied snapshot without
   awaiting the settings cache.
+- [x] 2.4 Prove an unreadable settings row falls back to the last loaded one,
+  and with no row at all skips the prewarm instead of failing the request.
 
 ## 3. Implementation
 
@@ -21,6 +23,8 @@
   into the admission gate and the reconnect.
 - [x] 3.2 Keep both new parameters optional so the unchanged callers keep
   reading the cache exactly as before.
+- [x] 3.3 Apply the request entry point's snapshot-failure fallback to the
+  pre-lock read so the move cannot add a failure mode.
 
 ## 4. Verification
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3629,23 +3629,28 @@ async def test_maybe_prewarm_http_bridge_session_honours_dashboard_switch_over_e
 
 
 @pytest.mark.asyncio
-async def test_maybe_prewarm_http_bridge_session_reads_no_settings_under_the_prewarm_lock(
+async def test_maybe_prewarm_http_bridge_session_success_path_reads_no_settings_under_the_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Driving a full prewarm body (warm-up built, admitted, sent upstream,
-    completed) reads the settings cache exactly once, before the lock, and never
-    while it is held.
+    """Driving a prewarm to completion (warm-up built, admitted, sent upstream,
+    stream ended) reads the settings cache exactly once, before the lock.
 
     A settings read under ``prewarm_lock`` can refresh the cache, run a DB query
     and suspend while the lock is held; issues #1971/#1972 wedged every keyed
     submit on exactly that pattern. The dashboard switch itself arrives on the
-    request-bound overlay (no read at all), and the row the locked body's
-    readers need -- the admission gate's account caps/tunables, and the
+    request-bound overlay (no read at all), and the row the prewarm's own
+    helpers need -- the admission gate's account caps/tunables, and the
     reconnect the timeout path takes -- is resolved by
     ``_maybe_prewarm_http_bridge_session`` before the lock and threaded in. So
     the recorded callers must be exactly one pre-lock read from the prewarm
-    helper: no caller may appear with the lock held, and nothing may open a
-    database session.
+    helper, with nothing opening a database session.
+
+    Scope: this is the success path, which never reconnects. The timeout path
+    does reconnect under the lock, and beyond the reconnect helper itself that
+    reaches account selection, token refresh and upstream route resolution,
+    which keep their own settings reads and database sessions (out of scope
+    here; ``test_prewarm_timeout_pins_only_account_neutral_recovery_session``
+    covers that the reconnect is handed this snapshot).
     """
     from unittest.mock import MagicMock
 
@@ -3712,7 +3717,7 @@ async def test_maybe_prewarm_http_bridge_session_reads_no_settings_under_the_pre
     assert lock.enter_count == 1
     assert len(sent) == 1
     assert json.loads(sent[0])["generate"] is False
-    # Nothing read the settings cache while the lock was held ...
+    # Nothing on this path read the settings cache while the lock was held ...
     assert [caller for caller, held in reads if held] == []
     # ... and the one read that did happen is the prewarm helper's own pre-lock
     # snapshot. Asserting the whole list keeps this non-vacuous: had the body
@@ -3720,6 +3725,69 @@ async def test_maybe_prewarm_http_bridge_session_reads_no_settings_under_the_pre
     # recorded callers would differ.
     assert reads == [("_maybe_prewarm_http_bridge_session", False)]
     session_factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("stale_row_available", "expected_status", "expected_prewarmed"),
+    [(True, "success", True), (False, "skipped", False)],
+)
+@pytest.mark.asyncio
+async def test_maybe_prewarm_http_bridge_session_survives_an_unreadable_settings_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    stale_row_available: bool,
+    expected_status: str,
+    expected_prewarmed: bool,
+) -> None:
+    """An unreadable settings row must not fail a request the bridge can serve.
+
+    The pre-lock snapshot applies the same fallback as the request entry
+    point's dashboard-overrides middleware: the last row this replica loaded,
+    and with no row at all the prewarm is skipped rather than run without a
+    snapshot -- which would put the read back under the lock.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    state, session = _make_prewarm_candidate(_PREWARM_CANDIDATE_TEXT)
+    lock = _SpyPrewarmLock()
+    session.prewarm_lock = cast(Any, lock)
+    service._http_bridge_sessions[session.key] = session
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: with_dashboard_overrides(_make_app_settings()))
+
+    row = DashboardSettings()
+    row.http_responses_session_bridge_codex_prewarm_enabled = True
+    cache = SimpleNamespace(
+        get=AsyncMock(side_effect=RuntimeError("settings database unavailable")),
+        cached_row=lambda: row if stale_row_available else None,
+    )
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: cache)
+
+    sent: list[str] = []
+
+    async def fake_send(
+        target_session: proxy_service._HTTPBridgeSession,
+        warmup_state: proxy_service._WebSocketRequestState,
+        text: str,
+        **kwargs: Any,
+    ) -> None:
+        del target_session, kwargs
+        sent.append(text)
+        queue = warmup_state.event_queue
+        assert queue is not None
+        queue.put_nowait(None)
+
+    monkeypatch.setattr(http_bridge_request_submit_module, "_send_http_bridge_request_text_with_archive_id", fake_send)
+
+    with dashboard_overrides_bound(row):
+        await service._maybe_prewarm_http_bridge_session(
+            session,
+            request_state=state,
+            text_data=state.request_text or "{}",
+        )
+
+    # The request is served either way; only the prewarm is affected.
+    assert state.prewarm_status == expected_status
+    assert session.prewarmed is expected_prewarmed
+    assert len(sent) == (1 if stale_row_available else 0)
+    assert lock.enter_count == (1 if stale_row_available else 0)
 
 
 @pytest.mark.asyncio
@@ -12631,15 +12699,21 @@ async def test_reconnect_goal_restart_can_leave_owner_that_failed_before_dispatc
 
 
 @pytest.mark.asyncio
-async def test_reconnect_with_caller_snapshot_reads_no_settings(
+async def test_reconnect_with_caller_snapshot_takes_no_settings_read_of_its_own(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A caller that already resolved the dashboard row passes it in and the
-    reconnect awaits no settings read.
+    reconnect helper itself awaits no settings read.
 
     The prewarm timeout path reconnects while holding ``prewarm_lock``; a cache
     refresh behind that read runs a DB query under a process-global lock and
     would suspend the critical section (issues #1971/#1972).
+
+    Scope: only the helper's own read is removed. The account selection, token
+    refresh and upstream route resolution it goes on to call are stubbed here
+    and keep their own settings reads and database sessions -- deliberately out
+    of scope for this change -- so the assertion is by call site rather than a
+    blanket "nothing read anything".
     """
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     session = _make_bridge_session(
@@ -12668,9 +12742,14 @@ async def test_reconnect_with_caller_snapshot_reads_no_settings(
         started_at=time.monotonic(),
     )
     snapshot = _bridge_selection_settings()
-    cache_get = AsyncMock(return_value=snapshot)
+    reads: list[str] = []
+
+    async def spying_get() -> Any:
+        reads.append(sys._getframe(1).f_code.co_name)
+        return snapshot
+
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
-    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SimpleNamespace(get=cache_get))
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SimpleNamespace(get=spying_get))
     monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=replacement))
     monkeypatch.setattr(
@@ -12685,9 +12764,12 @@ async def test_reconnect_with_caller_snapshot_reads_no_settings(
         dashboard_settings=cast(Any, snapshot),
     )
 
-    # The reconnect completed on the caller's snapshot alone.
+    # The reconnect completed on the caller's snapshot alone: no read is
+    # attributed to the helper itself, and with the selection/refresh/route
+    # calls stubbed out nothing else read either.
     assert session.account is replacement
-    cache_get.assert_not_awaited()
+    assert [caller for caller in reads if caller == "_reconnect_http_bridge_session"] == []
+    assert reads == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3629,20 +3629,23 @@ async def test_maybe_prewarm_http_bridge_session_honours_dashboard_switch_over_e
 
 
 @pytest.mark.asyncio
-async def test_maybe_prewarm_http_bridge_session_adds_no_settings_read_under_the_prewarm_lock(
+async def test_maybe_prewarm_http_bridge_session_reads_no_settings_under_the_prewarm_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """M3 codex prewarm: driving a full prewarm body (warm-up built, admitted,
-    sent upstream, completed) adds no settings-cache read of its own, because the
-    dashboard switch arrives on the request-bound overlay.
+    """Driving a full prewarm body (warm-up built, admitted, sent upstream,
+    completed) reads the settings cache exactly once, before the lock, and never
+    while it is held.
 
     A settings read under ``prewarm_lock`` can refresh the cache, run a DB query
     and suspend while the lock is held; issues #1971/#1972 wedged every keyed
-    submit on exactly that pattern. The lock body's admission gate has its own
-    snapshot read that predates this change, so the assertion is scoped by call
-    site: no read is attributed to ``_maybe_prewarm_http_bridge_session``
-    itself, and any read taken while the lock is held comes from that
-    pre-existing helper. Either way nothing may open a database session.
+    submit on exactly that pattern. The dashboard switch itself arrives on the
+    request-bound overlay (no read at all), and the row the locked body's
+    readers need -- the admission gate's account caps/tunables, and the
+    reconnect the timeout path takes -- is resolved by
+    ``_maybe_prewarm_http_bridge_session`` before the lock and threaded in. So
+    the recorded callers must be exactly one pre-lock read from the prewarm
+    helper: no caller may appear with the lock held, and nothing may open a
+    database session.
     """
     from unittest.mock import MagicMock
 
@@ -3709,12 +3712,13 @@ async def test_maybe_prewarm_http_bridge_session_adds_no_settings_read_under_the
     assert lock.enter_count == 1
     assert len(sent) == 1
     assert json.loads(sent[0])["generate"] is False
-    # The prewarm path itself reads no snapshot, before or under the lock ...
-    assert [caller for caller, _ in reads if caller == "_maybe_prewarm_http_bridge_session"] == []
-    # ... and the only reads under the lock are the admission gate's own, which
-    # must actually have happened -- otherwise the body was never driven and the
-    # assertion above would be vacuous.
-    assert reads == [("_acquire_request_state_response_create_admission", True)]
+    # Nothing read the settings cache while the lock was held ...
+    assert [caller for caller, held in reads if held] == []
+    # ... and the one read that did happen is the prewarm helper's own pre-lock
+    # snapshot. Asserting the whole list keeps this non-vacuous: had the body
+    # not been driven, or had the admission gate kept reading for itself, the
+    # recorded callers would differ.
+    assert reads == [("_maybe_prewarm_http_bridge_session", False)]
     session_factory.assert_not_called()
 
 
@@ -12624,6 +12628,66 @@ async def test_reconnect_goal_restart_can_leave_owner_that_failed_before_dispatc
     assert selection_kwargs[0]["preferred_account_id"] == old_account.id
     assert selection_kwargs[0]["fallback_on_preferred_account_unavailable"] is True
     assert session.account is replacement
+
+
+@pytest.mark.asyncio
+async def test_reconnect_with_caller_snapshot_reads_no_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller that already resolved the dashboard row passes it in and the
+    reconnect awaits no settings read.
+
+    The prewarm timeout path reconnects while holding ``prewarm_lock``; a cache
+    refresh behind that read runs a DB query under a process-global lock and
+    would suspend the critical section (issues #1971/#1972).
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-snapshot-reconnect", None),
+        key_value="sid-snapshot-reconnect",
+    )
+    replacement = cast(
+        Any,
+        SimpleNamespace(
+            id="acc-snapshot-reconnect-replacement",
+            status=AccountStatus.ACTIVE,
+            plan_type="plus",
+        ),
+    )
+
+    async def select_account(_deadline: float, **_kwargs: object) -> proxy_service.AccountSelection:
+        return proxy_service.AccountSelection(account=replacement, error_message=None)
+
+    replacement_upstream = cast(Any, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-snapshot-reconnect",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    snapshot = _bridge_selection_settings()
+    cache_get = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SimpleNamespace(get=cache_get))
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=replacement))
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(return_value=replacement_upstream),
+    )
+
+    await service._reconnect_http_bridge_session(
+        session,
+        request_state=request_state,
+        dashboard_settings=cast(Any, snapshot),
+    )
+
+    # The reconnect completed on the caller's snapshot alone.
+    assert session.account is replacement
+    cache_get.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -24848,6 +24912,9 @@ async def test_prewarm_timeout_pins_only_account_neutral_recovery_session(
     reconnect_call = reconnect.await_args
     assert reconnect_call is not None
     assert reconnect_call.kwargs["require_same_account"] is expected_same_account
+    # This reconnect runs under ``prewarm_lock``, so it is handed the snapshot
+    # resolved before the lock instead of reading the settings cache itself.
+    assert reconnect_call.kwargs["dashboard_settings"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -49979,12 +49979,15 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
         account_id: str | None = None,
         surface: str = "websocket",
         bridge_session: proxy_service._HTTPBridgeSession | None = None,
+        dashboard_settings: Any | None = None,
     ) -> None:
         admission_observations.append(
             {
                 "request_id": state.request_id,
                 "account_id": account_id,
                 "surface": surface,
+                # The prewarm resolves this before its lock and threads it in.
+                "dashboard_settings_supplied": dashboard_settings is not None,
             }
         )
         await original_acquire_admission(
@@ -49994,6 +49997,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
             account_id=account_id,
             surface=surface,
             bridge_session=bridge_session,
+            dashboard_settings=dashboard_settings,
         )
 
     async def fake_reconnect_http_bridge_session(
@@ -50003,6 +50007,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
         restart_reader: bool = False,
         require_same_account: bool = False,
         require_preferred_account: bool = False,
+        dashboard_settings: Any | None = None,
     ) -> None:
         del require_same_account, require_preferred_account
         reconnect_observations.append(
@@ -50010,6 +50015,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
                 "pending_request_ids": [state.request_id for state in reconnect_session.pending_requests],
                 "request_id": request_state.request_id,
                 "restart_reader": restart_reader,
+                "dashboard_settings_supplied": dashboard_settings is not None,
             }
         )
         reconnect_session.upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -50039,12 +50045,16 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
             "request_id": prewarm_admission["request_id"],
             "account_id": "acc_prewarm_timeout",
             "surface": "http_bridge_prewarm",
+            "dashboard_settings_supplied": True,
         }
     ]
     assert cast(str, prewarm_admission["request_id"]).startswith("http_prewarm_")
     observation = reconnect_observations[0]
     assert observation["request_id"] == "req_prewarm_timeout"
     assert observation["restart_reader"] is True
+    # Both helpers run under ``prewarm_lock`` and are handed the snapshot the
+    # prewarm resolved before taking it, so neither reads settings there.
+    assert observation["dashboard_settings_supplied"] is True
     pending_request_ids = cast(list[str], observation["pending_request_ids"])
     assert len(pending_request_ids) == 1
     assert pending_request_ids[0].startswith("http_prewarm_")


### PR DESCRIPTION
## Summary

The Codex HTTP-bridge prewarm holds a per-session `prewarm_lock` across its whole body, and two helpers it calls under that lock read the dashboard settings row for themselves. This resolves that row once **before** the lock and threads it into both, so neither helper takes a settings read while the lock is held.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [x] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: follow-up to #2264 (which could only state the invariant partially); wedge class of #1971 / #1972.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/no-settings-reads-under-prewarm-lock/`

## Why this is a wedge-risk reduction

`SettingsCache.get()` serves from memory within its 5 s TTL, but on a miss it takes a process-global `anyio.Lock` and runs a database query. Awaiting that while a per-session lock is held means one stalled query pins the lock and stalls every later turn on that session. That is the shape of #1971/#1972, which wedged every keyed submit for days, and the reason `_http_bridge_reacquire_snapshot` already exists for `pending_lock`. `prewarm_lock` had no such discipline.

## Scope of the invariant (read this before the map)

This removes the two settings reads the **prewarm's own helpers** take under the lock. It does **not** make the lock body settings-free end to end, and the spec wording says so explicitly.

The success path (which is what a prewarm normally is) ends up with zero settings reads and zero DB sessions under the lock. The **timeout path** reconnects under the lock, and past `_reconnect_http_bridge_session` itself that reaches work which keeps its own reads and sessions:

- account selection — `_select_account_with_budget_for_stream` → `await get_settings_cache().get()` in `service.py`
- token refresh — `_ensure_fresh_with_budget` → `async with self._repo_factory()`
- upstream route resolution — `_open_upstream_websocket_with_budget` → `async with SessionLocal()` on a route-cache miss

Threading the snapshot through those is a much larger change (route resolution has its own cache), so they are named as out of scope in the requirement rather than papered over. The earlier draft of this PR claimed the absolute invariant; that claim was wrong and is now corrected.

## Lock critical-section map

Every call reachable from the `async with prewarm_lock:` body of `_maybe_prewarm_http_bridge_session`, audited for a settings-cache `get()` or a `SessionLocal()`:

**Before**

| Call under the lock | Settings read | Reached on |
| --- | --- | --- |
| `_acquire_request_state_response_create_admission` | `await get_settings_cache().get()` (`service.py`) | every prewarm — `account_id` is always passed |
| `_reconnect_http_bridge_session` | `await _service_get_settings_cache().get()` (`http_bridge/mixin.py`) | prewarm response timeout |

**After**: both are `None`-defaulted parameters filled from one snapshot resolved before the lock. Success path: zero settings reads, zero DB sessions between acquire and release. Timeout path: the reconnect helper's own read is gone; the residual paths listed above remain.

Checked and confirmed **outside** the lock (the two call sites raised as possible extras):

- `service.py` `thread_goal_request` — a separate Codex thread-goal entry point, not reachable from prewarm.
- `http_bridge/mixin.py` `_create_http_bridge_session` — the connect path that *constructs* `prewarm_lock`; it runs before the lock exists.

The remaining calls in the body (`_build_http_bridge_prewarm_text`, `_record_http_bridge_prewarm_outcome`, `_log_http_bridge_event`, `_send_http_bridge_request_text_with_archive_id`, `_cleanup_http_bridge_submit_interruption`, `_release_websocket_response_create_gate`, `_retire_http_bridge_after_drain_if_ready`, SSE parsing) reach neither. `archive_enabled()` on the send path uses `SettingsCache.cached_row()` — synchronous, no DB, no await.

## Changes

- `_maybe_prewarm_http_bridge_session`: resolve the dashboard row once before `async with prewarm_lock`, pass it to the admission gate and to the timeout-path reconnect.
- That pre-lock read applies the same failure fallback as `DashboardOverridesMiddleware` — last loaded row, else skip the prewarm — so moving the read cannot fail a request the bridge can otherwise serve.
- `_acquire_request_state_response_create_admission(dashboard_settings=None)`: use the caller's row when given, else read the cache exactly as today. Caller-supplied `routing_tunables` still take precedence, unchanged.
- `_reconnect_http_bridge_session(dashboard_settings=None)`: same shape.
- Same optional-parameter pattern as `routing_tunables` threading (#2224) and `run_due_jobs(dashboard_settings=...)` (#2281).

**Callers audited** — both parameters default to today's behaviour, so nothing else changes:

- `_acquire_request_state_response_create_admission`, 3 production call sites: bridge submit (`request_submit.py`, outside any lock — unchanged), the prewarm (now passes the snapshot), and the websocket path (`websocket/mixin.py` — unchanged).
- `_reconnect_http_bridge_session`, 8 production call sites: the prewarm-timeout one now passes the snapshot; the other 7 (retry-precreated, security-work retry, and the recovery/reroute paths in `request_submit.py`) still read the cache themselves, which is correct — none of them holds `prewarm_lock`.

No value changes meaning; only where it is read changes.

## Simplicity

No new setting, no default change, no README/nav surface. Two optional internal parameters.

## Test plan

The #2264 spy test is upgraded from "no read is *attributed to the prewarm helper*" to "**zero** reads while the lock is held on the success path". It drives a real prewarm body — warm-up text built, admission acquired for it, sent to a fake upstream, stream completed — with a real `SettingsCache` holding a fresh row and `SessionLocal` replaced by a tripwire, and records the calling frame of every `get()` so the assertion cannot go vacuous: the recorded list must be exactly one pre-lock read from `_maybe_prewarm_http_bridge_session`. Its docstring states the timeout path is out of scope and names the test that covers the reconnect threading.

Also added: the reconnect helper takes no read of its own when handed a snapshot (asserted by call site, with the stubbed-out residual paths called out in the docstring), the prewarm-timeout path hands its snapshot to the reconnect, and both branches of the snapshot-failure fallback.

Verified the core assertions fail without the app change (app files reverted to `origin/main` in a scratch copy, not in the branch):

```
FAILED test_maybe_prewarm_http_bridge_session_..._reads_no_settings_under_the_lock
  assert ['_acquire_request_state_response_create_admission'] == []
FAILED test_reconnect_with_caller_snapshot_...
FAILED test_prewarm_timeout_pins_only_account_neutral_recovery_session[False-False]
FAILED test_prewarm_timeout_pins_only_account_neutral_recovery_session[True-True]
4 failed
```

```
make lint                                             # ruff + format + architecture/cancellation/timing/settings-tier guards: pass
uv run ty check                                       # All checks passed!
uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py -q
                                                      # 2461 passed
uv run pytest tests/integration/test_http_responses_bridge.py -q   # 185 passed
uv run pytest tests/integration/test_settings_api.py -q            # 93 passed
uv run pytest tests/unit -q                           # full unit suite: 9719 passed, 4 skipped
uv run openspec validate no-settings-reads-under-prewarm-lock --strict   # valid
uv run openspec validate --specs --strict             # 65 passed, 0 failed
# archive simulation on a temp copy of current main's openspec/: applies
# cleanly, re-validates 65/65, and the resulting spec diff is only the intended
# requirement rewording + two new scenarios
```

## Screenshots / output

No user-visible surface: the prewarm's `prewarm_status` outcomes, metrics and logs are unchanged, except that an unreadable settings row now yields `prewarm_status=skipped` with a warning instead of propagating.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make lint` / `uv run ty check` / pytest subsets locally.
- [x] If touching specs: `openspec validate --specs --strict` passes, plus an archive simulation.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand.
