### PR TITLE
fix(proxy): preserve local quarantine evidence during completion

### DIFF
--- a/app/modules/proxy/_service/http_bridge/quarantine.py
+++ b/app/modules/proxy/_service/http_bridge/quarantine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import weakref
 from dataclasses import dataclass
 from typing import Any
 
@@ -44,6 +45,10 @@ _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON = "retry_circuit_poisoned_anchor"
 @dataclass(slots=True)
 class _HTTPBridgeQuarantineEntry:
     generation: int = 0
+    owner_ref: weakref.ReferenceType[_HTTPBridgeSession] | None = None
+    local_failure_generation: int = 0
+    local_poison_generation: int = 0
+    local_poison_until: float = 0.0
     quarantined_until: float = 0.0
     consecutive_eventless_timeouts: int = 0
     last_touched_monotonic: float = 0.0
@@ -75,6 +80,53 @@ def _http_bridge_quarantine_registry(
         registry = {}
         service._http_bridge_quarantined_keys = registry
     return registry
+
+
+def _http_bridge_local_failure_fence(service: Any) -> int:
+    return getattr(service, "_http_bridge_quarantine_sequence", 0)
+
+
+def _next_http_bridge_quarantine_generation(service: Any) -> int:
+    generation = _http_bridge_local_failure_fence(service) + 1
+    service._http_bridge_quarantine_sequence = generation
+    return generation
+
+
+def _http_bridge_quarantine_owned_by(
+    service: Any, session: _HTTPBridgeSession, entry: _HTTPBridgeQuarantineEntry
+) -> bool:
+    current = getattr(service, "_http_bridge_sessions", {}).get(session.key)
+    if current is not None:
+        return current is session
+    return entry.owner_ref is not None and entry.owner_ref() is session
+
+
+def _retain_http_bridge_local_failure(service: Any, entry: _HTTPBridgeQuarantineEntry, cutoff: int, now: float) -> bool:
+    """Subtract settled poison while retaining independent local evidence."""
+    if entry.local_failure_generation <= cutoff:
+        return False
+    poison_until = entry.local_poison_until if entry.local_poison_generation > cutoff else 0.0
+    weaker_until = entry.suppressed_weaker_until
+    weaker_reason = entry.suppressed_weaker_reason
+    if entry.reason != _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON:
+        return True
+    if poison_until <= now:
+        entry.local_poison_generation = 0
+        entry.local_poison_until = 0.0
+    entry.poison_quarantined_until = poison_until
+    entry.poison_generation = entry.local_poison_generation if poison_until > now else 0
+    if poison_until > now:
+        entry.quarantined_until = max(poison_until, weaker_until)
+    elif weaker_reason is not None and weaker_until > now:
+        entry.reason = weaker_reason
+        entry.quarantined_until = weaker_until
+        entry.suppressed_weaker_reason = None
+        entry.suppressed_weaker_until = 0.0
+    else:
+        entry.reason = None
+        entry.quarantined_until = 0.0
+    entry.generation = _next_http_bridge_quarantine_generation(service)
+    return entry.quarantined_until > now or entry.consecutive_eventless_timeouts > 0
 
 
 def _prune_http_bridge_quarantine_registry(
@@ -110,6 +162,8 @@ def _revoke_http_bridge_poison_quarantine(
     generation: int | None,
     restore_reason: str | None = None,
     restore_until: float = 0.0,
+    local_failure_fence: int | None = None,
+    session: _HTTPBridgeSession | None = None,
 ) -> bool:
     """Remove a poison quarantine whose opening did not survive persistence.
 
@@ -138,7 +192,14 @@ def _revoke_http_bridge_poison_quarantine(
         # let disproved poison evidence outlive its revocation.
         and entry.poison_generation == generation
     ):
+        if local_failure_fence is not None:
+            if session is not None and not _http_bridge_quarantine_owned_by(service, session, entry):
+                return False
+            if _retain_http_bridge_local_failure(service, entry, local_failure_fence, clock_for(service).monotonic()):
+                return False
         entry.poison_quarantined_until = 0.0
+        entry.local_poison_generation = 0
+        entry.local_poison_until = 0.0
         if (
             entry.suppressed_weaker_reason is not None
             and entry.suppressed_weaker_until > clock_for(service).monotonic()
@@ -147,12 +208,12 @@ def _revoke_http_bridge_poison_quarantine(
             entry.quarantined_until = entry.suppressed_weaker_until
             entry.suppressed_weaker_reason = None
             entry.suppressed_weaker_until = 0.0
-            entry.generation += 1
+            entry.generation = _next_http_bridge_quarantine_generation(service)
             return True
         if restore_reason is not None and restore_until > clock_for(service).monotonic():
             entry.reason = restore_reason
             entry.quarantined_until = restore_until
-            entry.generation += 1
+            entry.generation = _next_http_bridge_quarantine_generation(service)
             return True
         registry.pop(key, None)
         return True
@@ -231,14 +292,14 @@ def _http_bridge_quarantine_clear_fence(service: Any, key: _HTTPBridgeSessionKey
 
     Poison entries fence on their poison provenance so a weaker arm during
     the completion's durable awaits cannot block the clear; other entries
-    fence on the raw generation. ``None`` records that nothing was active at
+    fence on the raw generation. ``None`` records that no entry was present at
     capture, so a quarantine armed afterwards survives the clear.
     """
     registry = _http_bridge_quarantine_registry(service)
     now = clock_for(service).monotonic()
     _prune_http_bridge_quarantine_registry(registry, now)
     entry = registry.get(key)
-    if entry is None or entry.quarantined_until <= now:
+    if entry is None:
         return None
     if entry.reason == _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON:
         return entry.poison_generation
@@ -251,11 +312,16 @@ def _quarantine_http_bridge_session(
     *,
     reason: str,
     minimum_seconds: float | None = None,
+    durable_adoption: bool = False,
 ) -> None:
     """Quarantine a bridge session that has proven silent/wedged.
 
     Session-scoped only: no account-health writes happen here, and the entry
     is bounded by TTL, a registry size cap, and the healthy-completion clear.
+
+    ``durable_adoption`` records a loaded row without granting cleanup
+    authority over local failures. Its deadline can be removed independently
+    of a newer local poison arm's own deadline.
 
     ``minimum_seconds`` raises the floor for callers whose suppression window
     is itself bounded elsewhere. The default TTL equals the retry circuit's
@@ -273,10 +339,18 @@ def _quarantine_http_bridge_session(
     # the window the weaker evidence earned.
     prior_reason = entry.reason
     prior_quarantined_until = entry.quarantined_until
-    entry.generation += 1
+    entry.generation = _next_http_bridge_quarantine_generation(service)
     ttl_seconds = _HTTP_BRIDGE_QUARANTINE_TTL_SECONDS
     if minimum_seconds is not None:
         ttl_seconds = max(ttl_seconds, minimum_seconds)
+    if not durable_adoption:
+        entry.local_failure_generation = entry.generation
+        entry.owner_ref = weakref.ref(session)
+        if reason == _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON:
+            entry.local_poison_generation = entry.generation
+            entry.local_poison_until = max(entry.local_poison_until, now + ttl_seconds)
+    elif entry.owner_ref is None and isinstance(session, _HTTPBridgeSession):
+        entry.owner_ref = weakref.ref(session)
     entry.quarantined_until = max(entry.quarantined_until, now + ttl_seconds)
     entry.last_touched_monotonic = now
     # The registry holds one entry per key, so a wedged-reattach or
@@ -363,6 +437,9 @@ def _record_http_bridge_quarantine_eventless_timeout(service: Any, session: _HTT
     # not be resurrected into a "consecutive" second strike hours later.
     _prune_http_bridge_quarantine_registry(registry, now)
     entry = registry.setdefault(session.key, _HTTPBridgeQuarantineEntry())
+    entry.generation = _next_http_bridge_quarantine_generation(service)
+    entry.local_failure_generation = entry.generation
+    entry.owner_ref = weakref.ref(session)
     entry.consecutive_eventless_timeouts += 1
     entry.last_touched_monotonic = now
     if entry.consecutive_eventless_timeouts < _HTTP_BRIDGE_QUARANTINE_EVENTLESS_TIMEOUT_THRESHOLD:
@@ -379,29 +456,38 @@ def _clear_http_bridge_quarantine(
     session: _HTTPBridgeSession,
     *,
     key_generation: int | None,
+    local_failure_fence: int | None = None,
     additional_key: _HTTPBridgeSessionKey | None = None,
     additional_key_generation: int | None = None,
+    additional_local_failure_fence: int | None = None,
 ) -> None:
     """A completed response disproves the wedges captured when it settled.
 
-    Each key clears only against the generation fence captured before the
-    completion's durable awaits: a strike arming a new quarantine during
-    those awaits is fresh evidence this response does not disprove, and it
-    survives the clear. A poison entry fences on its own provenance — a
-    weaker arm during the window bumps the raw generation without disproving
+    The early local cutoff protects failures during every completion await.
+    The later generation fence authorizes cleanup of adopted durable evidence
+    only after settlement and registration succeed. A poison entry fences
+    on its own provenance: a weaker arm bumps the raw generation without disproving
     the recovery — and a matched clear downgrades to a concurrent weaker
     fence instead of evicting it.
     """
     registry = _http_bridge_quarantine_registry(service)
     now = clock_for(service).monotonic()
 
-    def clear_fenced(key: _HTTPBridgeSessionKey, captured_generation: int | None) -> bool:
+    def clear_fenced(key: _HTTPBridgeSessionKey, captured_generation: int | None, local_cutoff: int | None) -> bool:
         entry = registry.get(key)
         if entry is None:
             return True
+        if key == session.key and not _http_bridge_quarantine_owned_by(service, session, entry):
+            return False
+        if local_cutoff is not None and entry.local_failure_generation > local_cutoff:
+            if entry.reason != _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON:
+                return False
         if entry.quarantined_until <= now:
-            # An inactive entry still carries the eventless strike counter;
-            # a healthy completion resets it regardless of the fence.
+            if local_cutoff is None:
+                if captured_generation is None or entry.generation != captured_generation:
+                    return False
+            elif entry.generation > local_cutoff:
+                return False
             registry.pop(key, None)
             return True
         fence_generation = (
@@ -411,6 +497,8 @@ def _clear_http_bridge_quarantine(
         )
         if captured_generation is None or fence_generation != captured_generation:
             return False
+        if local_cutoff is not None and _retain_http_bridge_local_failure(service, entry, local_cutoff, now):
+            return entry.quarantined_until <= now
         if (
             entry.reason == _HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON
             and entry.suppressed_weaker_reason is not None
@@ -419,11 +507,14 @@ def _clear_http_bridge_quarantine(
             # The concurrent weaker fence stands on its own evidence:
             # downgrade to it instead of evicting the entry with the
             # disproved poison classification.
+            entry.local_poison_generation = 0
+            entry.local_poison_until = 0.0
+            entry.poison_quarantined_until = 0.0
             entry.reason = entry.suppressed_weaker_reason
             entry.quarantined_until = entry.suppressed_weaker_until
             entry.suppressed_weaker_reason = None
             entry.suppressed_weaker_until = 0.0
-            entry.generation += 1
+            entry.generation = _next_http_bridge_quarantine_generation(service)
             return False
         registry.pop(key, None)
         _log_http_bridge_event(
@@ -437,7 +528,13 @@ def _clear_http_bridge_quarantine(
         )
         return True
 
-    if clear_fenced(session.key, key_generation):
+    origin_cutoff = (
+        additional_local_failure_fence if additional_local_failure_fence is not None else additional_key_generation
+    )
+    if additional_key == session.key:
+        key_generation = additional_key_generation
+        local_failure_fence = origin_cutoff
+    if clear_fenced(session.key, key_generation, local_failure_fence):
         session.quarantined = False
     if additional_key is not None and additional_key != session.key:
-        clear_fenced(additional_key, additional_key_generation)
+        clear_fenced(additional_key, additional_key_generation, origin_cutoff)

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -538,7 +538,9 @@ class _HTTPBridgeRetryCircuitMixin:
                 raise
             key_lock.release()
 
-    async def _load_http_bridge_retry_circuit(self: Any, session: _HTTPBridgeSession) -> bool:
+    async def _load_http_bridge_retry_circuit(
+        self: Any, session: _HTTPBridgeSession, *, local_failure_fence: int | None = None
+    ) -> bool:
         key = session.key
         if key.strength != "hard":
             return True
@@ -617,6 +619,8 @@ class _HTTPBridgeRetryCircuitMixin:
                             self,
                             key,
                             generation=_http_bridge_quarantine_clear_fence(self, key),
+                            local_failure_fence=local_failure_fence,
+                            session=session,
                         )
             return True
 
@@ -724,6 +728,8 @@ class _HTTPBridgeRetryCircuitMixin:
                                 self,
                                 key,
                                 generation=_http_bridge_quarantine_clear_fence(self, key),
+                                local_failure_fence=local_failure_fence,
+                                session=session,
                             )
                 return True
 
@@ -893,12 +899,15 @@ class _HTTPBridgeRetryCircuitMixin:
                 session,
                 reason=_HTTP_BRIDGE_QUARANTINE_POISONED_ANCHOR_REASON,
                 minimum_seconds=_http_bridge_poison_quarantine_minimum_seconds(poison_cooldown_remaining),
+                durable_adoption=True,
             )
         elif revoke_stale_poison_quarantine and _http_bridge_session_key_poison_quarantined(self, key):
             _revoke_http_bridge_poison_quarantine(
                 self,
                 key,
                 generation=_http_bridge_quarantine_clear_fence(self, key),
+                local_failure_fence=local_failure_fence,
+                session=session,
             )
         return True
 
@@ -2155,6 +2164,7 @@ class _HTTPBridgeRetryCircuitMixin:
         settled_detail: str | None = None,
         settled_detail_authoritative: bool = False,
         expected_episode: tuple[float, int, int] | None = None,
+        local_failure_fence: int | None = None,
     ) -> bool:
         """Settle a hard key's retry circuit; ``True`` when settlement held.
 
@@ -2176,6 +2186,7 @@ class _HTTPBridgeRetryCircuitMixin:
                 settled_detail=settled_detail,
                 settled_detail_authoritative=settled_detail_authoritative,
                 expected_episode=expected_episode,
+                local_failure_fence=local_failure_fence,
             )
         finally:
             key_lock.release()
@@ -2187,9 +2198,12 @@ class _HTTPBridgeRetryCircuitMixin:
         settled_detail: str | None = None,
         settled_detail_authoritative: bool = False,
         expected_episode: tuple[float, int, int] | None = None,
+        local_failure_fence: int | None = None,
     ) -> bool:
         key = session.key
