### PR TITLE
test: stub ambient account deletion scheduler

### DIFF
--- a/scripts/run_dashboard_browser_smoke.py
+++ b/scripts/run_dashboard_browser_smoke.py
@@ -40,6 +40,7 @@ BACKGROUND_LOOP_BUILDERS: tuple[str, ...] = (
     "build_account_usage_rollup_scheduler",
     "build_data_retention_scheduler",
     "build_telemetry_scheduler",
+    "build_account_deletion_scheduler",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ BACKGROUND_LOOP_BUILDERS: tuple[str, ...] = (
     "build_account_usage_rollup_scheduler",
     "build_data_retention_scheduler",
     "build_telemetry_scheduler",
+    "build_account_deletion_scheduler",
 )
 
 

--- a/tests/integration/test_account_deletion_lifespan.py
+++ b/tests/integration/test_account_deletion_lifespan.py
@@ -1,0 +1,45 @@
+"""Explicit opt-in to real deletion work through the app lifespan."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.main as main_module
+import app.modules.accounts.deletion as deletion_module
+from app.db.models import Account
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from tests.integration.test_account_deletion_background import _seed_account
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_lifespan_can_opt_into_real_account_deletion(app_instance, monkeypatch):
+    # The real builder publishes a wake target. Restore it after this test too.
+    monkeypatch.setattr(deletion_module, "_scheduler", None)
+    schedulers: list[deletion_module.AccountDeletionScheduler] = []
+
+    def build_scheduler() -> deletion_module.AccountDeletionScheduler:
+        scheduler = deletion_module.build_account_deletion_scheduler()
+        schedulers.append(scheduler)
+        return scheduler
+
+    monkeypatch.setattr(main_module, "build_account_deletion_scheduler", build_scheduler)
+    account_id = "acc_lifespan_deletion"
+    await _seed_account(account_id, log_count=1, usage_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete(account_id)
+
+    async with app_instance.router.lifespan_context(app_instance):
+        assert len(schedulers) == 1
+        async with asyncio.timeout(5):
+            while True:
+                async with SessionLocal() as session:
+                    if await session.get(Account, account_id) is None:
+                        break
+                await asyncio.sleep(0.01)
+
+    assert schedulers[0]._task is None

--- a/tests/unit/test_background_loop_harness.py
+++ b/tests/unit/test_background_loop_harness.py
@@ -28,7 +28,6 @@ from tests.conftest import BACKGROUND_LOOP_BUILDERS, _NoopScheduler
 LIVE_MAINTENANCE_LOOP_BUILDERS: tuple[str, ...] = (
     "build_api_key_limit_reset_scheduler",
     "build_api_key_last_used_flush_scheduler",
-    "build_account_deletion_scheduler",
 )
 
 # ``CODEX_LB_*_ENABLED`` toggles the harness used to export as ``false``. They
@@ -68,6 +67,7 @@ def test_background_loop_seam_is_explicit_and_complete() -> None:
         "build_account_usage_rollup_scheduler",
         "build_data_retention_scheduler",
         "build_telemetry_scheduler",
+        "build_account_deletion_scheduler",
     )
     patched = set(BACKGROUND_LOOP_BUILDERS)
     live = set(LIVE_MAINTENANCE_LOOP_BUILDERS)
@@ -76,6 +76,14 @@ def test_background_loop_seam_is_explicit_and_complete() -> None:
         "app.main imports a build_*_scheduler that tests/conftest.py neither patches nor "
         "classifies as an always-on maintenance loop"
     )
+
+
+@pytest.mark.asyncio
+async def test_ambient_account_deletion_scheduler_is_noop() -> None:
+    scheduler = main_module.build_account_deletion_scheduler()
+    assert isinstance(scheduler, _NoopScheduler)
+    assert await scheduler.start() is None
+    assert await scheduler.stop() is None
 
 
 def test_every_patched_builder_is_started_by_the_lifespan() -> None:


### PR DESCRIPTION
## Summary

Stub the ambient account-deletion scheduler through the existing test fixture so unrelated lifespans cannot start its real database work or interval timer. Explicit deletion tests can still restore the real builder.

## Type of change

- [x] `test:` — test-only change

Linked issue: Fixes #2338

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Test-harness isolation only. The account-deletion production requirements, scheduler, startup retries, and prewarm behavior are unchanged.

## Changes

- Move the deletion builder from the live-maintenance allowance into the shared no-op fixture and mirror it in the browser-smoke backend.
- Pin its ambient no-op contract with a deterministic regression.
- Exercise an explicit real-builder lifespan that drains a pending account and stops its task. Existing deletion-pass tests and bridge-capacity/singleflight shutdown assertions remain unchanged.

## Test plan

Both database variables pointed to the same dedicated disposable SQLite file before imports. Main, background, and fixture engines were checked against it.

- Before the fixture fix, the harness tests reported **2 failed, 4 passed**. The new regression received a real `AccountDeletionScheduler(interval_seconds=30)` instead of the no-op.
- After the fix, the harness tests plus the named bridge-capacity/singleflight shutdown test reported **7 passed**.
- The bounded named shutdown control took 0.17 s before and 0.10 s after. This run did **not** reproduce the natural timer stall; the deterministic ambient-builder contract is the regression proof. No conclusion about #1949's separate SQLite lock failures.

```bash
uv run pytest tests/integration/test_account_deletion_lifespan.py \
  tests/integration/test_account_deletion_background.py \
  tests/integration/test_accounts_api_extended.py tests/unit/test_otel.py \
  tests/unit/test_background_loop_harness.py -q --timeout=60 --durations=10
# 117 passed, 3 PostgreSQL-only tests skipped
make lint typecheck
# passed
pnpm dlx @fission-ai/openspec@1.11.0 validate --specs --strict
# 65 passed
.venv/bin/python .github/scripts/check_simplicity_budgets.py
# passed
```

Independent review found no actionable findings against base `3b4222a08561f2e948e212535680cf3f1773252d`. Validation used the relevant local subset; full CI and PostgreSQL checks remain hosted gates.

The first hosted unit run caught a missing browser-smoke tuple update. The unchanged parity test reproduced locally as 1 failure. After aligning that builder list, the smoke harness tests, background harness tests, original shutdown control, and explicit real-deletion lifespan test passed: 16 passed. `make lint typecheck` and independent repair review also passed. All parity and shutdown assertions remain intact.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local check subset.
- [x] Simplicity gates reviewed; no settings, product defaults, navigation, or README additions.
- [x] CHANGELOG is not edited by hand.

