### PR TITLE
fix(http-bridge): reuse reservations after owner rejection

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2674,25 +2674,14 @@ class _HTTPBridgeStreamingMixin:
                         request_scope_id=owner_recovery_scope_id,
                     )
                 retry_request_state: _WebSocketRequestState | None = None
-                retry_unowned_lifecycle: _DeferredAccountBackoffLifecycle | None = None
                 try:
-                    retry_api_key_reservation = api_key_reservation
-                    retry_reservation_reacquired = False
-                    if api_key is not None and api_key_reservation is not None:
-                        retry_api_key_reservation = await self._reserve_websocket_api_key_usage(
-                            api_key,
-                            request_model=recovery_payload.model,
-                            request_service_tier=_normalize_service_tier_value(
-                                dict(recovery_payload.to_payload()).get("service_tier"),
-                            ),
-                            request_usage_budget=estimate_api_key_request_usage(recovery_payload),
-                        )
-                        retry_reservation_reacquired = True
-                        retry_unowned_lifecycle = begin_bridge_lifecycle(retry_api_key_reservation)
-
                     retry_request_state, retry_text_data = prepare_bridge_request(
                         recovery_payload,
-                        reservation=retry_api_key_reservation,
+                        # The owner rejected before dispatch, so the origin's
+                        # reservation is transferred to the local request.
+                        # Reacquiring here would consume quota twice and leave
+                        # the original hold without its lifecycle owner.
+                        reservation=request_state.api_key_reservation,
                     )
                     retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                     retry_request_state.affinity_policy = affinity
@@ -2748,21 +2737,6 @@ class _HTTPBridgeStreamingMixin:
                         request_deadline=request_deadline,
                     ):
                         yield event_block
-                except BaseException:
-                    if retry_reservation_reacquired and retry_api_key_reservation is not None:
-                        retry_lifecycle = (
-                            retry_request_state.deferred_account_backoff_lifecycle
-                            if retry_request_state is not None
-                            else retry_unowned_lifecycle
-                        )
-                        try:
-                            await release_unowned_bridge_lifecycle(retry_lifecycle, retry_request_state)
-                        except Exception:
-                            logger.warning(
-                                "Failed to release owner-recovery HTTP bridge reservation",
-                                exc_info=True,
-                            )
-                    raise
                 finally:
                     if owner_recovery_scope_id is not None:
                         _release_http_bridge_unanchored_handoff(

--- a/openspec/changes/reuse-owner-rejection-reservation/.openspec.yaml
+++ b/openspec/changes/reuse-owner-rejection-reservation/.openspec.yaml
@@ -1,0 +1,2 @@
+status: pending
+owner: proxy

--- a/openspec/changes/reuse-owner-rejection-reservation/proposal.md
+++ b/openspec/changes/reuse-owner-rejection-reservation/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+When an HTTP bridge owner rejects a bootstrap request before upstream
+dispatch, the origin can recover locally. The recovery must transfer the
+existing API-key usage reservation instead of acquiring a second hold.
+
+## What Changes
+
+- Reuse the original reservation during pre-dispatch local recovery.
+- Preserve the existing owner-forward classification and fail-closed paths.
+- Add regression coverage for exactly-once reservation ownership.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `sticky-session-operations`: local owner-forward recovery preserves the
+  original API-key reservation.

--- a/openspec/changes/reuse-owner-rejection-reservation/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/reuse-owner-rejection-reservation/specs/sticky-session-operations/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Pre-dispatch owner recovery reuses the original reservation
+
+The origin MUST reuse the original API-key reservation during pre-dispatch local recovery.
+This applies when an owner-forwarded bootstrap request is rejected before upstream
+dispatch and the origin enters its existing recovery path. It MUST NOT acquire
+a second reservation for the same request.
+
+The reservation lifecycle MUST still settle exactly once. A cancellation,
+acknowledged owner response, or ambiguous dispatch failure MUST remain on its
+existing fail-closed path and MUST NOT be treated as a local pre-dispatch
+recovery.
+
+#### Scenario: Local recovery transfers the original hold
+
+- **GIVEN** an API-key request owns a reservation
+- **AND** the HTTP bridge owner rejects the bootstrap request before dispatch
+- **WHEN** the origin creates the local recovery request
+- **THEN** the local request carries the original reservation identity
+- **AND** no second reservation is acquired
+
+#### Scenario: Ambiguous dispatch remains fail-closed
+
+- **GIVEN** an API-key request owns a reservation
+- **AND** owner forwarding is acknowledged or dispatch status is ambiguous
+- **WHEN** forwarding fails
+- **THEN** the origin does not enter local pre-dispatch recovery

--- a/openspec/changes/reuse-owner-rejection-reservation/tasks.md
+++ b/openspec/changes/reuse-owner-rejection-reservation/tasks.md
@@ -1,0 +1,9 @@
+## 1. Reservation transfer
+
+- [x] 1.1 Reuse the original API-key reservation in local owner-recovery.
+- [x] 1.2 Preserve the existing lifecycle settlement and fail-closed guards.
+
+## 2. Validation
+
+- [x] 2.1 Add a regression test proving no second reservation is acquired.
+- [x] 2.2 Validate the OpenSpec delta strictly.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -18847,7 +18847,7 @@ async def test_http_bridge_local_owner_rejects_aliases_for_distinct_live_session
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner_forward_failure(
+async def test_stream_via_http_bridge_reuses_api_key_reservation_after_pre_dispatch_owner_rejection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -18858,17 +18858,11 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
         key_id=api_key.id,
         model="gpt-5.4",
     )
-    retried_reservation = proxy_service.ApiKeyUsageReservationData(
-        reservation_id="resv-retry",
-        key_id=api_key.id,
-        model="gpt-5.4",
-    )
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.4",
             "instructions": "hi",
             "input": "hello",
-            "previous_response_id": "resp_prev_1",
         }
     )
 
