### PR TITLE
fix(db): retry the startup sentinel seed on SQLite lock contention and name the lock error

### DIFF
--- a/app/core/config/key_fingerprint.py
+++ b/app/core/config/key_fingerprint.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 from collections.abc import Callable
@@ -9,18 +8,17 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.settings import get_settings
 from app.core.crypto import get_or_create_key
 from app.db.models import RuntimeSentinel
+from app.db.sqlite_lock_retry import retry_on_sqlite_lock
 
 logger = logging.getLogger(__name__)
 
 ENCRYPTION_KEY_FINGERPRINT_SENTINEL = "encryption_key_fingerprint"
 _FINGERPRINT_PREFIX_CHARS = 12
-_SQLITE_LOCK_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
 
 
 class EncryptionKeyFingerprintMismatchError(RuntimeError):
@@ -35,11 +33,6 @@ def compute_encryption_key_fingerprint(key_file: Path | None = None) -> str:
 
 def _fingerprint_prefix(fingerprint: str) -> str:
     return fingerprint[: len("sha256:") + _FINGERPRINT_PREFIX_CHARS]
-
-
-def _is_sqlite_lock_error(exc: OperationalError) -> bool:
-    message = str(exc.orig if exc.orig is not None else exc).lower()
-    return "database is locked" in message or "database is busy" in message
 
 
 async def _stamp_if_absent(session: AsyncSession, fingerprint: str) -> None:
