### PR TITLE
refactor(bridge): retire the durable recovery-dispatch storage surface

### DIFF
--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -115,9 +115,9 @@ _SQLITE_FLOAT_TYPE_COMPAT_COLUMNS = frozenset(
     }
 )
 # Columns the ORM no longer maps but the schema still carries. A replica running
-# the previous release keeps mapping them and renders explicit NULLs in its
-# request-log INSERTs, so the physical drop must wait one release after the
-# mapping retirement (the Helm migration Job runs before old replicas drain).
+# the previous release keeps mapping them and renders an explicit value in its
+# INSERTs, so the physical drop must wait one release after the mapping
+# retirement (the Helm migration Job runs before old replicas drain).
 _LEGACY_EXTRA_COLUMNS = frozenset(
     {
         ("request_logs", "slim_summary_json"),
@@ -125,6 +125,10 @@ _LEGACY_EXTRA_COLUMNS = frozenset(
         # revision + removal from this set is queued for the following release.
         ("request_logs", "prewarm_canary_bucket"),
         ("request_logs", "prewarm_eligible_reason"),
+        # Retired from the ORM in retire-recovery-dispatch-storage; same
+        # queued drop. The column is NOT NULL with a server default, so this
+        # release's INSERTs simply omit it.
+        ("http_bridge_operations", "recovery_dispatch_count"),
     }
 )
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2508,7 +2508,10 @@ class HttpBridgeOperationRecord(Base):
     request_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     state: Mapped[str] = mapped_column(String(32), nullable=False, server_default=text("'submitted'"))
     response_id: Mapped[str | None] = mapped_column(Text, nullable=True)
-    recovery_dispatch_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    # ``recovery_dispatch_count`` is intentionally unmapped: the server-owned
+    # recovery dispatch it counted was deleted, so nothing reads or writes it.
+    # The physical column stays for one release so a previous-release replica
+    # can keep inserting operations (see ``_LEGACY_EXTRA_COLUMNS``).
     event_bytes: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     event_spool_complete: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     spool_format: Mapped[str] = mapped_column(

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1540,7 +1540,6 @@ class _HTTPBridgeRequestSubmitMixin:
                 operation, "rebound_from_parent_response_id", None
             )
             request_state.operation_persisted_response_id = getattr(operation, "response_id", None)
-            request_state.operation_attempt_generation = getattr(operation, "recovery_dispatch_count", 0)
 
         async def _cleanup_unsubmitted_recovery_claim() -> None:
             if (

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2079,9 +2079,6 @@ class _HTTPBridgeStreamingMixin:
                 else None
             )
             prior_operation_registered = request_state.operation_registered if preserve_operation_identity else False
-            prior_operation_attempt_generation = (
-                request_state.operation_attempt_generation if preserve_operation_identity else 0
-            )
             prior_operation_persisted_response_id = (
                 request_state.operation_persisted_response_id if preserve_operation_identity else None
             )
@@ -2114,7 +2111,6 @@ class _HTTPBridgeStreamingMixin:
                 request_state.operation_fingerprint = prior_operation_fingerprint
                 request_state.operation_parent_response_id = prior_operation_parent_response_id
                 request_state.operation_registered = prior_operation_registered
-                request_state.operation_attempt_generation = prior_operation_attempt_generation
                 request_state.operation_persisted_response_id = prior_operation_persisted_response_id
                 request_state.operation_rebind_required = True
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
@@ -3856,7 +3852,6 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_state.operation_fingerprint = request_state.operation_fingerprint
                 retry_request_state.operation_parent_response_id = request_state.operation_parent_response_id
                 retry_request_state.operation_registered = request_state.operation_registered
-                retry_request_state.operation_attempt_generation = request_state.operation_attempt_generation
                 retry_request_state.operation_persisted_response_id = request_state.operation_persisted_response_id
                 retry_request_state.operation_rebind_required = request_state.operation_rebind_required
                 # An anchored recovery replays the proxy's own anchor, so the

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -484,7 +484,6 @@ async def _persist_http_bridge_operation_event(
                                 )
                             ),
                             state=terminal_state,
-                            expected_recovery_dispatch_count=request_state.operation_attempt_generation,
                             response_id=response_id,
                         ),
                         None,
@@ -534,7 +533,6 @@ async def _persist_http_bridge_operation_event(
                             owner_epoch=owner_epoch,
                             state=terminal_state,
                             expected_response_id=expected_response_id,
-                            expected_recovery_dispatch_count=request_state.operation_attempt_generation,
                             alternate_expected_response_id=alternate_expected_response_id,
                             response_id=response_id,
                         )

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1177,9 +1177,6 @@ class _WebSocketRequestState:
     operation_rebound_from_parent_response_id: str | None = None
     operation_replay: bool = False
     operation_dispatched: bool = False
-    # Immutable durable attempt generation. Recovery claims increment the
-    # operation's dispatch count before sending a replacement attempt.
-    operation_attempt_generation: int = 0
     # Last response identity successfully written to the durable operation.
     # Retry setup may clear the active response before a replacement is
     # acknowledged, but fallback settlement must still fence against this ID.

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -770,7 +770,6 @@ class DurableBridgeSessionCoordinator:
         event_text: str,
         max_bytes: int,
         state: str,
-        expected_recovery_dispatch_count: int = 0,
         response_id: str | None = None,
     ) -> bool:
         async with self._session() as session:
@@ -782,7 +781,6 @@ class DurableBridgeSessionCoordinator:
                 event_text=event_text,
                 max_bytes=max_bytes,
                 state=state,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                 response_id=response_id,
             )
 
@@ -820,7 +818,6 @@ class DurableBridgeSessionCoordinator:
         event_text: str,
         max_bytes: int,
         state: str,
-        expected_recovery_dispatch_count: int = 0,
         response_id: str | None = None,
     ) -> bool:
         async with self._session() as session:
@@ -832,7 +829,6 @@ class DurableBridgeSessionCoordinator:
                 event_text=event_text,
                 max_bytes=max_bytes,
                 state=state,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                 response_id=response_id,
             )
 
@@ -861,7 +857,6 @@ class DurableBridgeSessionCoordinator:
         owner_epoch: int,
         state: str,
         expected_response_id: str | None,
-        expected_recovery_dispatch_count: int = 0,
         alternate_expected_response_id: str | None = None,
         response_id: str | None = None,
     ) -> bool:
@@ -873,7 +868,6 @@ class DurableBridgeSessionCoordinator:
                 owner_epoch=owner_epoch,
                 state=state,
                 expected_response_id=expected_response_id,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                 alternate_expected_response_id=alternate_expected_response_id,
                 response_id=response_id,
             )
@@ -918,24 +912,6 @@ class DurableBridgeSessionCoordinator:
                 owner_epoch=owner_epoch,
             )
 
-    async def claim_unknown_operation_for_recovery(
-        self,
-        *,
-        operation_id: str,
-        session_id: str,
-        instance_id: str,
-        owner_epoch: int,
-        max_recovery_dispatches: int | None = None,
-    ) -> bool:
-        async with self._session() as session:
-            return await DurableBridgeRepository(session).claim_unknown_operation_for_recovery(
-                operation_id=operation_id,
-                session_id=session_id,
-                instance_id=instance_id,
-                owner_epoch=owner_epoch,
-                max_recovery_dispatches=max_recovery_dispatches,
-            )
-
     async def mark_operation_unknown(
         self,
         *,
@@ -943,7 +919,6 @@ class DurableBridgeSessionCoordinator:
         session_id: str,
         instance_id: str,
         owner_epoch: int,
-        restore_recovery_dispatch_claim: bool = False,
     ) -> bool:
         async with self._session() as session:
             return await DurableBridgeRepository(session).mark_operation_unknown(
@@ -951,7 +926,6 @@ class DurableBridgeSessionCoordinator:
                 session_id=session_id,
                 instance_id=instance_id,
                 owner_epoch=owner_epoch,
-                restore_recovery_dispatch_claim=restore_recovery_dispatch_claim,
             )
 
     async def rollback_operation_before_dispatch(

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -214,7 +214,6 @@ class DurableBridgeOperationSnapshot:
     parent_response_id: str | None
     state: str
     response_id: str | None
-    recovery_dispatch_count: int = 0
     request_text: str | None = None
     event_spool_complete: bool = True
     created: bool = False
@@ -320,7 +319,6 @@ class DurableBridgeRepository:
         session_id: str,
         instance_id: str,
         owner_epoch: int,
-        expected_recovery_dispatch_count: int | None = None,
     ) -> tuple[HttpBridgeOperationRecord, bool] | None:
         owner_exists = await self._session.scalar(
             select(HttpBridgeSessionRecord.id)
@@ -335,10 +333,6 @@ class DurableBridgeRepository:
             HttpBridgeOperationRecord.operation_id == operation_id,
             HttpBridgeOperationRecord.session_id == session_id,
         )