@@ -18881,20 +18875,18 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
         started_at=started_at,
         event_queue=asyncio.Queue(),
         transport="http",
-        previous_response_id="resp_prev_1",
     )
-    request_state_initial.request_stage = "follow_up"
+    request_state_initial.request_stage = "first_turn"
     request_state_initial.preferred_account_id = "acc-1"
     request_state_retry = proxy_service._WebSocketRequestState(
         request_id="req-retry",
         model="gpt-5.4",
         service_tier=None,
         reasoning_effort=None,
-        api_key_reservation=retried_reservation,
+        api_key_reservation=initial_reservation,
         started_at=started_at,
         event_queue=asyncio.Queue(),
         transport="http",
-        previous_response_id="resp_prev_1",
     )
 
     prepare_reservations: list[proxy_service.ApiKeyUsageReservationData | None] = []
@@ -18942,7 +18934,18 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
 
     async def fake_forward_http_bridge_request_to_owner(**kwargs: object):
         del kwargs
-        raise ProxyResponseError(400, proxy_service.openai_error("previous_response_not_found", "missing"))
+        source = ProxyResponseError(
+            503,
+            proxy_service.openai_error(
+                "bridge_owner_unreachable",
+                "HTTP bridge owner is unreachable",
+                error_type="server_error",
+            ),
+        )
+        raise http_bridge_owner_forwarding_module._OwnerForwardRequestError(
+            source,
+            outcome=http_bridge_owner_forwarding_module._OwnerForwardOutcome.RECEIVER_REJECTED,
+        )
         yield ""
 
     async def fake_submit_http_bridge_request(
@@ -18964,7 +18967,7 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
 
         asyncio.create_task(produce_after_reattach_delay())
 
-    reserve_retry = AsyncMock(return_value=retried_reservation)
+    reserve_retry = AsyncMock(side_effect=AssertionError("pre-dispatch replay must reuse the original reservation"))
     capacity_unavailable = ProxyResponseError(
         503,
         proxy_service.openai_error("no_accounts", "Rate limit exceeded. Try again in 120s"),
@@ -19029,9 +19032,9 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
     assert any('"type":"codex.keepalive"' in chunk for chunk in chunks)
     assert chunks[-1] == 'data: {"type":"response.completed"}\n\n'
     assert get_or_create.await_count == 3
-    assert prepare_reservations == [initial_reservation, retried_reservation]
-    assert submitted_reservations == [retried_reservation]
-    reserve_retry.assert_awaited_once()
+    assert prepare_reservations == [initial_reservation, initial_reservation]
+    assert submitted_reservations == [initial_reservation]
+    reserve_retry.assert_not_awaited()
 
 
 async def _run_owner_forward_recovery_with_session(


### PR DESCRIPTION
## Summary

When an HTTP bridge owner rejects a bootstrap request before dispatch, local recovery acquires a second API-key reservation. The original hold can remain reserved, and a low request limit can reject recovery before it starts.

Transfer the original reservation into the local recovery request. Its existing lifecycle keeps settlement ownership through capacity waits, submission and cancellation.

## Validation

- The regression fails on main at the second reservation and passes with this change.
- 76 reservation, cancellation and release tests pass.
- Repository lint/type checks and strict OpenSpec validation pass.

OpenSpec: `reuse-owner-rejection-reservation`. This follows the [maintainer's request to separate the reservation repair from draining-owner recovery](https://github.com/Soju06/codex-lb/pull/2088#issuecomment-5584817676).