@@ -88,23 +81,22 @@ async def verify_encryption_key_fingerprint(
     if session_factory is None:
         from app.db.session import SessionLocal
 
-        session_factory = SessionLocal
+        make_session: Callable[[], AsyncSession] = SessionLocal
+    else:
+        make_session = session_factory
 
     local_fingerprint = compute_encryption_key_fingerprint(key_file)
-    stored: str | None = None
-    for attempt, delay_seconds in enumerate((*_SQLITE_LOCK_RETRY_DELAYS_SECONDS, None)):
-        try:
-            async with session_factory() as session:
-                await _stamp_if_absent(session, local_fingerprint)
-                stored = await session.scalar(
-                    select(RuntimeSentinel.value).where(RuntimeSentinel.name == ENCRYPTION_KEY_FINGERPRINT_SENTINEL)
-                )
-        except OperationalError as exc:
-            if delay_seconds is None or not _is_sqlite_lock_error(exc):
-                raise
-            await asyncio.sleep(delay_seconds)
-            continue
-        break
+
+    async def stamp_and_read() -> str | None:
+        async with make_session() as session:
+            await _stamp_if_absent(session, local_fingerprint)
+            return await session.scalar(
+                select(RuntimeSentinel.value).where(RuntimeSentinel.name == ENCRYPTION_KEY_FINGERPRINT_SENTINEL)
+            )
+
+    # A lock failure that outlives the budget still propagates and fails
+    # startup, exactly as it did before the retry was factored out.
+    stored = await retry_on_sqlite_lock(stamp_and_read, what="encryption-key fingerprint stamp")
 
     if stored is None or stored == local_fingerprint:
         return

--- a/app/db/sqlite_lock_retry.py
+++ b/app/db/sqlite_lock_retry.py
@@ -1,0 +1,104 @@
+"""Bounded retry for the startup writes that race SQLite's single writer slot.
+
+Startup stamps two insert-if-absent sentinels into ``runtime_sentinels``
+(the encryption-key fingerprint and the hard-sticky outage-grace marker).
+Both are the first statement of their transaction on a fresh connection, so
+neither can be protected by ``BEGIN IMMEDIATE`` (there is no earlier read to
+upgrade), and on a loaded host either can lose the writer slot and surface
+``database is locked`` (issue #1949). The window is short and self-healing,
+so a small bounded retry is the whole fix; it is shared here so both call
+sites keep one budget and one diagnostic instead of drifting apart.
+
+The diagnostic matters as much as the retry: ``database is locked`` is
+emitted for two opposite mechanisms that only ``sqlite_errorname``
+separates. ``SQLITE_BUSY_SNAPSHOT`` (a stale WAL snapshot that cannot be
+upgraded) returns immediately and a retry on a fresh transaction fixes it;
+``SQLITE_BUSY`` returns only after the full ``busy_timeout``, meaning
+another writer held the slot that long and the retry budget is irrelevant.
+Logging the name plus the elapsed time makes the next occurrence
+self-classifying.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from sqlalchemy.exc import OperationalError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Three attempts inside ~0.35s: long enough to outlast the sub-second
+# snapshot-upgrade class, short enough that a genuinely wedged writer slot
+# still surfaces at startup instead of being hidden behind a long sleep.
+SQLITE_LOCK_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
+
+
+def is_sqlite_lock_error(exc: OperationalError) -> bool:
+    """Return True for a transient SQLite ``database is locked``/``busy``."""
+    message = str(exc.orig if exc.orig is not None else exc).lower()
+    return "database is locked" in message or "database is busy" in message
+
+
+def sqlite_error_name(exc: OperationalError) -> str | None:
+    """Return the driver's extended result code name, when the driver set one.
+
+    ``sqlite3`` populates ``sqlite_errorname`` only on exceptions it raises
+    itself, so a constructed ``OperationalError`` has no such attribute:
+    read it defensively rather than with ``hasattr``-guarded access.
+    """
+    return getattr(exc.orig, "sqlite_errorname", None)
+
+
+async def retry_on_sqlite_lock(
+    operation: Callable[[], Awaitable[T]],
+    *,
+    what: str,
+    before_retry: Callable[[], Awaitable[None]] | None = None,
+) -> T:
+    """Run ``operation``, retrying transient SQLite lock failures.
+
+    Non-lock ``OperationalError``s propagate untouched, and so does a lock
+    failure that survives the whole budget — the caller's existing
+    failure semantics are preserved either way. ``before_retry`` runs
+    between attempts for callers that must reset a session whose
+    transaction the failure left dirty.
+    """
+    started_at = time.monotonic()
+    for delay_seconds in (*SQLITE_LOCK_RETRY_DELAYS_SECONDS, None):
+        attempt_started_at = time.monotonic()
+        try:
+            return await operation()
+        except OperationalError as exc:
+            if not is_sqlite_lock_error(exc):
+                raise
+            attempt_seconds = time.monotonic() - attempt_started_at
+            total_seconds = time.monotonic() - started_at
+            if delay_seconds is None:
+                logger.warning(
+                    "sqlite lock retry budget exhausted what=%s sqlite_errorname=%s "
+                    "attempt_seconds=%.3f total_seconds=%.3f",
+                    what,
+                    sqlite_error_name(exc),
+                    attempt_seconds,
+                    total_seconds,
+                )
+                raise
+            logger.debug(
+                "retrying sqlite lock failure what=%s sqlite_errorname=%s "
+                "attempt_seconds=%.3f total_seconds=%.3f next_delay_seconds=%.3f",
+                what,
+                sqlite_error_name(exc),
+                attempt_seconds,
+                total_seconds,
+                delay_seconds,
+            )
+            if before_retry is not None:
+                await before_retry()
+            await asyncio.sleep(delay_seconds)
+    raise AssertionError("unreachable: the retry loop either returns or raises")

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -36,6 +36,7 @@ from app.db.models import (
     UsageHistory,
 )
 from app.db.session import sqlite_writer_section
+from app.db.sqlite_lock_retry import retry_on_sqlite_lock
 from app.modules.accounts.usage_rollup import (
     AccountUsageRollupRepository,
     deduped_usage_aggregate_stmt,
@@ -896,7 +897,8 @@ class AccountsRepository:
             .on_conflict_do_nothing(index_elements=[RuntimeSentinel.name])
             .returning(RuntimeSentinel.name)
         )
-        try:
+
+        async def seed_once() -> int:
             async with sqlite_writer_section():
                 stamp_result = await self._session.execute(stamp_stmt)
                 stamped_by_this_boot = stamp_result.scalar_one_or_none() is not None
@@ -911,12 +913,24 @@ class AccountsRepository:
                 for account_id in account_ids:
                     await self._refresh_hard_sticky_outage_grace(account_id)
                 await self._session.commit()
+                return len(account_ids)
+
+        try:
+            # This stamp is the first statement of its transaction on a
+            # startup-fresh connection, so it can simply lose SQLite's writer
+            # slot (issue #1949) — retry the whole attempt, rolling the failed
+            # transaction back first so the next one starts clean. Exhausting
+            # the budget still raises and fails startup, as it always has.
+            return await retry_on_sqlite_lock(
+                seed_once,
+                what="hard-sticky outage grace startup seed",
+                before_retry=self._session.rollback,
+            )
         except OperationalError as exc:
             if not _is_missing_hard_sticky_seed_table(exc):
                 raise
             await self._session.rollback()
             return 0
-        return len(account_ids)
 
     async def _close_http_bridge_sessions_for_account(self, account_id: str) -> None:
         session_ids = select(HttpBridgeSessionRecord.id).where(HttpBridgeSessionRecord.account_id == account_id)

--- a/openspec/changes/retry-startup-sentinel-sqlite-lock/.openspec.yaml
+++ b/openspec/changes/retry-startup-sentinel-sqlite-lock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/retry-startup-sentinel-sqlite-lock/proposal.md
+++ b/openspec/changes/retry-startup-sentinel-sqlite-lock/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Startup stamps two insert-if-absent sentinels into `runtime_sentinels`: the
+encryption-key fingerprint and the hard-sticky outage-grace marker. Both are
+the first statement of their transaction on a startup-fresh connection, so
+neither can be protected by `BEGIN IMMEDIATE` (there is no earlier read to
+upgrade) and either can lose SQLite's single writer slot on a loaded host.
+The fingerprint stamp already retries; the outage-grace seed has no lock
+tolerance at all, and it is the failing statement in most of the CI hits on
+issue #1949. Worse, both mechanisms behind `database is locked` — an instant
+`SQLITE_BUSY_SNAPSHOT` and a `SQLITE_BUSY` returned only after the full busy
+timeout — produce the identical message, so today's failures cannot be told
+apart after the fact.
+
+## What Changes
+
+- Share one bounded lock-retry budget (three retries, under a second in
+  total) between both startup sentinel writes, rolling back the dirty
+  transaction between attempts.
+- Preserve each call site's existing failure outcome: a lock that outlives
+  the budget still fails startup, and non-lock `OperationalError`s still
+  propagate unretried so the seed's missing-table degrade is untouched.
+- Log the driver's `sqlite_errorname` and the elapsed time when a budget is
+  exhausted (WARNING) and on each retry (DEBUG), so the next occurrence
+  classifies itself.
+
+## Capabilities
+
+### Modified Capabilities
+- database-backends: startup sentinel writes tolerate, and name, transient SQLite lock contention.
+
+## Impact
+
+Two startup call sites (`app/core/config/key_fingerprint.py`,
+`AccountsRepository.seed_hard_sticky_outage_grace_on_startup`) plus a shared
+`app/db/sqlite_lock_retry.py` helper. No configuration, schema, or
+request-path change.

--- a/openspec/changes/retry-startup-sentinel-sqlite-lock/specs/database-backends/spec.md
+++ b/openspec/changes/retry-startup-sentinel-sqlite-lock/specs/database-backends/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Startup sentinel writes tolerate and name transient SQLite lock contention
+
+The startup writes that insert-if-absent into `runtime_sentinels` — the encryption-key fingerprint stamp and the hard-sticky outage-grace seed — MUST retry a transient SQLite lock failure (`database is locked` / `database is busy`) on one shared bounded budget of three retries totalling under one second, and MUST reset a session whose transaction the failed attempt left dirty before the next attempt. Each of these writes is the first statement of its transaction on a startup-fresh connection, so `BEGIN IMMEDIATE` cannot pre-acquire the writer slot for it. A lock failure that outlives the budget MUST preserve the call site's existing outcome rather than newly degrading or newly failing startup, and an `OperationalError` that is not a lock failure MUST propagate without being retried, so the seed's existing not-yet-migrated (`no such table`) degrade to a no-op still applies. Exhausting the budget MUST be reported at WARNING, and each retry at DEBUG, with the driver's extended result-code name (`sqlite_errorname`, or its absence) and the elapsed time — the two mechanisms behind `database is locked` are otherwise indistinguishable, since `SQLITE_BUSY_SNAPSHOT` returns immediately while `SQLITE_BUSY` returns only after the full busy timeout. These reports MUST NOT include the values being written.
+
+#### Scenario: A transient lock on the outage-grace seed is retried
+- **GIVEN** the startup hard-sticky outage-grace seed whose sentinel stamp fails once with `database is locked`
+- **WHEN** startup runs the seed
+- **THEN** the failed transaction is rolled back and the stamp is retried within the shared budget
+- **AND** the backfill completes on the retry
+
+#### Scenario: A lock that outlives the budget keeps the existing outcome
+- **GIVEN** a startup sentinel write whose every attempt within the budget fails with `database is locked`
+- **WHEN** the budget is exhausted
+- **THEN** the failure propagates and startup fails, as it did before the retry existed
+
+#### Scenario: A non-lock operational error is not retried
+- **GIVEN** a database whose `runtime_sentinels` table does not exist yet
+- **WHEN** the outage-grace seed runs
+- **THEN** the error is not retried
+- **AND** the seed rolls back and returns without stamping, exactly as before
+
+#### Scenario: The give-up report classifies the lock failure
+- **GIVEN** a startup sentinel write that exhausts its retry budget
+- **WHEN** the exhaustion is reported
+- **THEN** the report names the write, the driver's `sqlite_errorname` (or its absence), and the elapsed time
+- **AND** the report contains none of the values the write was stamping

--- a/openspec/changes/retry-startup-sentinel-sqlite-lock/tasks.md
+++ b/openspec/changes/retry-startup-sentinel-sqlite-lock/tasks.md
@@ -1,0 +1,10 @@
+## 1. Shared retry
+- [x] 1.1 Factor the fingerprint stamp's inline retry into a shared bounded helper with one module-level budget.
+- [x] 1.2 Route the hard-sticky outage-grace startup seed through the same helper, rolling back between attempts.
+
+## 2. Diagnosis
+- [x] 2.1 Log `sqlite_errorname` and elapsed time on retry (DEBUG) and on give-up (WARNING), without logging written values.
+
+## 3. Coverage
+- [x] 3.1 Cover the retried transient seed, the exhausted budget's preserved outcome and named error, the missing-table degrade, and the unchanged fingerprint behaviour.
+- [x] 3.2 Pass lint, type check, migration check, the touched suites, and strict OpenSpec validation.

--- a/tests/integration/test_replica_guardrails.py
+++ b/tests/integration/test_replica_guardrails.py
@@ -18,6 +18,7 @@ from app.core.config.key_fingerprint import (
 )
 from app.core.exceptions import DashboardSettingsConflictError
 from app.core.utils.time import utcnow
+from app.db import sqlite_lock_retry
 from app.db.models import BridgeRingMember, RuntimeSentinel
 from app.db.session import SessionLocal
 from app.modules.dashboard_auth.repository import DashboardAuthRepository
@@ -99,11 +100,10 @@ async def test_fingerprint_retries_transient_sqlite_lock(db_setup, monkeypatch):
             raise OperationalError("INSERT runtime_sentinels", {}, Exception("database is locked"))
         await real_stamp_if_absent(session, fingerprint)
 
-    async def no_sleep(_delay_seconds: float) -> None:
-        return None
-
     monkeypatch.setattr(key_fingerprint_module, "_stamp_if_absent", fail_once_then_stamp)
-    monkeypatch.setattr(key_fingerprint_module.asyncio, "sleep", no_sleep)
+    # The retry budget now lives in the shared helper; zero the delays so the
+    # test exercises the retry without waiting it out.
+    monkeypatch.setattr(sqlite_lock_retry, "SQLITE_LOCK_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
 
     await verify_encryption_key_fingerprint()
 

--- a/tests/unit/test_startup_sentinel_lock_retry.py
+++ b/tests/unit/test_startup_sentinel_lock_retry.py
@@ -1,0 +1,242 @@
+"""Startup sentinel writes survive a transient SQLite writer-slot loss (issue #1949).
+
+Both startup sentinel stamps — the encryption-key fingerprint and the
+hard-sticky outage-grace marker — are the first statement of their
+transaction on a fresh connection, so they can simply lose SQLite's single
+writer slot on a loaded host. These tests pin the shared bounded retry and
+the diagnostic that classifies the failure for the next occurrence: the
+driver's ``sqlite_errorname`` separates an instant ``SQLITE_BUSY_SNAPSHOT``
+from a ``SQLITE_BUSY`` that only returns after the full busy timeout.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.core.config.key_fingerprint as key_fingerprint_module
+from app.core.config.key_fingerprint import verify_encryption_key_fingerprint
+from app.db import sqlite_lock_retry
+from app.modules.accounts.repository import AccountsRepository
+
+pytestmark = pytest.mark.unit
+
+RETRY_LOGGER = "app.db.sqlite_lock_retry"
+
+
+class _DriverLockError(sqlite3.OperationalError):
+    """The driver-raised shape: ``sqlite3`` sets ``sqlite_errorname`` itself.
+
+    A constructed ``sqlite3.OperationalError`` has no such attribute, which
+    is why the helper reads it with ``getattr`` rather than ``hasattr``.
+    """
+
+    def __init__(self, error_name: str) -> None:
+        super().__init__("database is locked")
+        self.sqlite_errorname = error_name
+
+
+def _lock_error(error_name: str | None) -> OperationalError:
+    orig: Exception = _DriverLockError(error_name) if error_name else sqlite3.OperationalError("database is locked")
+    return OperationalError("INSERT INTO runtime_sentinels ...", {}, orig)
+
+
+class _StampResult:
+    def scalar_one_or_none(self) -> str | None:
+        return "hard_sticky_outage_grace_seeded"
+
+
+class _ScalarsResult:
+    def __init__(self, ids: list[str]) -> None:
+        self._ids = ids
+
+    def all(self) -> list[str]:
+        return self._ids
+
+
+class _FakeBind:
+    dialect = type("_Dialect", (), {"name": "sqlite"})()
+
+
+class _FakeSeedSession:
+    """The seed's session surface, failing its stamp a fixed number of times."""
+
+    def __init__(self, *, failures: int, error_name: str | None = "SQLITE_BUSY_SNAPSHOT") -> None:
+        self._failures = failures
+        self._error_name = error_name
+        self.stamp_attempts = 0
+        self.rollbacks = 0
+        self.commits = 0
+        self.refreshed_account_ids: list[str] = []
+
+    def get_bind(self) -> _FakeBind:
+        return _FakeBind()
+
+    async def execute(self, statement: Any) -> _StampResult:
+        compiled = str(statement).lower()
+        if "insert into runtime_sentinels" in compiled:
+            self.stamp_attempts += 1
+            if self.stamp_attempts <= self._failures:
+                raise _lock_error(self._error_name)
+            return _StampResult()
+        self.refreshed_account_ids.append("refresh")
+        return _StampResult()
+
+    async def scalars(self, statement: Any) -> _ScalarsResult:
+        return _ScalarsResult(["account-a", "account-b"])
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+@pytest.fixture(autouse=True)
+def _instant_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sqlite_lock_retry, "SQLITE_LOCK_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
+
+
+def test_retry_budget_stays_three_attempts_under_a_second() -> None:
+    # The budget is deliberately small: long enough to outlast the
+    # sub-second snapshot-upgrade class, short enough that a wedged writer
+    # slot still surfaces at startup instead of hiding behind a long sleep.
+    delays = sqlite_lock_retry.SQLITE_LOCK_RETRY_DELAYS_SECONDS
+    assert len(delays) == 3
+    assert sum(delays) < 1.0
+
+
+async def test_seed_retries_a_transient_lock_and_completes(caplog: pytest.LogCaptureFixture) -> None:
+    session = _FakeSeedSession(failures=1)
+    repository = AccountsRepository(cast(AsyncSession, session))
+
+    with caplog.at_level(logging.DEBUG, logger=RETRY_LOGGER):
+        seeded = await repository.seed_hard_sticky_outage_grace_on_startup()
+
+    assert seeded == 2
+    assert session.stamp_attempts == 2
+    # The failed attempt left the transaction dirty; the next one starts clean.
+    assert session.rollbacks == 1
+    retry_logs = [record.getMessage() for record in caplog.records if record.levelno == logging.DEBUG]
+    assert any("sqlite_errorname=SQLITE_BUSY_SNAPSHOT" in message for message in retry_logs)
+
+
+async def test_seed_still_fails_startup_when_the_lock_outlives_the_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session = _FakeSeedSession(failures=99, error_name="SQLITE_BUSY")
+    repository = AccountsRepository(cast(AsyncSession, session))
+
+    with caplog.at_level(logging.WARNING, logger=RETRY_LOGGER):
+        with pytest.raises(OperationalError):
+            await repository.seed_hard_sticky_outage_grace_on_startup()
+
+    assert session.stamp_attempts == 4
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("sqlite_errorname=SQLITE_BUSY" in message for message in warnings)
+    assert any("total_seconds=" in message for message in warnings)
+
+
+async def test_seed_gives_up_without_an_error_name_from_a_constructed_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # ``sqlite3`` only populates ``sqlite_errorname`` on exceptions it raises
+    # itself; reading it must not blow up when the attribute is absent.
+    session = _FakeSeedSession(failures=99, error_name=None)
+    repository = AccountsRepository(cast(AsyncSession, session))
+
+    with caplog.at_level(logging.WARNING, logger=RETRY_LOGGER):
+        with pytest.raises(OperationalError):
+            await repository.seed_hard_sticky_outage_grace_on_startup()
+
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("sqlite_errorname=None" in message for message in warnings)
+
+
+async def test_seed_missing_table_still_degrades_to_a_no_op() -> None:
+    class _MissingTableSession(_FakeSeedSession):
+        async def execute(self, statement: Any) -> _StampResult:
+            self.stamp_attempts += 1
+            raise OperationalError(
+                "INSERT INTO runtime_sentinels ...",
+                {},
+                sqlite3.OperationalError("no such table: runtime_sentinels"),
+            )
+
+    session = _MissingTableSession(failures=0)
+    repository = AccountsRepository(cast(AsyncSession, session))
+
+    assert await repository.seed_hard_sticky_outage_grace_on_startup() == 0
+    # Not a lock error: no retry, and the pre-existing degrade path stands.
+    assert session.stamp_attempts == 1
+    assert session.rollbacks == 1
+
+
+class _FakeFingerprintSession:
+    def __init__(self, stored: str | None) -> None:
+        self._stored = stored
+
+    async def __aenter__(self) -> _FakeFingerprintSession:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+    async def scalar(self, statement: Any) -> str | None:
+        return self._stored
+
+
+async def test_fingerprint_retries_a_transient_lock_and_still_verifies(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    attempts = 0
+
+    async def stamp(session: Any, fingerprint: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _lock_error("SQLITE_BUSY_SNAPSHOT")
+
+    monkeypatch.setattr(key_fingerprint_module, "_stamp_if_absent", stamp)
+    key_file = tmp_path / "encryption.key"
+    stored = key_fingerprint_module.compute_encryption_key_fingerprint(key_file)
+
+    await verify_encryption_key_fingerprint(
+        lambda: cast(AsyncSession, _FakeFingerprintSession(stored)),
+        key_file=key_file,
+        mode="enforce",
+    )
+
+    assert attempts == 2
+
+
+async def test_fingerprint_still_raises_when_the_lock_outlives_the_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    attempts = 0
+
+    async def always_locked(session: Any, fingerprint: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise _lock_error("SQLITE_BUSY")
+
+    monkeypatch.setattr(key_fingerprint_module, "_stamp_if_absent", always_locked)
+    key_file = tmp_path / "encryption.key"
+
+    with caplog.at_level(logging.WARNING, logger=RETRY_LOGGER):
+        with pytest.raises(OperationalError):
+            await verify_encryption_key_fingerprint(
+                lambda: cast(AsyncSession, _FakeFingerprintSession(None)),
+                key_file=key_file,
+                mode="enforce",
+            )
+
+    assert attempts == 4
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("encryption-key fingerprint stamp" in message for message in warnings)
+    assert any("sqlite_errorname=SQLITE_BUSY" in message for message in warnings)

--- a/tests/unit/test_startup_sentinel_lock_retry.py
+++ b/tests/unit/test_startup_sentinel_lock_retry.py
@@ -97,8 +97,14 @@ class _FakeSeedSession:
         self.rollbacks += 1
 
 
-@pytest.fixture(autouse=True)
-def _instant_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def instant_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the retried tests fast.
+
+    Deliberately not autouse: ``test_retry_budget_stays_three_attempts_under_a_second``
+    asserts the shipped budget, and an autouse override would make it assert
+    the override instead.
+    """
     monkeypatch.setattr(sqlite_lock_retry, "SQLITE_LOCK_RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0))
 
 
@@ -111,7 +117,9 @@ def test_retry_budget_stays_three_attempts_under_a_second() -> None:
     assert sum(delays) < 1.0
 
 
-async def test_seed_retries_a_transient_lock_and_completes(caplog: pytest.LogCaptureFixture) -> None:
+async def test_seed_retries_a_transient_lock_and_completes(
+    instant_retries: None, caplog: pytest.LogCaptureFixture
+) -> None:
     session = _FakeSeedSession(failures=1)
     repository = AccountsRepository(cast(AsyncSession, session))
 
@@ -127,6 +135,7 @@ async def test_seed_retries_a_transient_lock_and_completes(caplog: pytest.LogCap
 
 
 async def test_seed_still_fails_startup_when_the_lock_outlives_the_budget(
+    instant_retries: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     session = _FakeSeedSession(failures=99, error_name="SQLITE_BUSY")
@@ -143,6 +152,7 @@ async def test_seed_still_fails_startup_when_the_lock_outlives_the_budget(
 
 
 async def test_seed_gives_up_without_an_error_name_from_a_constructed_exception(
+    instant_retries: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # ``sqlite3`` only populates ``sqlite_errorname`` on exceptions it raises
@@ -192,7 +202,7 @@ class _FakeFingerprintSession:
 
 
 async def test_fingerprint_retries_a_transient_lock_and_still_verifies(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    instant_retries: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
     attempts = 0
 
@@ -216,7 +226,7 @@ async def test_fingerprint_retries_a_transient_lock_and_still_verifies(
 
 
 async def test_fingerprint_still_raises_when_the_lock_outlives_the_budget(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture
+    instant_retries: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
     attempts = 0
 


### PR DESCRIPTION
## Summary

The hard-sticky outage-grace startup seed stamps `runtime_sentinels` with **zero** SQLite lock-retry tolerance, and it is the failing statement in 7 of the 9 CI jobs listed on #1949. This gives it the same bounded retry the encryption-key fingerprint stamp already had (now shared between the two), and makes both sites log *which* `database is locked` they hit, so the next CI occurrence classifies itself instead of needing another investigation.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: `Refs #1949` — deliberately not `Fixes`. The sub-second `SQLITE_BUSY_SNAPSHOT` class is still unreproduced (400-iteration targeted stress on a loaded 20-core host produced 0 `OperationalError`), so this hardens and instruments the reported path rather than proving it closed.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/retry-startup-sentinel-sqlite-lock/` (delta on `database-backends`, which owns the SQLite writer-slot/lock requirements).

## Changes

**The two call sites.** Startup performs two insert-if-absent writes into `runtime_sentinels`:

| call site | before | after |
|---|---|---|
| `app/core/config/key_fingerprint.py` `verify_encryption_key_fingerprint` | inline 3-attempt / ~0.35 s retry loop | same budget, now via the shared helper; behaviour unchanged |
| `AccountsRepository.seed_hard_sticky_outage_grace_on_startup` (`app/main.py:644`) | **no** lock retry — one lost writer slot fails startup | same shared budget, with a `rollback()` between attempts |

Both emit `BEGIN (implicit)` → `INSERT … ON CONFLICT DO NOTHING` → `COMMIT` on a fresh `NullPool` connection, so the stamp is the *first* statement of its transaction and `BEGIN IMMEDIATE` cannot pre-acquire the writer slot for it (there is no earlier read to upgrade). A bounded retry is the available fix.

- New `app/db/sqlite_lock_retry.py`: one module constant `SQLITE_LOCK_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)` — the pre-existing budget, 3 retries inside ~0.35 s — plus the lock-error predicate (factored out of `key_fingerprint`, not duplicated) and one retry loop used by both sites.
- The seed passes `before_retry=self._session.rollback`: unlike the fingerprint path it reuses the lifespan's session, so a failed attempt must not leave a dirty transaction for the next one.

**Failure-outcome semantics, unchanged on both sides** (per the "do not newly fail, do not newly degrade" rule):

- Lock error surviving the budget → **still raises, still fails startup**. That is what both sites did before; neither newly degrades.
- Non-lock `OperationalError` → propagates unretried, so the seed's existing not-yet-migrated (`no such table: runtime_sentinels` / `accounts`) degrade-to-no-op is untouched — verified by a regression test.

**Instrumentation — what the next CI hit will tell us.** `database is locked` is emitted for two opposite mechanisms with an identical message, and only the driver's extended result code separates them:

| `sqlite_errorname` | mechanism | elapsed |
|---|---|---|
| `SQLITE_BUSY_SNAPSHOT` | stale WAL snapshot cannot be upgraded | ~0 ms |
| `SQLITE_BUSY` | another connection held the writer slot | exactly `busy_timeout` |

On give-up we log at WARNING (`what`, `sqlite_errorname`, `attempt_seconds`, `total_seconds`); each retry logs the same at DEBUG. So the next failure says directly whether the retry budget was ever relevant (`BUSY_SNAPSHOT`, retry helps) or whether a foreign writer sat on the slot for the full 30 s (`BUSY`, the budget is irrelevant and the holder is the bug). Only the error name and timings are logged — never the values being stamped.

Implementation gotcha recorded in the helper: `hasattr(sqlite3.OperationalError("x"), "sqlite_errorname")` is `False` — the attribute exists only on driver-raised instances — so it is read as `getattr(exc.orig, "sqlite_errorname", None)`.

**Not in this PR:** the ~30 s `test_otel.py` stalls from the same investigation are a `DELETION_INTERVAL_SECONDS` timer wait, not a lock wait, and are filed separately as #2338 (a harness decision).

## Test plan

New `tests/unit/test_startup_sentinel_lock_retry.py` (7 tests, driver-shaped exceptions — a `sqlite3.OperationalError` subclass carrying `sqlite_errorname`, wrapped in `OperationalError`):

- transient lock on the seed is retried, rolled back once, and the backfill completes;
- a persistent lock ends in the documented outcome (raises / startup fails) with `sqlite_errorname=SQLITE_BUSY` and the timings in the log record;
- a constructed exception with no `sqlite_errorname` logs `None` instead of blowing up;
- the seed's missing-table path still degrades to a no-op without retrying;
- the fingerprint path keeps its behaviour (retries once and verifies; a persistent lock still raises and names the error);
- the budget stays 3 attempts / sub-second.

```
uv run pytest tests/unit -q -x -k "fingerprint or sentinel or sticky_outage or accounts_repository or db_"
  → 295 passed, 9431 deselected (528.99s)
uv run pytest tests/integration/test_replica_guardrails.py tests/integration/test_migrations.py \
             tests/unit/test_startup_sentinel_lock_retry.py -q
  → 67 passed, 8 skipped (525.64s)
uv run pytest tests/integration/test_proxy_sticky_sessions.py -q -k "seed_hard_sticky or outage_grace"
  → 1 passed, 41 deselected
make lint            → ruff check/format + architecture/cancellation/timing/settings-tier checks pass
uv run ty check      → All checks passed!
make migration-check → migration_policy=ok, schema_drift=none
python3 .github/scripts/check_simplicity_budgets.py → exit 0 (all budgets OK)
openspec validate retry-startup-sentinel-sqlite-lock --strict → valid
openspec validate --specs --strict → 65 passed, 0 failed
archive simulation on a temp copy of main's openspec/ → applies cleanly (+1 requirement on database-backends), specs still validate strict
```

## Screenshots / output

Give-up log line shape (WARNING, `app.db.sqlite_lock_retry`):

```
sqlite lock retry budget exhausted what=hard-sticky outage grace startup seed \
  sqlite_errorname=SQLITE_BUSY attempt_seconds=30.002 total_seconds=30.352
```

No dashboard-visible surface.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally (see Test plan).
- [x] If touching specs: `openspec validate --specs` passes; the change validates strict and archive-simulates cleanly.
- [x] Simplicity gates reviewed: no new setting, no README section, no `.env.example` line, no nav item, no default changed (P1-P6 unaffected).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
