### PR TITLE
fix(db): merge the affinity and role-mapping migration heads

### DIFF
--- a/app/db/alembic/versions/20260911_010000_merge_affinity_and_role_mapping_heads.py
+++ b/app/db/alembic/versions/20260911_010000_merge_affinity_and_role_mapping_heads.py
@@ -1,0 +1,17 @@
+"""Merge the affinity-invite and role-mapping migration histories."""
+
+revision = "20260911_010000_merge_affinity_and_role_mapping_heads"
+down_revision = (
+    "20260910_220000_merge_affinity_invite_heads",
+    "20260911_000000_model_source_pins_kind_expires_index",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

`main` cannot migrate right now. Two branches landed migrations that both descend from `20260909_040000_add_dashboard_user_invites` without either referencing the other:

- `20260910_220000_merge_affinity_invite_heads` (#2352, affinity observation)
- `20260911_000000_model_source_pins_kind_expires_index` (on top of the RBAC role-mapping line)

So `alembic upgrade head` raises `Multiple head revisions are present`, which fails startup migration, the `Migration check (alembic)` and `(alembic, PostgreSQL)` jobs, and every test that walks to head.

Reproduced on `origin/main` at `4096c18ac`:

```
$ uv run codex-lb-db --db-url sqlite+aiosqlite:///tmp.db upgrade head
alembic.util.exc.CommandError: Multiple head revisions are present for given argument 'head'
```

## Type of change

- [x] `fix:` — repairs a broken `main`

## Changes

One empty merge revision joining the two heads, in the same style as `20260910_200000_merge_affinity_identity_heads`. No schema change, no data movement, reversible.

## OpenSpec

- [ ] Not applicable — no behaviour change; this restores the single-head invariant that `database-migrations` already requires.

## Test plan

```
uv run codex-lb-db --db-url sqlite+aiosqlite:///tmp.db upgrade head   # current_revision=20260911_010000_merge_affinity_and_role_mapping_heads
uv run codex-lb-db --db-url sqlite+aiosqlite:///tmp.db check          # migration_policy=ok, schema_drift=none
uv run pytest tests/unit/test_db_migrate.py                           # 59 passed
uv run ruff check . && uv run ruff format --check .                   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)