### PR TITLE
fix(proxy): retry output-free overload SSE on an eligible sibling

### DIFF
--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -88,6 +88,7 @@ from app.modules.proxy._service.compact import (
 from app.modules.proxy._service.compact import (
     _sticky_key_from_compact_payload as _sticky_key_from_compact_payload,
 )
+from app.modules.proxy._service.http_bridge.accepted_replay import _terminal_payload_reports_output
 from app.modules.proxy._service.http_bridge.helpers import (
     _active_http_bridge_instance_ring as _active_http_bridge_instance_ring,
 )
@@ -302,6 +303,7 @@ from app.modules.proxy._service.support import (
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _event_type_from_payload,
     _RequestLogFailureMetadata,
+    _RetryableStreamError,
     _signal_propagated_capacity_startup_ready,
     _StreamSettlement,
     _WebSocketRequestState,
@@ -501,6 +503,50 @@ def _stream_iterator_after_capacity_admission(
 
 
 _REQUEST_TRANSPORT_HTTP = "http"
+
+
+class _OutputFreeOverloadReplayBuffer:
+    """Keep a fresh direct-HTTP lifecycle prelude replayable until model output."""
+
+    _PRELUDE_EVENT_TYPES = frozenset({"response.created", "response.in_progress"})
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+        self._lines: list[str] = []
+
+    def raise_if_retryable(
+        self,
+        event_type: str | None,
+        error_code: str | None,
+        event_payload: dict[str, JsonValue] | None,
+        settlement: _StreamSettlement,
+        error_message: str | None,
+    ) -> None:
+        if not self.enabled or settlement.downstream_visible or event_type not in {"response.failed", "error"}:
+            return
+        if error_code not in UPSTREAM_OVERLOAD_CODES or _terminal_payload_reports_output(event_payload):
+            return
+        raise _RetryableStreamError(
+            error_code,
+            settlement.error or cast(UpstreamError, {"message": error_message or "Upstream overloaded"}),
+            exclude_account=True,
+        )
+
+    def relay(self, event_type: str | None, line: str, settlement: _StreamSettlement) -> list[str]:
+        if self.enabled and event_type in self._PRELUDE_EVENT_TYPES:
+            self._lines.append(line)
+            return []
+        lines, self._lines = [*self._lines, line], []
+        settlement.downstream_visible = True
+        if event_type in _facade()._TEXT_DELTA_EVENT_TYPES:
+            settlement.downstream_text_visible = True
+        return lines
+
+    def flush(self, settlement: _StreamSettlement) -> list[str]:
+        lines, self._lines = self._lines, []
+        if lines:
+            settlement.downstream_visible = True
+        return lines
 
 
 def _should_penalize_stream_error(code: str | None) -> bool:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -513,6 +513,7 @@ class _OutputFreeOverloadReplayBuffer:
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
         self._lines: list[str] = []
+        self._buffered_prelude_types: set[str] = set()
 
     def raise_if_retryable(
         self,
@@ -532,11 +533,32 @@ class _OutputFreeOverloadReplayBuffer:
             exclude_account=True,
         )
 
-    def relay(self, event_type: str | None, line: str, settlement: _StreamSettlement) -> list[str]:
-        if self.enabled and event_type in self._PRELUDE_EVENT_TYPES:
+    @staticmethod
+    def should_retry_first_terminal(
+        allow_retry: bool, error_code: str | None, event_payload: dict[str, JsonValue] | None
+    ) -> bool:
+        return (
+            allow_retry
+            and not _terminal_payload_reports_output(event_payload)
+            and _facade()._should_retry_stream_error(error_code)
+        )
+
+    def relay(
+        self, event_type: str | None, line: str, settlement: _StreamSettlement, terminal: bool = False
+    ) -> list[str]:
+        if self.enabled and self._is_account_neutral_comment(line):
+            return [line]
+        if (
+            self.enabled
+            and not terminal
+            and event_type in self._PRELUDE_EVENT_TYPES
+            and event_type not in self._buffered_prelude_types
+        ):
+            self._buffered_prelude_types.add(event_type)
             self._lines.append(line)
             return []
         lines, self._lines = [*self._lines, line], []
+        self._buffered_prelude_types.clear()
         settlement.downstream_visible = True
         if event_type in _facade()._TEXT_DELTA_EVENT_TYPES:
             settlement.downstream_text_visible = True
@@ -544,9 +566,15 @@ class _OutputFreeOverloadReplayBuffer:
 
     def flush(self, settlement: _StreamSettlement) -> list[str]:
         lines, self._lines = self._lines, []
+        self._buffered_prelude_types.clear()
         if lines:
             settlement.downstream_visible = True
         return lines
+
+    @staticmethod
+    def _is_account_neutral_comment(line: str) -> bool:
+        """SSE comments carry no response state and do not commit replay."""
+        return bool(line.strip()) and all(not field or field.lstrip().startswith(":") for field in line.splitlines())
 
 
 def _should_penalize_stream_error(code: str | None) -> bool:

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from typing import Any, AsyncIterator, Mapping, cast
 
 import aiohttp
@@ -272,10 +271,12 @@ from app.modules.proxy._service.observability import (
 )
 from app.modules.proxy._service.streaming.helpers import (
     _classify_terminal_stream_error_frame,
+    _facade,
     _mark_downstream_stream_cancelled,
     _mark_upstream_stream_incomplete,
     _observe_terminal_stream_error_frame,
     _openai_error_fields,
+    _OutputFreeOverloadReplayBuffer,
     _rewrite_malformed_stream_error_event,
     _stamp_terminal,
     _stream_transport_failure_event_or_raise,
@@ -429,13 +430,6 @@ from app.modules.proxy.tool_call_dedupe import (
 from app.modules.proxy.work_admission import AdmissionLease
 
 
-def _facade() -> Any:
-    return sys.modules["app.modules.proxy.service"]
-
-
-_REQUEST_TRANSPORT_HTTP = "http"
-
-
 class _StreamingMixin(_StreamingRetryMixin):
     _handle_stream_error = _handle_stream_error_helper
     _resolve_upstream_route_for_account = _resolve_upstream_route_for_account_helper
@@ -452,7 +446,7 @@ class _StreamingMixin(_StreamingRetryMixin):
         api_key: ApiKeyData | None = None,
         api_key_reservation: ApiKeyUsageReservationData | None = None,
         suppress_text_done_events: bool = False,
-        request_transport: str = _REQUEST_TRANSPORT_HTTP,
+        request_transport: str = "http",
         client_ip: str | None = None,
         enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
@@ -505,13 +499,11 @@ class _StreamingMixin(_StreamingRetryMixin):
         access_token = proxy._encryptor.decrypt(account.access_token_encrypted)
         account_id = _header_account_id(account.chatgpt_account_id)
         model = payload.model
-        requested_service_tier = payload.service_tier
-        service_tier = requested_service_tier
+        requested_service_tier = service_tier = payload.service_tier
         actual_service_tier: str | None = None
         reasoning_effort = payload.reasoning.effort if payload.reasoning else None
         session_id = _owner_lookup_session_id_from_headers(headers)
-        # Keep selection/failover waits out of latency and TTFT, record them as
-        # queue time, then re-anchor after this attempt's admission wait.
+        # Keep selection/failover waits out of latency and TTFT; re-anchor after this attempt's admission wait.
         attempt_started_at = start = clock.monotonic()
         latency_queue_ms = max(0, int((start - request_started_at) * 1000))
         status, error_code, error_message = "success", None, None
@@ -522,6 +514,7 @@ class _StreamingMixin(_StreamingRetryMixin):
         route_trace = UpstreamProxyRouteTrace()
         route_fail_closed_reason: str | None = None
         saw_text_delta = terminal_event_seen = suppressed_duplicate_tool_call = False
+        overload_replay = _OutputFreeOverloadReplayBuffer(enabled=allow_transient_retry)
         latency_first_token_ms: int | None = None
         ttft_reasoning_deltas: dict[tuple[str | None, int | None, int | None], Any] = {}
         if tool_call_dedupe is None:
@@ -747,6 +740,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 settlement.account_health_error = False
 
+            overload_replay.raise_if_retryable(event_type, error_code, first_payload, settlement, error_message)
+
             if event and event.type in ("response.completed", "response.incomplete"):
                 usage = event.response.usage if event.response else None
                 if event.response and event.response.id:
@@ -778,10 +773,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                         latency_first_token_ms = _ttft_event_latency_ms(
                             event_type, first_payload, ttft_reasoning_deltas, attempt_started_at, now=clock.monotonic()
                         )
-                    settlement.downstream_visible = True
-                    if event_type in _facade()._TEXT_DELTA_EVENT_TYPES:
-                        settlement.downstream_text_visible = True
-                    yield first
+                    for relay_line in overload_replay.relay(event_type, first, settlement):
+                        yield relay_line
             if terminal_stream_error is not None:
                 raise terminal_stream_error
             async for line in iterator:
@@ -905,6 +898,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                     settlement.error = {"message": raw_error_message or "Upstream error"}
                     settlement.record_success = False
                     settlement.account_health_error = not saw_text_delta
+                overload_replay.raise_if_retryable(event_type, error_code, event_payload, settlement, error_message)
                 if event_type in ("response.completed", "response.incomplete"):
                     response = event.response if event is not None else None
                     usage = response.usage if response else None
@@ -943,14 +937,16 @@ class _StreamingMixin(_StreamingRetryMixin):
                     continue
                 if event_payload is not None and not preserve_raw_sse_line:
                     line = format_sse_event(event_payload)
-                settlement.downstream_visible = True
-                if event_type in _facade()._TEXT_DELTA_EVENT_TYPES:
-                    settlement.downstream_text_visible = True
-                terminal_event_seen = terminal_event_seen or _stamp_terminal(settlement, event_type, clock)
-                yield line
+                for relay_line in overload_replay.relay(event_type, line, settlement):
+                    terminal_event_seen = terminal_event_seen or _stamp_terminal(settlement, event_type, clock)
+                    yield relay_line
             if not terminal_event_seen:
                 status, error_code, error_message, failure_metadata = _mark_upstream_stream_incomplete(settlement)
+                for deferred_line in overload_replay.flush(settlement):
+                    yield deferred_line
         except ProxyResponseError as exc:
+            for deferred_line in overload_replay.flush(settlement):
+                yield deferred_line
             response_create_lease.release()
             failure_metadata = _facade()._request_log_failure_metadata(exc)
             error = _parse_openai_error(exc.payload)
@@ -1004,13 +1000,15 @@ class _StreamingMixin(_StreamingRetryMixin):
                 )
             )
             return
-        except _TerminalStreamError:
+        except (_TerminalStreamError, _RetryableStreamError):
             raise
         except (asyncio.CancelledError, GeneratorExit):
             if not terminal_event_seen:
                 status, error_code, error_message, failure_metadata = _mark_downstream_stream_cancelled(settlement)
             raise
         except Exception:
+            for deferred_line in overload_replay.flush(settlement):
+                yield deferred_line
             if settlement.downstream_visible:
                 status, error_code, error_message, failure_metadata = _mark_upstream_stream_incomplete(settlement)
                 yield _stream_transport_failure_event_or_raise(

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -719,7 +719,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                             _facade()._SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE,
                             upstream_error,
                         )
-                    if allow_retry and _facade()._should_retry_stream_error(code):
+                    if overload_replay.should_retry_first_terminal(allow_retry, code, first_payload):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
                 terminal_stream_error = _TerminalStreamError(
                     error_code or code,
@@ -773,7 +773,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         latency_first_token_ms = _ttft_event_latency_ms(
                             event_type, first_payload, ttft_reasoning_deltas, attempt_started_at, now=clock.monotonic()
                         )
-                    for relay_line in overload_replay.relay(event_type, first, settlement):
+                    for relay_line in overload_replay.relay(event_type, first, settlement, terminal_event_seen):
                         yield relay_line
             if terminal_stream_error is not None:
                 raise terminal_stream_error
@@ -937,8 +937,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                     continue
                 if event_payload is not None and not preserve_raw_sse_line:
                     line = format_sse_event(event_payload)
-                for relay_line in overload_replay.relay(event_type, line, settlement):
-                    terminal_event_seen = terminal_event_seen or _stamp_terminal(settlement, event_type, clock)
+                terminal_event_seen = terminal_event_seen or _stamp_terminal(settlement, event_type, clock)
+                for relay_line in overload_replay.relay(event_type, line, settlement, terminal_event_seen):
                     yield relay_line
             if not terminal_event_seen:
                 status, error_code, error_message, failure_metadata = _mark_upstream_stream_incomplete(settlement)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -2220,8 +2220,14 @@ class _StreamingRetryMixin:
                                 allow_retry_flag,
                                 request_started_at=start,
                                 allow_transient_retry=(
-                                    transient_retries < _facade()._MAX_TRANSIENT_SAME_ACCOUNT_RETRIES - 1
-                                    or allow_retry_flag
+                                    resilience.deterministic_failover_enabled
+                                    and allow_retry_flag
+                                    and payload.previous_response_id is None
+                                    and affinity.kind != StickySessionKind.CODEX_SESSION
+                                    and not _stream_owner_bound_to(account)
+                                    and responses_payload_is_account_neutral_fresh_replay(
+                                        payload.to_replay_safety_payload()
+                                    )
                                 ),
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -929,7 +929,10 @@ class _StreamingRetryMixin:
                     request_id,
                     False,
                     request_started_at=start,
-                    allow_transient_retry=True,
+                    # Forced refresh has its own bounded same-account recovery
+                    # and ordered settlement path. The fresh-request sibling
+                    # replay buffer must not escape that lifecycle.
+                    allow_transient_retry=False,
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
                     settlement=settlement,

--- a/openspec/changes/replay-fresh-overload-on-sibling/proposal.md
+++ b/openspec/changes/replay-fresh-overload-on-sibling/proposal.md
@@ -1,0 +1,34 @@
+# Change: replay-fresh-overload-on-sibling
+
+## Why
+
+A fresh, self-contained HTTP Responses request can receive the upstream
+`server_is_overloaded` terminal as either its first SSE event or after only
+`response.created` / `response.in_progress`.  The direct HTTP stream currently
+forwards those lifecycle frames and the terminal before its retry owner can
+classify the failure.  The request is therefore downstream-visible and the
+already-enabled deterministic failover policy cannot exclude the rejected
+account.  A soft prompt-cache affinity can then send several independent fresh
+requests to that same account until the separate three-rejection overload
+backoff changes later selection.
+
+## What Changes
+
+- Hold only the accepted lifecycle prelude of a replay-safe fresh HTTP stream
+  until the first output or terminal event.
+- Route an output-free `server_is_overloaded` or `overloaded_error` terminal
+  back to the existing bounded account-exclusion path while deterministic
+  failover is enabled.
+- Keep this exception unavailable to a request with a previous-response,
+  turn-state, file, single-account, dispatched-payload, or other hard owner;
+  and unavailable after content, tool output, or terminal output evidence.
+- Reuse the existing account exclusion, lease release, health settlement, and
+  `overload_backoff` paths.  Disabling deterministic failover remains
+  fail-closed.  No caller retry loop, timeout, or model routing is changed.
+
+## Impact
+
+- Code: `app/modules/proxy/_service/streaming/mixin.py` and its existing retry
+  owner in `app/modules/proxy/_service/streaming/retry.py`.
+- Tests: `tests/unit/test_proxy_utils.py`.
+- No schema, setting, deployment, or upstream protocol change.

--- a/openspec/changes/replay-fresh-overload-on-sibling/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/replay-fresh-overload-on-sibling/specs/proxy-admission-control/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Fresh output-free overloads probe an alternate account
+
+Codex-lb MUST make a bounded alternate-account selection after a fresh,
+account-neutral Responses stream with no model output returns
+`server_is_overloaded` or `overloaded_error` while
+deterministic failover is enabled. The terminal MAY be the first SSE event or
+follow only `response.created` and optional `response.in_progress`. The
+rejected account MUST be excluded from that request's replay selection and its
+existing health and overload-backoff handling MUST still run. The client MUST
+observe only the replacement account's response lifecycle.
+
+The recovery MUST NOT cross accounts when deterministic failover is disabled;
+after content, a tool call, or terminal output evidence; or when the request
+has a required previous-response, turn-state, durable Codex-session, file,
+single-account, or dispatched-payload owner.
+
+#### Scenario: Fresh HTTP first turn moves off an overloaded account
+
+- **GIVEN** a self-contained HTTP Responses stream selects account A
+- **AND** account B is eligible for the requested model
+- **AND** deterministic failover is enabled
+- **WHEN** A returns `response.created` followed by an output-free
+  `server_is_overloaded` rejection
+- **THEN** the stream excludes A and sends one bounded replay selection to B
+- **AND** the client observes only B's response lifecycle
+
+#### Scenario: First-event overload moves off an overloaded account
+
+- **GIVEN** a self-contained HTTP Responses stream selects account A
+- **AND** account B is eligible for the requested model
+- **AND** deterministic failover is enabled
+- **WHEN** A returns `server_is_overloaded` as its first SSE event
+- **THEN** the stream excludes A and sends one bounded replay selection to B
+- **AND** the client observes only B's response lifecycle
+
+#### Scenario: Continuity owner remains fail closed
+
+- **GIVEN** a Responses stream requires account A through a previous-response
+  owner
+- **AND** deterministic failover is enabled
+- **WHEN** A returns `server_is_overloaded`
+- **THEN** the request does not select account B
+- **AND** it retains the existing terminal continuity behavior
+
+#### Scenario: Visible output remains fail closed
+
+- **GIVEN** a self-contained HTTP Responses stream selects account A
+- **AND** deterministic failover is enabled
+- **WHEN** A emits content or a tool-call item before `server_is_overloaded`
+- **THEN** the request does not select account B
+- **AND** the original response lifecycle and terminal remain visible
+
+#### Scenario: Disabled deterministic failover remains fail closed
+
+- **GIVEN** a self-contained HTTP Responses stream selects account A
+- **AND** deterministic failover is disabled
+- **WHEN** A returns an output-free `server_is_overloaded` rejection
+- **THEN** the request does not select account B
+- **AND** the terminal remains visible

--- a/openspec/changes/replay-fresh-overload-on-sibling/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/replay-fresh-overload-on-sibling/specs/proxy-admission-control/spec.md
@@ -22,7 +22,7 @@ single-account, or dispatched-payload owner.
 - **AND** account B is eligible for the requested model
 - **AND** deterministic failover is enabled
 - **WHEN** A returns `response.created` followed by an output-free
-  `server_is_overloaded` rejection
+  `server_is_overloaded` or `overloaded_error` rejection
 - **THEN** the stream excludes A and sends one bounded replay selection to B
 - **AND** the client observes only B's response lifecycle
 
@@ -31,7 +31,8 @@ single-account, or dispatched-payload owner.
 - **GIVEN** a self-contained HTTP Responses stream selects account A
 - **AND** account B is eligible for the requested model
 - **AND** deterministic failover is enabled
-- **WHEN** A returns `server_is_overloaded` as its first SSE event
+- **WHEN** A returns `server_is_overloaded` or `overloaded_error` as its first
+  SSE event
 - **THEN** the stream excludes A and sends one bounded replay selection to B
 - **AND** the client observes only B's response lifecycle
 

--- a/openspec/changes/replay-fresh-overload-on-sibling/tasks.md
+++ b/openspec/changes/replay-fresh-overload-on-sibling/tasks.md
@@ -1,8 +1,9 @@
 ## 1. Regression coverage
 
-- [x] 1.1 Reproduce a fresh HTTP stream receiving `server_is_overloaded` as
-  either the first SSE event or after only `response.created`, then succeeding
-  on excluded-account sibling B with live-effective deterministic failover.
+- [x] 1.1 Reproduce a fresh HTTP stream receiving `server_is_overloaded` or
+  `overloaded_error` as either the first SSE event or after only
+  `response.created`, then succeeding on excluded-account sibling B with
+  live-effective deterministic failover.
 - [x] 1.2 Prove previous-response ownership, disabled deterministic failover,
   emitted content/tool output, and terminal output evidence remain fail closed.
 

--- a/openspec/changes/replay-fresh-overload-on-sibling/tasks.md
+++ b/openspec/changes/replay-fresh-overload-on-sibling/tasks.md
@@ -1,0 +1,21 @@
+## 1. Regression coverage
+
+- [x] 1.1 Reproduce a fresh HTTP stream receiving `server_is_overloaded` as
+  either the first SSE event or after only `response.created`, then succeeding
+  on excluded-account sibling B with live-effective deterministic failover.
+- [x] 1.2 Prove previous-response ownership, disabled deterministic failover,
+  emitted content/tool output, and terminal output evidence remain fail closed.
+
+## 2. Stream routing
+
+- [x] 2.1 Defer only the replay-safe lifecycle prelude at the direct HTTP SSE
+  boundary and return its output-free overload terminal to the existing retry
+  owner.
+- [x] 2.2 Retain the existing health, lease, exclusion, and overload-backoff
+  handling.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused stream retry regression and the proxy architecture
+  guard.
+- [x] 3.2 Validate this OpenSpec change strictly. Repository-wide spec validation remains a pre-existing baseline failure outside this delta.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16333,9 +16333,13 @@ async def test_stream_with_retry_previous_response_overload_does_not_cross_owner
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("created_first", [False, True], ids=["error_first", "created_then_error"])
+@pytest.mark.parametrize("error_code", ["server_is_overloaded", "overloaded_error"])
+@pytest.mark.parametrize("include_keepalive", [False, True], ids=["direct", "comment_keepalive"])
 async def test_stream_with_retry_replays_fresh_in_band_overload_on_sibling(
     monkeypatch: pytest.MonkeyPatch,
     created_first: bool,
+    error_code: str,
+    include_keepalive: bool,
 ):
     """The Reemxy classifier uses an unowned HTTP stream with failover enabled.
 
@@ -16374,9 +16378,11 @@ async def test_stream_with_retry_replays_fresh_in_band_overload_on_sibling(
         if account_id == rejected.chatgpt_account_id:
             if created_first:
                 yield ('data: {"type":"response.created","response":{"id":"resp_rejected","status":"in_progress"}}\n\n')
+            if include_keepalive:
+                yield ": upstream keepalive\n\n"
             yield (
                 'data: {"type":"error","error":{"type":"server_error",'
-                '"code":"server_is_overloaded","message":'
+                f'"code":"{error_code}","message":'
                 '"Our servers are currently overloaded. Please try again later."}}\n\n'
             )
             return
@@ -16432,7 +16438,141 @@ async def test_stream_with_retry_replays_fresh_in_band_overload_on_sibling(
     handle_stream_error.assert_awaited_once()
     assert handle_stream_error.await_args is not None
     assert handle_stream_error.await_args.args[0] is rejected
-    assert handle_stream_error.await_args.args[2] == "server_is_overloaded"
+    assert handle_stream_error.await_args.args[2] == error_code
+
+
+def test_output_free_overload_prelude_buffer_releases_duplicate_lifecycle() -> None:
+    buffer = streaming_helpers_module._OutputFreeOverloadReplayBuffer(enabled=True)
+    settlement = proxy_service._StreamSettlement()
+    created = 'data: {"type":"response.created"}\n\n'
+
+    assert buffer.relay("response.created", created, settlement) == []
+    assert buffer.relay("response.created", created, settlement) == [created, created]
+    assert settlement.downstream_visible is True
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_flushes_terminal_background_ack_after_replay_prelude(monkeypatch: pytest.MonkeyPatch):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = True
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_background_ack")
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        yield proxy_service.format_sse_event(
+            {
+                "type": "response.in_progress",
+                "response": {"id": "resp_background_ack", "object": "response", "status": "in_progress", "output": []},
+            }
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-luna", "instructions": "background", "input": [], "stream": False}
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert [parse_sse_data_json(chunk) for chunk in chunks] == [
+        {
+            "type": "response.in_progress",
+            "response": {"id": "resp_background_ack", "object": "response", "status": "in_progress", "output": []},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner_bound", [False, True], ids=["failover_disabled", "previous_response_owner"])
+async def test_stream_with_retry_post_refresh_overload_surfaces_without_replay_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+    owner_bound: bool,
+):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = owner_bound
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_overload")
+    stream_attempts = 0
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        nonlocal stream_attempts
+        stream_attempts += 1
+        if stream_attempts == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        yield 'data: {"type":"response.created","response":{"id":"resp_post_refresh","status":"in_progress"}}\n\n'
+        yield (
+            'data: {"type":"error","error":{"type":"server_error",'
+            '"code":"server_is_overloaded","message":"overloaded"}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account, account]))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    if owner_bound:
+        monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+
+    payload_data: dict[str, object] = {
+        "model": "gpt-5.6-luna",
+        "instructions": "retry after refresh",
+        "input": [],
+        "stream": True,
+    }
+    if owner_bound:
+        payload_data["previous_response_id"] = "resp_owner"
+    payload = ResponsesRequest.model_validate(payload_data)
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    event_payloads = [parse_sse_data_json(chunk) for chunk in chunks]
+    assert [event_payload["type"] for event_payload in event_payloads if event_payload is not None] == [
+        "response.created",
+        "error",
+    ]
+    assert stream_attempts == 2
 
 
 @pytest.mark.asyncio
@@ -16863,7 +17003,7 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
         if stream_once_calls == 2:
-            assert _kwargs["allow_transient_retry"] is True
+            assert _kwargs["allow_transient_retry"] is False
             settlement.record_success = False
             raise proxy_module.ProxyResponseError(
                 429,
@@ -16950,7 +17090,7 @@ async def test_stream_with_retry_post_refresh_model_capacity_retries_same_accoun
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
         if stream_once_calls == 2:
-            assert kwargs["allow_transient_retry"] is True
+            assert kwargs["allow_transient_retry"] is False
             raise proxy_module.ProxyResponseError(
                 400,
                 proxy_module.openai_error(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16188,6 +16188,493 @@ async def test_stream_with_retry_reprobes_alternate_after_capacity_wait(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_fresh_overload_respects_disabled_deterministic_failover(monkeypatch):
+    """A disabled policy remains fail-closed; the live incident has it enabled."""
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = False
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected = _make_account("acc_fresh_overload_rejected")
+    replacement = _make_account("acc_fresh_overload_replacement")
+    selected_account_ids: list[str] = []
+    selection_exclusions: list[set[str]] = []
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        selection_exclusions.append(excluded)
+        account = replacement if rejected.id in excluded else rejected
+        selected_account_ids.append(account.id)
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        if account.id == rejected.id:
+            raise proxy_module.ProxyResponseError(
+                503,
+                proxy_module.openai_error(
+                    "server_is_overloaded",
+                    "Our servers are currently overloaded. Please try again later.",
+                    error_type="service_unavailable_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_fresh_overload_replacement"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda account, **_kwargs: account),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-luna", "instructions": "classify", "input": [], "stream": True}
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "fresh-overload-prompt-cache", "prompt_cache_key": "fresh-overload"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert failed["response"]["error"]["code"] == "server_is_overloaded"
+    assert selected_account_ids == [rejected.id]
+    assert selection_exclusions == [set()]
+    handle_stream_error.assert_awaited_once()
+    assert handle_stream_error.await_args is not None
+    assert handle_stream_error.await_args.args[0] is rejected
+    assert handle_stream_error.await_args.args[2] == "server_is_overloaded"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_previous_response_overload_does_not_cross_owner_when_generic_failover_is_disabled(
+    monkeypatch,
+):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = False
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    owner = _make_account("acc_fresh_overload_previous_owner")
+    alternate = _make_account("acc_fresh_overload_previous_alternate")
+    selected_account_ids: list[str] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=owner.id))
+
+    async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
+        account = owner if not selected_account_ids else alternate
+        selected_account_ids.append(account.id)
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        raise proxy_module.ProxyResponseError(
+            503,
+            proxy_module.openai_error(
+                "server_is_overloaded",
+                "Our servers are currently overloaded. Please try again later.",
+                error_type="service_unavailable_error",
+            ),
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda account, **_kwargs: account),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "continue",
+            "input": [],
+            "previous_response_id": "resp_fresh_overload_owner",
+            "stream": True,
+        }
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "fresh-overload-previous-owner"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert failed["response"]["error"]["code"] == "server_is_overloaded"
+    assert selected_account_ids == [owner.id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("created_first", [False, True], ids=["error_first", "created_then_error"])
+async def test_stream_with_retry_replays_fresh_in_band_overload_on_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+    created_first: bool,
+):
+    """The Reemxy classifier uses an unowned HTTP stream with failover enabled.
+
+    Upstream may reject that fresh turn as the first SSE event, or may accept
+    the lifecycle and then fail it before any output.  Neither shape may pin
+    the soft prompt-cache affinity to the rejected account.
+    """
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = True
+    assert settings.deterministic_failover_enabled is True
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected = _make_account("acc_in_band_overload_rejected")
+    replacement = _make_account("acc_in_band_overload_replacement")
+    selected_account_ids: list[str] = []
+    selection_exclusions: list[set[str]] = []
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        selection_exclusions.append(excluded)
+        account = replacement if rejected.id in excluded else rejected
+        selected_account_ids.append(account.id)
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream(
+        _payload: ResponsesRequest,
+        _headers: Mapping[str, str],
+        _access_token: str,
+        account_id: str | None,
+        **_kwargs: object,
+    ) -> AsyncIterator[str]:
+        if account_id == rejected.chatgpt_account_id:
+            if created_first:
+                yield ('data: {"type":"response.created","response":{"id":"resp_rejected","status":"in_progress"}}\n\n')
+            yield (
+                'data: {"type":"error","error":{"type":"server_error",'
+                '"code":"server_is_overloaded","message":'
+                '"Our servers are currently overloaded. Please try again later."}}\n\n'
+            )
+            return
+        yield ('data: {"type":"response.created","response":{"id":"resp_replacement","status":"in_progress"}}\n\n')
+        yield (
+            'data: {"type":"response.completed","response":'
+            '{"id":"resp_replacement","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda account, **_kwargs: account),
+    )
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Return the classifier schema.",
+            "input": [{"role": "user", "content": "classify"}],
+            "stream": True,
+            "store": False,
+        }
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"prompt_cache_key": "reemxy-classifier"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    event_payloads = [parse_sse_data_json(chunk) for chunk in chunks]
+    assert [item["type"] for item in event_payloads if item is not None] == [
+        "response.created",
+        "response.completed",
+    ]
+    assert all("resp_rejected" not in chunk for chunk in chunks)
+    assert selected_account_ids == [rejected.id, replacement.id]
+    assert selection_exclusions == [set(), {rejected.id}]
+    handle_stream_error.assert_awaited_once()
+    assert handle_stream_error.await_args is not None
+    assert handle_stream_error.await_args.args[0] is rejected
+    assert handle_stream_error.await_args.args[2] == "server_is_overloaded"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_does_not_replay_in_band_overload_for_previous_response_owner(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = True
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    owner = _make_account("acc_in_band_overload_owner")
+    alternate = _make_account("acc_in_band_overload_owner_alternate")
+    selected_account_ids: list[str] = []
+
+    async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
+        account = owner if not selected_account_ids else alternate
+        selected_account_ids.append(account.id)
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        yield ('data: {"type":"response.created","response":{"id":"resp_owned","status":"in_progress"}}\n\n')
+        yield (
+            'data: {"type":"error","error":{"type":"server_error",'
+            '"code":"server_is_overloaded","message":"overloaded"}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=owner.id))
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=owner))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "continue",
+            "input": [{"role": "user", "content": "next"}],
+            "previous_response_id": "resp_owned",
+            "stream": True,
+        }
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    event_types = []
+    for chunk in chunks:
+        parsed = parse_sse_data_json(chunk)
+        assert parsed is not None
+        event_types.append(parsed["type"])
+
+    assert event_types == ["response.created", "error"]
+    assert selected_account_ids == [owner.id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_response",
+    [
+        pytest.param(
+            {"output": [{"type": "message", "id": "msg_terminal"}]},
+            id="terminal_output",
+        ),
+        pytest.param(
+            {"output": [], "usage": {"output_tokens": 1}},
+            id="terminal_billed_output",
+        ),
+    ],
+)
+async def test_stream_with_retry_does_not_replay_overload_with_terminal_output_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_response: dict[str, JsonValue],
+):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = True
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_in_band_overload_terminal_output")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        yield ('data: {"type":"response.created","response":{"id":"resp_terminal_output","status":"in_progress"}}\n\n')
+        response = {
+            "id": "resp_terminal_output",
+            "status": "failed",
+            "error": {"type": "server_error", "code": "server_is_overloaded", "message": "overloaded"},
+            **terminal_response,
+        }
+        yield proxy_service.format_sse_event({"type": "response.failed", "response": response})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "classify",
+            "input": [{"role": "user", "content": "classify"}],
+            "stream": True,
+        }
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"prompt_cache_key": "reemxy-classifier"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert select_account.await_count == 1
+    event_types = []
+    for chunk in chunks:
+        parsed = parse_sse_data_json(chunk)
+        assert parsed is not None
+        event_types.append(parsed["type"])
+
+    assert event_types == ["response.created", "response.failed"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "visible_event",
+    [
+        pytest.param(
+            {
+                "type": "response.output_text.delta",
+                "response_id": "resp_visible",
+                "item_id": "msg_visible",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": "partial",
+            },
+            id="text_output",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp_visible",
+                "output_index": 0,
+                "item": {
+                    "id": "call_visible",
+                    "type": "function_call",
+                    "call_id": "call_visible",
+                    "name": "lookup",
+                    "arguments": "",
+                    "status": "in_progress",
+                },
+            },
+            id="tool_output",
+        ),
+    ],
+)
+async def test_stream_with_retry_does_not_replay_overload_after_output(
+    monkeypatch: pytest.MonkeyPatch,
+    visible_event: dict[str, JsonValue],
+):
+    settings = _make_proxy_settings()
+    settings.deterministic_failover_enabled = True
+    assert settings.deterministic_failover_enabled is True
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_in_band_overload_visible")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        yield ('data: {"type":"response.created","response":{"id":"resp_visible","status":"in_progress"}}\n\n')
+        yield proxy_service.format_sse_event(visible_event)
+        yield (
+            'data: {"type":"error","error":{"type":"server_error",'
+            '"code":"server_is_overloaded","message":'
+            '"Our servers are currently overloaded. Please try again later."}}\n\n'
+        )
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Return the classifier schema.",
+            "input": [{"role": "user", "content": "classify"}],
+            "stream": True,
+        }
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"prompt_cache_key": "reemxy-classifier"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert select_account.await_count == 1
+    event_types = []
+    for chunk in chunks:
+        parsed = parse_sse_data_json(chunk)
+        assert parsed is not None
+        event_types.append(parsed["type"])
+
+    assert visible_event["type"] in event_types
+    assert "error" in event_types
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_propagation_prefers_other_account_before_response_create_cap_raise(monkeypatch):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))


### PR DESCRIPTION
An upstream overload can arrive after `response.created` or `response.in_progress` without any model output. Those lifecycle frames previously made the request downstream-visible, preventing the existing eligible-account failover from recovering it.

Buffer at most one frame of each lifecycle type for fresh, account-neutral requests and hand an output-free overload to the existing account exclusion, settlement and retry path. Both `server_is_overloaded` and `overloaded_error` are covered. Terminals reporting output or positive output/reasoning usage remain terminal, including when they are the first frame. Previous-response and other account owners stay pinned.

SSE comments preserve replay eligibility, duplicate lifecycle frames flush the buffer, terminal background acknowledgements are delivered, and forced-refresh attempts retain their separate capacity-recovery lifecycle.

Validation:

- Full proxy-utils suite: 1410 passed.
- Focused architecture and lifecycle selection: 31 passed.
- `make lint` passed, including architecture, cancellation, timing and settings checks; repository type checking passed.
- Strict validation of `replay-fresh-overload-on-sibling` passed.