-        durable_load_succeeded = await self._load_http_bridge_retry_circuit(session)
+        durable_load_succeeded = await self._load_http_bridge_retry_circuit(
+            session, local_failure_fence=local_failure_fence
+        )
         if expected_episode is not None:
             # The caller settles a specific authorized episode — an
             # abandonment clears only the circuit its abandonment

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -129,6 +129,7 @@ from app.modules.proxy._service.http_bridge.owner_forwarding import (
     _owner_forward_failure_allows_local_recovery,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
+    _http_bridge_local_failure_fence,
     _http_bridge_quarantine_clear_fence,
     _http_bridge_session_key_poison_quarantined,
     _http_bridge_session_key_quarantined,
@@ -2010,6 +2011,7 @@ class _HTTPBridgeStreamingMixin:
         verified_stale_anchor_circuit_key: _HTTPBridgeSessionKey | None = None
         verified_stale_anchor_generation: tuple[int, float, int, float, int, float, float] | None = None
         verified_stale_anchor_quarantine_generation: int | None = None
+        verified_stale_anchor_quarantine_local_failure_fence: int | None = None
 
         def durable_full_resend_retains_required_context() -> bool:
             nonlocal durable_full_resend_retains_required_context_cache
@@ -3233,6 +3235,8 @@ class _HTTPBridgeStreamingMixin:
                 recovery_session: "_HTTPBridgeSession",
             ) -> None:
                 nonlocal verified_stale_anchor_quarantine_generation