-        if expected_recovery_dispatch_count is not None:
-            operation_statement = operation_statement.where(
-                HttpBridgeOperationRecord.recovery_dispatch_count == expected_recovery_dispatch_count
-            )
         operation = await self._session.scalar(operation_statement.with_for_update())
         # ``abandoned`` is a terminal duplicate-suppression fence that the
         # maintenance sweep applies without clearing session ownership, so the
@@ -2154,59 +2148,6 @@ class DurableBridgeRepository:
             await self._session.commit()
         return True
 
-    async def claim_unknown_operation_for_recovery(
-        self,
-        *,
-        operation_id: str,
-        session_id: str,
-        instance_id: str,
-        owner_epoch: int,
-        max_recovery_dispatches: int | None = None,
-    ) -> bool:
-        """Atomically claim an UNKNOWN operation for one recovery attempt.
-
-        Recovery admission can be reached by multiple reconnects at once. A
-        reset followed by a later state transition leaves a window where each
-        reconnect can observe UNKNOWN and submit the same operation. Keep the
-        owner fence, state transition, and transcript reset in one serialized
-        write so exactly one caller can move UNKNOWN back to SUBMITTED.
-        """
-        async with sqlite_writer_section():
-            owner_exists = await self._session.scalar(
-                select(HttpBridgeSessionRecord.id)
-                .where(
-                    HttpBridgeSessionRecord.id == session_id,
-                    HttpBridgeSessionRecord.owner_instance_id == instance_id,
-                    HttpBridgeSessionRecord.owner_epoch == owner_epoch,
-                )
-                .with_for_update()
-            )
-            operation = await self._session.scalar(
-                select(HttpBridgeOperationRecord)
-                .where(
-                    HttpBridgeOperationRecord.operation_id == operation_id,
-                    HttpBridgeOperationRecord.session_id == session_id,
-                    HttpBridgeOperationRecord.state == "unknown",
-                )
-                .with_for_update()
-            )
-            if owner_exists is None or operation is None or operation.state == "abandoned":
-                await self._session.rollback()
-                return False
-            if max_recovery_dispatches is not None and operation.recovery_dispatch_count >= max_recovery_dispatches:
-                await self._session.rollback()
-                return False
-            await self._delete_operation_spool_material((operation_id,))
-            operation.state = "submitted"
-            operation.response_id = None
-            operation.recovery_dispatch_count += 1
-            operation.event_bytes = 0
-            operation.event_spool_complete = False
-            operation.spool_format = HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
-            operation.updated_at = utcnow()
-            await self._session.commit()
-        return True
-
     async def mark_operation_unknown(
         self,
         *,
@@ -2214,7 +2155,6 @@ class DurableBridgeRepository:
         session_id: str,
         instance_id: str,
         owner_epoch: int,
-        restore_recovery_dispatch_claim: bool = False,
     ) -> bool:
         """Fence an ambiguously dispatched SUBMITTED operation as UNKNOWN.
 
@@ -2246,18 +2186,6 @@ class DurableBridgeRepository:
                 return False
             if operation.state == "submitted":
                 operation.state = "unknown"
-                if restore_recovery_dispatch_claim and operation.recovery_dispatch_count > 0:
-                    operation.recovery_dispatch_count -= 1
-                operation.updated_at = utcnow()
-            elif (
-                restore_recovery_dispatch_claim
-                and operation.state == "unknown"
-                and operation.recovery_dispatch_count > 0
-            ):
-                # A concurrent cleanup may have fenced the row first. The
-                # caller still owns a proven pre-dispatch recovery claim, so
-                # refund exactly that claim while retaining UNKNOWN.
-                operation.recovery_dispatch_count -= 1
                 operation.updated_at = utcnow()
             await self._session.commit()
         return True
@@ -2626,7 +2554,6 @@ class DurableBridgeRepository:
         event_text: str,
         max_bytes: int,
         state: str,
-        expected_recovery_dispatch_count: int = 0,
         response_id: str | None = None,
     ) -> bool:
         """Append a terminal v2 chunk and expose its outcome atomically."""
@@ -2654,7 +2581,6 @@ class DurableBridgeRepository:
                 session_id=session_id,
                 instance_id=instance_id,
                 owner_epoch=owner_epoch,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
             )
             if locked_operation is None:
                 return False
@@ -2773,7 +2699,6 @@ class DurableBridgeRepository:
         event_text: str,
         max_bytes: int,
         state: str,
-        expected_recovery_dispatch_count: int = 0,
         response_id: str | None = None,
     ) -> bool:
         """Append a terminal event and expose its operation state atomically."""
@@ -2792,7 +2717,6 @@ class DurableBridgeRepository:
                 .where(
                     HttpBridgeOperationRecord.operation_id == operation_id,
                     HttpBridgeOperationRecord.session_id == session_id,
-                    HttpBridgeOperationRecord.recovery_dispatch_count == expected_recovery_dispatch_count,
                     HttpBridgeOperationRecord.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
                 )
                 .with_for_update()
@@ -3012,7 +2936,6 @@ class DurableBridgeRepository:
         owner_epoch: int,
         state: str,
         expected_response_id: str | None,
-        expected_recovery_dispatch_count: int = 0,
         alternate_expected_response_id: str | None = None,
         response_id: str | None = None,
     ) -> bool:
@@ -3058,7 +2981,10 @@ class DurableBridgeRepository:
                     HttpBridgeOperationRecord.operation_id == operation_id,
                     HttpBridgeOperationRecord.session_id == session_id,
                     HttpBridgeOperationRecord.state != "abandoned",
-                    HttpBridgeOperationRecord.recovery_dispatch_count == expected_recovery_dispatch_count,
+                    # The state fence is what rejects a newer attempt: a retry
+                    # that reset the row to ``submitted`` matches neither
+                    # ``acknowledged`` nor the terminal state being settled, so
+                    # the update affects no row and the caller sees a rejection.
                     or_(
                         and_(HttpBridgeOperationRecord.state == "acknowledged", acknowledged_response_matches),
                         and_(
@@ -4187,7 +4113,6 @@ def _to_operation_snapshot(
         parent_response_id=row.parent_response_id,
         state=row.state,
         response_id=row.response_id,
-        recovery_dispatch_count=row.recovery_dispatch_count,
         request_text=row.request_text,
         event_spool_complete=bool(row.event_spool_complete),
         created=created,

--- a/app/modules/proxy/http_bridge_event_batcher.py
+++ b/app/modules/proxy/http_bridge_event_batcher.py
@@ -268,7 +268,6 @@ class HttpBridgeOperationEventBatcher:
         event_text: str,
         max_bytes: int,
         state: str,
-        expected_recovery_dispatch_count: int = 0,
         response_id: str | None = None,
     ) -> TerminalOperationEventAppendResult:
         """Drain queued events and atomically append the terminal outcome."""
@@ -306,7 +305,6 @@ class HttpBridgeOperationEventBatcher:
                     event_text=event_text,
                     max_bytes=max_bytes,
                     state=state,
-                    expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                     response_id=response_id,
                 )
             else:
@@ -318,7 +316,6 @@ class HttpBridgeOperationEventBatcher:
                     event_text=event_text,
                     max_bytes=max_bytes,
                     state=state,
-                    expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                     response_id=response_id,
                 )
             terminal_persisted = bool(persisted and not dropped)
@@ -351,7 +348,6 @@ class HttpBridgeOperationEventBatcher:
         owner_epoch: int,
         state: str,
         expected_response_id: str | None,
-        expected_recovery_dispatch_count: int = 0,
         alternate_expected_response_id: str | None = None,
         response_id: str | None = None,
     ) -> None:
@@ -364,7 +360,6 @@ class HttpBridgeOperationEventBatcher:
                 owner_epoch=owner_epoch,
                 state=state,
                 expected_response_id=expected_response_id,
-                expected_recovery_dispatch_count=expected_recovery_dispatch_count,
                 alternate_expected_response_id=alternate_expected_response_id,
                 response_id=response_id,
             )

--- a/openspec/changes/retire-recovery-dispatch-storage/design.md
+++ b/openspec/changes/retire-recovery-dispatch-storage/design.md
@@ -1,0 +1,64 @@
+# Design
+
+## Proof: no writer can advance `recovery_dispatch_count` on `main`
+
+Every occurrence of the column name in the tree at `origin/main`, grouped by
+role (`grep -rn recovery_dispatch_count .`, excluding `.git`/`node_modules`).
+
+Writes — all three sit inside the callerless surface this change deletes:
+
+- `durable_bridge_repository.py` `operation.recovery_dispatch_count += 1`, the
+  only increment, inside `claim_unknown_operation_for_recovery`. Its only
+  in-repo references are the `DurableBridgeSessionCoordinator` pass-through
+  (itself callerless) and repository tests; the request-path caller went away
+  with `drop-bridge-recovery-modes`.
+- Two `-= 1` refunds in `mark_operation_unknown`, both guarded by
+  `restore_recovery_dispatch_claim and recovery_dispatch_count > 0`. The
+  single production caller
+  (`request_submit._submit_http_bridge_request_with_handoff`) passes only
+  `operation_id`/`session_id`/`instance_id`/`owner_epoch`, so the flag is
+  always `False`; and with no increment left, the `> 0` floor could never hold
+  either.
+
+Non-writes: the ORM mapping (retired here), the Alembic revision that created
+the column `NOT NULL DEFAULT 0` plus its merge revision, the read-only
+`DurableBridgeOperationSnapshot` field and its row mapper, the three
+`== expected_recovery_dispatch_count` read predicates, the
+`request_state.operation_attempt_generation` initialiser in
+`request_submit.py`, keyword pass-throughs in `durable_bridge_coordinator.py`
+/ `http_bridge_event_batcher.py` / `_service/http_bridge/upstream_events.py`,
+and tests/prose. No raw `text()` SQL, no bulk `update(...).values(...)` and no
+ORM INSERT anywhere in `app/` names the column; the only INSERT that still
+sets it is a deliberately legacy-shaped one in
+`tests/integration/test_migrations.py`.
+
+## Why the CAS predicates are safe to drop
+
+The expectation was never a hardcoded constant: `request_submit.py` seeds
+`request_state.operation_attempt_generation` from the snapshot's
+`recovery_dispatch_count`, and `streaming.py` only preserves or copies that
+value across the account-neutral replay and the server-owned retry hand-off.
+Because no writer can move the column between the snapshot and the append, and
+because `record_operation`'s `failed` -> `submitted` rebind leaves the counter
+alone, the predicate compared a value to itself for every row the code could
+reach — including rows carried over from before `drop-bridge-recovery-modes`
+with a non-zero counter. Removing it is a no-op, not a latent fix.
+
+Note that `append_terminal_operation_event` and `_lock_operation_for_chunk_append`
+therefore had no newer-attempt discriminator before this change either: the
+counter did not move across a rebind, so the surviving fences (session owner
+instance/epoch, `session_id`, the `abandoned` refusal, and `spool_format ==
+rows_v1` for the terminal append) are the same protection they always were.
+`settle_terminal_append_failure` keeps its real newer-attempt fence in the
+operation-state plus persisted-response-identity `or_` predicate.
+
+## Column retention
+
+`retire-prewarm-canary-column-mappings` (#2189) is the precedent: retire the
+ORM mapping now, allow-list the physical column in `_LEGACY_EXTRA_COLUMNS` so
+the schema-drift gate stays clean, and queue the Alembic drop for the release
+after the last release whose ORM mapped it. The Helm migration Job is a
+`pre-upgrade` hook that runs before the old replicas drain, so a
+previous-release replica must still be able to INSERT an operation row that
+names the column. The column is `NOT NULL` with `server_default 0`, so this
+release's INSERTs simply omit it.

--- a/openspec/changes/retire-recovery-dispatch-storage/proposal.md
+++ b/openspec/changes/retire-recovery-dispatch-storage/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+`drop-bridge-recovery-modes` (#2336) deleted every request-path caller of the
+server-owned recovery dispatch and deferred the storage cleanup to a follow-up
+that retires it "together with the `recovery_dispatch_count` column
+semantics". This is that follow-up.
+
+Every writer of `http_bridge_operations.recovery_dispatch_count` on `main`
+sits inside that callerless surface, so no supported path can advance the
+counter and the three `expected_recovery_dispatch_count` CAS predicates can no
+longer reject anything. A fence that can never reject is not a fence.
+`design.md` carries the per-writer proof.
+
+## What Changes
+
+- **Delete the callerless recovery-dispatch surface.**
+  `claim_unknown_operation_for_recovery` (repository + coordinator), the
+  `max_recovery_dispatches` bound, and the `restore_recovery_dispatch_claim`
+  flag on `mark_operation_unknown` (repository + coordinator).
+  `mark_operation_unknown` itself stays: it is the live ambiguous-dispatch
+  fence.
+- **Drop the tautological CAS arguments, keep every fence that still guards
+  something.** `expected_recovery_dispatch_count` is removed from
+  `append_terminal_operation_event`, `append_terminal_operation_chunk`,
+  `settle_terminal_append_failure`,
+  `_lock_operation_for_chunk_append` (repository), their coordinator
+  pass-throughs, `HttpBridgeOperationEventBatcher.append_terminal_event` /
+  `settle_terminal_event`, and the two `upstream_events` call sites. What
+  remains:
+  - `append_terminal_operation_event`: session-owner instance/epoch fence,
+    `session_id`, the `abandoned` refusal, and the
+    `spool_format == rows_v1` predicate in the same `SELECT ... FOR UPDATE`.
+  - `_lock_operation_for_chunk_append`: session-owner instance/epoch fence,
+    `session_id`, and the `abandoned` refusal (the only other caller already
+    passed no expected count).
+  - `settle_terminal_append_failure`: session-owner fence, `state != abandoned`,
+    and the operation-state plus persisted-response-identity `or_` predicate.
+    That state predicate is what rejects the delayed fallback settlement of a
+    prior attempt after a newer attempt rebinds the row to `submitted`
+    (`record_operation` is the only remaining path that does so) — `submitted`
+    matches neither `acknowledged` nor the terminal state being settled, so the
+    UPDATE touches no row.
+- **Delete the now-unread request-state field.**
+  `HTTPRequestState.operation_attempt_generation` and its propagation through
+  the account-neutral replay and the server-owned retry hand-off in
+  `_service/http_bridge/streaming.py`.
+- **Keep the physical column this release; retire only the ORM mapping.**
+  `HttpBridgeOperationRecord.recovery_dispatch_count` is removed from the
+  model and the column is added to `_LEGACY_EXTRA_COLUMNS` in
+  `app/db/migrate.py`, exactly as `retire-prewarm-canary-column-mappings`
+  (#2189) did for the prewarm canary columns. The Helm migration Job is a
+  `pre-upgrade` hook that runs before the old replicas drain, so a
+  previous-release replica must still be able to INSERT an operation row. The
+  column is `NOT NULL` with `server_default 0`, so this release's INSERTs
+  simply omit it and the default fills it. The Alembic drop revision plus the
+  allow-list removal is queued in
+  `openspec/specs/deployment-installation/context.md` under the next-release
+  entry titled "Drop the retired bridge recovery-dispatch column".
+
+No behaviour change for legacy rows either. On `main` the expectation is read
+from the row itself (`request_state.operation_attempt_generation =
+getattr(operation, "recovery_dispatch_count", 0)` in `request_submit.py`), and
+`record_operation`'s `failed` -> `submitted` rebind leaves the counter alone,
+so a pre-#2336 row with a non-zero counter always compared equal too. The
+predicate was satisfied by every row the code could reach, which is exactly
+why removing it is a no-op.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: the durable one-shot recovery-dispatch budget is
+  gone with its dispatcher; terminal-append fallback settlement is fenced by
+  operation state and persisted response identity rather than by a durable
+  attempt generation; the operation ORM no longer maps the retired counter
+  column while the physical column remains insertable for legacy replicas.
+
+## Impact
+
+`app/db/models.py`, `app/db/migrate.py`,
+`app/modules/proxy/durable_bridge_repository.py`,
+`app/modules/proxy/durable_bridge_coordinator.py`,
+`app/modules/proxy/http_bridge_event_batcher.py`,
+`app/modules/proxy/_service/support.py`,
+`app/modules/proxy/_service/http_bridge/{request_submit,streaming,upstream_events}.py`,
+and their tests. No Alembic revision and no runtime behaviour change at the
+shipped default: every removed predicate was satisfied by every row the
+current release can write. No rolling-upgrade caveat — a previous-release
+replica still finds the column it maps, and this release never writes it.
+
+## Orphan sweep from #2336
+
+Also checked, and deliberately **not** removed (all still live on `main`):
+
+- `HttpBridgeRecoveryAttemptRecord` and the `recovery_attempt_*` request-state
+  fields — the *fresh-replay* recovery journal, a separate table with live
+  readers/writers in `_service/http_bridge/upstream_events.py`,
+  `request_submit.py` and the shutdown drain in `app/main.py`.
+- `request_state.replay_count` / `clean_close_replay_count` — client-observed
+  replay accounting, read at 20+ sites.
+- `operation_replay`, `operation_created`, `operation_rebound*`,
+  `operation_dispatched`, `operation_rebind_required`,
+  `operation_persisted_response_id` — all still read on the request path.
+- `mark_operation_unknown` and `rollback_operation_before_dispatch` — live
+  cleanup primitives.

--- a/openspec/changes/retire-recovery-dispatch-storage/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retire-recovery-dispatch-storage/specs/responses-api-compat/spec.md
@@ -1,0 +1,80 @@
+# responses-api-compat Delta
+
+## REMOVED Requirements
+
+### Requirement: Fenced one-shot recovery dispatch
+
+**Reason**: The requirement MUSTs a durable one-shot replay budget that is "consumed atomically when a replay is claimed for dispatch". `drop-bridge-recovery-modes` deleted the only claimant; the primitive that implemented the claim (`DurableBridgeRepository.claim_unknown_operation_for_recovery`, its `max_recovery_dispatches` bound and the `restore_recovery_dispatch_claim` refund on `mark_operation_unknown`) has had zero production callers since, so nothing can consume, restore or settle the budget. All three of its scenarios drive that deleted claim path, and its own title states the deleted dispatch, so a MODIFIED block cannot express the removal.
+
+**Migration**: None. No supported configuration could claim a replay after `drop-bridge-recovery-modes`: an `unknown` operation already returns the `upstream_operation_status_unknown` 503 with a cooldown `Retry-After` unconditionally. The `http_bridge_operations.recovery_dispatch_count` column is retained for one release for rolling-upgrade safety and its ORM mapping is retired; the Alembic drop is queued in `openspec/specs/deployment-installation/context.md`.
+
+## MODIFIED Requirements
+
+### Requirement: Terminal append failure preserves authoritative settlement
+
+When durable append of a terminal HTTP-bridge event raises after the operation was acknowledged, the proxy MUST attempt to persist the intended terminal operation state through the same operation, session, instance, and owner-epoch fence. Cancellation MUST be deferred through the append and any required fallback settlement. The event spool MUST remain incomplete, and the persistence failure MUST NOT replace or block the terminal event and end-of-stream marker already selected for downstream delivery. A rejected or failed fallback settlement MUST be logged and MUST NOT bypass the owner fence or overwrite a newer operation attempt admitted under the same owner epoch. That newer-attempt rejection MUST rest on the operation's own state and persisted upstream-response identity; no durable per-attempt dispatch counter is kept for it. The durable operation model MUST NOT map a retired recovery-dispatch counter column. Such a column MAY remain in the physical schema, allow-listed by the schema-drift gate, until the release after the last release whose ORM mapped it, because a supported previous-release replica still writes it while the migration Job runs ahead of the workload roll.
+
+#### Scenario: Terminal append exception settles the current owner operation
+
+- **GIVEN** an acknowledged HTTP-bridge operation owned by the current session epoch
+- **WHEN** durable terminal-event append raises
+- **THEN** the operation is persisted in the intended terminal state
+- **AND** its event spool remains incomplete
+- **AND** the terminal event and end-of-stream marker are queued before fallback settlement can stall
+- **AND** reconnect or recovery does not observe the operation as acknowledged work
+
+#### Scenario: Grouped failures deliver every sibling before settlement
+
+- **GIVEN** one upstream error selects terminal failures for multiple pending operations
+- **WHEN** the first operation's fallback settlement stalls
+- **THEN** every selected operation attempts its owner-fenced terminal append before any terminal queue is exposed
+- **AND** every selected operation then receives its terminal event and end-of-stream marker before fallback settlement
+- **AND** sibling delivery does not wait for the first fallback settlement
+- **AND** cancellation is preserved as the final outcome only after every pre-delivered sibling finishes settlement and finalization
+- **AND** one sibling's finalization failure does not prevent later siblings from settling or replace pending cancellation
+
+#### Scenario: Cancellation preserves terminal delivery authority
+
+- **GIVEN** terminal append finishes while relay cancellation is deferred
+- **WHEN** the append result becomes available
+- **THEN** the terminal event and end-of-stream marker are queued
+- **AND** a completed-delivery scope is marked authoritative before cleanup can deactivate it
+- **AND** cancellation during that delivery-authority claim does not skip required fallback settlement
+- **AND** cancellation is preserved only after delivery and required settlement
+
+#### Scenario: Stale owner cannot settle after terminal append exception
+
+- **GIVEN** an HTTP-bridge operation whose owner epoch has advanced
+- **WHEN** the stale batcher encounters a terminal-event append exception
+- **THEN** fallback settlement is rejected by the durable owner fence
+- **AND** the stale batcher does not mutate the operation state
+
+#### Scenario: Newer retry rejects delayed fallback settlement
+
+- **GIVEN** terminal append committed its operation state before reporting an exception
+- **AND** a retry under the same owner epoch has since reset the operation to submitted
+- **WHEN** fallback settlement for the prior attempt runs
+- **THEN** the fallback is rejected by the operation-state and persisted upstream-response identity fence
+- **AND** the newer submitted attempt remains unchanged
+
+#### Scenario: Replay alias preserves the acknowledged-attempt fence
+
+- **GIVEN** a replay whose client-visible response alias differs from its persisted upstream response ID or whose active upstream response ID was reset before a replacement response was created
+- **WHEN** durable terminal-event append raises
+- **THEN** fallback settlement compares the acknowledged or already terminal operation against every response identity that may remain persisted when a replacement acknowledgement update fails
+- **AND** persists the intended client-visible terminal response ID when present
+- **AND** otherwise preserves the known upstream response ID
+
+#### Scenario: Successful terminal append remains atomic and replayable
+
+- **WHEN** durable terminal-event append succeeds
+- **THEN** the terminal event and intended operation state are persisted atomically
+- **AND** the completed event spool remains eligible for replay
+
+#### Scenario: Retired recovery-dispatch column stays insertable during the rolling upgrade
+
+- **GIVEN** a database at the current Alembic head
+- **WHEN** a replica running the previous release inserts a durable operation row with an explicit recovery-dispatch counter value
+- **THEN** the insert succeeds because the physical column still exists
+- **AND** the current release's operation model does not map that column, so its own inserts take the column default
+- **AND** the schema-drift check reports no drift for the retained column

--- a/openspec/changes/retire-recovery-dispatch-storage/tasks.md
+++ b/openspec/changes/retire-recovery-dispatch-storage/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+- [x] 1.1 Prove no writer can advance `recovery_dispatch_count` on `main`:
+      grep every occurrence across `app/`, `tests/`, `frontend/`, `scripts/`,
+      `deploy/`, `openspec/` and confirm the only increments/decrements are
+      inside `claim_unknown_operation_for_recovery` and the
+      `restore_recovery_dispatch_claim` branches, both callerless.
+- [x] 1.2 Delete `claim_unknown_operation_for_recovery` and the
+      `max_recovery_dispatches` bound from the repository and the coordinator.
+- [x] 1.3 Delete the `restore_recovery_dispatch_claim` flag and its refund
+      branches from `mark_operation_unknown` (repository + coordinator),
+      keeping the SUBMITTED -> UNKNOWN transition.
+- [x] 1.4 Remove `expected_recovery_dispatch_count` from the three CAS sites,
+      their coordinator/batcher pass-throughs and the `upstream_events` call
+      sites; keep the owner, `abandoned`, `spool_format` and
+      operation-state/response-identity predicates.
+- [x] 1.5 Delete `HTTPRequestState.operation_attempt_generation` and its
+      propagation in `request_submit.py` / `streaming.py`.
+- [x] 1.6 Remove the `recovery_dispatch_count` ORM mapping and allow-list the
+      retained physical column in `_LEGACY_EXTRA_COLUMNS`.
+- [x] 1.7 Cover the mixed-version contract: head schema still carries the
+      column, the ORM does not map it, a legacy-style INSERT with an explicit
+      value succeeds, a current-release ORM INSERT defaults it to 0, and
+      `check_schema_drift` is clean.
+- [x] 1.8 Replace the deleted repository tests: prove the operation-state
+      fence (not a durable generation) rejects a prior attempt's delayed
+      fallback settlement after a rebind to SUBMITTED.
+- [x] 1.9 Queue the physical drop in
+      `openspec/specs/deployment-installation/context.md` under the
+      next-release entry titled "Drop the retired bridge recovery-dispatch
+      column" (cited by title, not by list position).

--- a/openspec/specs/deployment-installation/context.md
+++ b/openspec/specs/deployment-installation/context.md
@@ -175,7 +175,21 @@ settings, merged as PRs #1351, #1360, #1362, #1363, #1364 in v1.21.x):
    `CODEX_LB_REQUEST_LOG_RETENTION_DAYS` /
    `CODEX_LB_USAGE_HISTORY_RETENTION_DAYS` are in `_REMOVED_SETTINGS` for
    their warning release. See `openspec/specs/data-retention/context.md`.
-3. **Retire the removal warning itself.** `_REMOVED_SETTINGS` and
+3. **Drop the retired bridge recovery-dispatch column.**
+   `http_bridge_operations.recovery_dispatch_count` has been unwritten since
+   `drop-bridge-recovery-modes` deleted the server-owned recovery dispatch and
+   is no longer mapped by the `HttpBridgeOperationRecord` ORM model since
+   `retire-recovery-dispatch-storage` (v1.25); the physical column is
+   allow-listed in `_LEGACY_EXTRA_COLUMNS` (`app/db/migrate.py`). It could not
+   be dropped in the same release that retired the mapping, for the same
+   reason as "Drop the deprecated prewarm request-log columns (phase B)"
+   above: the Helm migration Job runs before old replicas drain,
+   and a previous-release replica still maps the column and renders an
+   explicit value in its operation INSERTs. Once v1.25 is the oldest supported
+   release, add the Alembic drop revision (batch-mode `drop_column` for
+   SQLite, `NOT NULL` re-add with `server_default 0` on downgrade) and remove
+   the allow-list entry in the same PR.
+4. **Retire the removal warning itself.** `_REMOVED_SETTINGS` and
    `warn_removed_settings()` in `app/core/config/settings.py` are a
    one-release courtesy per removed batch ("at least one release"). The
    phase 1-4 names were pruned by `remove-dead-env-settings` (their warning release shipped in

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -2656,6 +2656,94 @@ async def test_retired_prewarm_canary_columns_stay_insertable_for_legacy_replica
 
 
 @pytest.mark.asyncio
+async def test_retired_recovery_dispatch_column_stays_insertable_for_legacy_replicas(tmp_path):
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.models import HttpBridgeOperationRecord
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'retired-recovery-dispatch-column.sqlite'}"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+
+    # The ORM no longer maps the retired column...
+    assert "recovery_dispatch_count" not in HttpBridgeOperationRecord.__table__.columns.keys()
+
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            head_columns = await conn.run_sync(
+                lambda sync_conn: {
+                    column["name"] for column in sa_inspect(sync_conn).get_columns("http_bridge_operations")
+                }
+            )
+            # ...but the head schema still carries it, so a replica running the
+            # previous release (which maps it and renders an explicit value in
+            # its INSERT) keeps recording operations while the migration Job has
+            # already run ahead of the workload roll.
+            assert "recovery_dispatch_count" in head_columns
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_sessions (
+                        id, session_key_kind, session_key_value, session_key_hash,
+                        api_key_scope, owner_epoch, state, created_at, updated_at, last_seen_at
+                    ) VALUES (
+                        'session-retired-dispatch', 'session_header', 'retired', 'retired-hash',
+                        '__anonymous__', 0, 'closed', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO http_bridge_operations (
+                        operation_id, session_id, request_fingerprint, request_text,
+                        state, response_id, recovery_dispatch_count, event_bytes,
+                        event_spool_complete, spool_format, created_at, updated_at
+                    ) VALUES (
+                        'operation-retired-dispatch', 'session-retired-dispatch', 'fingerprint-retired', '{}',
+                        'completed', 'response-retired', 1, 8, true, 'rows_v1',
+                        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+        # This release's ORM INSERT omits the column entirely; the NOT NULL
+        # server default fills it.
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as db_session:
+            db_session.add(
+                HttpBridgeOperationRecord(
+                    operation_id="operation-current-release",
+                    session_id="session-retired-dispatch",
+                    request_fingerprint="fingerprint-current",
+                    state="submitted",
+                    event_bytes=0,
+                    event_spool_complete=False,
+                )
+            )
+            await db_session.commit()
+        async with engine.connect() as conn:
+            rows = (
+                await conn.execute(
+                    text(
+                        "SELECT operation_id, recovery_dispatch_count FROM http_bridge_operations ORDER BY operation_id"
+                    )
+                )
+            ).all()
+        assert [tuple(row) for row in rows] == [
+            ("operation-current-release", 0),
+            ("operation-retired-dispatch", 1),
+        ]
+    finally:
+        await engine.dispose()
+
+    # The retained physical column is an allow-listed drift, not a schema defect.
+    assert await to_thread.run_sync(lambda: check_schema_drift(db_url)) == ()
+
+
+@pytest.mark.asyncio
 async def test_dashboard_stream_bridge_budget_migration_upgrade_and_downgrade(tmp_path):
     """M1: upgrade adds the two nullable ``dashboard_settings`` budget columns,
     downgrade drops them, and a final walk to head proves a single-head graph."""

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -2015,7 +2015,7 @@ async def test_durable_bridge_presence_query_includes_chunk_table(
 
 
 @pytest.mark.asyncio
-async def test_chunk_format_resets_on_failed_rebind_and_unknown_claim(
+async def test_chunk_format_resets_on_failed_rebind(
     async_session_factory: Callable[[], AsyncSession],
 ) -> None:
     session = async_session_factory()
@@ -2076,20 +2076,6 @@ async def test_chunk_format_resets_on_failed_rebind_and_unknown_claim(
         assert failed_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
         assert failed_row.event_bytes == 0
 
-        unknown_fingerprint = durable_bridge_hash("unknown-format-reset")
-        unknown_operation_id = durable_bridge_operation_id(claim.id, unknown_fingerprint)
-        await seed(unknown_operation_id, unknown_fingerprint, "unknown")
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=unknown_operation_id,
-            session_id=claim.id,
-            instance_id="inst-format-reset",
-            owner_epoch=claim.owner_epoch,
-        )
-        unknown_row = await session.get(HttpBridgeOperationRecord, unknown_operation_id)
-        assert unknown_row is not None
-        await session.refresh(unknown_row)
-        assert unknown_row.spool_format == HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1
-        assert unknown_row.event_bytes == 0
     finally:
         await session.close()
 
@@ -2427,38 +2413,31 @@ async def test_terminal_append_failure_settlement_is_visible_to_recovery(
         assert null_alias_settlement.state == "failed"
         assert null_alias_settlement.response_id == "resp-upstream-replay"
 
+        # A newer attempt admitted under the same owner epoch rebinds the
+        # failed row back to SUBMITTED. The operation-state fence -- not a
+        # durable attempt generation -- is what rejects the prior attempt's
+        # delayed fallback settlement.
         assert await repository.update_operation(
             operation_id=replay_operation_id,
             session_id=claim.id,
             instance_id="inst-terminal-recovery",
             owner_epoch=claim.owner_epoch,
-            state="unknown",
-        )
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=replay_operation_id,
-            session_id=claim.id,
-            instance_id="inst-terminal-recovery",
-            owner_epoch=claim.owner_epoch,
-        )
-        assert await repository.update_operation(
-            operation_id=replay_operation_id,
-            session_id=claim.id,
-            instance_id="inst-terminal-recovery",
-            owner_epoch=claim.owner_epoch,
-            state="acknowledged",
+            state="failed",
             response_id="resp-upstream-replay",
         )
-        assert not await repository.append_terminal_operation_event(
+        rebound_replay = await repository.record_operation(
             operation_id=replay_operation_id,
             session_id=claim.id,
             instance_id="inst-terminal-recovery",
             owner_epoch=claim.owner_epoch,
-            event_text='data: {"type":"response.failed"}\n\n',
-            max_bytes=1024,
-            state="failed",
-            expected_recovery_dispatch_count=0,
-            response_id="resp-client-visible-replay",
+            request_fingerprint=replay_fingerprint,
+            account_id="account-terminal-recovery",
+            model="gpt-5.6",
+            parent_response_id="resp-parent",
         )
+        assert rebound_replay is not None
+        assert rebound_replay.rebound is True
+        assert rebound_replay.state == "submitted"
         assert not await repository.settle_terminal_append_failure(
             operation_id=replay_operation_id,
             session_id=claim.id,
@@ -2466,13 +2445,12 @@ async def test_terminal_append_failure_settlement_is_visible_to_recovery(
             owner_epoch=claim.owner_epoch,
             state="failed",
             expected_response_id="resp-upstream-replay",
-            expected_recovery_dispatch_count=0,
             response_id="resp-client-visible-replay",
         )
         newer_attempt = await repository.get_operation(operation_id=replay_operation_id)
         assert newer_attempt is not None
-        assert newer_attempt.state == "acknowledged"
-        assert newer_attempt.recovery_dispatch_count == 1
+        assert newer_attempt.state == "submitted"
+        assert newer_attempt.response_id is None
         assert newer_attempt.event_spool_complete is False
     finally:
         await session.close()
@@ -2624,191 +2602,6 @@ async def test_consumed_recovery_checkpoint_does_not_rebind_failed_operation(
         assert persisted is not None
         assert persisted.session_id == original.id
         assert persisted.state == "failed"
-    finally:
-        await session.close()
-
-
-@pytest.mark.asyncio
-async def test_unknown_operation_recovery_claim_is_atomic_and_single_use(
-    async_session_factory: Callable[[], AsyncSession],
-) -> None:
-    session = async_session_factory()
-    try:
-        repository = DurableBridgeRepository(session)
-        claim = await _claim(repository, instance_id="inst-operation-claim", session_key_value="sid-operation-claim")
-        fingerprint = durable_bridge_hash("continuation-claim")
-        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
-        operation = await repository.record_operation(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-claim",
-            owner_epoch=claim.owner_epoch,
-            request_fingerprint=fingerprint,
-            account_id="account-operation",
-            model="gpt-5.6",
-            parent_response_id="resp-parent",
-        )
-        assert operation is not None
-        assert await repository.append_operation_event(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-claim",
-            owner_epoch=claim.owner_epoch,
-            event_text='data: {"type":"response.output_text.delta"}\n\n',
-            max_bytes=1024,
-        )
-        assert await repository.mark_operation_unknown(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-claim",
-            owner_epoch=claim.owner_epoch,
-        )
-
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-claim",
-            owner_epoch=claim.owner_epoch,
-        )
-        claimed = await repository.get_operation(operation_id=operation_id)
-        assert claimed is not None
-        assert claimed.state == "submitted"
-        assert claimed.response_id is None
-        assert claimed.event_spool_complete is False
-        assert await repository.get_operation_events(operation_id=operation_id) == []
-
-        # The state transition is the claim: a concurrent reconnect that gets
-        # the write lock later cannot reset and submit the same operation.
-        assert not await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-claim",
-            owner_epoch=claim.owner_epoch,
-        )
-    finally:
-        await session.close()
-
-
-@pytest.mark.asyncio
-async def test_one_shot_recovery_budget_survives_unknown_reset(
-    async_session_factory: Callable[[], AsyncSession],
-) -> None:
-    session = async_session_factory()
-    try:
-        repository = DurableBridgeRepository(session)
-        claim = await _claim(
-            repository,
-            instance_id="inst-operation-one-shot",
-            session_key_value="sid-operation-one-shot",
-        )
-        fingerprint = durable_bridge_hash("continuation-one-shot")
-        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
-        operation = await repository.record_operation(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-one-shot",
-            owner_epoch=claim.owner_epoch,
-            request_fingerprint=fingerprint,
-            account_id="account-operation",
-            model="gpt-5.6",
-            parent_response_id="resp-parent",
-        )
-        assert operation is not None
-        assert await repository.mark_operation_unknown(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-one-shot",
-            owner_epoch=claim.owner_epoch,
-        )
-
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-one-shot",
-            owner_epoch=claim.owner_epoch,
-            max_recovery_dispatches=1,
-        )
-        # A failed or ambiguous dispatch may return the operation to UNKNOWN,
-        # but that must not refund the durable one-shot recovery budget.
-        assert await repository.mark_operation_unknown(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-one-shot",
-            owner_epoch=claim.owner_epoch,
-        )
-        assert not await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-one-shot",
-            owner_epoch=claim.owner_epoch,
-            max_recovery_dispatches=1,
-        )
-        persisted = await repository.get_operation(operation_id=operation_id)
-        assert persisted is not None
-        assert persisted.state == "unknown"
-        assert persisted.recovery_dispatch_count == 1
-    finally:
-        await session.close()
-
-
-@pytest.mark.asyncio
-async def test_pre_dispatch_recovery_claim_restores_one_shot_budget(
-    async_session_factory: Callable[[], AsyncSession],
-) -> None:
-    session = async_session_factory()
-    try:
-        repository = DurableBridgeRepository(session)
-        claim = await _claim(
-            repository,
-            instance_id="inst-operation-refund",
-            session_key_value="sid-operation-refund",
-        )
-        fingerprint = durable_bridge_hash("continuation-refund")
-        operation_id = durable_bridge_operation_id(claim.id, fingerprint)
-        operation = await repository.record_operation(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-refund",
-            owner_epoch=claim.owner_epoch,
-            request_fingerprint=fingerprint,
-            account_id="account-operation",
-            model="gpt-5.6",
-            parent_response_id="resp-parent",
-        )
-        assert operation is not None
-        assert await repository.mark_operation_unknown(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-refund",
-            owner_epoch=claim.owner_epoch,
-        )
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-refund",
-            owner_epoch=claim.owner_epoch,
-            max_recovery_dispatches=1,
-        )
-
-        # A cancellation before send_text() is proven pre-dispatch and must
-        # refund the claim so the next reconnect can make the one safe retry.
-        assert await repository.mark_operation_unknown(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-refund",
-            owner_epoch=claim.owner_epoch,
-            restore_recovery_dispatch_claim=True,
-        )
-        assert await repository.claim_unknown_operation_for_recovery(
-            operation_id=operation_id,
-            session_id=claim.id,
-            instance_id="inst-operation-refund",
-            owner_epoch=claim.owner_epoch,
-            max_recovery_dispatches=1,
-        )
-        persisted = await repository.get_operation(operation_id=operation_id)
-        assert persisted is not None
-        assert persisted.recovery_dispatch_count == 1
     finally:
         await session.close()
 
@@ -3038,15 +2831,6 @@ async def test_stale_ambiguous_operation_is_abandoned_and_late_writers_are_fence
                 event_text="data: late-terminal\n\n",
                 max_bytes=1024,
                 state="failed",
-            )
-            is False
-        )
-        assert (
-            await repository.claim_unknown_operation_for_recovery(
-                operation_id=operation_id,
-                session_id=successor.id,
-                instance_id="inst-operation-abandonment-successor",
-                owner_epoch=successor.owner_epoch,
             )
             is False
         )

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -1498,6 +1498,24 @@ def test_check_schema_drift_ignores_retired_prewarm_canary_columns_kept_for_roll
     assert check_schema_drift(url) == ()
 
 
+def test_check_schema_drift_ignores_retired_recovery_dispatch_column_kept_for_rolling_upgrade(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "retired-recovery-dispatch-column.db"
+    url = _db_url(db_path)
+
+    run_upgrade(url, "head", bootstrap_legacy=False)
+
+    assert "recovery_dispatch_count" not in Base.metadata.tables["http_bridge_operations"].columns.keys()
+
+    sync_url = to_sync_database_url(url)
+    with create_engine(sync_url, future=True).connect() as connection:
+        head_columns = {column["name"] for column in inspect(connection).get_columns("http_bridge_operations")}
+    assert "recovery_dispatch_count" in head_columns
+
+    assert check_schema_drift(url) == ()
+
+
 def test_check_schema_drift_ignores_sqlite_real_float_reflection_for_sticky_thresholds(
     monkeypatch,
     tmp_path: Path,

--- a/tests/unit/test_http_bridge_event_batcher.py
+++ b/tests/unit/test_http_bridge_event_batcher.py
@@ -271,7 +271,6 @@ async def test_terminal_append_failure_settles_operation() -> None:
             "owner_epoch": 7,
             "state": "failed",
             "expected_response_id": "resp-upstream-1",
-            "expected_recovery_dispatch_count": 0,
             "alternate_expected_response_id": None,
             "response_id": "resp-1",
             "event_spool_complete": False,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -388,7 +388,6 @@ async def test_submit_abandoned_operation_returns_full_history_recovery_without_
     request_state.recovery_attempt_fingerprint = "recovery-attempt-abandoned-operation"
     request_state.recovery_attempt_session_id = session.durable_session_id
     request_state.recovery_attempt_owner_epoch = session.durable_owner_epoch
-    claim_unknown = AsyncMock()
     rollback_recovery_attempt = AsyncMock(return_value=True)
     service._durable_bridge = cast(
         Any,
@@ -396,7 +395,6 @@ async def test_submit_abandoned_operation_returns_full_history_recovery_without_
             get_operation_by_fingerprint=AsyncMock(return_value=abandoned),
             get_operation=AsyncMock(return_value=abandoned),
             record_operation=AsyncMock(return_value=abandoned),
-            claim_unknown_operation_for_recovery=claim_unknown,
             rollback_recovery_attempt_before_dispatch=rollback_recovery_attempt,
         ),
     )
@@ -424,7 +422,6 @@ async def test_submit_abandoned_operation_returns_full_history_recovery_without_
     assert exc_info.value.payload["error"]["type"] == "invalid_request_error"
     assert exc_info.value.payload["error"]["code"] == "previous_response_not_found"
     assert exc_info.value.payload["error"]["param"] == "previous_response_id"
-    claim_unknown.assert_not_awaited()
     send_text.assert_not_awaited()
     # The journaled UNKNOWN checkpoint is released with the rejection so an
     # identical resend is not refused as an in-flight recovery request.
@@ -7520,7 +7517,6 @@ async def test_terminal_append_failure_retains_last_persisted_response_id_after_
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     request_state = SimpleNamespace(
         operation_id="op-terminal-retry-reset",
-        operation_attempt_generation=0,
         operation_persisted_response_id=None,
         request_id="req-terminal-retry-reset",
         response_id="resp-before-retry",
@@ -7599,7 +7595,6 @@ async def test_terminal_append_failure_queues_before_stalled_fallback_settlement
         skip_request_log=True,
     )
     request_state.operation_id = "op-terminal-append-fallback-order"
-    request_state.operation_attempt_generation = 2
     request_state.replay_downstream_response_id = replay_response_id
     session = _make_bridge_session(
         key_value="terminal-append-fallback-order",
@@ -7657,9 +7652,9 @@ async def test_terminal_append_failure_queues_before_stalled_fallback_settlement
     release_append.set()
     await asyncio.wait_for(settlement_started.wait(), timeout=1.0)
     assert append_kwargs["response_id"] == replay_response_id
-    assert append_kwargs["expected_recovery_dispatch_count"] == 2
+    assert "expected_recovery_dispatch_count" not in append_kwargs
     assert settlement_kwargs["expected_response_id"] == expected_response_id
-    assert settlement_kwargs["expected_recovery_dispatch_count"] == 2
+    assert "expected_recovery_dispatch_count" not in settlement_kwargs
     assert settlement_kwargs["alternate_expected_response_id"] == alternate_expected_response_id
     assert settlement_kwargs["response_id"] == replay_response_id
     assert await asyncio.wait_for(event_queue.get(), timeout=1.0) == event_block


### PR DESCRIPTION
## Summary

`drop-bridge-recovery-modes` (#2336) deleted every request-path caller of the server-owned recovery dispatch and explicitly deferred the storage cleanup: its own delta says the durable primitive "is now unreferenced by the request path and keeps its repository-level tests until a follow-up retires it together with the `recovery_dispatch_count` column semantics." This is that follow-up — it deletes the callerless surface, drops three CAS predicates that can no longer reject anything, and retires the ORM mapping while keeping the physical column one more release for rolling-upgrade safety.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [x] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #2336 — the deferral this PR follows up. Refs #2189 — the column-retention precedent (`retire-prewarm-canary-column-mappings`). **No issue is closed by this PR**; both references are context, not fixes.

## Proof: no writer can advance `recovery_dispatch_count` on `main`

Every occurrence of the column name in the tree at `origin/main`, grouped by role. Reproduce with `grep -rn recovery_dispatch_count .` (excluding `.git`/`node_modules`). The full write-up lives in `openspec/changes/retire-recovery-dispatch-storage/design.md`.

**Writes — all three are inside the callerless surface:**

| Site | Kind | Reachable? |
|---|---|---|
| `durable_bridge_repository.py:2202` `operation.recovery_dispatch_count += 1` | increment | No. Inside `claim_unknown_operation_for_recovery` (`:2157`). Its only in-repo references are `durable_bridge_coordinator.py:931` (a pass-through whose own method has zero callers) and repository tests. |
| `durable_bridge_repository.py:2250` `-= 1` | decrement | No. Guarded by `restore_recovery_dispatch_claim and recovery_dispatch_count > 0`. The single production caller of `mark_operation_unknown` (`_service/http_bridge/request_submit.py:2291`) passes only `operation_id`/`session_id`/`instance_id`/`owner_epoch`, so the flag is always `False`. And even if it were `True`, `> 0` can never hold with no increment. |
| `durable_bridge_repository.py:2260` `-= 1` | decrement | No. Same flag, same `> 0` floor. |

**Non-writes (the rest of the hits):**

- `app/db/models.py:2511` — the ORM mapping (this PR retires it).
- `app/db/alembic/versions/20260810_000000_add_http_bridge_recovery_dispatch_count.py` + the `20260812` merge revision — DDL that creates the column `NOT NULL DEFAULT 0`.
- `durable_bridge_repository.py:217`, `:4190` — the read-only `DurableBridgeOperationSnapshot` field and its mapper.
- `durable_bridge_repository.py:340`, `:2795`, `:3061` — the three `== expected_recovery_dispatch_count` **read** predicates.
- `_service/http_bridge/request_submit.py:1543` — a read: `request_state.operation_attempt_generation = getattr(operation, "recovery_dispatch_count", 0)`.
- Pass-through keyword arguments in `durable_bridge_coordinator.py`, `http_bridge_event_batcher.py`, `_service/http_bridge/upstream_events.py`.
- `tests/…`, `openspec/…` — tests and prose.

No raw SQL `text()`, no bulk `update(...).values(...)`, and no ORM `INSERT` anywhere in `app/` names the column outside the rows above. The only remaining INSERT that sets it is a deliberately legacy-shaped one in `tests/integration/test_migrations.py`.

**Consequence.** The expectation is not a hardcoded constant: `request_submit.py:1543` seeds `request_state.operation_attempt_generation` from the operation snapshot's own `recovery_dispatch_count`, and `streaming.py` only preserves it across the account-neutral replay (`:2082`, `:2117`) or copies it to the retry state (`:3859`) — where the identity is *not* preserved, a fresh `request_state` is built and reseeded from the row it then finds. Since no writer can move the column between that read and the append, and since `record_operation`'s `failed`→`submitted` rebind does not touch the counter, each `expected_recovery_dispatch_count` CAS compares a value to itself for **every row the code can reach — including rows carried over from before #2336 with a non-zero counter**. A predicate that can never reject is not a fence, and the two orphaned request-state hops that carried the value around are pure noise. Removing it is a no-op, not a latent fix and not a regression.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/retire-recovery-dispatch-storage/`

- **REMOVED** `responses-api-compat` → "Fenced one-shot recovery dispatch". The requirement MUSTs a durable one-shot replay budget "consumed atomically when a replay is claimed for dispatch"; all three of its scenarios drive the deleted claim path and its title names the deleted dispatch, so `MODIFIED` cannot express it.
- **MODIFIED** `responses-api-compat` → "Terminal append failure preserves authoritative settlement". The newer-attempt rejection now rests on operation state + persisted upstream-response identity (no durable per-attempt counter), and the requirement records the ORM-mapping retirement plus the one-release physical-column retention. Adds a rolling-upgrade scenario mirroring #2189's.
- `drop-bridge-recovery-modes` is **already archived on `main`** (`openspec/changes/archive/2026-09-11-drop-bridge-recovery-modes/`), so both blocks are transcribed from the **post-archive** `main` spec text (`openspec/specs/responses-api-compat/spec.md`) — the state a reviewer sees today. There is no longer a pending interleaving to worry about.
- Free-form rationale (the per-writer proof, why each CAS predicate is safe to drop, the column-retention reasoning) lives in `design.md` beside the proposal, per `AGENTS.md`; `proposal.md`'s `Why` is 603 characters, under the archive lint's 1000-character threshold.

Validation and archive simulation on a temp copy of current `main`'s `openspec/` (`git archive origin/main openspec`), with only this change dir copied in:

```
$ openspec validate --specs --strict            → Totals: 65 passed, 0 failed (65 items)
$ openspec validate retire-recovery-dispatch-storage --strict
                                                → Change 'retire-recovery-dispatch-storage' is valid
$ openspec archive retire-recovery-dispatch-storage --yes
  Specs to update:
    responses-api-compat: update
  Applying changes to openspec/specs/responses-api-compat/spec.md:
    ~ 1 modified
    - 1 removed
  Totals: + 0, ~ 1, - 1, → 0
  Specs updated successfully.
  Change 'retire-recovery-dispatch-storage' archived as '2026-09-11-retire-recovery-dispatch-storage'.
$ openspec validate --specs --strict   (post-archive)  → 65 passed, 0 failed
$ grep -c "Fenced one-shot recovery dispatch" openspec/specs/responses-api-compat/spec.md → 0
```

## Changes

**Deleted (callerless):**

- `DurableBridgeRepository.claim_unknown_operation_for_recovery` and its `max_recovery_dispatches` bound; the `DurableBridgeSessionCoordinator` pass-through.
- The `restore_recovery_dispatch_claim` flag and both refund branches on `mark_operation_unknown` (repository + coordinator). **`mark_operation_unknown` itself stays** — it is the live ambiguous-dispatch fence called from `request_submit`.
- `HTTPRequestState.operation_attempt_generation` (`_service/support.py`) and its propagation through the account-neutral replay and the server-owned retry hand-off in `_service/http_bridge/streaming.py`, plus the `request_submit` assignment.

**CAS arguments removed — what each fence still guards:**

| Site | Removed | Still guarded by |
|---|---|---|
| `append_terminal_operation_event` | `expected_recovery_dispatch_count` predicate | session-owner `instance_id`/`owner_epoch` `SELECT … FOR UPDATE`, `session_id`, the `state == "abandoned"` refusal, and **`spool_format == rows_v1`** in the same statement |
| `_lock_operation_for_chunk_append` (used by `append_terminal_operation_chunk`) | the whole optional parameter | session-owner fence, `session_id`, `abandoned` refusal. Its other caller (`append_operation_event_chunk`) already passed no expected count, so the parameter's only value was the tautology |
| `settle_terminal_append_failure` | `expected_recovery_dispatch_count` predicate | session-owner fence, `state != "abandoned"`, and the operation-state + persisted-response-identity `or_` |

Note on the first two rows: because the counter cannot move across a retry or a rebind (see **Consequence** above), `append_terminal_operation_event` and `_lock_operation_for_chunk_append` had **no newer-attempt discriminator before this change either** — the removed predicate never distinguished attempts, so their protection is unchanged.

The last row is the interesting fence. Its spec scenario ("Newer retry rejects delayed fallback settlement") is preserved by the **state** predicate alone: the only path left that can reset a live row to `submitted` is `record_operation`'s `failed`→`submitted` rebind, and `submitted` matches neither `state == "acknowledged"` nor `state == <terminal state>`, so the `UPDATE` touches no row and the caller sees the rejection. A comment at the predicate records this.

**Column retention (#2189 precedent):**

- `HttpBridgeOperationRecord.recovery_dispatch_count` removed from the ORM; a comment at the former site explains why the column is unmapped.
- `("http_bridge_operations", "recovery_dispatch_count")` added to `_LEGACY_EXTRA_COLUMNS` in `app/db/migrate.py` so the drift gate treats the retained column as known drift.
- **The physical column is NOT dropped.** The Helm migration Job is a `pre-upgrade` hook that runs before old replicas drain, so a replica on the previous build must still be able to `INSERT` an operation row naming the column. Because it is `NOT NULL DEFAULT 0`, this release's INSERTs simply omit it.
- Queued in `openspec/specs/deployment-installation/context.md` under the next-release entry titled **"Drop the retired bridge recovery-dispatch column"** (cited by title, not by list position, so renumbering cannot break the reference), worded the same way #2189's entry was (Alembic `drop_column` in batch mode for SQLite, `NOT NULL` re-add with `server_default 0` on downgrade, allow-list entry removed in the same PR).

## Orphan sweep from #2336

Checked and **still live** — not touched by this PR:

- `HttpBridgeRecoveryAttemptRecord` and the `recovery_attempt_*` request-state fields. This is a *different* journal (fresh-replay attempts), with live readers/writers in `_service/http_bridge/upstream_events.py` (~20 sites), `request_submit.py`, and the `http-bridge-recovery-settlement-*` shutdown drain in `app/main.py`.
- `request_state.replay_count` / `clean_close_replay_count` — client-observed replay accounting, read at 20+ sites across `request_submit.py`, `streaming.py`, `upstream_events.py`, `support.py`, and surfaced in `response_create.py`.
- `operation_replay`, `operation_created`, `operation_rebound*`, `operation_dispatched`, `operation_rebind_required`, `operation_persisted_response_id` — every one still read on the request path.
- `mark_operation_unknown`, `rollback_operation_before_dispatch`, `reset_operation_event_spool` — live cleanup primitives.

## Test plan

```
$ make lint                                            → all checks passed
$ uv run ty check                                      → All checks passed!
$ make migration-check                                 → current_revision=20260911_010000_merge_pin_index_and_affinity_heads
                                                         migration_policy=ok, schema_drift=none
$ python3 .github/scripts/check_simplicity_budgets.py  → all OK

# full touched files
$ uv run pytest tests/unit/test_bridge_ring_lifecycle.py tests/unit/test_proxy_http_bridge.py \
      tests/unit/test_db_migrate.py tests/unit/test_http_bridge_event_batcher.py -q
  1206 passed

$ uv run pytest tests/unit -q -x
  9923 passed, 4 skipped

# integration for the touched modules
$ uv run pytest tests/integration/test_migrations.py tests/integration/test_http_responses_bridge.py \
      tests/integration/test_multi_instance_bridge.py tests/integration/test_startup_bridge_cleanup.py -q
  242 passed, 9 skipped

$ codex review --base origin/main   (run on the pre-rebase head; the rebase changed
                                     only hunk offsets, the app/ + tests/ diff content
                                     is byte-identical)
  "No actionable correctness defects were found in the changes. The retired storage
   surface is removed consistently, while rolling-upgrade compatibility for the
   physical column is preserved."
```

Test changes:

- Deleted `test_unknown_operation_recovery_claim_is_atomic_and_single_use`, `test_one_shot_recovery_budget_survives_unknown_reset`, `test_pre_dispatch_recovery_claim_restores_one_shot_budget` — each exercised only the deleted claim path.
- Renamed `test_chunk_format_resets_on_failed_rebind_and_unknown_claim` → `test_chunk_format_resets_on_failed_rebind` and dropped its unknown-claim half; the failed-rebind half is unchanged.
- Rewrote the generation-fence block in `test_terminal_append_failure_settlement_is_visible_to_recovery` to prove the **state** fence rejects a prior attempt's delayed fallback settlement after `record_operation` rebinds the row to `submitted`.
- Dropped the `claim_unknown_operation_for_recovery` assertion from the abandoned-fence test; the four other late writers there already cover it.
- New `tests/unit/test_db_migrate.py::test_check_schema_drift_ignores_retired_recovery_dispatch_column_kept_for_rolling_upgrade` and `tests/integration/test_migrations.py::test_retired_recovery_dispatch_column_stays_insertable_for_legacy_replicas` — head schema still carries the column, the ORM does not map it, a legacy-style INSERT with an explicit `1` succeeds, a current-release ORM INSERT defaults to `0`, and `check_schema_drift` is clean.

## Screenshots / output

No user-visible surface. Every removed predicate was satisfied by every row the current release can write, so request/response behaviour is byte-identical at the shipped default.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above (`Refs #2336`, `Refs #2189`; no issue is closed).
- [x] Added or updated tests covering the change.
- [x] Ran `make lint`, `uv run ty check`, `make migration-check`, `check_simplicity_budgets.py`, the full touched test files, `tests/unit`, and the bridge/migration integration files locally.
- [x] If touching specs: `openspec validate --specs --strict` passes, the change validates `--strict`, and `openspec archive --yes` was simulated on a temp copy of current `main`'s `openspec/` (which already contains the archived `drop-bridge-recovery-modes`).
- [x] Simplicity gates reviewed: **net +68 lines** — `app/` −110, `tests/` −116, `openspec/` +294 (the spec delta, proposal, design notes, tasks and the deployment context entry). No new setting, no new default.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
