### PR TITLE
chore: release v1.25.0-beta.8

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.25.0-beta.7"  # x-release-please-version
+__version__ = "1.25.0-beta.8"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.25.0-beta.7
-appVersion: 1.25.0-beta.7
+version: 1.25.0-beta.8
+appVersion: 1.25.0-beta.8
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.25.0-beta.7",
+  "version": "1.25.0-beta.8",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.25.0-beta.7"
+version = "1.25.0-beta.8"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.25.0-beta.7"
+version = "1.25.0-beta.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.25.0-beta.8 for the 1.25.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.25.0-beta.8 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1922; no manual beta workflow dispatch is required.

## Changes since v1.25.0-beta.7
- fix(db): retry the startup sentinel seed on SQLite lock contention and name the lock error (#2339) (
1f3428)
- perf(bridge): resolve the prewarm snapshot only for eligible payloads (#2340) (
c52941)
- feat(settings): manage the bridge operation spool retention from the dashboard (#2337) (
6d11e5)
- feat(auth)!: add resource-scoped dashboard permission vocabulary (#2196) (
955960)
- feat(auth): restrict guest-visible sensitive surfaces and make guest sessions revocable (#2201) (
d6a7ca)
- feat(dashboard): hide restricted surfaces from read-only guests (#2203) (
478e96)
- feat(auth): reject cross-site dashboard mutations and start the client least-privilege (#2204) (
e04005)
- feat(auth): add dashboard role rows with code-defined preset grants (#2217) (
08f963)
- feat(auth): add dashboard user tables and migrate the shared admin into a user (#2218) (
195b33)
- feat(auth): make dashboard users the source of truth for login and sessions (#2223) (
9cfce7)
- feat(audit): record the acting account, target and severity on audit rows (#2225) (
8e5760)
- feat(users): add account management, invite links and the roles read API (#2226) (
561311)
- feat(frontend): tier the login form and header by account facts, add the invite route (#2237) (
04a309)
- feat(frontend): fold the auth cards into one Access card that grows with the team (#2251) (
53253c)
- feat(auth): enable the operator and viewer presets end to end, require TOTP for admin-level accounts (#2328) (
aa75e1)
- feat(auth): resolve trusted-header identities to accounts through sign-in providers (#2331) (
94fb4d)
- feat(auth): re-verify a credential before sensitive dashboard changes (#2334) (
c9d544)
- feat(auth): map identity-provider groups to roles and add the organisation settings group (#2358) (
4096c1)
- fix(overflow): keep a delivered source turn anchored before the first content frame (#2354) (
9368d4)
- feat(dashboard): surface subscription-overflow attribution in the request log and dashboard (#2123 WP-G) (#2355) (
21eedb)
- feat(proxy): persist hashed affinity decisions on request logs (#2352) (
e32f85)
- fix(proxy): retire a denied proxy-injected WebSocket anchor instead of re-injecting it (#2248) (
6b3d03)
- fix(images): select compatible host for images and probes (#2320) (
92c7f6)
- fix(http-bridge): reuse reservation during local recovery (#2353) (
98d225)
- fix(proxy): bound aggregate detached retirement lock waits (#2315) (
09b8e8)
- fix(db): merge the pin-index and affinity alembic heads (#2368) (
53f968)
- fix(balancer): count bare server_error terminals toward overload backoff (#2360) (
7f7929)
- fix(proxy): route anonymous output frames to the created response (#2357) (
976d20)
- fix(accounts): let the deletion scheduler exit its wait promptly (#2362) (
c62bdd)
- revert(bridge): restore the recovery-dispatch claim and its fence (#2383) (
a096b6)
- fix(proxy): fork model-transition owner conflicts (#2083) (
9db05a)
- fix(proxy): narrow the input-image upstream transport pin (#2386) (
cb21da)
- fix(proxy): deliver the denied-anchor refusal to native clients (#2387) (
b04b27)
- fix(balancer): stop waiting on a hard affinity owner the caller excluded (#2381) (
2c8539)
- fix(http-bridge): bound terminal spool writes (#1997) (
3d9027)
- feat(auth): gate local password sign-in behind a policy and protect break-glass access (#2385) (
133085)
- fix(observability): derive sticky_key_source once, from the resolved policy (#2375) (
cc25f2)
- fix(proxy): anchor unanchored HTTP threads to a stable cache key (#2367) (
ef7010)
- feat(dashboard): surface thread identity and cache locality metrics (#2378) (
b36e5a)
- feat(dashboard): add a cross-account prompt cache isolation probe (#2372) (
825675)
- fix(proxy): attribute refused cross-account continuity replays (#2384) (
63314a)
- fix(proxy): retire durably unroutable bridge continuity owners (#2390) (
10cd71)
- feat(proxy): add shared/isolated thread cache identity modes (default shared) (#2376) (
883c91)
- fix(proxy): retire a continuity owner that cannot return in time (#2397) (
2852cf)
- fix(db): converge the forked thread-cache and bridge-retirement heads (#2400) (
d28b3a)

## Release-candidate validation
Validated candidate: 00416007e0514e5c0c8923735345f017174c2f0b

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run [34689947135](https://github.com/Soju06/codex-lb/actions/runs/34689947135) on this SHA: `Tests (pytest, unit)`, `integration-core-1..3`, `integration-bridge`, `e2e`, `PostgreSQL`, plus `Migration check (alembic)` and `Migration check (alembic, PostgreSQL)` — all pass.
- [x] Frontend tests/build — same run: `Frontend tests (vitest + coverage)`, `Frontend build (vite)`, `Frontend type check (tsc)`, `Frontend lint (eslint)` — all pass.
- [x] Wheel/package validation — same run: `Package (build)` passes.
- [x] Docker/container smoke — same run: `Docker build`, `Helm lint + template + kubeconform` and `Helm smoke install (kind)` pass; `Dashboard browser smoke (Playwright)` also passes against the built dashboard.
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required **before merge** — the container image for this candidate does not exist until this PR is merged and the tag is published, so a live upstream smoke cannot bind to this SHA beforehand. It is instead run against production immediately after the deploy of `1.25.0-beta.8`, and the result is reported back on this PR. 39 of 40 checks on this SHA are green; the only red one is this guard.

## Install after publish
```bash
uvx --from "codex-lb==1.25.0b8" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.25.0-beta.8
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.25.0-beta.8 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.25.0.