+                nonlocal verified_stale_anchor_quarantine_local_failure_fence
+                verified_stale_anchor_quarantine_local_failure_fence = _http_bridge_local_failure_fence(self)
 
                 # Provenance-aware capture: the completion's clear fences a
                 # poison entry on its poison provenance, so capturing the raw
@@ -3905,6 +3909,9 @@ class _HTTPBridgeStreamingMixin:
                     )
                     retry_request_state.verified_stale_anchor_quarantine_generation = (
                         verified_stale_anchor_quarantine_generation
+                    )
+                    retry_request_state.verified_stale_anchor_quarantine_local_failure_fence = (
+                        verified_stale_anchor_quarantine_local_failure_fence
                     )
                 # Keep the durable operation identity attached to the
                 # server-owned recovery attempt. Re-registering the same

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -90,6 +90,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
     _clear_http_bridge_quarantine,
+    _http_bridge_local_failure_fence,
     _http_bridge_quarantine_clear_fence,
     _record_http_bridge_quarantine_eventless_timeout,
     _record_http_bridge_quarantine_wedged_pending,
@@ -2681,6 +2682,7 @@ class _HTTPBridgeUpstreamEventsMixin:
             event=event,
         )
 
+        completion_local_failure_fence = _http_bridge_local_failure_fence(self)
         completed_event_queue: asyncio.Queue[str | None] | None = None
         completed_event_queue_claimed = False
         async with session.pending_lock:
@@ -3752,7 +3754,19 @@ class _HTTPBridgeUpstreamEventsMixin:
             # suppressed for the TTL because the clear cannot match), and a
             # failed registration would find no pre-settle poison detail to
             # re-seed.
-            completion_pre_settle_load_succeeded = await self._load_http_bridge_retry_circuit(session)
+            if (
+                terminal_request_state.verified_stale_anchor_retry_circuit_key == session.key
+                and terminal_request_state.verified_stale_anchor_quarantine_local_failure_fence is not None
+            ):
+                # A same-key replay carries older authority than this terminal
+                # event. Its load must not revoke post-origin local evidence.
+                completion_local_failure_fence = min(
+                    completion_local_failure_fence,
+                    terminal_request_state.verified_stale_anchor_quarantine_local_failure_fence,
+                )
+            completion_pre_settle_load_succeeded = await self._load_http_bridge_retry_circuit(
+                session, local_failure_fence=completion_local_failure_fence
+            )
             completion_quarantine_clear_fence = _http_bridge_quarantine_clear_fence(self, session.key)
             async with self._http_bridge_retry_circuit_lock:
                 pre_settle_state = self._http_bridge_retry_circuits.get(session.key)
@@ -3797,6 +3811,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 # anchor commits.
                 circuit_settled = await self._clear_http_bridge_retry_circuit(
                     session,
+                    local_failure_fence=completion_local_failure_fence,
                     settled_detail=(
                         _HTTP_BRIDGE_RETRY_CIRCUIT_ANCHOR_ABANDONED_DETAIL
                         if completion_settles_onto_tombstone
@@ -3943,8 +3958,10 @@ class _HTTPBridgeUpstreamEventsMixin:
                 self,
                 session,
                 key_generation=completion_quarantine_clear_fence,
+                local_failure_fence=completion_local_failure_fence,
                 additional_key=terminal_request_state.verified_stale_anchor_retry_circuit_key,
                 additional_key_generation=terminal_request_state.verified_stale_anchor_quarantine_generation,
+                additional_local_failure_fence=terminal_request_state.verified_stale_anchor_quarantine_local_failure_fence,
             )
 
         operation_state = _http_bridge_operation_state_for_event(event_type)

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1129,6 +1129,7 @@ class _WebSocketRequestState:
     verified_stale_anchor_retry_circuit_key: _HTTPBridgeSessionKey | None = None
     verified_stale_anchor_retry_circuit_generation: tuple[int, float, int, float, int, float, float] | None = None
     verified_stale_anchor_quarantine_generation: int | None = None
+    verified_stale_anchor_quarantine_local_failure_fence: int | None = None
     # The exact half-open lease this request's admission claimed (0.0 when
     # it claimed none); released by the submit finalizer whenever the probe
     # was never dispatched, so no pre-dispatch exit can strand the lease.
@@ -1320,7 +1321,7 @@ class _HTTPBridgeOwnerForward:
     key: _HTTPBridgeSessionKey
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, weakref_slot=True)
 class _HTTPBridgeSession:
     key: _HTTPBridgeSessionKey
     headers: dict[str, str]

--- a/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/design.md
+++ b/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/design.md
@@ -1,0 +1,17 @@
+## Context
+
+Completion loads durable poison before capturing its cleanup fence. A concurrent local failure during that load becomes part of the captured entry, so cleanup wrongly treats it as disproved. An early fence alone changes durable-only cleanup timing.
+
+## Decisions
+
+Capture a service-lifetime local-failure cutoff before the pending lock. First strikes also advance the sequence. Durable adoption advances entry identity without changing local failure provenance; local poison retains its own deadline. Successful cleanup removes the adopted contribution while preserving newer local evidence and existing suppressed weaker evidence.
+
+Pass the cutoff explicitly through completion loads and their revocations. Keep the existing late durable fence and failed-load recapture. Verified replay carries an origin cutoff; same-key completion loads use that older authority too. Outside completion, durable disproof keeps its existing behavior.
+
+Fence primary cleanup by the canonical session or its weak owner reference. A planning-only durable probe owns no session reference. The sequence survives entry eviction, preventing a recreated entry from matching an old fence. Revocation clears local poison metadata so a later arm cannot reuse its disproved deadline.
+
+## Scope and verification
+
+The existing poison-preserving soft cap, TTLs and unknown-key behavior remain unchanged. This resolves the cleanup concern without choosing PR2276's broader overflow policy. The quarantine module remains one cohesive responsibility; callers pass only the cleanup authorities it needs.
+
+Public-route regressions cover pre-lock/pre-load/registration interleavings, retry and disproof, exact deadlines/counts, failed settlement/registration, replacement identity and replay-origin propagation. Transport and race placement are controlled; the same-key completion case seeds admitted replay metadata. These prove deterministic behavior, not production incidence.

