### PR TITLE
perf(bridge): resolve the prewarm snapshot only for eligible payloads

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -62,7 +62,7 @@ from app.core.utils.request_id import (
     set_request_id,
 )
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
-from app.db.models import StickySessionKind
+from app.db.models import DashboardSettings, StickySessionKind
 from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyUsageReservationData,
@@ -2563,27 +2563,37 @@ class _HTTPBridgeRequestSubmitMixin:
             request_state.prewarm_status = "skipped"
             _record_http_bridge_prewarm_outcome(outcome="skipped")
             return
+        # Build the warm-up outside the lock. It is a pure function of
+        # ``text_data``, so the locked body gets the same answer, and this keeps
+        # a parse of a possibly large payload off the critical section.
+        warmup_text = _build_http_bridge_prewarm_text(text_data)
         # The two settings readers the locked body reaches -- the admission
         # gate's account caps/tunables and the reconnect the timeout path takes
-        # -- get this one row instead of reading it themselves, so nothing
+        # -- get this one row instead of reading it themselves, so neither
         # awaits the settings cache while ``prewarm_lock`` is held. A refresh
         # behind that read runs a DB query under a process-global lock; one
         # stalled query would then hold this session's prewarm lock and stall
-        # every later turn on it (issues #1971 and #1972).
-        settings_cache = _service_get_settings_cache()
-        try:
-            dashboard_settings = await settings_cache.get()
-        except Exception:  # noqa: BLE001 - a prewarm must never fail a servable request
-            # The same fallback the request entry point's dashboard-overrides
-            # middleware applies to this row: prefer the last one this replica
-            # loaded. With no row at all the prewarm is skipped rather than run
-            # without a snapshot, which would put the read back under the lock.
-            dashboard_settings = settings_cache.cached_row()
-            logger.warning(
-                "HTTP bridge prewarm settings snapshot unavailable; %s",
-                "using the last loaded dashboard values" if dashboard_settings is not None else "skipping the prewarm",
-                exc_info=True,
-            )
+        # every later turn on it (issues #1971 and #1972). A payload with no
+        # warm-up to send reaches neither reader, so it resolves nothing and
+        # reads nothing, exactly as before the snapshot existed.
+        dashboard_settings: DashboardSettings | None = None
+        if warmup_text is not None:
+            settings_cache = _service_get_settings_cache()
+            try:
+                dashboard_settings = await settings_cache.get()
+            except Exception:  # noqa: BLE001 - a prewarm must never fail a servable request
+                # The same fallback the request entry point's dashboard-overrides
+                # middleware applies to this row: prefer the last one this replica
+                # loaded. With no row at all the prewarm is skipped rather than run
+                # without a snapshot, which would put the read back under the lock.
+                dashboard_settings = settings_cache.cached_row()
+                logger.warning(
+                    "HTTP bridge prewarm settings snapshot unavailable; %s",
+                    "using the last loaded dashboard values"
+                    if dashboard_settings is not None
+                    else "skipping the prewarm",
+                    exc_info=True,
+                )
             if dashboard_settings is None:
                 request_state.prewarm_status = "skipped"
                 _record_http_bridge_prewarm_outcome(outcome="skipped")
@@ -2593,7 +2603,6 @@ class _HTTPBridgeRequestSubmitMixin:
                 request_state.prewarm_status = "skipped"
                 _record_http_bridge_prewarm_outcome(outcome="skipped")
                 return
-            warmup_text = _build_http_bridge_prewarm_text(text_data)
             session.prewarmed = True
             if warmup_text is None:
                 request_state.prewarm_status = "skipped"

