### PR TITLE
chore(dashboard): keep the request-log source literals in sync with the backend enum

### DIFF
--- a/frontend/src/features/dashboard/request-log-source.test.ts
+++ b/frontend/src/features/dashboard/request-log-source.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it } from "vitest";
 
+import * as requestLogSourceModule from "@/features/dashboard/request-log-source";
 import {
   REQUEST_LOG_SOURCE_FILTER_VALUES,
+  REQUEST_LOG_SOURCE_KINDS,
   REQUEST_LOG_SOURCE_OVERFLOW,
   REQUEST_LOG_SOURCE_OVERFLOW_PINNED,
   requestLogSourceKind,
 } from "@/features/dashboard/request-log-source";
+import en from "@/i18n/locales/en.json";
+import ko from "@/i18n/locales/ko.json";
+import zhCN from "@/i18n/locales/zh-CN.json";
+
+/**
+ * Every exported `REQUEST_LOG_SOURCE_*` string constant. The backend enum in
+ * `app/modules/proxy/overflow.py` is the authority for these values and
+ * `tests/unit/test_request_log_source_parity.py` fails when they drift from it;
+ * the tests below keep the frontend half internally closed, so a literal or a
+ * label removed here fails the frontend suite too rather than only pytest.
+ */
+const EXPORTED_SOURCE_LITERALS = Object.entries(requestLogSourceModule)
+  .filter(([name, value]) => name.startsWith("REQUEST_LOG_SOURCE_") && typeof value === "string")
+  .map(([, value]) => value as string);
+
+const LOCALES: ReadonlyArray<[string, Record<string, string>]> = [
+  ["en", en],
+  ["ko", ko],
+  ["zh-CN", zhCN],
+];
 
 describe("requestLogSourceKind", () => {
   it.each([
@@ -40,6 +62,38 @@ describe("REQUEST_LOG_SOURCE_FILTER_VALUES", () => {
   it("only contains values the chip can attribute", () => {
     for (const value of REQUEST_LOG_SOURCE_FILTER_VALUES) {
       expect(requestLogSourceKind(value)).not.toBeNull();
+    }
+  });
+
+  it("offers every exported source literal", () => {
+    expect([...REQUEST_LOG_SOURCE_FILTER_VALUES].sort()).toEqual([...EXPORTED_SOURCE_LITERALS].sort());
+  });
+});
+
+describe("REQUEST_LOG_SOURCE_KINDS", () => {
+  it("is exactly the set of kinds the mapping can return", () => {
+    const mapped = EXPORTED_SOURCE_LITERALS.map((value) => requestLogSourceKind(value));
+
+    expect(mapped).not.toContain(null);
+    expect([...new Set(mapped)].sort()).toEqual([...REQUEST_LOG_SOURCE_KINDS].sort());
+    // One kind per value: a duplicated kind would collapse two chips into one.
+    expect(new Set(mapped).size).toBe(EXPORTED_SOURCE_LITERALS.length);
+  });
+
+  it.each(LOCALES)("has a chip label and tooltip for every kind in %s", (_locale, resource) => {
+    for (const kind of REQUEST_LOG_SOURCE_KINDS) {
+      // The detail dialog reuses the chip label key; the tooltip is chip-only.
+      expect(resource).toHaveProperty(`dashboard.requests.source.${kind}`);
+      expect(resource).toHaveProperty(`dashboard.requests.source.${kind}Title`);
+    }
+  });
+
+  it.each(LOCALES)("has a Source filter option label for every kind in %s", (_locale, resource) => {
+    for (const kind of REQUEST_LOG_SOURCE_KINDS) {
+      // `dashboard-page.tsx` labels option `n` with the `n`th kind; the Python
+      // guard checks the exact key that file passes to `t()`.
+      const suffix = `${kind.charAt(0).toUpperCase()}${kind.slice(1)}`;
+      expect(resource).toHaveProperty(`dashboard.filters.source${suffix}`);
     }
   });
 });

--- a/frontend/src/features/dashboard/request-log-source.test.ts
+++ b/frontend/src/features/dashboard/request-log-source.test.ts
@@ -80,20 +80,26 @@ describe("REQUEST_LOG_SOURCE_KINDS", () => {
     expect(new Set(mapped).size).toBe(EXPORTED_SOURCE_LITERALS.length);
   });
 
+  // The locale resources are flat maps whose keys contain dots, so assert
+  // against the key list rather than a `toHaveProperty` dot path.
   it.each(LOCALES)("has a chip label and tooltip for every kind in %s", (_locale, resource) => {
+    const keys = Object.keys(resource);
+
     for (const kind of REQUEST_LOG_SOURCE_KINDS) {
       // The detail dialog reuses the chip label key; the tooltip is chip-only.
-      expect(resource).toHaveProperty(`dashboard.requests.source.${kind}`);
-      expect(resource).toHaveProperty(`dashboard.requests.source.${kind}Title`);
+      expect(keys).toContain(`dashboard.requests.source.${kind}`);
+      expect(keys).toContain(`dashboard.requests.source.${kind}Title`);
     }
   });
 
   it.each(LOCALES)("has a Source filter option label for every kind in %s", (_locale, resource) => {
+    const keys = Object.keys(resource);
+
     for (const kind of REQUEST_LOG_SOURCE_KINDS) {
       // `dashboard-page.tsx` labels option `n` with the `n`th kind; the Python
       // guard checks the exact key that file passes to `t()`.
       const suffix = `${kind.charAt(0).toUpperCase()}${kind.slice(1)}`;
-      expect(resource).toHaveProperty(`dashboard.filters.source${suffix}`);
+      expect(keys).toContain(`dashboard.filters.source${suffix}`);
     }
   });
 });

--- a/frontend/src/features/dashboard/request-log-source.ts
+++ b/frontend/src/features/dashboard/request-log-source.ts
@@ -10,11 +10,20 @@
  * Anchor dispatches (SDK `previous_response_id` chains) share the pinned label
  * with thread pins, so the distinction is strictly two-way: an "anchor" chip
  * cannot be derived from a row.
+ *
+ * The literals below must stay equal to the `REQUEST_LOG_SOURCE_*` constants in
+ * `app/modules/proxy/overflow.py`, which is the authority.
+ * `tests/unit/test_request_log_source_parity.py` fails when either side drifts,
+ * and `request-log-source.test.ts` keeps the labels for every kind present in
+ * every locale.
  */
 export const REQUEST_LOG_SOURCE_OVERFLOW = "subscription_overflow";
 export const REQUEST_LOG_SOURCE_OVERFLOW_PINNED = "subscription_overflow_pinned";
 
-export type RequestLogSourceKind = "overflow" | "overflowPinned";
+/** Every chip/dialog label kind, in the same order as the filter values. */
+export const REQUEST_LOG_SOURCE_KINDS = ["overflow", "overflowPinned"] as const;
+
+export type RequestLogSourceKind = (typeof REQUEST_LOG_SOURCE_KINDS)[number];
 
 /** The two values the request-log `source` filter offers, in menu order. */
 export const REQUEST_LOG_SOURCE_FILTER_VALUES: readonly [string, string] = [

--- a/tests/unit/test_request_log_source_parity.py
+++ b/tests/unit/test_request_log_source_parity.py
@@ -1,0 +1,246 @@
+"""Cross-language drift guard: the dashboard's request-log ``source`` literals vs the backend enum (#2123 WP-G).
+
+WP-G shipped the ``source`` chip, the ``Source`` filter and the detail-dialog
+block against two hand-copied string literals in
+``frontend/src/features/dashboard/request-log-source.ts``. Nothing tied them to
+``app/modules/proxy/overflow.py``, so a backend rename -- or a third overflow
+source value -- would silently stop matching the UI: the chip would quietly stop
+rendering and the filter would return nothing, with every test on both sides
+still green. This file closes that residual, the way
+``tests/unit/test_subscription_overflow_spec_delta.py`` already does for the spec
+deltas and the operator docs.
+
+The backend is the authority and is read by *import*, not by parsing: every
+module-level ``REQUEST_LOG_SOURCE_*`` string in ``overflow.py`` is discovered
+dynamically, so adding a constant grows the expected set without anyone
+remembering to update this file. The frontend side is parsed out of the one
+module WP-G made the single closed mapping, and the assertions are exact set
+equality in both directions:
+
+* a backend value with no frontend literal fails (the new value would render as
+  an unattributed row);
+* a frontend literal the backend does not define fails (a rename left dead
+  code behind, or a literal was typo'd);
+* a value the filter does not offer, or that the chip cannot map to a kind,
+  fails;
+* a kind or filter option whose label is missing from any of en/ko/zh-CN fails.
+
+``_parity_error`` is exercised directly against mutated sets below, so the guard
+itself is covered rather than merely trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from app.modules.proxy import overflow
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_FRONTEND_SRC = REPO_ROOT / "frontend/src"
+_SOURCE_MODULE = _FRONTEND_SRC / "features/dashboard/request-log-source.ts"
+_DASHBOARD_PAGE = _FRONTEND_SRC / "features/dashboard/components/dashboard-page.tsx"
+_LOCALES = _FRONTEND_SRC / "i18n/locales"
+_LOCALE_NAMES = ("en.json", "ko.json", "zh-CN.json")
+
+_BACKEND_MODULE = "app/modules/proxy/overflow.py"
+_FIX_HINT = (
+    f"{_BACKEND_MODULE} is the authority for request-log `source` values; "
+    "update frontend/src/features/dashboard/request-log-source.ts (and the chip "
+    "labels / filter options / locales that hang off it) to match"
+)
+
+# ``REQUEST_LOG_SOURCE_KINDS`` / ``_FILTER_VALUES`` share the prefix but are
+# arrays, so requiring a quoted string here keeps them out of the literal set.
+_BACKEND_NAME = re.compile(r"REQUEST_LOG_SOURCE_[A-Z0-9_]+")
+_TS_LITERAL = re.compile(r'^export const (REQUEST_LOG_SOURCE_[A-Z0-9_]+) = "([^"]*)";$', re.MULTILINE)
+_TS_KINDS = re.compile(r"^export const REQUEST_LOG_SOURCE_KINDS = \[([^\]]*)\] as const;$", re.MULTILINE)
+_TS_FILTER_VALUES = re.compile(r"^export const REQUEST_LOG_SOURCE_FILTER_VALUES[^=\n]*= \[([^\]]*)\];$", re.MULTILINE)
+_TS_SWITCH_CASE = re.compile(r'case (REQUEST_LOG_SOURCE_[A-Z0-9_]+):\s*\n\s*return "([A-Za-z0-9]+)";')
+_TSX_FILTER_OPTION = re.compile(r'\{\s*value: (REQUEST_LOG_SOURCE_[A-Z0-9_]+),\s*label: t\("([^"]+)"\)\s*\}')
+_TS_QUOTED = re.compile(r'"([^"]*)"')
+_TS_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _backend_literals() -> dict[str, str]:
+    """Every module-level ``REQUEST_LOG_SOURCE_*`` string constant, by name."""
+    return {
+        name: value
+        for name, value in vars(overflow).items()
+        if _BACKEND_NAME.fullmatch(name) and isinstance(value, str)
+    }
+
+
+def _frontend_literals() -> dict[str, str]:
+    """Every exported ``REQUEST_LOG_SOURCE_*`` string constant, by TS name."""
+    return dict(_TS_LITERAL.findall(_read(_SOURCE_MODULE)))
+
+
+def _parity_error(backend: frozenset[str], frontend: frozenset[str]) -> str | None:
+    """The loud message, or ``None`` when the two sides agree exactly."""
+    missing = sorted(backend - frontend)
+    unknown = sorted(frontend - backend)
+    if not missing and not unknown:
+        return None
+    parts: list[str] = []
+    if missing:
+        parts.append(f"defined by {_BACKEND_MODULE} but absent from {_rel(_SOURCE_MODULE)}: {missing}")
+    if unknown:
+        parts.append(f"spelled in {_rel(_SOURCE_MODULE)} but not defined by {_BACKEND_MODULE}: {unknown}")
+    return f"request-log `source` literals drifted -- {'; '.join(parts)}. {_FIX_HINT}."
+
+
+def _sole_group(pattern: re.Pattern[str], text: str, label: str) -> str:
+    matches = pattern.findall(text)
+    assert len(matches) == 1, f"expected exactly one {label} declaration in {_rel(_SOURCE_MODULE)}, found {matches}"
+    return matches[0]
+
+
+def _locales() -> dict[str, dict[str, str]]:
+    resources = {path.name: json.loads(_read(path)) for path in sorted(_LOCALES.glob("*.json"))}
+    assert set(resources) == set(_LOCALE_NAMES), sorted(resources)
+    return resources
+
+
+BACKEND_LITERALS = _backend_literals()
+LOCALES = _locales()
+
+
+# -- the backend side is discoverable and publicly declared ------------------------------------
+
+
+def test_backend_declares_its_request_log_source_literals() -> None:
+    """Sanity-check the authority before comparing against it.
+
+    Discovery is by name prefix, so a new value only reaches the guard if it is
+    spelled and exported like the existing two. An empty or private set would
+    make every comparison below vacuously pass.
+    """
+    assert BACKEND_LITERALS, f"no REQUEST_LOG_SOURCE_* string constants found in {_BACKEND_MODULE}"
+    assert len(set(BACKEND_LITERALS.values())) == len(BACKEND_LITERALS), BACKEND_LITERALS
+
+    undeclared = sorted(set(BACKEND_LITERALS) - set(overflow.__all__))
+    assert not undeclared, (
+        f"{_BACKEND_MODULE} defines {undeclared} without listing them in __all__; "
+        "the dashboard parity guard discovers the enum through the public surface"
+    )
+
+
+# -- backend <-> frontend literal parity, both directions --------------------------------------
+
+
+def test_frontend_declares_exactly_the_backend_source_literals() -> None:
+    frontend = _frontend_literals()
+    assert frontend, f"failed to parse any exported REQUEST_LOG_SOURCE_* literal from {_rel(_SOURCE_MODULE)}"
+
+    error = _parity_error(frozenset(BACKEND_LITERALS.values()), frozenset(frontend.values()))
+    assert error is None, error
+
+
+def test_filter_offers_every_source_literal() -> None:
+    """A new value must reach the `Source` filter, not just the chip."""
+    text = _read(_SOURCE_MODULE)
+    offered = set(_TS_IDENTIFIER.findall(_sole_group(_TS_FILTER_VALUES, text, "REQUEST_LOG_SOURCE_FILTER_VALUES")))
+
+    assert offered == set(_frontend_literals()), (
+        f"REQUEST_LOG_SOURCE_FILTER_VALUES offers {sorted(offered)} but the module declares "
+        f"{sorted(_frontend_literals())}; every attributable source value must be filterable"
+    )
+
+
+def test_every_source_literal_maps_to_its_own_chip_kind() -> None:
+    """`requestLogSourceKind` must be a bijection onto the declared kinds."""
+    text = _read(_SOURCE_MODULE)
+    cases = dict(_TS_SWITCH_CASE.findall(text))
+    declared_kinds = _TS_QUOTED.findall(_sole_group(_TS_KINDS, text, "REQUEST_LOG_SOURCE_KINDS"))
+
+    assert set(cases) == set(_frontend_literals()), (
+        f"requestLogSourceKind maps {sorted(cases)} but the module declares "
+        f"{sorted(_frontend_literals())}; an unmapped value renders with no chip"
+    )
+    assert sorted(cases.values()) == sorted(declared_kinds), (
+        f"requestLogSourceKind returns {sorted(cases.values())} but REQUEST_LOG_SOURCE_KINDS "
+        f"declares {sorted(declared_kinds)}"
+    )
+
+
+# -- every kind and filter option is labelled in every locale ----------------------------------
+
+
+def _declared_kinds() -> list[str]:
+    return _TS_QUOTED.findall(_sole_group(_TS_KINDS, _read(_SOURCE_MODULE), "REQUEST_LOG_SOURCE_KINDS"))
+
+
+@pytest.mark.parametrize("locale", _LOCALE_NAMES)
+def test_every_chip_kind_is_labelled_in_every_locale(locale: str) -> None:
+    """The chip label, its tooltip, and the detail-dialog reuse of the label."""
+    resource = LOCALES[locale]
+
+    for kind in _declared_kinds():
+        for key in (f"dashboard.requests.source.{kind}", f"dashboard.requests.source.{kind}Title"):
+            assert key in resource, f"{locale} is missing {key}"
+
+
+@pytest.mark.parametrize("locale", _LOCALE_NAMES)
+def test_every_filter_option_is_labelled_in_every_locale(locale: str) -> None:
+    resource = LOCALES[locale]
+    options = dict(_TSX_FILTER_OPTION.findall(_read(_DASHBOARD_PAGE)))
+
+    assert set(options) == set(_frontend_literals()), (
+        f"{_rel(_DASHBOARD_PAGE)} builds filter options for {sorted(options)} but "
+        f"{_rel(_SOURCE_MODULE)} declares {sorted(_frontend_literals())}"
+    )
+    for constant, key in options.items():
+        assert key in resource, f"{locale} is missing {key} (filter option for {constant})"
+
+
+# -- the guard itself bites in both directions -------------------------------------------------
+
+_BACKEND_SET = frozenset(BACKEND_LITERALS.values())
+# Deliberately unspellable as a real ``source`` value, so these self-tests cannot
+# collide with a value someone genuinely adds later.
+_SYNTHETIC = "<synthetic source value>"
+
+
+def test_guard_accepts_the_shipped_pair() -> None:
+    assert _parity_error(_BACKEND_SET, _BACKEND_SET) is None
+
+
+def test_guard_detects_a_backend_value_added_without_the_frontend() -> None:
+    error = _parity_error(_BACKEND_SET | {_SYNTHETIC}, _BACKEND_SET)
+
+    assert error is not None
+    assert _SYNTHETIC in error
+    assert "absent from" in error
+
+
+def test_guard_detects_a_frontend_literal_removed_or_typoed() -> None:
+    surviving = frozenset(sorted(_BACKEND_SET)[1:])
+    error = _parity_error(_BACKEND_SET, surviving)
+
+    assert error is not None
+    assert sorted(_BACKEND_SET)[0] in error
+    assert "absent from" in error
+
+
+def test_guard_detects_a_renamed_backend_value() -> None:
+    """A rename is an addition and a removal at once; both halves must be named."""
+    old = sorted(_BACKEND_SET)[0]
+    renamed = (_BACKEND_SET - {old}) | {_SYNTHETIC}
+    error = _parity_error(renamed, _BACKEND_SET)
+
+    assert error is not None
+    assert _SYNTHETIC in error
+    assert "absent from" in error
+    assert "not defined by" in error


### PR DESCRIPTION
## Summary

Closes the one residual WP-G (#2355, `21eedbfda`) left open: **no mechanical guard tied the frontend's request-log `source` literals to the backend enum**, so a backend rename — or a third overflow source value — would silently stop matching the dashboard chip and `Source` filter with every test on both sides still green. This adds a cross-language drift guard; the literals themselves are untouched.

## Type of change

- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging

Linked issue: Part of #2123

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Change directory: n/a — dev-tooling only. The guard adds no requirement and changes no observable behaviour: it asserts that code already shipped under `add-subscription-overflow-model-source` task 4.1 ("`request-log-source.ts` as the single closed exact-match mapping shared by the chip, the filter options and the tests") stays true. `openspec validate add-subscription-overflow-model-source --strict` still passes unchanged, and the existing spec-delta guard (`tests/unit/test_subscription_overflow_spec_delta.py`) is untouched and green.

## Changes

**Guard shape: a Python test that imports the backend values (option b), not a generated TypeScript module.**

Why this shape and not regenerate-and-diff:

- **It is already the house style.** `tests/unit/test_subscription_overflow_spec_delta.py` imports `app.modules.proxy.overflow` and reads `frontend/src` + `i18n/locales/*.json` to assert names haven't drifted; `tests/unit/test_subscription_overflow_inert.py` is the positive ratchet over app sources. There is **no Python→TypeScript codegen anywhere in the repo** — the only regenerate-and-diff artifact (`frontend/bun.nix`) is produced by a bun tool from a bun lockfile, and `scripts/generate_settings_reference.py` generates *docs*, not code.
- **`request-log-source.ts` is not a pure data table.** It carries the contract doc comment (why non-overflow rows map to `null`, why an "anchor" chip cannot be derived from a row), the `RequestLogSourceKind` union and the exact-match switch. Generating it would either drop that reviewer-facing rationale or need a hand-kept template — a codegen script plus a CI regenerate job for two string constants is disproportionate.
- **The backend is the authority, so the assertion belongs on the Python side**, where it reads the real values by import instead of parsing Python. `tests/unit` already runs on every PR that touches `tests/**` or `app/**`.

Added / changed:

- `tests/unit/test_request_log_source_parity.py` (new). Discovers every module-level `REQUEST_LOG_SOURCE_*` string in `overflow.py` **by import**, so a new constant grows the expected set without anyone remembering to update the test. Parses the exported literals, `REQUEST_LOG_SOURCE_FILTER_VALUES` and the `requestLogSourceKind` switch out of `request-log-source.ts`, and the `{ value, label: t(...) }` filter options out of `dashboard-page.tsx`. Asserts:
  - exact set equality of literals **in both directions** (the loud one);
  - every literal is offered by the filter and maps to its own chip kind (bijection);
  - every kind has `dashboard.requests.source.{kind}` + `{kind}Title` in **each** of en/ko/zh-CN (chip label, tooltip, and the detail dialog which reuses the chip key);
  - every filter option's `t()` key exists in each locale;
  - sanity: discovery is non-empty and each constant is in `overflow.__all__`, so a regex that stops matching fails loudly instead of passing vacuously.
- `frontend/src/features/dashboard/request-log-source.ts`: derive `RequestLogSourceKind` from a new `REQUEST_LOG_SOURCE_KINDS` value (same union, now enumerable at runtime) and point the doc comment at the authority + both guards.
- `frontend/src/features/dashboard/request-log-source.test.ts`: keep the frontend half internally closed so a frontend-only edit fails the frontend suite too, not only pytest — filter values cover every exported literal, the kind mapping is a bijection onto `REQUEST_LOG_SOURCE_KINDS`, and no locale is missing a chip/tooltip/filter label.

## Test plan

Both directions were proven by temporarily planting each mutation and confirming a failure, then reverting.

**Direction 1 — backend value added without touching the frontend.** Planted `REQUEST_LOG_SOURCE_TRIAL = "subscription_overflow_trial"` in `overflow.py` (+ `__all__`):

```
FAILED tests/unit/test_request_log_source_parity.py::test_frontend_declares_exactly_the_backend_source_literals
E  AssertionError: request-log `source` literals drifted -- defined by app/modules/proxy/overflow.py
   but absent from frontend/src/features/dashboard/request-log-source.ts: ['subscription_overflow_trial'].
   app/modules/proxy/overflow.py is the authority for request-log `source` values; update
   frontend/src/features/dashboard/request-log-source.ts (and the chip labels / filter options /
   locales that hang off it) to match.
```

**Direction 2 — frontend literal renamed.** Planted `subscription_overflow_pinned` → `subscription_overflow_pin` in `request-log-source.ts`; the guard names **both halves** of the rename:

```
FAILED tests/unit/test_request_log_source_parity.py::test_frontend_declares_exactly_the_backend_source_literals
E  AssertionError: request-log `source` literals drifted -- defined by app/modules/proxy/overflow.py
   but absent from .../request-log-source.ts: ['subscription_overflow_pinned']; spelled in
   .../request-log-source.ts but not defined by app/modules/proxy/overflow.py:
   ['subscription_overflow_pin']. ...
```

**Direction 3 — a locale label removed.** Deleted `dashboard.requests.source.overflowPinnedTitle` from `ko.json`; *both* suites bite:

```
FAIL  src/features/dashboard/request-log-source.test.ts > REQUEST_LOG_SOURCE_KINDS
      > has a chip label and tooltip for every kind in ko
FAILED tests/unit/test_request_log_source_parity.py::test_every_chip_kind_is_labelled_in_every_locale[ko.json]
E  AssertionError: ko.json is missing dashboard.requests.source.overflowPinnedTitle
```

All mutations reverted; `git diff --stat` against `origin/main` is exactly the three files above.

Gates (all green on `7f792970d` + this commit):

```
ruff check .                     All checks passed!
ruff format --check .            1255 files already formatted
ty check                         All checks passed!
check_proxy_architecture.py      proxy architecture checks passed
check_cancellation_safety.py     cancellation safety checks passed
check_proxy_timing_seams.py      proxy timing seam checks passed
check_settings_tiers.py          settings fields: 96/96; ok
pytest tests/unit/test_request_log_source_parity.py
        tests/unit/test_subscription_overflow_spec_delta.py
        tests/unit/test_subscription_overflow_inert.py      50 passed
bun run lint                     clean
bun run typecheck                clean
bun run test                     177 files, 1563 tests passed
openspec validate add-subscription-overflow-model-source --strict
                                 Change 'add-subscription-overflow-model-source' is valid
alembic heads                    ['20260911_010000_merge_pin_index_and_affinity_heads']  (single, unchanged — no migration here)
```

## Screenshots / output

N/A — no visual change. The guard is test-only tooling; the `source` literals, chip, filter options and locale strings are all byte-identical, and the only production-file edit derives the existing `RequestLogSourceKind` union from a value instead of spelling it twice.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant gate subset locally (see Test plan).
- [x] If touching specs: n/a — no spec change; `openspec validate ... --strict` re-run and still valid.
- [x] Simplicity gates reviewed: the six simplicity rules (PRINCIPLES.md P1-P6). No new setting, no README section, no dashboard nav item, no default changed.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