--- a/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/proposal.md
+++ b/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+A completion can erase a local first strike or quarantine recorded while it loads durable state. Moving the cleanup fence earlier protects the failure but delays cleanup of durable-only poison. Separating their provenance fixes the race while preserving the existing cleanup policy.
+
+## What Changes
+
+- Preserve local failures recorded after completion or verified-replay origin capture, including replacement-session evidence.
+- Keep main's immediate cleanup of adopted durable-only evidence after successful settlement and registration.
+- Retain TTL, soft-cap and unknown-key behavior.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: local quarantine cleanup authority is independent of durable adoption.
+
+## Impact
+
+HTTP bridge quarantine, durable loading and completion bookkeeping. Refs #2268 for the stale-cleanup portion; unconditional memory bounds and service-wide overflow policy remain outside this change. No settings, schema or wire-format changes.

--- a/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/specs/responses-api-compat/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Completion cleanup distinguishes local failures from durable adoption
+
+A completed HTTP bridge response MUST preserve local quarantine failures recorded after completion processing begins, including the first eventless strike and replacement-session evidence. Successful settlement and fresh-anchor registration MUST retain existing immediate cleanup of durable-only poison adopted for that settlement. Removing that evidence MUST NOT extend or discard an intervening local failure's own deadline or count. Failed settlement or registration MUST retain existing poison protection. Quarantine capacity, TTL and unknown-key behavior MUST remain unchanged.
+
+#### Scenario: Local failure during completion
+- **WHEN** a local failure is recorded while completion waits for its pending lock, loads durable state or registers continuity
+- **THEN** cleanup preserves that failure's quarantine or strike behavior
+
+#### Scenario: Retry adopts durable-only poison
+- **WHEN** the initial load fails and settlement's retry adopts durable-only poison
+- **AND** settlement and fresh-anchor registration succeed
+- **THEN** the adopted poison is cleared immediately and intervening local evidence retains its own deadline and count
+
+#### Scenario: Replacement owns the key
+- **WHEN** a predecessor completes after another session records evidence under the same key
+- **THEN** predecessor cleanup does not modify replacement evidence or its quarantine marker, even after entry eviction and recreation
+
+#### Scenario: Settlement or registration fails
+- **WHEN** completion adopts durable poison but settlement or fresh-anchor registration fails
+- **THEN** existing protection against the old anchor remains
+
+### Requirement: Verified replay cleanup retains origin authority
+
+A verified stale-anchor replay MUST preserve local failures recorded after it captures its origin's quarantine evidence. When the replay completes under its origin key, durable loading and revocation MUST use that same authority before final cleanup.
+
+#### Scenario: First strike during replay
+- **WHEN** a first strike is recorded after origin capture and before replay completion
+- **THEN** replay cleanup retains the strike, including when the origin capture observed absence or poison
+
+#### Scenario: Same-key replay adopts durable disproof
+- **WHEN** a same-key replay's completion load disproves durable poison after a local failure was recorded during replay
+- **THEN** loading and final cleanup preserve the intervening local failure's own deadline and count

--- a/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/tasks.md
+++ b/openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implement and prove cleanup authority
+
+- [x] 1.1 Reproduce the public completion race on current main with isolated database engines.
+- [x] 1.2 Separate local provenance and durable adoption; verify deadline, count, identity and replay-origin behavior.
+- [x] 1.3 Consolidate the public regressions without losing the proven cases; verify the complete affected suite.
+- [x] 1.4 Pass lint, type and strict spec checks and independent candidate review.
+- [x] 1.5 Sync the verified requirements before publication.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -297,3 +297,11 @@ stream. Predispatch failures and cancellation release origin-owned reservations;
 accepted or delivery-ambiguous owner forwards retain their settlement owner.
 Context bindings do not span yields because startup probes and consumers may
 advance the stream from different tasks.
