### PR TITLE
fix(observability): derive sticky_key_source once, from the resolved policy

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -52,7 +52,6 @@ from app.modules.proxy.affinity import (
     _prompt_cache_key_from_request_model,
     _request_allows_bare_session_cap_spillover,
     _resolve_prompt_cache_key,
-    _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
     _thread_codex_session_affinity,
 )
@@ -441,7 +440,7 @@ def _sticky_key_for_compact_request(
     sticky_threads_enabled: bool,
     api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
-    cache_key, _ = _resolve_prompt_cache_key(
+    cache_key, cache_key_source = _resolve_prompt_cache_key(
         payload,
         openai_cache_affinity=openai_cache_affinity,
         api_key=api_key,
@@ -474,12 +473,14 @@ def _sticky_key_for_compact_request(
             key=cache_key,
             kind=StickySessionKind.PROMPT_CACHE,
             max_age_seconds=openai_cache_affinity_max_age_seconds,
+            prompt_cache_key_source=cache_key_source,
         )
     elif sticky_threads_enabled:
         policy = _AffinityPolicy(
             key=cache_key,
             kind=StickySessionKind.STICKY_THREAD,
             reallocate_sticky=True,
+            prompt_cache_key_source=cache_key_source,
         )
     else:
         policy = _AffinityPolicy()
@@ -854,7 +855,6 @@ class _CompactMixin:
         resilience = bind_resilience_toggles(settings, startup_settings=base_settings)
         concurrency_caps = effective_account_concurrency_caps(settings)
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
-        had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
         affinity = _sticky_key_for_compact_request(
             payload,
             headers,
@@ -864,27 +864,13 @@ class _CompactMixin:
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
         )
-        sticky_key_source = "none"
-        if affinity.codex_session_source == "thread_header":
-            # The payload cache hint remains unchanged; diagnostics must not
-            # imply that it supplied the internal thread-local routing key.
-            sticky_key_source = "thread_header"
-        elif affinity.kind == StickySessionKind.CODEX_SESSION:
-            if _sticky_key_from_turn_state_header(headers) is not None:
-                sticky_key_source = "turn_state_header"
-            elif _sticky_key_from_session_header(headers) is not None:
-                sticky_key_source = "session_header"
-            else:
-                sticky_key_source = "payload"
-        elif affinity.key:
-            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
-        affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+        affinity_observation = AffinityObservation.from_policy(affinity)
         _maybe_log_proxy_request_shape(
             "compact",
             payload,
             headers,
-            sticky_kind=affinity.kind.value if affinity.kind is not None else None,
-            sticky_key_source=sticky_key_source,
+            sticky_kind=affinity_observation.kind,
+            sticky_key_source=affinity_observation.source,
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -4258,7 +4258,7 @@ class _HTTPBridgeRequestSubmitMixin:
             reallocate_sticky=True,
         )
         if previous_affinity_observation is not None:
-            request_state.affinity_observation = AffinityObservation.from_policy(
+            request_state.affinity_observation = AffinityObservation.retaining_source(
                 previous_affinity_observation.source, request_state.affinity_policy
             )
         replacement_session_affinity = replace(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1309,7 +1309,6 @@ class _HTTPBridgeStreamingMixin:
         incoming_turn_state_header = _sticky_key_from_turn_state_header(headers) if not forwarded_request else None
         incoming_session_header = _sticky_key_from_session_header(headers) if not forwarded_request else None
         explicit_prompt_cache_key = _prompt_cache_key_from_request_model(payload)
-        had_prompt_cache_key = explicit_prompt_cache_key is not None
         affinity = _sticky_key_for_responses_request(
             payload,
             headers,
@@ -1319,21 +1318,13 @@ class _HTTPBridgeStreamingMixin:
             sticky_threads_enabled=dashboard_settings.sticky_threads_enabled,
             api_key=api_key,
         )
-        sticky_key_source = "none"
-        if affinity.codex_session_source == "thread_header":
-            sticky_key_source = "thread_header"
-        elif affinity.kind == StickySessionKind.CODEX_SESSION:
-            sticky_key_source = (
-                "turn_state_header" if _sticky_key_from_turn_state_header(headers) is not None else "session_header"
-            )
-        elif affinity.key:
-            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
+        inbound_affinity_observation = AffinityObservation.from_policy(affinity)
         _maybe_log_proxy_request_shape(
             "stream_http_bridge",
             payload,
             headers,
-            sticky_kind=affinity.kind.value if affinity.kind is not None else None,
-            sticky_key_source=sticky_key_source,
+            sticky_kind=inbound_affinity_observation.kind,
+            sticky_key_source=inbound_affinity_observation.source,
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
 
@@ -1818,7 +1809,9 @@ class _HTTPBridgeStreamingMixin:
             )
         request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
         request_state.affinity_policy = affinity
-        request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+        request_state.affinity_observation = AffinityObservation.retaining_source(
+            inbound_affinity_observation.source, affinity
+        )
         _apply_http_bridge_downstream_turn_state(
             request_state,
             downstream_turn_state=downstream_turn_state,
@@ -2119,7 +2112,9 @@ class _HTTPBridgeStreamingMixin:
                 request_state.operation_rebind_required = True
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
-            request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+            request_state.affinity_observation = AffinityObservation.retaining_source(
+                inbound_affinity_observation.source, affinity
+            )
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             if downstream_turn_state is not None:
                 request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -2688,8 +2683,8 @@ class _HTTPBridgeStreamingMixin:
                     )
                     retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                     retry_request_state.affinity_policy = affinity
-                    retry_request_state.affinity_observation = AffinityObservation.from_policy(
-                        sticky_key_source, affinity
+                    retry_request_state.affinity_observation = AffinityObservation.retaining_source(
+                        inbound_affinity_observation.source, affinity
                     )
                     _apply_http_bridge_downstream_turn_state(
                         retry_request_state,
@@ -2861,7 +2856,9 @@ class _HTTPBridgeStreamingMixin:
             request_state, text_data = prepare_bridge_request(effective_payload)
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
-            request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+            request_state.affinity_observation = AffinityObservation.retaining_source(
+                inbound_affinity_observation.source, affinity
+            )
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
                 headers=headers,
@@ -2995,7 +2992,9 @@ class _HTTPBridgeStreamingMixin:
             request_state, text_data = prepare_bridge_request(submit_payload)
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
-            request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+            request_state.affinity_observation = AffinityObservation.retaining_source(
+                inbound_affinity_observation.source, affinity
+            )
             _apply_http_bridge_downstream_turn_state(
                 request_state,
                 downstream_turn_state=downstream_turn_state,
@@ -3905,7 +3904,9 @@ class _HTTPBridgeStreamingMixin:
                     # atomically moves it back to submitted before send.
                     retry_request_state.operation_rebind_required = True
                 retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
-                retry_request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+                retry_request_state.affinity_observation = AffinityObservation.retaining_source(
+                    inbound_affinity_observation.source, affinity
+                )
                 _apply_http_bridge_downstream_turn_state(
                     retry_request_state,
                     downstream_turn_state=downstream_turn_state,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -45,7 +45,7 @@ from app.core.utils.request_id import ensure_request_id
 from app.core.utils.retry import backoff_seconds
 from app.core.utils.shared_future import _await_task_deferring_cancellation
 from app.core.utils.sse import format_sse_event
-from app.db.models import Account, StickySessionKind
+from app.db.models import Account
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy._load_balancer.overload_backoff import (
     UPSTREAM_OVERLOAD_CODES,
@@ -432,7 +432,6 @@ class _StreamingRetryMixin:
         if rewritten_file_account_id is None and not file_account_resolution_complete:
             proxy._raise_for_unsupported_input_image_references(payload)
             rewritten_file_account_id = await proxy._resolve_file_account_for_responses(payload, headers)
-        had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
         affinity = _sticky_key_for_responses_request(
             payload,
             headers,
@@ -453,20 +452,13 @@ class _StreamingRetryMixin:
                 api_key=api_key,
                 fail_on_missing=not _is_synthesized_turn_state(turn_state),
             )
-        sticky_key_source = "none"
-        if affinity.codex_session_source == "thread_header":
-            sticky_key_source = "thread_header"
-        elif affinity.kind == StickySessionKind.CODEX_SESSION:
-            sticky_key_source = "session_header"
-        elif affinity.key:
-            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
-        affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity)
+        affinity_observation = AffinityObservation.from_policy(affinity)
         _maybe_log_proxy_request_shape(
             "stream",
             payload,
             headers,
-            sticky_kind=affinity.kind.value if affinity.kind is not None else None,
-            sticky_key_source=sticky_key_source,
+            sticky_kind=affinity_observation.kind,
+            sticky_key_source=affinity_observation.source,
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _facade()._routing_strategy(settings)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -3427,7 +3427,6 @@ class _WebSocketMixin:
                 if isinstance(responses_payload.input, list)
                 else None,
             )
-        had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         if previous_response_trimmed_input_count is not None:
             request_state.input_item_count = previous_response_trimmed_input_count
             request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
@@ -3479,29 +3478,20 @@ class _WebSocketMixin:
             api_key=api_key,
             synthesized_turn_state=synthesized_turn_state,
         )
-        sticky_key_source = "none"
-        if affinity_policy.codex_session_source == "thread_header":
-            sticky_key_source = "thread_header"
-        elif affinity_policy.kind == StickySessionKind.CODEX_SESSION:
-            turn_state_key = _sticky_key_from_turn_state_header(headers)
-            if turn_state_key is not None and turn_state_key == synthesized_turn_state:
-                sticky_key_source = "generated_turn_state"
-            elif turn_state_key is not None:
-                sticky_key_source = "turn_state_header"
-            else:
-                sticky_key_source = "session_header"
-        elif affinity_policy.key:
-            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
+        affinity_observation = AffinityObservation.from_policy(
+            affinity_policy,
+            synthesized_turn_state=synthesized_turn_state,
+        )
         _maybe_log_proxy_request_shape(
             "websocket",
             responses_payload,
             headers,
-            sticky_kind=affinity_policy.kind.value if affinity_policy.kind is not None else None,
-            sticky_key_source=sticky_key_source,
+            sticky_kind=affinity_observation.kind,
+            sticky_key_source=affinity_observation.source,
             prompt_cache_key_set=_prompt_cache_key_from_request_model(responses_payload) is not None,
         )
         request_state.affinity_policy = affinity_policy
-        request_state.affinity_observation = AffinityObservation.from_policy(sticky_key_source, affinity_policy)
+        request_state.affinity_observation = affinity_observation
 
         # First-turn ``input_file.file_id`` references must land on the
         # account that registered the upload (chatgpt-account-id-scoped).

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -82,6 +82,14 @@ class _AffinityPolicy:
     # ``conversation`` has no dedicated owner index. Preserve that provenance
     # until selection can prove one hard owner or a one-account pool.
     require_unambiguous_account: bool = False
+    # For a policy whose key IS the prompt cache key: whether the client sent
+    # that key (``payload``) or the proxy derived it (``derived``). Recorded by
+    # the resolver rather than re-derived by callers, because
+    # ``_resolve_prompt_cache_key`` writes the derived key back onto the
+    # payload — so a later reader of the payload cannot tell the two apart, and
+    # a blank client hint the resolver rejected still looks present. Routing
+    # never reads this; it exists so the request log can describe the decision.
+    prompt_cache_key_source: str | None = None
 
     @property
     def selection_key(self) -> str | None:
@@ -684,7 +692,7 @@ def _sticky_key_for_responses_request(
     # This helper only classifies locality keys. Stored-object continuity such
     # as `previous_response_id` is resolved later by ProxyService and must stay
     # hard owner-bound even if this returns a prompt-cache affinity policy.
-    cache_key, _ = _resolve_prompt_cache_key(
+    cache_key, cache_key_source = _resolve_prompt_cache_key(
         payload,
         openai_cache_affinity=openai_cache_affinity,
         api_key=api_key,
@@ -717,12 +725,14 @@ def _sticky_key_for_responses_request(
             key=cache_key,
             kind=StickySessionKind.PROMPT_CACHE,
             max_age_seconds=openai_cache_affinity_max_age_seconds,
+            prompt_cache_key_source=cache_key_source,
         )
     elif sticky_threads_enabled:
         policy = _AffinityPolicy(
             key=cache_key,
             kind=StickySessionKind.STICKY_THREAD,
             reallocate_sticky=True,
+            prompt_cache_key_source=cache_key_source,
         )
     elif turn_state_key is not None and turn_state_key == synthesized_turn_state:
         policy = _AffinityPolicy(

--- a/app/modules/proxy/affinity_observation.py
+++ b/app/modules/proxy/affinity_observation.py
@@ -5,6 +5,22 @@ from dataclasses import dataclass
 
 from app.modules.proxy.affinity import _AffinityPolicy
 
+# Length of the persisted key digest. Not comparable to the shape trace's
+# ``prompt_cache_key`` digest: for a header-sourced policy the routing
+# selection key is a different value.
+_KEY_HASH_HEX_LENGTH = 16
+
+# The complete domain of ``request_logs.sticky_key_source``.
+AFFINITY_SOURCES: tuple[str, ...] = (
+    "thread_header",
+    "turn_state_header",
+    "generated_turn_state",
+    "session_header",
+    "payload",
+    "derived",
+    "none",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class AffinityObservation:
@@ -15,10 +31,71 @@ class AffinityObservation:
     key_hash: str | None
 
     @classmethod
-    def from_policy(cls, source: str, policy: _AffinityPolicy) -> AffinityObservation:
+    def from_policy(
+        cls,
+        policy: _AffinityPolicy,
+        *,
+        synthesized_turn_state: str | None = None,
+    ) -> AffinityObservation:
+        """Classify one resolved affinity policy.
+
+        The single source of truth for every request-log path. Every input is
+        read off the policy — ``codex_session_source`` and
+        ``prompt_cache_key_source``, both recorded by the resolver — rather
+        than re-sniffed from the headers or the payload. That matters because
+        resolution mutates the payload (the derived cache key is written back
+        onto it), so a caller re-deriving "did the payload carry a cache key"
+        afterwards describes a request that was never sent.
+
+        A policy carrying no key describes no decision, so a neutralized
+        policy (``replace(policy, key=None, kind=None)``) reports ``none``.
+        """
         key = policy.selection_key
+        return cls(
+            source=cls._classify(policy, synthesized_turn_state=synthesized_turn_state),
+            kind=policy.kind.value if policy.kind is not None else None,
+            key_hash=cls._hash(key),
+        )
+
+    @classmethod
+    def retaining_source(cls, source: str, policy: _AffinityPolicy) -> AffinityObservation:
+        """Re-project a policy while keeping the source already observed.
+
+        Used only where a request is deliberately replayed with its affinity
+        neutralized and the row should still say which signal the original
+        attempt resolved.
+        """
         return cls(
             source=source,
             kind=policy.kind.value if policy.kind is not None else None,
-            key_hash=hashlib.sha256(key.encode("utf-8")).hexdigest()[:16] if key is not None else None,
+            key_hash=cls._hash(policy.selection_key),
         )
+
+    @staticmethod
+    def _hash(key: str | None) -> str | None:
+        """Digest a routing key for persistence.
+
+        Only the digest is ever stored: a *derived* key embeds a hash of
+        prompt material, so the raw value stays behind the opt-in
+        ``shape_raw_cache_key`` trace channel and never reaches a row.
+        """
+        if key is None:
+            return None
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:_KEY_HASH_HEX_LENGTH]
+
+    @staticmethod
+    def _classify(policy: _AffinityPolicy, *, synthesized_turn_state: str | None) -> str:
+        if policy.key is None:
+            return "none"
+        codex_session_source = policy.codex_session_source
+        if codex_session_source == "thread_header":
+            return "thread_header"
+        if codex_session_source == "turn_state":
+            if synthesized_turn_state is not None and policy.key == synthesized_turn_state:
+                return "generated_turn_state"
+            return "turn_state_header"
+        if codex_session_source == "session_header":
+            return "session_header"
+        # The key is the prompt cache key; the resolver recorded whether the
+        # client supplied it or the proxy derived it.
+        return policy.prompt_cache_key_source or "derived"

--- a/openspec/changes/unify-affinity-observation-source/proposal.md
+++ b/openspec/changes/unify-affinity-observation-source/proposal.md
@@ -1,0 +1,77 @@
+# Change: unify-affinity-observation-source
+
+## Why
+
+`persist-affinity-decision-on-request-logs` (#2352) landed the three
+`request_logs` affinity columns and wired every emitter, but deliberately kept
+`sticky_key_source` as "the existing resolved source classification" — four
+independent if/elif ladders, one per transport, that had already drifted apart:
+
+| policy | HTTP stream | compact | HTTP bridge | native WS |
+|---|---|---|---|---|
+| CODEX_SESSION from a client turn-state header | `session_header` | `turn_state_header` | `turn_state_header` | `turn_state_header` |
+| CODEX_SESSION, no header present | `session_header` | `payload` | `session_header` | `session_header` |
+| CODEX_SESSION from a proxy-synthesized turn state | `session_header` | `turn_state_header` | `turn_state_header` | `generated_turn_state` |
+
+So the new column is not comparable across transports: the same continuity
+signal is labelled differently depending on how the client connected, and the
+HTTP stream path — the largest share of traffic — cannot report
+`turn_state_header` at all. Any query that groups by `sticky_key_source` is
+measuring the transport as much as the signal.
+
+Two further cases mislabel the cohort the column exists to measure. All four
+ladders decide `payload` vs `derived` from a boolean the caller reads off the
+payload *before* resolution, but `_resolve_prompt_cache_key` writes the derived
+key back onto the payload and rejects a blank client hint:
+
+- `prompt_cache_key: "   "` is stripped, rejected, and a key is derived — but
+  the pre-resolution boolean still saw a string, so the row says `payload`.
+- When HTTP bridge setup falls back to `_stream_with_retry`, the second path
+  recomputes that boolean from the payload the first path already mutated with
+  its derived key, so a derived request is recorded as `payload`.
+
+Both inflate `payload` at the expense of `derived` — the ~28% unkeyed cohort
+whose cache behaviour motivated the column.
+
+## What Changes
+
+- `AffinityObservation.from_policy(policy, *, synthesized_turn_state=None)`
+  now performs the classification itself, reading only the resolved policy.
+  The four ladders are deleted. Because `_AffinityPolicy.codex_session_source`
+  already records which signal the resolver used, the classification cannot
+  disagree with the policy it describes the way header re-sniffing could.
+- `_AffinityPolicy` gains `prompt_cache_key_source`, set by the two resolvers
+  from `_resolve_prompt_cache_key`'s own return value. Routing never reads it.
+  The `had_prompt_cache_key` locals in all four paths are deleted.
+- `AffinityObservation.retaining_source(source, policy)` keeps the landed
+  behaviour where a routing adjustment clears the key but the row should still
+  report the signal the original attempt resolved (the HTTP bridge rebinds and
+  the security-work replay). Those call sites are unchanged in meaning.
+- The shape trace now reports the same source and kind as the persisted row,
+  rather than computing its own from the same drifted ladder.
+
+Out of scope: the columns, the migration, the emitter wiring, the listing
+fields and the retention behaviour, all of which #2352 already landed.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: MODIFIED requirement "Durable affinity
+  observation on request logs" — the sentence deferring to "the existing
+  resolved source classification" is replaced by an explicit source domain,
+  a single-shared-classification rule reading only the resolved policy, and a
+  rule that the `payload`/`derived` verdict is recorded by the resolver rather
+  than recomputed from the mutated payload. All six existing scenarios are
+  kept verbatim; two are added.
+
+## Impact
+
+- Code: `affinity_observation.py`, `affinity.py`, `compact.py`,
+  `streaming/retry.py`, `websocket/mixin.py`, `http_bridge/streaming.py`,
+  `http_bridge/request_submit.py`.
+- Schema: none. No migration, no new setting, no API change.
+- Data: rows written before this change keep whatever their transport's ladder
+  produced, so `sticky_key_source` is only cross-transport comparable from this
+  revision forward. There is no backfill — the decision cannot be
+  reconstructed from a persisted row.

--- a/openspec/changes/unify-affinity-observation-source/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/unify-affinity-observation-source/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Durable affinity observation on request logs
+
+The system MUST persist `sticky_key_source`, `sticky_kind`, and `sticky_key_hash` on existing Responses and compact request-log rows independently of trace settings. Kind and hash MUST describe the resolved affinity policy associated with the logged attempt or final request state. The hash MUST be the first 16 lowercase hexadecimal characters of SHA-256 over the resolved key's UTF-8 bytes. Observation MUST NOT rederive keys, change routing, health, retries, settlement ordering, callback ownership, or persistence drain semantics.
+
+Source MUST be one of `thread_header`, `turn_state_header`, `generated_turn_state`, `session_header`, `payload`, `derived`, or `none`, and every request-log path MUST derive it from one shared classification so that two paths resolving the same affinity policy record the same source. The classification MUST read only the resolved policy; it MUST NOT re-read the inbound headers or the request payload after resolution.
+
+Whether a prompt-cache key was supplied by the client (`payload`) or derived by the proxy (`derived`) MUST be recorded by the resolver that made that determination. It MUST NOT be recomputed from the request payload after resolution, because resolution writes a derived key back onto the payload and rejects a blank client hint; a post-resolution reader cannot distinguish either case.
+
+#### Scenario: Resolved affinity is recorded without trace
+- **WHEN** an HTTP or native WebSocket Responses request resolves affinity and emits a request-log row with tracing disabled
+- **THEN** the row stores the source, kind, and hash from that decision
+- **AND** the authorized request-log listing returns `stickyKeySource`, `stickyKind`, and `stickyKeyHash`
+- **AND** these fields contain no raw keys or prompt content
+
+#### Scenario: Stable grouping across requests
+- **WHEN** two requests use the same resolved key
+- **THEN** their stored hashes match
+- **AND** different synthetic keys with distinct SHA-256 prefixes produce different hashes
+
+#### Scenario: Failure and retry rows retain their meaning
+- **WHEN** an existing emitter records an attempt failure or final settlement row
+- **THEN** the row records the affinity associated with that attempt or final request state
+- **AND** no extra rows are added to simulate an attempt history
+- **AND** a final row that covers multiple sends does not claim to enumerate intermediate decisions
+
+#### Scenario: Affinity is absent or unavailable
+- **WHEN** resolution explicitly finds no affinity
+- **THEN** the source is `none` and kind and hash are null
+- **WHEN** the policy has no key after an existing routing adjustment
+- **THEN** the hash is null and source retains its original resolved classification
+- **AND** kind equals the adjusted policy kind: null when recovery clears it, or `codex_session` when only a broad session key is ignored
+- **WHEN** a row predates the migration or no affinity observation was available to its emitter
+- **THEN** all three fields are null without an invented backfill
+
+#### Scenario: Existing privacy and retention apply
+- **WHEN** request logs are read, retained, or deleted
+- **THEN** affinity metadata follows the same access controls and retention lifecycle as its owning row
+- **AND** request-log responses without `conversations:read` permission return null for the three affinity fields
+- **AND** enabling raw-key tracing does not make these columns store raw keys
+
+#### Scenario: Upgrade and downgrade preserve existing records
+- **WHEN** a populated database upgrades to the affinity metadata revision
+- **THEN** existing request and ownership records remain intact and historical affinity metadata is null
+- **WHEN** that revision is downgraded
+- **THEN** only the three new columns are removed and existing record values remain intact
+
+#### Scenario: One classification across transports
+- **GIVEN** the same resolved affinity policy on the HTTP stream, compact, native WebSocket, and HTTP bridge paths
+- **WHEN** each path records its request log
+- **THEN** all four rows store the same source
+- **AND** a request whose key came from a client turn-state header is never recorded as `session_header`
+
+#### Scenario: A derived key is not misreported as client-supplied
+- **WHEN** a request carries no usable prompt-cache key and the proxy derives one, including when the client sent a blank key that resolution rejected
+- **THEN** the stored source is `derived`
+- **AND** a later emitter that reads the payload after resolution still records `derived`

--- a/openspec/changes/unify-affinity-observation-source/tasks.md
+++ b/openspec/changes/unify-affinity-observation-source/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## 1. Shared classification
+
+- [x] 1.1 `AffinityObservation.from_policy` classifies from the policy;
+  add `AFFINITY_SOURCES` as the documented domain.
+- [x] 1.2 Add `AffinityObservation.retaining_source` for the sites that
+  deliberately carry a prior source across a routing adjustment.
+- [x] 1.3 Delete the four ladders and the four `had_prompt_cache_key` locals;
+  feed the shape trace from the observation.
+
+## 2. Resolver-recorded cache-key provenance
+
+- [x] 2.1 `_AffinityPolicy.prompt_cache_key_source`, set by
+  `_sticky_key_for_responses_request` and `_sticky_key_for_compact_request`
+  from `_resolve_prompt_cache_key`.
+
+## 3. Verification
+
+- [x] 3.1 Tests: one source per signal; all four transports agree for one
+  policy; blank hint and post-resolution payload reads record `derived`;
+  retained-source adjustment still reports the original signal.
+- [x] 3.2 `ruff check` / `ruff format --check`, `check_proxy_architecture.py`,
+  `ty check`, proxy unit suites, `openspec validate --strict`.

--- a/tests/unit/test_affinity_observation_source.py
+++ b/tests/unit/test_affinity_observation_source.py
@@ -1,0 +1,218 @@
+"""One classification of `sticky_key_source`, shared by every request-log path.
+
+`persist-affinity-decision-on-request-logs` landed the three `request_logs`
+affinity columns but left `sticky_key_source` to four per-transport if/elif
+ladders that had drifted apart, so the same continuity signal was labelled
+differently depending on how the client connected. These tests pin the single
+classification that replaced them, and the two cases the old ladders got wrong
+for the derived-key cohort the column exists to measure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.db.models import StickySessionKind
+from app.modules.proxy._service.compact import _sticky_key_for_compact_request
+from app.modules.proxy.affinity import _AffinityPolicy, _sticky_key_for_responses_request
+from app.modules.proxy.affinity_observation import AFFINITY_SOURCES, AffinityObservation
+
+pytestmark = pytest.mark.unit
+
+
+def _payload(**updates: object) -> ResponsesRequest:
+    body: dict[str, object] = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        "stream": True,
+        **updates,
+    }
+    return ResponsesRequest.model_validate(body)
+
+
+def _payload_with_cache_key(cache_key: str) -> ResponsesRequest:
+    payload = _payload()
+    payload.prompt_cache_key = cache_key
+    return payload
+
+
+def _policy(headers: dict[str, str], **overrides: object) -> _AffinityPolicy:
+    kwargs: dict[str, Any] = {
+        "codex_session_affinity": True,
+        "openai_cache_affinity": True,
+        "openai_cache_affinity_max_age_seconds": 300,
+        "sticky_threads_enabled": False,
+    }
+    payload = cast(ResponsesRequest, overrides.pop("payload", None)) or _payload()
+    kwargs.update(overrides)
+    return _sticky_key_for_responses_request(payload, headers, **kwargs)
+
+
+def _source(policy: _AffinityPolicy, **kwargs: Any) -> str:
+    return AffinityObservation.from_policy(policy, **kwargs).source
+
+
+# --------------------------------------------------------------------------
+# One source per signal
+# --------------------------------------------------------------------------
+
+
+def test_each_continuity_signal_has_its_own_source() -> None:
+    assert _source(_policy({"session_id": "sid-1"})) == "session_header"
+    assert _source(_policy({"thread-id": "thread-1"})) == "thread_header"
+    assert _source(_policy({"x-codex-turn-state": "client-turn-owner"})) == "turn_state_header"
+    assert _source(_policy({}, payload=_payload_with_cache_key("client-thread-1"))) == "payload"
+    assert _source(_policy({})) == "derived"
+    assert _source(_AffinityPolicy()) == "none"
+
+
+def test_a_proxy_synthesized_turn_state_is_distinguished_from_a_client_one() -> None:
+    synthesized = f"turn_{'a' * 32}"
+    policy = _policy(
+        {"x-codex-turn-state": synthesized},
+        synthesized_turn_state=synthesized,
+        openai_cache_affinity=False,
+    )
+
+    assert _source(policy) == "turn_state_header"
+    assert _source(policy, synthesized_turn_state=synthesized) == "generated_turn_state"
+
+
+def test_every_emitted_source_is_in_the_documented_domain() -> None:
+    synthesized = f"turn_{'b' * 32}"
+    emitted = {
+        _source(policy)
+        for policy in (
+            _AffinityPolicy(),
+            _policy({}),
+            _policy({}, payload=_payload_with_cache_key("client-thread-1")),
+            _policy({"session_id": "sid-1"}),
+            _policy({"thread-id": "thread-1"}),
+            _policy({"x-codex-turn-state": "client-turn-owner"}),
+        )
+    }
+    emitted.add(
+        _source(
+            _policy(
+                {"x-codex-turn-state": synthesized},
+                synthesized_turn_state=synthesized,
+                openai_cache_affinity=False,
+            ),
+            synthesized_turn_state=synthesized,
+        )
+    )
+
+    assert emitted == set(AFFINITY_SOURCES)
+
+
+# --------------------------------------------------------------------------
+# The transports agree
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        ({"session_id": "sid-1"}, "session_header"),
+        # The HTTP stream ladder reported ``session_header`` here while the
+        # compact, bridge and websocket ladders reported ``turn_state_header``.
+        ({"session_id": "sid-1", "x-codex-turn-state": "client-turn-owner"}, "turn_state_header"),
+        ({"thread-id": "thread-1"}, "thread_header"),
+        ({}, "derived"),
+    ],
+)
+def test_responses_and_compact_paths_agree_on_one_policy(headers: dict[str, str], expected: str) -> None:
+    responses_policy = _policy(headers)
+    compact_policy = _sticky_key_for_compact_request(
+        ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []}),
+        headers,
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert _source(responses_policy) == expected
+    assert _source(compact_policy) == expected
+
+
+def test_a_turn_state_request_is_never_labelled_session_header() -> None:
+    policy = _policy({"session_id": "sid-1", "x-codex-turn-state": "client-turn-owner"})
+
+    assert policy.codex_session_source == "turn_state"
+    assert _source(policy) != "session_header"
+
+
+# --------------------------------------------------------------------------
+# payload vs derived
+# --------------------------------------------------------------------------
+
+
+def test_a_blank_client_cache_hint_is_recorded_as_derived() -> None:
+    # The resolver strips the hint, rejects it as empty and derives its own
+    # key; the row must describe the key that was actually produced.
+    policy = _policy({}, payload=_payload_with_cache_key("   "))
+
+    assert _source(policy) == "derived"
+
+
+def test_reading_the_payload_after_resolution_cannot_change_the_source() -> None:
+    # ``_resolve_prompt_cache_key`` writes the derived key back onto the
+    # payload, so an emitter that recomputed "did the payload carry a cache
+    # key" afterwards — as the bridge-to-stream fallback does — would report
+    # ``payload`` for a key the proxy itself derived.
+    payload = _payload()
+    assert payload.prompt_cache_key is None
+
+    policy = _policy({}, payload=payload)
+
+    assert payload.prompt_cache_key is not None
+    assert _source(policy) == "derived"
+
+
+def test_the_resolver_records_the_cache_key_provenance_on_the_policy() -> None:
+    assert _policy({}).prompt_cache_key_source == "derived"
+    assert _policy({}, payload=_payload_with_cache_key("client-thread-1")).prompt_cache_key_source == "payload"
+
+
+# --------------------------------------------------------------------------
+# Kind, hash and retained source
+# --------------------------------------------------------------------------
+
+
+def test_kind_and_hash_describe_the_resolved_policy() -> None:
+    policy = _policy({"session_id": "sid-1"})
+
+    observation = AffinityObservation.from_policy(policy)
+
+    assert observation.kind == StickySessionKind.CODEX_SESSION.value
+    # The hash covers ``selection_key`` — the key selection routes on — not the
+    # raw header, which for a soft session source is a different value.
+    assert observation.key_hash is not None
+    assert len(observation.key_hash) == 16
+    assert all(character in "0123456789abcdef" for character in observation.key_hash)
+    assert AffinityObservation.from_policy(_policy({"session_id": "sid-2"})).key_hash != observation.key_hash
+
+
+def test_a_keyless_policy_reports_no_decision() -> None:
+    observation = AffinityObservation.from_policy(_AffinityPolicy())
+
+    assert (observation.source, observation.kind, observation.key_hash) == ("none", None, None)
+
+
+def test_a_routing_adjustment_can_retain_the_originally_resolved_source() -> None:
+    # Recovery clears the key so the replay is account-neutral, but the row
+    # still reports which signal the original attempt resolved.
+    resolved = _policy({"session_id": "sid-1"})
+    observed = AffinityObservation.from_policy(resolved)
+    neutralized = replace(resolved, key=None, kind=None, reallocate_sticky=True)
+
+    retained = AffinityObservation.retaining_source(observed.source, neutralized)
+
+    assert retained.source == "session_header"
+    assert (retained.kind, retained.key_hash) == (None, None)


### PR DESCRIPTION
## Context

This is a follow-up to #2352, which closed #2349 by landing the three
`request_logs` affinity columns and wiring every emitter. That PR deliberately
left `sticky_key_source` as "the existing resolved source classification" — the
four per-transport if/elif ladders that already existed for the `shape` trace
channel. Promoting those ladders from an opt-in trace to a persisted column
exposed that they had drifted apart.

**I did not re-implement #2349.** This PR only changes *how `source` is
computed*. The columns, the migration, the emitter wiring, the listing fields
and the retention behaviour are #2352's and are untouched.

## The four ladders disagreed

| resolved policy | HTTP stream | compact | HTTP bridge | native WS |
|---|---|---|---|---|
| CODEX_SESSION from a client turn-state header | `session_header` | `turn_state_header` | `turn_state_header` | `turn_state_header` |
| CODEX_SESSION, no header present | `session_header` | `payload` | `session_header` | `session_header` |
| CODEX_SESSION from a proxy-synthesized turn state | `session_header` | `turn_state_header` | `turn_state_header` | `generated_turn_state` |

So `GROUP BY sticky_key_source` measured the transport as much as the signal,
and the HTTP stream path — the largest share of traffic — could not emit
`turn_state_header` at all (`streaming/retry.py`'s ladder collapsed every
CODEX_SESSION policy to `session_header`).

## Two cases mislabelled the `derived` cohort

All four ladders decided `payload` vs `derived` from a boolean sampled off the
payload **before** resolution:

```python
had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
affinity = _sticky_key_for_responses_request(payload, headers, ...)
```

But `_resolve_prompt_cache_key` both rejects a blank hint and writes the derived
key back onto the payload:

```python
if isinstance(cache_key, str):
    stripped = cache_key.strip()
    if stripped:
        ...
        return stripped, "payload"
if not openai_cache_affinity:
    return None, "none"
cache_key = _derive_prompt_cache_key(payload, api_key)
payload.prompt_cache_key = cache_key          # <- the payload now looks keyed
return cache_key, "derived"
```

1. `prompt_cache_key: "   "` is stripped, rejected, and a key is derived — but
   the pre-resolution boolean saw a non-empty string, so the row says `payload`.
2. When HTTP bridge setup falls back to `_stream_with_retry`, the second path
   re-samples the payload the first path already mutated with its derived key,
   so a derived request is recorded as `payload`.

Both inflate `payload` at the expense of `derived` — precisely the ~28% unkeyed
cohort whose cache behaviour motivated the column (91.0% cached / 8% switching
for keyed traffic vs 51.2% / 60% for unkeyed, ~0.6 B avoidable input tokens per
day).

## What this changes

- `AffinityObservation.from_policy(policy, *, synthesized_turn_state=None)` now
  classifies from the resolved policy. The four ladders are deleted, and the
  shape trace is fed from the same observation the row stores. Because
  `_AffinityPolicy.codex_session_source` already records which signal the
  resolver used, the label can no longer contradict the policy it describes.
- `_AffinityPolicy` gains `prompt_cache_key_source`, set by the two resolvers
  from `_resolve_prompt_cache_key`'s own return value. The four
  `had_prompt_cache_key` locals are deleted. **Routing never reads the field.**
- `AffinityObservation.retaining_source(source, policy)` preserves #2352's
  behaviour where a routing adjustment clears the key but the row still reports
  the signal the original attempt resolved. The six HTTP-bridge rebind sites and
  the security-work replay use it, so their meaning is unchanged — the existing
  "policy has no key after an existing routing adjustment" scenario still holds.
- `AFFINITY_SOURCES` documents the complete seven-value domain, including
  `generated_turn_state`, which the original issue's list omitted.

## Reviewer query

With the source now consistent across transports, this answers "how often does
a derived key change between consecutive turns of one thread":

```sql
SELECT count(*) FILTER (WHERE sticky_key_hash <> prev_hash)::float / nullif(count(prev_hash), 0) AS derived_key_change_rate FROM (SELECT sticky_key_hash, lag(sticky_key_hash) OVER (PARTITION BY conversation_id ORDER BY requested_at, id) AS prev_hash FROM request_logs WHERE sticky_key_source = 'derived' AND conversation_id IS NOT NULL AND requested_at >= now() - interval '1 day') t;
```

## Notes for the reviewer

- **No schema, migration, setting or API change.** The `settings_fields = 96`
  budget and every architecture ratchet are untouched
  (`check_proxy_architecture.py`, `check_proxy_timing_seams.py`,
  `check_cancellation_safety.py`, `check_settings_tiers.py` all pass).
- **Data compatibility:** rows written before this revision keep whatever their
  transport's ladder produced, so `sticky_key_source` is only cross-transport
  comparable going forward. There is no backfill — the decision cannot be
  reconstructed from a persisted row.
- **`main` is currently red for an unrelated reason.** `origin/main` has **two
  alembic heads** (`20260910_220000_merge_affinity_invite_heads` and
  `20260911_000000_model_source_pins_kind_expires_index`), which fails 23 tests
  in `tests/unit/test_db_migrate.py`, 5 in
  `tests/integration/test_affinity_observation_migration.py`, and 2 more
  (`test_db_rate_limiter`, `test_telemetry_migration`) with
  `CommandError: Multiple head revisions are present`. I verified every one of
  these fails identically on a clean `origin/main` checkout. This PR adds no
  migration and neither causes nor fixes it, but it needs a merge revision
  before CI can be green.

## Verification

- `tests/unit/test_affinity_observation_source.py` (new, 14 tests): one source
  per signal; the responses and compact paths agree for the same policy; a
  turn-state request is never labelled `session_header`; blank hint and
  post-resolution payload reads record `derived`; the resolver records the
  provenance on the policy; a keyless policy reports no decision; a retained
  source survives a routing adjustment.
- `tests/unit` excluding the pre-broken `test_db_migrate.py`: **9867 passed,
  4 skipped, 2 failed** — both failures reproduce identically on clean `main`.
- `tests/integration/test_proxy_affinity_observation.py` and
  `test_proxy_affinity_websocket_observation.py`: pass.
- `ruff check` / `ruff format --check` clean, `ty check` clean,
  `openspec validate unify-affinity-observation-source --strict` clean.
- `codex review --base origin/main`: no findings.

Refs #2349, #2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