--- a/openspec/changes/prewarm-snapshot-only-when-eligible/proposal.md
+++ b/openspec/changes/prewarm-snapshot-only-when-eligible/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+`no-settings-reads-under-prewarm-lock` (#2335) moved the Codex HTTP-bridge
+prewarm's dashboard-settings read out of `prewarm_lock` and threaded the
+snapshot into the admission gate and the reconnect. It resolves that snapshot
+unconditionally, before the warm-up payload has been built.
+
+Most prewarm candidates never send a warm-up: `_build_http_bridge_prewarm_text`
+returns `None` for a payload that already carries `generate: false`, is not a
+JSON object, or is otherwise not warm-up shaped. Those requests reach neither
+of the two readers the snapshot exists for, so before #2335 they took no
+settings read at all and now they take one — pure cost on a cached hit, a
+database query on an expired one, and a needless failure surface (handled, but
+still exercised) on a request that is served normally either way.
+
+## What Changes
+
+- Build the warm-up text before taking `prewarm_lock` and resolve the settings
+  snapshot only when there is a warm-up to send, so an ineligible payload reads
+  nothing, as it did before #2335.
+- Keep the locked body's decisions identical: it still re-checks
+  `session.prewarmed` under the lock, still sets it, and still records
+  `prewarm_status=skipped` for a payload with no warm-up. The builder is a pure
+  function of the request text, so the answer cannot differ.
+- As a side effect the payload parse leaves the critical section, which is
+  aligned with why the lock is being kept short in the first place.
+- Assert the snapshot's identity, not just its presence, where the prewarm
+  timeout path hands it to the admission gate and the reconnect.
+
+No dashboard value changes meaning, and no value is read that was not read
+before; only the condition under which it is read changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: The prewarm snapshot must be resolved only when a
+  warm-up will actually be sent.
+
+## Impact
+
+- Affected code: the HTTP-bridge prewarm helper.
+- Affected tests: HTTP-bridge prewarm unit coverage and the prewarm-timeout
+  observation assertions.
+- No schema, API, or configuration surface change.
+- Ordering: this change's delta is written against the requirement text
+  `no-settings-reads-under-prewarm-lock` introduces (already merged, still
+  unarchived on main), so its text is a superset of that change's. Archiving
+  the two in either order converges on the same spec, verified by simulation.

--- a/openspec/changes/prewarm-snapshot-only-when-eligible/specs/deployment-installation/spec.md
+++ b/openspec/changes/prewarm-snapshot-only-when-eligible/specs/deployment-installation/spec.md
@@ -1,0 +1,286 @@
+## MODIFIED Requirements
+
+### Requirement: Removed tunables are fixed constants, derived values, or dashboard settings
+
+Values that are protocol constants or internal tuning details SHALL NOT be
+operator-configurable, and values the dashboard runtime settings own SHALL NOT
+also be operator-configurable through the environment. When a previously
+supported `CODEX_LB_*` setting is removed from the configuration surface, its
+environment variable MUST be ignored without failing startup, and for at
+least one release after removal, startup MUST emit a single warning log
+listing every removed setting name found in the process environment or the
+loaded env files (never the values), referencing the simplicity principle
+that motivated the removal. Once a removed name has had its warning release,
+it MUST be pruned from the warning list while staying inert (`extra="ignore"`);
+the warning list therefore covers only the most recent removal batch. Each
+subsystem affected by a removal MUST retain at most one enable/disable
+setting, and the Helm chart MUST NOT render environment variables for removed
+settings.
+
+The following values MUST be fixed at their previously documented defaults:
+
+- The OAuth protocol identity values (authorization base URL, client id,
+  originator, scope, redirect URI, and callback port): they identify
+  codex-lb to OpenAI exactly like the Codex CLI, and changing any of them
+  breaks login.
+- Background scheduler cadences (quota planner tick, automations poll,
+  model registry refresh, sticky-session cleanup).
+- The Codex client fingerprint (OS, architecture, terminal).
+- Live-usage write coalescing (minimum write interval and queue size).
+- The request-log count-cache TTL.
+- Circuit-breaker tuning (failure threshold and recovery timeout).
+- The images-route internals (internal host model and partial-images cap).
+- The PostgreSQL pool checkout timeout (30 seconds) and pooled-connection
+  recycle window (1800 seconds).
+- The soft-drain/probe thresholds (primary drain threshold 85%, secondary
+  drain threshold 90%, error window 60 seconds, error count 2, probe quiet
+  window 60 seconds, probe success streak 3), fixed in
+  `app/core/balancer/logic.py`.
+- The never-tuned core tunables constantized by `constantize-core-tunables`:
+  the upstream SSE event / websocket frame budget (16 MiB) and the derived
+  serialized `response.create` budget (15 MiB); the OAuth exchange timeout
+  (30 s), token-refresh exchange timeout (8 s), refresh-failure negative
+  cache (5 s) and the token-refresh claim TTL (`max(30 s, admission wait +
+  2 x refresh timeout)`, all in code); the admission wait (10 s) and the
+  token-refresh (64), upstream websocket connect (128) and compact
+  response-create (64) gates; the usage / reset-credits fetch timeout (10 s)
+  and retry budget (2), the usage refresh interval (60 s) with its derived
+  freshness horizon, the usage auth-failure cooldown (300 s) and the
+  reset-credits polling interval (60 s); the always-on switches for usage
+  refresh, live usage ingestion, sticky-session cleanup, the model registry
+  and the quota planner scheduler (the dashboard `quota_planner_settings.mode
+  = "off"` remains the only planner switch); the HTTP ingress body budgets
+  (32 MiB general, 128 MiB Responses); inline image fetching (always on, no
+  host allowlist); the public default image model (`gpt-image-2`); and
+  proxy-generated prompt-cache-key derivation (always on). There is no
+  separate upstream compact timeout: the dashboard compact request budget is
+  the only cap.
+
+The following values MUST be derived rather than configured:
+
+- The memory-pressure warning threshold: 80% of the configurable reject
+  threshold (`CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`), with both disabled
+  when the reject threshold is 0.
+- The background-task database engine's pool size and max overflow: always
+  taken from `database_pool_size` and `database_max_overflow`.
+
+The following values MUST be owned by the dashboard runtime settings alone,
+with the first-created settings row taking the column defaults (`smart`,
+`1800`, `gpt-5.4-mini`, `false`) instead of an environment seed:
+`http_downstream_transport_policy`, `openai_cache_affinity_max_age_seconds`,
+`warmup_model`, and `http_responses_session_bridge_gateway_safe_mode`. The
+retention windows (`request_log_retention_days`,
+`usage_history_retention_days`) MUST be dashboard runtime settings with no
+environment alias (see `data-retention`).
+
+Incident-debugging trace logging SHALL be controlled by the single
+`CODEX_LB_TRACE` comma-separated channel list, whose empty default disables
+all trace channels. The Codex HTTP-bridge prewarm rollout scoping SHALL NOT
+be operator-configurable: prewarm eligibility MUST be the single
+`http_responses_session_bridge_codex_prewarm_enabled` switch alone, with no
+canary sampling percent and no API-key allow/deny cohort lists. That switch
+MUST be a dashboard runtime setting (a nullable `dashboard_settings` column of
+the same name, NULL on the first-created row and never seeded from the
+environment) whose
+`CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED` variable is a
+deprecated alias that applies only while the column is NULL and that joins the
+removed-settings warning list in the next minor release. The bridge MUST
+resolve the switch before it takes a session's prewarm lock, from the dashboard
+overrides the request entry point already bound. The prewarm's own helpers
+MUST NOT read the dashboard row for themselves while that lock is held: the
+values the response-create admission gate needs (account concurrency caps and
+routing tunables) and the row the reconnect on the prewarm timeout path
+resolves MUST come from one snapshot taken before the lock and passed in, and
+that snapshot MUST be resolved only when a warm-up will actually be sent. If
+that snapshot cannot be loaded, the bridge MUST fall back to the last
+dashboard row the replica loaded, exactly as the request entry point does, and
+where no row has ever been loaded it MUST skip the prewarm rather than serve
+it without a snapshot; a prewarm MUST NOT fail a request the bridge can
+otherwise serve. Work the recovery path reaches beyond those two helpers --
+account selection, token refresh, and upstream route resolution, each with its
+own settings read or database session -- is out of scope for this requirement
+and keeps its existing behaviour.
+`database_pool_size` and `database_max_overflow` MUST remain
+operator-configurable settings, and `soft_drain_enabled` and
+`deterministic_failover_enabled` MUST remain the failover subsystem's only
+enable switches. Those two switches and `circuit_breaker_enabled` MUST be
+dashboard runtime settings (`dashboard_settings` columns of the same name,
+NULL on the first-created row; see `account-routing` and
+`outbound-http-clients`) whose `CODEX_LB_*` variables are deprecated aliases
+that apply only while the column is NULL and that join the removed-settings
+warning list in the next minor release.
+
+#### Scenario: Removed env vars are ignored with one startup warning
+
+- **GIVEN** a deployment whose environment still sets removed settings such
+  as `CODEX_LB_REQUEST_LOG_RETENTION_DAYS` and
+  `CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS`
+- **WHEN** the application starts
+- **THEN** startup succeeds and the dashboard runtime values are used
+- **AND** exactly one warning log lists both removed names without their
+  values
+
+#### Scenario: Clean environment starts without removal warnings
+
+- **GIVEN** a deployment that sets no removed setting names
+- **WHEN** the application starts
+- **THEN** no removed-settings warning is logged
+
+#### Scenario: Names past their warning release are silently inert
+
+- **GIVEN** a deployment whose environment still sets names removed in an
+  earlier batch, such as `CODEX_LB_AUTH_BASE_URL`,
+  `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS`, or
+  `CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS`
+- **WHEN** the application starts
+- **THEN** startup succeeds, the fixed built-in values are used
+- **AND** no removed-settings warning is logged for those names
+
+#### Scenario: Trace channels default to off
+
+- **GIVEN** a default install with `CODEX_LB_TRACE` unset
+- **WHEN** the proxy serves requests
+- **THEN** no request-shape, payload, service-tier, or upstream trace logs
+  are emitted
+
+#### Scenario: A trace channel can be enabled for an incident
+
+- **GIVEN** `CODEX_LB_TRACE=shape,upstream_payload`
+- **WHEN** the proxy serves requests
+- **THEN** request-shape and upstream-payload trace logs are emitted while
+  all other trace channels stay off
+
+#### Scenario: Memory warning threshold derives from the reject threshold
+
+- **GIVEN** `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB=100`
+- **WHEN** process RSS reaches 80 MiB
+- **THEN** a memory warning is logged while requests continue to be served
+- **AND** requests are rejected with 503 only once RSS reaches 100 MiB
+
+#### Scenario: Memory guard stays fully disabled by default
+
+- **GIVEN** a default install with `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`
+  unset (0)
+- **WHEN** the proxy serves requests under any memory usage
+- **THEN** no memory warning is logged and no request is rejected for
+  memory pressure
+
+#### Scenario: Helm chart renders no removed settings
+
+- **GIVEN** a Helm install using the chart's default values
+- **WHEN** the config map is rendered
+- **THEN** it contains no `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS`,
+  `CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD`, or
+  `CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS` entries
+- **AND** startup emits no removed-settings warning
+
+#### Scenario: Dashboard-owned columns seed from their defaults
+
+- **GIVEN** a fresh database and `CODEX_LB_WARMUP_MODEL=gpt-5.4-nano` still
+  set in the environment
+- **WHEN** the dashboard settings row is created for the first time
+- **THEN** `warmup_model` is `gpt-5.4-mini`, `http_downstream_transport_policy`
+  is `smart`, and `openai_cache_affinity_max_age_seconds` is `1800`
+- **AND** the startup warning names `CODEX_LB_WARMUP_MODEL`
+
+#### Scenario: Fresh database bootstrap ignores a removed variable
+
+- **GIVEN** an empty database and
+  `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS=64` still set in the
+  environment
+- **WHEN** the Alembic chain is upgraded to head
+- **THEN** the seeded `dashboard_settings` row has
+  `openai_cache_affinity_max_age_seconds` `1800`
+- **AND** no migration reads the removed variable
+
+#### Scenario: Removed names are matched case-insensitively
+
+- **GIVEN** a deployment whose environment sets `codex_lb_warmup_model`
+  in lowercase (which the former field honoured)
+- **WHEN** the application starts
+- **THEN** the startup warning lists `CODEX_LB_WARMUP_MODEL`
+
+#### Scenario: Background pool sizing derives from the main pool settings
+
+- **GIVEN** `CODEX_LB_DATABASE_POOL_SIZE=12` and
+  `CODEX_LB_DATABASE_MAX_OVERFLOW=4` on a PostgreSQL deployment
+- **WHEN** the application creates the background-task database engine
+- **THEN** the background engine uses pool size 12 and max overflow 4
+- **AND** no separate background pool sizing can be configured
+
+#### Scenario: Drain and probe thresholds are fixed constants
+
+- **GIVEN** a deployment with `soft_drain_enabled` left at its default
+- **WHEN** an account's primary window usage reaches 85%
+- **THEN** the account enters the draining health tier
+- **AND** a drained account enters the probing tier only after the fixed
+  60-second quiet window, regardless of any `CODEX_LB_PROBE_QUIET_SECONDS`
+  value still present in the environment
+
+#### Scenario: Prewarm stays off by default
+
+- **GIVEN** a default install with no prewarm variables set and the dashboard
+  prewarm switch unset (NULL)
+- **WHEN** Codex bridge requests are served
+- **THEN** no session prewarm is attempted and visible requests record
+  `prewarm_status=not_applicable`
+
+#### Scenario: Prewarm eligibility is the enabled flag alone
+
+- **GIVEN** the Codex session prewarm switch is on, either in the dashboard or
+  through `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED=true`
+  while the dashboard value is unset
+- **WHEN** a first-turn Codex bridge request arrives on a session that has
+  not been prewarmed
+- **THEN** the session prewarm is attempted for that request
+- **AND** no request is excluded by canary sampling or an allow/deny cohort
+
+#### Scenario: A prewarm's own helpers read no settings under its lock
+
+- **GIVEN** the Codex session prewarm switch is on in the dashboard
+- **WHEN** a session prewarm runs its body under the prewarm lock -- the
+  warm-up request built, response-create admission taken for it, and the
+  warm-up sent upstream to a stream that completes
+- **THEN** the dashboard settings row is read once, before the lock is taken
+- **AND** the admission gate takes no settings read of its own while the lock
+  is held, and that path opens no database session
+
+#### Scenario: An unreadable settings row does not fail the request
+
+- **GIVEN** the Codex session prewarm switch is on and the settings row cannot
+  be loaded when a first-turn Codex bridge request arrives
+- **WHEN** the bridge resolves its pre-lock snapshot
+- **THEN** the last dashboard row this replica loaded is used and the prewarm
+  proceeds
+- **AND** where no row has ever been loaded, the prewarm records
+  `prewarm_status=skipped` and the request is still served
+
+#### Scenario: A payload with no warm-up resolves no snapshot
+
+- **GIVEN** the Codex session prewarm switch is on and a first-turn Codex
+  bridge request whose payload yields no warm-up to send
+- **WHEN** the bridge evaluates the prewarm
+- **THEN** it records `prewarm_status=skipped` without reading the dashboard
+  settings row at all
+
+#### Scenario: Prewarm env alias applies only until the dashboard sets a value
+
+- **GIVEN** `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED=true`
+  and a `dashboard_settings` row whose
+  `http_responses_session_bridge_codex_prewarm_enabled` column is NULL
+- **WHEN** an operator turns the Codex session prewarm off in the dashboard
+- **THEN** the next new Codex bridge session on every replica is served
+  without a prewarm and without a restart, and the settings API reports
+  `source: "dashboard"`
+- **AND** clearing the dashboard value returns to the environment alias
+  (`source: "env"`) until that alias is removed in the next minor release
+
+#### Scenario: Resilience toggle env aliases apply only until the dashboard sets a value
+
+- **GIVEN** `CODEX_LB_CIRCUIT_BREAKER_ENABLED=true` and a `dashboard_settings`
+  row whose `circuit_breaker_enabled` column is NULL
+- **WHEN** an operator sets the circuit breaker off in the dashboard
+- **THEN** the next request runs with the breaker off on every replica without
+  a restart, and the settings API reports `source: "dashboard"`
+- **AND** clearing the dashboard value returns to the environment alias
+  (`source: "env"`) until that alias is removed in the next minor release

--- a/openspec/changes/prewarm-snapshot-only-when-eligible/tasks.md
+++ b/openspec/changes/prewarm-snapshot-only-when-eligible/tasks.md
@@ -1,0 +1,23 @@
+## 1. Regression coverage
+
+- [x] 1.1 Prove a payload with no warm-up to send resolves no snapshot, reads
+  no settings and opens no database session, while still recording
+  `prewarm_status=skipped` under the lock with the session marked prewarmed.
+- [x] 1.2 Prove the eligible path is unchanged: one pre-lock read, none while
+  the lock is held.
+- [x] 1.3 Prove the prewarm timeout path hands the admission gate and the
+  reconnect that exact snapshot object, and that it is the only settings read.
+
+## 2. Implementation
+
+- [x] 2.1 Build the warm-up before the lock and resolve the snapshot only when
+  one will be sent.
+- [x] 2.2 Keep the locked body's `session.prewarmed` bookkeeping and skip
+  statuses byte-for-byte identical.
+
+## 3. Verification
+
+- [x] 3.1 Run the HTTP-bridge and proxy-utils unit suites and the bridge
+  integration suite.
+- [x] 3.2 Run Ruff, Ty, strict OpenSpec validation, and an archive simulation
+  that archives `no-settings-reads-under-prewarm-lock` first.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3727,6 +3727,64 @@ async def test_maybe_prewarm_http_bridge_session_success_path_reads_no_settings_
     session_factory.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_maybe_prewarm_http_bridge_session_reads_no_settings_for_an_ineligible_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A payload with no warm-up to send resolves no snapshot and reads nothing.
+
+    Neither reader the snapshot exists for -- the admission gate and the
+    reconnect -- is reached when there is nothing to send, so resolving it
+    would be pure cost and a needless failure surface on a request that is
+    served normally either way. Before the snapshot existed this path took no
+    settings read at all, and it still takes none.
+    """
+    from unittest.mock import MagicMock
+
+    import app.core.config.settings_cache as settings_cache_module
+    from app.core.config.settings_cache import SettingsCache
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    # ``generate: false`` already: nothing to warm up.
+    state, session = _make_prewarm_candidate(_PREWARM_SHAPED_TEXT)
+    lock = _SpyPrewarmLock()
+    session.prewarm_lock = cast(Any, lock)
+    service._http_bridge_sessions[session.key] = session
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: with_dashboard_overrides(_make_app_settings()))
+
+    row = DashboardSettings()
+    row.http_responses_session_bridge_codex_prewarm_enabled = True
+    cache = SettingsCache()
+    cache._cached_settings = row
+    cache._cached_at = time.monotonic()
+    session_factory = MagicMock(side_effect=AssertionError("prewarm path must not open a DB session"))
+    monkeypatch.setattr(settings_cache_module, "SessionLocal", session_factory)
+    reads: list[str] = []
+    real_get = cache.get
+
+    async def spying_get() -> DashboardSettings:
+        reads.append(sys._getframe(1).f_code.co_name)
+        return await real_get()
+
+    monkeypatch.setattr(cache, "get", spying_get)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: cache)
+
+    with dashboard_overrides_bound(row):
+        await service._maybe_prewarm_http_bridge_session(
+            session,
+            request_state=state,
+            text_data=state.request_text or "{}",
+        )
+
+    # The skip is recorded exactly as before -- under the lock, with the
+    # session marked prewarmed -- and no snapshot was resolved for it.
+    assert state.prewarm_status == "skipped"
+    assert session.prewarmed is True
+    assert lock.enter_count == 1
+    assert reads == []
+    session_factory.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("stale_row_available", "expected_status", "expected_prewarmed"),
     [(True, "success", True), (False, "skipped", False)],

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8,6 +8,7 @@ import json
 import logging
 import socket
 import ssl
+import sys
 import time
 from collections import deque
 from collections.abc import Callable, Mapping, Sequence
@@ -49967,6 +49968,21 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_PREWARM_RESPONSE_TIMEOUT_SECONDS", 0.05)
+    # The one row the prewarm resolves before its lock. Both helpers under the
+    # lock must receive this exact object rather than reading their own, so the
+    # assertions below compare by identity and pin the read's call site.
+    expected_snapshot = settings
+    settings_reads: list[str] = []
+
+    async def snapshot_get() -> Any:
+        settings_reads.append(sys._getframe(1).f_code.co_name)
+        return expected_snapshot
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(get=snapshot_get, cached_row=lambda: expected_snapshot),
+    )
     reconnect_observations: list[dict[str, object]] = []
     admission_observations: list[dict[str, object]] = []
     original_acquire_admission = service._acquire_request_state_response_create_admission
@@ -49987,7 +50003,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
                 "account_id": account_id,
                 "surface": surface,
                 # The prewarm resolves this before its lock and threads it in.
-                "dashboard_settings_supplied": dashboard_settings is not None,
+                "dashboard_settings": dashboard_settings,
             }
         )
         await original_acquire_admission(
@@ -50015,7 +50031,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
                 "pending_request_ids": [state.request_id for state in reconnect_session.pending_requests],
                 "request_id": request_state.request_id,
                 "restart_reader": restart_reader,
-                "dashboard_settings_supplied": dashboard_settings is not None,
+                "dashboard_settings": dashboard_settings,
             }
         )
         reconnect_session.upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -50045,16 +50061,20 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
             "request_id": prewarm_admission["request_id"],
             "account_id": "acc_prewarm_timeout",
             "surface": "http_bridge_prewarm",
-            "dashboard_settings_supplied": True,
+            "dashboard_settings": expected_snapshot,
         }
     ]
     assert cast(str, prewarm_admission["request_id"]).startswith("http_prewarm_")
     observation = reconnect_observations[0]
     assert observation["request_id"] == "req_prewarm_timeout"
     assert observation["restart_reader"] is True
-    # Both helpers run under ``prewarm_lock`` and are handed the snapshot the
-    # prewarm resolved before taking it, so neither reads settings there.
-    assert observation["dashboard_settings_supplied"] is True
+    # Both helpers run under ``prewarm_lock`` and are handed the very snapshot
+    # the prewarm resolved before taking it ...
+    assert observation["dashboard_settings"] is expected_snapshot
+    assert admission_observations[0]["dashboard_settings"] is expected_snapshot
+    # ... which is the only settings read on the path, and it happened before
+    # the lock, in the prewarm helper itself.
+    assert settings_reads == ["_maybe_prewarm_http_bridge_session"]
     pending_request_ids = cast(list[str], observation["pending_request_ids"])
     assert len(pending_request_ids) == 1
     assert pending_request_ids[0].startswith("http_prewarm_")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -49970,14 +49970,28 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     monkeypatch.setattr(proxy_service, "_PREWARM_RESPONSE_TIMEOUT_SECONDS", 0.05)
     # The one row the prewarm resolves before its lock. Both helpers under the
     # lock must receive this exact object rather than reading their own, so the
-    # assertions below compare by identity and pin the read's call site.
+    # assertions below compare by identity, pin the read's call site, and -- via
+    # one shared event log with the lock -- pin that it happened first.
     expected_snapshot = settings
-    settings_reads: list[str] = []
+    events: list[str] = []
 
     async def snapshot_get() -> Any:
-        settings_reads.append(sys._getframe(1).f_code.co_name)
+        events.append(f"read:{sys._getframe(1).f_code.co_name}")
         return expected_snapshot
 
+    class _RecordingPrewarmLock:
+        def __init__(self) -> None:
+            self._lock = anyio.Lock()
+
+        async def __aenter__(self) -> None:
+            await self._lock.acquire()
+            events.append("lock_acquired")
+
+        async def __aexit__(self, *exc: object) -> None:
+            events.append("lock_released")
+            self._lock.release()
+
+    session.prewarm_lock = cast(Any, _RecordingPrewarmLock())
     monkeypatch.setattr(
         proxy_service,
         "get_settings_cache",
@@ -50072,9 +50086,10 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     # the prewarm resolved before taking it ...
     assert observation["dashboard_settings"] is expected_snapshot
     assert admission_observations[0]["dashboard_settings"] is expected_snapshot
-    # ... which is the only settings read on the path, and it happened before
-    # the lock, in the prewarm helper itself.
-    assert settings_reads == ["_maybe_prewarm_http_bridge_session"]
+    # ... which is the only settings read on the path, taken by the prewarm
+    # helper itself and -- ordering asserted directly, not inferred from the
+    # caller -- strictly before the lock was acquired.
+    assert events == ["read:_maybe_prewarm_http_bridge_session", "lock_acquired", "lock_released"]
     pending_request_ids = cast(list[str], observation["pending_request_ids"])
     assert len(pending_request_ids) == 1
     assert pending_request_ids[0].startswith("http_prewarm_")


### PR DESCRIPTION
## Summary

Completes #2335. That PR moved the Codex HTTP-bridge prewarm's dashboard-settings read out of `prewarm_lock`, but it resolves the snapshot **before** the warm-up payload has been built — so a payload that yields no warm-up now takes a settings read where it previously took none. This makes the read conditional on there actually being a warm-up to send.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [x] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: completes #2335 (follow-up to its post-merge review findings); wedge class of #1971 / #1972.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/prewarm-snapshot-only-when-eligible/`

## Why the read is now conditional

`_build_http_bridge_prewarm_text` returns `None` for a payload that already carries `generate: false`, is not a JSON object, or is otherwise not warm-up shaped. On that path the locked body returns `prewarm_status=skipped` before it ever reaches the two readers the snapshot exists for — the response-create admission gate and the timeout-path reconnect. So the snapshot is resolved for nothing:

- on a cached hit, a wasted `await` on a hot first-turn path;
- on an expired TTL, an actual database query behind the settings cache's process-global lock;
- and a needless failure surface — handled by #2335's `cached_row()` fallback, but still exercised — on a request that is served normally either way.

Before #2335 this path read no settings at all. It reads none again.

Moving the build out also takes the payload parse off the critical section, which is the same reason the lock is being kept short in the first place.

## Why the locked body is unchanged

`_build_http_bridge_prewarm_text` is a pure function of `text_data`, which does not change across the lock, so hoisting it cannot change the answer. The locked body still:

- re-checks `session.prewarmed` (the concurrent-prewarm race guard) and returns `skipped`,
- sets `session.prewarmed = True`,
- returns `skipped` when there is no warm-up text.

The only ordering shift is that the build now happens before that re-check rather than after it, so a losing racer does one extra (sync, pure) build instead of parsing under the lock.

## Changes

- `_maybe_prewarm_http_bridge_session`: build the warm-up before `async with prewarm_lock`, and resolve the dashboard snapshot only when `warmup_text is not None`.
- Test: an ineligible payload resolves no snapshot, records `prewarm_status=skipped` under the lock with the session marked prewarmed, reads nothing and opens no DB session.
- Test (CodeRabbit follow-up on #2335): the prewarm-timeout observations now assert the snapshot by **identity** in both helpers and pin `settings_reads == ["_maybe_prewarm_http_bridge_session"]`, instead of only `dashboard_settings is not None` — which could have passed on a different non-`None` snapshot or alongside another read under the lock.

## Simplicity

No new setting, no default change, no README/nav surface. One hoisted pure call and one `if`.

## Test plan

The new ineligible-payload test fails without the app change (verified with `request_submit.py` reverted to `origin/main` in a scratch copy, not in the branch):

```
FAILED tests/unit/test_proxy_http_bridge.py::test_maybe_prewarm_http_bridge_session_reads_no_settings_for_an_ineligible_payload
  assert ['_maybe_prewarm_http_bridge_session'] == []
1 failed, 1 passed
```

```
make lint                                             # ruff + format + architecture/cancellation/timing/settings-tier guards: pass
uv run ty check                                       # All checks passed!
uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py -q   # 2462 passed
uv run pytest tests/integration/test_http_responses_bridge.py -q                       # 185 passed
uv run openspec validate prewarm-snapshot-only-when-eligible --strict   # valid
uv run openspec validate --specs --strict                              # 65 passed, 0 failed
```

Archive simulation on a temp copy of current main's `openspec/`: `no-settings-reads-under-prewarm-lock` (merged in #2335, still unarchived on main) archives first, then this change; both apply cleanly, re-validate 65/65, and the net spec diff is #2335's requirement rewording plus this change's one clause and one scenario. Because this delta's text is a superset of #2335's, archiving the two in **either** order converges on the same spec — also verified by simulation.

## Screenshots / output

No user-visible surface: `prewarm_status` outcomes, metrics and logs are unchanged.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make lint` / `uv run ty check` / pytest subsets locally.
- [x] If touching specs: `openspec validate --specs --strict` passes, plus an archive simulation.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is **not** edited by hand.