+
+## Local quarantine cleanup and durable adoption
+
+The [cleanup requirements](spec.md#requirement-completion-cleanup-distinguishes-local-failures-from-durable-adoption) distinguish a response's local failure cutoff from the durable evidence it later adopts. A cutoff captured only after loading can erase a concurrent first strike; moving every fence earlier instead delays durable-only cleanup. Keeping both authorities preserves the existing settlement and registration timing.
+
+For example, a local poison arm at time 100 with deadline 700 keeps deadline 700 after a longer durable poison contribution is settled. A first strike recorded during the same completion remains count 1, so the next timeout can reach the existing threshold. A verified replay retains the origin's older cutoff, including when a same-key completion load revokes durable poison before final cleanup.
+
+This change retains the poison-preserving soft cap and TTL behavior. It does not classify unrelated keys as poisoned when the registry fills; broader overflow and unconditional memory-bound choices remain separate.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -6254,6 +6254,39 @@ ordinary selection, and MUST NOT reclassify local capacity or overload codes
 - **THEN** the proxy keeps the existing continuity-owner failure semantics
 - **AND** it does not report pool-wide `usage_limit_reached`
 
+### Requirement: Completion cleanup distinguishes local failures from durable adoption
+
+A completed HTTP bridge response MUST preserve local quarantine failures recorded after completion processing begins, including the first eventless strike and replacement-session evidence. Successful settlement and fresh-anchor registration MUST retain existing immediate cleanup of durable-only poison adopted for that settlement. Removing that evidence MUST NOT extend or discard an intervening local failure's own deadline or count. Failed settlement or registration MUST retain existing poison protection. Quarantine capacity, TTL and unknown-key behavior MUST remain unchanged.
+
+#### Scenario: Local failure during completion
+- **WHEN** a local failure is recorded while completion waits for its pending lock, loads durable state or registers continuity
+- **THEN** cleanup preserves that failure's quarantine or strike behavior
+
+#### Scenario: Retry adopts durable-only poison
+- **WHEN** the initial load fails and settlement's retry adopts durable-only poison
+- **AND** settlement and fresh-anchor registration succeed
+- **THEN** the adopted poison is cleared immediately and intervening local evidence retains its own deadline and count
+
+#### Scenario: Replacement owns the key
+- **WHEN** a predecessor completes after another session records evidence under the same key
+- **THEN** predecessor cleanup does not modify replacement evidence or its quarantine marker, even after entry eviction and recreation
+
+#### Scenario: Settlement or registration fails
+- **WHEN** completion adopts durable poison but settlement or fresh-anchor registration fails
+- **THEN** existing protection against the old anchor remains
+
+### Requirement: Verified replay cleanup retains origin authority
+
+A verified stale-anchor replay MUST preserve local failures recorded after it captures its origin's quarantine evidence. When the replay completes under its origin key, durable loading and revocation MUST use that same authority before final cleanup.
+
+#### Scenario: First strike during replay
+- **WHEN** a first strike is recorded after origin capture and before replay completion
+- **THEN** replay cleanup retains the strike, including when the origin capture observed absence or poison
+
+#### Scenario: Same-key replay adopts durable disproof
+- **WHEN** a same-key replay's completion load disproves durable poison after a local failure was recorded during replay
+- **THEN** loading and final cleanup preserve the intervening local failure's own deadline and count
+
 ### Requirement: Silent HTTP bridge sessions are quarantined from re-attach and reuse
 
 When an HTTP bridge session proves silent/wedged, the proxy MUST quarantine its session key for a bounded window so later requests stop attaching to it. A session proves silent/wedged when either (a) a pending request being failed or retired carried a proxy-injected `previous_response_id`, had sent `response.create`, observed upstream response events, and never had `response.created` assigned, (b) the session key hits two consecutive eventless `missing_response_created_timeout` retires, or (c) the hard-affinity retry circuit for the key opens on an eventless poison-class failure (`stream_incomplete` or `stream_idle_timeout`), in which case the quarantine reason MUST be `retry_circuit_poisoned_anchor`. This holds for every path that fails or retires the request — partial stale-holder cleanup, the reader-failure funnel, and direct all-stale session retirement alike. The quarantine MUST be evaluated only when a request is already being failed or its session retired — never against a live owned turn — so a stream whose `response.created` was observed (including deferred-reasoning streams with long event gaps) MUST NOT be quarantined, and mere event silence during an owned live turn MUST NOT trigger quarantine by itself.

--- a/tests/integration/http_quarantine_fixtures.py
+++ b/tests/integration/http_quarantine_fixtures.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
+
+import pytest
+
+from app.core.clock import clock_for
+from app.modules.proxy._service.http_bridge import quarantine
+from tests.integration.test_http_responses_bridge import _collect_sse_events, _promotion_history
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+    from app.core.types import JsonValue
+    from app.modules.proxy._service.support import _HTTPBridgeSession
+    from app.modules.proxy.service import ProxyService
+
+
+class _CircuitKey(TypedDict):
+    session_key_kind: str
+    session_key_value: str
+    api_key_id: str | None
+
+
+@pytest.fixture(autouse=True)
+def quarantine_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(quarantine, "clock_for", lambda _: SimpleNamespace(monotonic=lambda: 100.0))
+
+
+async def complete(
+    async_client: AsyncClient,
+    *,
+    session_id: str | None = None,
+    history: list[dict[str, JsonValue]] | None = None,
+) -> list[dict[str, JsonValue]]:
+    body = {
+        "model": "gpt-5.4",
+        "instructions": "test",
+        "stream": True,
+        "input": _promotion_history() if history is None else history,
+    }
+    events = await _collect_sse_events(
+        async_client,
+        "/v1/responses",
+        json_body=body,
+        headers={"session_id": session_id} if session_id else None,
+    )
+    assert events[-1]["type"] == "response.completed"
+    return events
+
+
+async def seed_durable_poison(service: ProxyService, *, cooldown: float = 900.0, **key: Unpack[_CircuitKey]) -> None:
+    now = clock_for(service).time()
+    await service._durable_bridge.persist_retry_circuit(
+        **key,
+        consecutive_failures=2,
+        cooldown_until_epoch=now + cooldown,
+        last_detail="stream_incomplete",
+        updated_at_epoch=now,
+    )
+
+
+def arm(
+    service: ProxyService,
+    session: _HTTPBridgeSession,
+    evidence: Literal["poison", "weaker", "first-strike"],
+) -> float:
+    if evidence == "first-strike":
+        quarantine._record_http_bridge_quarantine_eventless_timeout(service, session)
+    else:
+        quarantine._quarantine_http_bridge_session(
+            service,
+            session,
+            reason="retry_circuit_poisoned_anchor" if evidence == "poison" else "reattach_missing_response_created",
+        )
+    return quarantine._http_bridge_quarantine_registry(service)[session.key].quarantined_until

--- a/tests/integration/test_http_promotion_quarantine.py
+++ b/tests/integration/test_http_promotion_quarantine.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.dependencies import get_proxy_service_for_app
+from app.modules.proxy._service.http_bridge import quarantine
+from tests.integration.http_quarantine_fixtures import arm
+from tests.integration.test_http_responses_bridge import (
+    _cleanup_http_bridge_sessions as cleanup_http_bridge_sessions,  # noqa: F401
+)
+from tests.integration.test_http_responses_bridge import (
+    _collect_sse_events,
+    _promotion_history,
+)
+from tests.integration.test_http_responses_bridge import (
+    promotion_transport as promotion_transport,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evidence", ["weaker", "poison", "first-strike"])
+@pytest.mark.parametrize("during_completion", [False, True], ids=["after-completion", "during-completion"])
+@pytest.mark.parametrize("capture_stage", ["registration", "preload"])
+async def test_promoted_history_quarantine_opens_fresh_without_injecting_an_anchor(
+    async_client, app_instance, promotion_transport, evidence, during_completion, capture_stage, monkeypatch
+):
+    upstreams, raw_calls, _ = promotion_transport
+    history = _promotion_history()
+    body = {"model": "gpt-5.4", "instructions": "test", "stream": True, "input": history}
+    service = get_proxy_service_for_app(app_instance)
+    hook_name = (
+        "_register_http_bridge_previous_response_id"
+        if capture_stage == "registration"
+        else "_load_http_bridge_retry_circuit"
+    )
+    register = getattr(service, hook_name)
+    armed = False
+    processing_completion = False
+    process = service._process_http_bridge_upstream_text
+
+    async def process_and_track(session, text, *args, **kwargs):
+        nonlocal processing_completion
+        processing_completion = json.loads(text).get("type") == "response.completed"
+        try:
+            return await process(session, text, *args, **kwargs)
+        finally:
+            processing_completion = False
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", process_and_track)
+
+    async def register_and_arm(session, *args, **kwargs):
+        nonlocal armed
+        result = await register(session, *args, **kwargs)
+        if not armed and (capture_stage == "registration" or processing_completion):
+            armed = True
+            arm(service, session, evidence)
+        return result
+
+    if during_completion:
+        monkeypatch.setattr(service, hook_name, register_and_arm)
+    first = await _collect_sse_events(async_client, "/v1/responses", json_body=body)
+    assert first[-1]["type"] == "response.completed"
+    if during_completion:
+        assert armed, "hook must inject evidence during completion"
+    assert len(service._http_bridge_sessions) == 1
+    original = next(iter(service._http_bridge_sessions.values()))
+    assert original.key.strength == "soft"
+    assert original.key.affinity_key.startswith("http-history:")
+    if not during_completion:
+        arm(service, original, evidence)
+    if evidence == "first-strike":
+        entry = quarantine._http_bridge_quarantine_registry(service).get(original.key)
+        assert entry is not None, (
+            "completion must preserve a first strike recorded during the selected completion await"
+        )
+        assert entry.consecutive_eventless_timeouts == 1
+        quarantine._record_http_bridge_quarantine_eventless_timeout(service, original)
+    assert quarantine._http_bridge_session_key_quarantined(service, original.key)
+
+    followup = [*history, {"role": "assistant", "content": "OK"}, {"role": "user", "content": "next"}]
+    second = await _collect_sse_events(async_client, "/v1/responses", json_body={**body, "input": followup})
+    assert second[-1]["type"] == "response.completed"
+    assert not raw_calls
+    assert len(upstreams) == 2
+    assert service._http_bridge_sessions[original.key] is not original
+    assert len(upstreams[0].sent_text) == 1
+    frame = json.loads(upstreams[1].sent_text[0])
+    assert frame["input"] == [
+        history[0],
+        {"role": "assistant", "content": [{"type": "output_text", "text": "first answer"}]},
+        history[2],
+        {"role": "assistant", "content": [{"type": "output_text", "text": "OK"}]},
+        followup[-1],
+    ]
+    assert "previous_response_id" not in frame

--- a/tests/integration/test_http_quarantine_provenance.py
+++ b/tests/integration/test_http_quarantine_provenance.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.dependencies import get_proxy_service_for_app
+from app.modules.proxy._service.http_bridge import quarantine
+from tests.integration.http_quarantine_fixtures import arm, complete, seed_durable_poison
+from tests.integration.http_quarantine_fixtures import quarantine_clock as quarantine_clock
+from tests.integration.test_http_responses_bridge import (
+    _cleanup_http_bridge_sessions as cleanup_http_bridge_sessions,  # noqa: F401
+)
+from tests.integration.test_http_responses_bridge import promotion_transport as promotion_transport
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evidence", ["none", "weaker", "poison", "first-strike"])
+@pytest.mark.parametrize("retry_load", [False, True], ids=["preload", "failed-load-retry"])
+@pytest.mark.parametrize("outcome", ["success", "settle-failure", "alias-failure"])
+async def test_completion_separates_local_failure_from_durable_adoption(
+    async_client, app_instance, promotion_transport, monkeypatch, evidence, retry_load, outcome
+):
+    service = get_proxy_service_for_app(app_instance)
+    lookup = service._durable_bridge.lookup_retry_circuit
+    clear = service._durable_bridge.clear_retry_circuit
+    register = service._register_http_bridge_previous_response_id
+    process = service._process_http_bridge_upstream_text
+    completing = None
+    original = None
+    lookups = 0
+    seeded = False
+    local_deadline = None
+    registered = False
+    settled = False
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal completing, original
+        completing = session if json.loads(text).get("type") == "response.completed" else None
+        if completing is not None:
+            original = session
+        try:
+            return await process(session, text, *args, **kwargs)
+        finally:
+            completing = None
+
+    async def load(**kwargs):
+        nonlocal lookups, seeded, local_deadline
+        if completing is not None:
+            lookups += 1
+            if not seeded:
+                seeded = True
+                assert completing.key.strength == "hard"
+                await seed_durable_poison(service, **kwargs)
+                if evidence != "none":
+                    local_deadline = arm(service, completing, evidence)
+                if retry_load:
+                    raise RuntimeError("injected first durable lookup failure")
+        return await lookup(**kwargs)
+
+    async def settle(**kwargs):
+        nonlocal settled
+        if completing is not None:
+            settled = True
+            if outcome == "settle-failure":
+                raise RuntimeError("injected durable settlement failure")
+        return await clear(**kwargs)
+
+    async def registration(session, *args, **kwargs):
+        nonlocal registered
+        if completing is not None:
+            registered = True
+            if outcome == "alias-failure":
+                return False
+        return await register(session, *args, **kwargs)
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    monkeypatch.setattr(service._durable_bridge, "lookup_retry_circuit", load)
+    monkeypatch.setattr(service._durable_bridge, "clear_retry_circuit", settle)
+    monkeypatch.setattr(service, "_register_http_bridge_previous_response_id", registration)
+    await complete(async_client, session_id="quarantine-provenance")
+    assert seeded and settled and registered
+    assert lookups >= 2
+    assert original is not None
+    entry = quarantine._http_bridge_quarantine_registry(service).get(original.key)
+    if outcome != "success":
+        assert entry is not None
+        assert quarantine._http_bridge_session_key_poison_quarantined(service, original.key) is True
+        return
+    if evidence == "none":
+        assert entry is None
+        assert original.quarantined is False
+    elif evidence == "first-strike":
+        assert entry is not None
+        assert entry.consecutive_eventless_timeouts == 1
+        assert entry.quarantined_until == 0.0
+        assert quarantine._http_bridge_session_key_poison_quarantined(service, original.key) is False
+        assert original.quarantined is False
+        quarantine._record_http_bridge_quarantine_eventless_timeout(service, original)
+        assert entry.consecutive_eventless_timeouts == 2
+        assert quarantine._http_bridge_session_key_quarantined(service, original.key) is True
+    else:
+        assert entry is not None
+        assert entry.reason == (
+            "retry_circuit_poisoned_anchor" if evidence == "poison" else "reattach_missing_response_created"
+        )
+        assert local_deadline == 700.0
+        assert entry.quarantined_until == 700.0
+        assert entry.poison_quarantined_until == (local_deadline if evidence == "poison" else 0.0)
+        assert original.quarantined is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evidence", ["poison", "first-strike", "weaker"])
+@pytest.mark.parametrize("registered_owner", [False, True], ids=["detached", "registered"])
+async def test_predecessor_completion_preserves_replacement_evidence(
+    async_client, app_instance, promotion_transport, monkeypatch, evidence, registered_owner
+):
+    from dataclasses import replace
+
+    service = get_proxy_service_for_app(app_instance)
+    process = service._process_http_bridge_upstream_text
+    register = service._register_http_bridge_previous_response_id
+    replacement = None
+    old_generation = None
+    expected_generation = None
+    original = None
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal old_generation, original
+        if json.loads(text).get("type") == "response.completed":
+            original = session
+            quarantine._quarantine_http_bridge_session(service, session, reason="retry_circuit_poisoned_anchor")
+            old_generation = quarantine._http_bridge_quarantine_registry(service)[session.key].generation
+        return await process(session, text, *args, **kwargs)
+
+    async def replace_owner(session, *args, **kwargs):
+        nonlocal replacement, expected_generation
+        result = await register(session, *args, **kwargs)
+        replacement = replace(session)
+        quarantine._http_bridge_quarantine_registry(service).pop(session.key, None)
+        if registered_owner:
+            service._http_bridge_sessions[session.key] = replacement
+        else:
+            service._http_bridge_sessions.pop(session.key, None)
+        arm(service, replacement, evidence)
+        expected_generation = quarantine._http_bridge_quarantine_registry(service)[session.key].generation
+        return result
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    monkeypatch.setattr(service, "_register_http_bridge_previous_response_id", replace_owner)
+    try:
+        await complete(async_client)
+        assert replacement is not None and original is not None
+        entry = quarantine._http_bridge_quarantine_registry(service).get(replacement.key)
+        assert entry is not None
+        assert entry.generation == expected_generation
+        assert old_generation is not None
+        assert expected_generation > old_generation
+        assert replacement.quarantined is True
+        if evidence == "first-strike":
+            assert entry.consecutive_eventless_timeouts == 1
+        else:
+            assert quarantine._http_bridge_session_key_quarantined(service, replacement.key) is True
+    finally:
+        if original is not None:
+            service._http_bridge_sessions[original.key] = original

--- a/tests/integration/test_http_quarantine_provenance_races.py
+++ b/tests/integration/test_http_quarantine_provenance_races.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.dependencies import get_proxy_service_for_app
+from app.modules.proxy._service.http_bridge import quarantine
+from tests.integration.http_quarantine_fixtures import arm, complete, seed_durable_poison
+from tests.integration.http_quarantine_fixtures import quarantine_clock as quarantine_clock
+from tests.integration.test_http_responses_bridge import (
+    _cleanup_http_bridge_sessions as cleanup_http_bridge_sessions,  # noqa: F401
+)
+from tests.integration.test_http_responses_bridge import _promotion_history
+from tests.integration.test_http_responses_bridge import promotion_transport as promotion_transport
+
+pytestmark = pytest.mark.integration
+
+
+def _assert_survives(service, session, evidence, deadline):
+    entry = quarantine._http_bridge_quarantine_registry(service).get(session.key)
+    assert entry is not None
+    if evidence == "first-strike":
+        assert entry.consecutive_eventless_timeouts == 1
+        assert entry.quarantined_until == 0.0
+        assert quarantine._http_bridge_session_key_poison_quarantined(service, session.key) is False
+    else:
+        assert entry.reason == (
+            "retry_circuit_poisoned_anchor" if evidence == "poison" else "reattach_missing_response_created"
+        )
+        assert entry.quarantined_until == deadline
+        assert quarantine._http_bridge_session_key_quarantined(service, session.key) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evidence", ["poison", "weaker", "first-strike"])
+async def test_failure_before_completion_pending_lock_survives(
+    async_client, app_instance, promotion_transport, monkeypatch, evidence
+):
+    service = get_proxy_service_for_app(app_instance)
+    process = service._process_http_bridge_upstream_text
+    original = None
+    deadline = None
+    injected = False
+
+    class InjectingLock:
+        def __init__(self, session):
+            self.session = session
+            self.lock = session.pending_lock
+
+        async def __aenter__(self):
+            nonlocal injected, deadline
+            await self.lock.acquire()
+            if not injected:
+                injected = True
+                deadline = arm(service, self.session, evidence)
+
+        async def __aexit__(self, *args):
+            self.lock.release()
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal original
+        if json.loads(text).get("type") != "response.completed":
+            return await process(session, text, *args, **kwargs)
+        original = session
+        lock = session.pending_lock
+        session.pending_lock = InjectingLock(session)
+        try:
+            return await process(session, text, *args, **kwargs)
+        finally:
+            session.pending_lock = lock
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    await complete(async_client)
+    assert injected and original is not None
+    _assert_survives(service, original, evidence, deadline)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("evidence", ["poison", "weaker", "first-strike"])
+@pytest.mark.parametrize("failure_origin", ["completion-load", "replay-origin"])
+async def test_durable_disproof_preserves_local_failure_after_captured_authority(
+    async_client, app_instance, promotion_transport, monkeypatch, evidence, failure_origin
+):
+    service = get_proxy_service_for_app(app_instance)
+    process = service._process_http_bridge_upstream_text
+    lookup = service._durable_bridge.lookup_retry_circuit
+    completing = None
+    original = None
+    injected = False
+    deadline = None
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal completing, original
+        if json.loads(text).get("type") != "response.completed":
+            return await process(session, text, *args, **kwargs)
+        original = session
+        await seed_durable_poison(
+            service,
+            session_key_kind=session.key.affinity_kind,
+            session_key_value=session.key.affinity_key,
+            api_key_id=session.key.api_key_id,
+        )
+        assert await service._load_http_bridge_retry_circuit(session)
+        assert quarantine._http_bridge_session_key_poison_quarantined(service, session.key)
+        if failure_origin == "replay-origin":
+            owner = next(iter(session.pending_requests))
+            # The real recovery test separately proves dispatch transports this metadata.
+            owner.verified_stale_anchor_replay = True
+            owner.verified_stale_anchor_retry_circuit_key = session.key
+            owner.verified_stale_anchor_quarantine_generation = quarantine._http_bridge_quarantine_clear_fence(
+                service, session.key
+            )
+            owner.verified_stale_anchor_quarantine_local_failure_fence = quarantine._http_bridge_local_failure_fence(
+                service
+            )
+            arm(service, session, evidence)
+        completing = session
+        try:
+            return await process(session, text, *args, **kwargs)
+        finally:
+            completing = None
+
+    async def load(**kwargs):
+        nonlocal injected, deadline
+        if completing is not None and not injected:
+            injected = True
+            if failure_origin == "completion-load":
+                arm(service, completing, evidence)
+            deadline = 0.0 if evidence == "first-strike" else 700.0
+            await service._durable_bridge.clear_retry_circuit(**kwargs)
+        return await lookup(**kwargs)
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    monkeypatch.setattr(service._durable_bridge, "lookup_retry_circuit", load)
+    await complete(async_client, session_id="quarantine-revoke")
+    assert injected and original is not None
+    if evidence == "weaker":
+        # The shared deadline still included the old durable poison at injection.
+        entry = quarantine._http_bridge_quarantine_registry(service)[original.key]
+        assert entry.reason == "reattach_missing_response_created"
+        assert entry.quarantined_until == 700.0
+    else:
+        _assert_survives(service, original, evidence, deadline)
+
+
+@pytest.mark.asyncio
+async def test_revoked_local_deadline_is_not_reused_by_next_completion_failure(
+    async_client, app_instance, promotion_transport, monkeypatch
+):
+    service = get_proxy_service_for_app(app_instance)
+    process = service._process_http_bridge_upstream_text
+    load = service._load_http_bridge_retry_circuit
+    completing = None
+    original = None
+    injected = False
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal completing, original
+        if json.loads(text).get("type") != "response.completed":
+            return await process(session, text, *args, **kwargs)
+        arm(service, session, "weaker")
+        quarantine._quarantine_http_bridge_session(
+            service, session, reason="retry_circuit_poisoned_anchor", minimum_seconds=2000.0
+        )
+        assert quarantine._revoke_http_bridge_poison_quarantine(
+            service, session.key, generation=quarantine._http_bridge_quarantine_clear_fence(service, session.key)
+        )
+        assert quarantine._http_bridge_quarantine_registry(service)[session.key].quarantined_until == 700.0
+        completing = session
+        original = session
+        try:
+            return await process(session, text, *args, **kwargs)
+        finally:
+            completing = None
+
+    async def inject(session, *args, **kwargs):
+        nonlocal injected
+        if completing is not None and not injected:
+            injected = True
+            arm(service, session, "poison")
+        return await load(session, *args, **kwargs)
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    monkeypatch.setattr(service, "_load_http_bridge_retry_circuit", inject)
+    await complete(async_client)
+    assert injected and original is not None
+    entry = quarantine._http_bridge_quarantine_registry(service)[original.key]
+    assert entry.poison_quarantined_until == 700.0
+    assert entry.quarantined_until == 700.0
+
+
+@pytest.mark.asyncio
+async def test_first_touch_durable_poison_uses_planning_probe_without_owner_failure(
+    async_client, app_instance, promotion_transport, monkeypatch
+):
+    service = get_proxy_service_for_app(app_instance)
+    lookup = service._durable_bridge.lookup_retry_circuit
+    seeded = False
+
+    async def load(**kwargs):
+        nonlocal seeded
+        if not seeded:
+            seeded = True
+            assert not service._http_bridge_sessions
+            await seed_durable_poison(service, cooldown=-1.0, **kwargs)
+        return await lookup(**kwargs)
+
+    monkeypatch.setattr(service._durable_bridge, "lookup_retry_circuit", load)
+    await complete(async_client, session_id="planning-poison")
+    assert seeded
+    assert not quarantine._http_bridge_quarantine_registry(service)
+
+
+@pytest.mark.asyncio
+async def test_completion_keeps_preexisting_suppressed_weaker_deadline(
+    async_client, app_instance, promotion_transport, monkeypatch
+):
+    service = get_proxy_service_for_app(app_instance)
+    process = service._process_http_bridge_upstream_text
+    original = None
+
+    async def track(session, text, *args, **kwargs):
+        nonlocal original
+        if json.loads(text).get("type") == "response.completed":
+            original = session
+            arm(service, session, "weaker")
+            quarantine._quarantine_http_bridge_session(
+                service, session, reason="retry_circuit_poisoned_anchor", minimum_seconds=900.0
+            )
+        return await process(session, text, *args, **kwargs)
+
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", track)
+    await complete(async_client)
+    assert original is not None
+    entry = quarantine._http_bridge_quarantine_registry(service)[original.key]
+    assert entry.reason == "reattach_missing_response_created"
+    assert entry.quarantined_until == 700.0
+    assert quarantine._http_bridge_session_key_poison_quarantined(service, original.key) is False
+
+
+@pytest.mark.asyncio
+async def test_all_poison_soft_cap_does_not_classify_unrelated_request_as_poisoned(
+    async_client, app_instance, promotion_transport, monkeypatch
+):
+    from dataclasses import replace
+
+    service = get_proxy_service_for_app(app_instance)
+    await complete(async_client)
+    original = next(iter(service._http_bridge_sessions.values()))
+    monkeypatch.setattr(quarantine, "_HTTP_BRIDGE_QUARANTINE_MAX_ENTRIES", 3)
+    for index in range(4):
+        poisoned = replace(original, key=replace(original.key, affinity_key=f"poisoned-{index}"))
+        arm(service, poisoned, "poison")
+    registry = quarantine._http_bridge_quarantine_registry(service)
+    assert len(registry) == 4
+    assert quarantine._http_bridge_session_key_poison_quarantined(service, original.key) is False
+    await complete(async_client, history=_promotion_history("unrelated"))
+    assert len(registry) == 4
+    assert len(promotion_transport[0]) == 2
+    assert not promotion_transport[1]

--- a/tests/integration/test_http_quarantine_recovery_origin.py
+++ b/tests/integration/test_http_quarantine_recovery_origin.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.http_bridge import quarantine, streaming, upstream_events
+from tests.integration.test_http_responses_bridge import (
+    test_backend_responses_http_bridge_replays_verified_full_resend_after_stale_owner as replay_scenario,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_poison", [False, True], ids=["captured-absence", "captured-poison"])
+async def test_verified_replay_retains_first_strike_after_origin_capture(
+    async_client, app_instance, monkeypatch, initial_poison
+):
+    capture = streaming._http_bridge_quarantine_clear_fence
+    process = proxy_service.ProxyService._process_http_bridge_upstream_text
+    local_fence = streaming._http_bridge_local_failure_fence
+    clear = upstream_events._clear_http_bridge_quarantine
+    source_key = None
+    injected = False
+    cleared = False
+    observations = []
+
+    def track_clear(service, session, **kwargs):
+        nonlocal cleared
+        cleared = True
+        return clear(service, session, **kwargs)
+
+    def prepare_capture(service):
+        if initial_poison:
+            assert len(service._http_bridge_sessions) == 1
+            source = next(iter(service._http_bridge_sessions.values()))
+            quarantine._quarantine_http_bridge_session(service, source, reason="retry_circuit_poisoned_anchor")
+        return local_fence(service)
+
+    def capture_then_strike(service, key):
+        nonlocal source_key, injected
+        source_key = key
+        source = service._http_bridge_sessions.get(key)
+        assert source is not None
+        if initial_poison and not quarantine._http_bridge_session_key_poison_quarantined(service, key):
+            quarantine._quarantine_http_bridge_session(service, source, reason="retry_circuit_poisoned_anchor")
+        result = capture(service, key)
+        if not initial_poison:
+            assert result is None
+        quarantine._record_http_bridge_quarantine_eventless_timeout(service, source)
+        injected = True
+        # The reused transport scenario spies on cleanup. Execute real cleanup
+        # for this proof; an untouched source entry would otherwise pass it.
+        monkeypatch.setattr(upstream_events, "_clear_http_bridge_quarantine", track_clear)
+        return result
+
+    async def check_replay(service, session, text, *args, **kwargs):
+        replay = None
+        if json.loads(text).get("type") == "response.completed":
+            replay = next((state for state in session.pending_requests if state.verified_stale_anchor_replay), None)
+        result = await process(service, session, text, *args, **kwargs)
+        if replay is not None:
+            assert injected and source_key is not None
+            assert replay.verified_stale_anchor_retry_circuit_key == source_key
+            entry = quarantine._http_bridge_quarantine_registry(service).get(source_key)
+            observations.append(
+                None
+                if entry is None
+                else (
+                    entry.consecutive_eventless_timeouts,
+                    entry.quarantined_until,
+                    quarantine._http_bridge_session_key_poison_quarantined(service, source_key),
+                )
+            )
+        return result
+
+    monkeypatch.setattr(streaming, "_http_bridge_local_failure_fence", prepare_capture)
+    monkeypatch.setattr(streaming, "_http_bridge_quarantine_clear_fence", capture_then_strike)
+    monkeypatch.setattr(proxy_service.ProxyService, "_process_http_bridge_upstream_text", check_replay)
+    await replay_scenario(async_client, app_instance, monkeypatch, "account-neutral")
+    assert injected and cleared
+    assert observations == [(1, 0.0, False)]

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -36887,8 +36887,8 @@ def test_http_bridge_session_reusable_for_lookup_rejects_fresh_session_under_qua
 
     assert reusable() is False
 
-    # A completed response on the key clears the quarantine and the
-    # replacement becomes reusable.
+    # A completed response on the current replacement clears the quarantine.
+    service._http_bridge_sessions = {replacement.key: replacement}
     http_bridge_quarantine_module._clear_http_bridge_quarantine(
         service,
         replacement,


### PR DESCRIPTION
## Summary

A successful response can erase a first strike or replacement quarantine recorded while completion loads durable state. Separate local-failure authority from durable adoption so newer evidence survives while adopted durable-only poison still clears after successful settlement and anchor registration.

This separates the accepted cleanup concern from #2276. It preserves the poison-preserving soft cap and adds no service-wide overflow rule. Start with the two cleanup authorities in `quarantine.py`, then their propagation through durable loading and replay completion. The 946 net lines cover one coupled cleanup invariant, including 57 regression/control cases and required OpenSpec records.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Refs #2268. Resolves its stale-cleanup portion; unconditional memory bounds and overflow policy remain open.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-09-10-separate-local-quarantine-provenance/`. Requirements are synced to `responses-api-compat`. No wire-format changes.

## Changes

- Capture local failure authority before completion awaits, with service-lifetime generations and replacement-session identity checks.
- Retain local poison's own deadline through durable adoption, and carry replay-origin authority through loading and cleanup.
- Add 57 public-route regression/control cases with shared setup. Distinct race hooks and literal deadline/count assertions remain explicit.

## Test plan

Dedicated disposable SQLite database, with both database variables and all three engines verified before imports/reset.

```sh
uv run pytest tests/unit/test_proxy_http_bridge.py \
  tests/integration/test_http_promotion_quarantine.py \
  tests/integration/test_http_quarantine_provenance.py \
  tests/integration/test_http_quarantine_provenance_races.py \
  tests/integration/test_http_quarantine_recovery_origin.py -q
# 1128 passed
make lint
uv run ty check
pnpm dlx @fission-ai/openspec validate --specs --strict
```

The original public diagnostic fails four cases on main. The retained proof also covers failed-load retry, durable disproof, replacement identity, replay-origin propagation and same-key completion metadata. Transport and race placement are controlled; this does not measure production incidence. Independent Medium review and targeted execution found no remaining actionable findings in the implementation.

Full local `make ci` recipes passed: 1,307 frontend tests, 9,782 unit tests, 2,611 core integration tests, 339 bridge tests, 27 end-to-end tests and 215 PostgreSQL tests, plus Rust audit, migrations, packaging, image scan and both Helm smoke modes. Task-owned database and container names isolated the run. The pre-commit wrapper returned 1 because staging unchanged files during execution changed its Git diff comparison; the coordinator accepted the unchanged-tree recipe evidence. The wrapper itself did not pass.

## Screenshots / output

| Completion interleaving | Main | Fixed |
| --- | --- | --- |
| First timeout recorded during durable lookup | Strike disappears | Count stays 1; next timeout quarantines |
| New replacement entry under the same key | Old completion can clear it | Replacement evidence survives |
| Durable-only poison, successful settlement and registration | Clears immediately | Still clears immediately |

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make` subset locally.
- [x] OpenSpec validation and implementation verification passed.
- [x] Simplicity gates reviewed; no settings, defaults, README or navigation changes.
- [x] CHANGELOG is not edited by hand.
