### PR TITLE
fix(balancer): stop waiting on a hard affinity owner the caller excluded

### DIFF
--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -370,6 +370,45 @@ class StickySelectionOutcome(Generic[SelectionInputsT]):
     error_code: str | None
     resets_at: int | None = None
     disposition: StickySelectionDisposition = "shared_result"
+    # Set only alongside ``hard_affinity_saturated`` when the resolved hard
+    # owner is one of the caller's own ``exclude_account_ids``
+    # (``_hard_affinity_owner_excluded_by_caller``).
+    hard_affinity_owner_excluded: bool = False
+
+
+def _hard_affinity_owner_excluded_by_caller(
+    *,
+    error_code: str | None,
+    owner_account_id: str | None | object,
+    exclude_account_ids: frozenset[str],
+) -> bool:
+    """Whether this ``hard_affinity_saturated`` was caused by the caller's own exclusion.
+
+    ``hard_affinity_saturated`` means "the resolved hard ``CODEX_SESSION``
+    owner is not selectable". Two causes reach the same code and the callers'
+    recovery wait (``_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS``) can only help
+    one of them:
+
+    * the owner is briefly unavailable (cap, health backoff, status) -- it may
+      recover inside the wait, which is exactly why the short wait exists;
+    * the caller passed the owner in ``exclude_account_ids`` -- the exclusion
+      filter drops it from the pool before ownership narrows selection to it
+      (``select_account``), so **no** amount of waiting can produce a
+      candidate while the caller keeps excluding it. Selection is not going to
+      spill to another account either: a resolved hard row is ownership
+      evidence, never a preference.
+
+    Only the selector can tell these apart, because only it knows which
+    account the row resolved to. Reporting the distinction (rather than the
+    owner id itself) keeps the account id out of surfaces that would have to
+    redact it, and answers exactly the question every caller asks: "is my own
+    exclusion set the reason, so is waiting futile?"
+    """
+    return (
+        error_code == "hard_affinity_saturated"
+        and isinstance(owner_account_id, str)
+        and owner_account_id in exclude_account_ids
+    )
 
 
 async def run_sticky_selection_path(
@@ -1306,6 +1345,11 @@ async def run_sticky_selection_path(
         error_message=error_message,
         error_code=selection_error_code,
         resets_at=selection_resets_at,
+        hard_affinity_owner_excluded=_hard_affinity_owner_excluded_by_caller(
+            error_code=selection_error_code,
+            owner_account_id=sticky_existing_account_id,
+            exclude_account_ids=request.exclude_account_ids,
+        ),
     )
 
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -496,6 +496,23 @@ def _account_selection_recovery_sleep_seconds_from_message(
 
 
 def _account_selection_recovery_sleep_seconds(selection: AccountSelection) -> float | None:
+    """The wait this selection failure earns before the caller re-selects.
+
+    ``hard_affinity_owner_excluded`` is the selector's proof that the hard
+    ``CODEX_SESSION`` owner it resolved is one of the caller's own
+    ``exclude_account_ids``. The owner cannot become selectable while that
+    exclusion holds and a hard row never spills to another account, so the
+    short owner-recovery window earns nothing here: every re-selection would
+    report the same ``hard_affinity_saturated`` until the request budget is
+    spent (7200s on the HTTP bridge), long after the client gave up. Fail
+    closed at once instead -- the same fail-closed the bridge already applies
+    when the request excludes the account its hard session is bound to
+    (``_require_http_bridge_bound_account_not_excluded``) -- and let the
+    client's own retry reach the owner with no exclusion. A genuinely
+    unavailable owner the caller did NOT exclude keeps its recovery wait.
+    """
+    if selection.hard_affinity_owner_excluded:
+        return None
     return _account_selection_recovery_sleep_seconds_from_message(
         selection.error_message,
         error_code=selection.error_code,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -221,6 +221,10 @@ class AccountSelection:
     lease: AccountLease | None = None
     catalog_omission_quota_admission: CatalogOmissionQuotaAdmission | None = None
     continuity_owner_no_longer_exists: bool = False
+    # ``hard_affinity_saturated`` whose resolved owner is one of the caller's
+    # own ``exclude_account_ids``: the wait a transient owner outage earns
+    # cannot clear this one (``_hard_affinity_owner_excluded_by_caller``).
+    hard_affinity_owner_excluded: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -614,6 +618,7 @@ class LoadBalancer:
 
         excluded_ids = set(exclude_account_ids or ())
         scoped_account_ids = None if account_ids is None else set(account_ids)
+        hard_affinity_owner_excluded = False
         owner_restricted_selection = required_account_is_ownership_constraint or required_continuity_owner
         sticky_selection_may_resolve_owner = sticky_key is not None and sticky_kind == StickySessionKind.CODEX_SESSION
         # C2-3 resilience toggles: resolved from the caller's dashboard snapshot
@@ -983,6 +988,7 @@ class LoadBalancer:
             error_message = sticky_outcome.error_message
             selection_error_code = sticky_outcome.error_code
             selection_resets_at = sticky_outcome.resets_at
+            hard_affinity_owner_excluded = sticky_outcome.hard_affinity_owner_excluded
             if sticky_outcome.disposition == "direct_error":
                 return AccountSelection(
                     account=None,
@@ -1034,6 +1040,7 @@ class LoadBalancer:
                 error_message=error_message,
                 error_code=selection_error_code,
                 resets_at=selection_resets_at,
+                hard_affinity_owner_excluded=hard_affinity_owner_excluded,
             )
         if not circuit_breaker_open:
             set_normal()

--- a/openspec/changes/bound-self-excluded-hard-owner-saturation/proposal.md
+++ b/openspec/changes/bound-self-excluded-hard-owner-saturation/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+Fixes #2163 (documented residual of #2150, follow-up to #2127).
+
+`hard_affinity_saturated` means "the resolved hard `CODEX_SESSION` owner is not
+selectable". Two different causes reach that one code, and the callers' short
+owner-recovery wait (`_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS`, 2s per attempt)
+only helps one of them:
+
+- the owner is briefly unavailable (cap, health backoff, status transition) —
+  it may recover inside the wait, which is why the wait exists;
+- the caller passed the owner in its own `exclude_account_ids` — the exclusion
+  filter drops it from the pool before hard ownership narrows selection to it,
+  so no amount of waiting can produce a candidate, and a resolved hard row
+  never spills to another account.
+
+Two HTTP bridge replays still exclude the account they are moving off (both
+deliberately left at `main` parity by #2150): the **created-only** pre-created
+replay (`fresh_hard_request_account_switch_allowed`) and the
+**model-fallback** replay (`_ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE`). On a
+native Codex session whose affinity resolves a **raw legacy** hard
+`CODEX_SESSION` row — the un-namespaced compatibility row written before
+v1.22.0 / #1382, consulted through `legacy_selection_key`, which never ages
+out — that owner is the only account selection may return. The reconnect loop
+therefore slept 2s per attempt until the bridge request budget
+(`http_responses_session_bridge_request_budget_seconds`, 7200s) was spent
+(~3600 attempts, two hours of `codex.keepalive`) before surfacing the failure.
+
+Measured on the pre-fix tree with the budget bounded to 15s and the recovery
+sleep to 50ms (`tests/integration/test_http_responses_bridge.py`): **294**
+saturated re-selections over 15.14s (created-only) and **295** over 15.10s
+(model-fallback). After the change: **1** re-selection, 0.36s / 0.29s.
+
+#2150 rejected the only cheap cap available to the caller — "the exclusion set
+repeated unchanged" — because it cannot distinguish the two causes and would
+also defeat the legitimate wait. Only the selector knows which account the row
+resolved to.
+
+## What Changes
+
+- **The selector reports the distinction.** `run_sticky_selection_path`
+  computes `_hard_affinity_owner_excluded_by_caller`: true only when the
+  failure is `hard_affinity_saturated` **and** the resolved sticky owner is one
+  of the caller's own `exclude_account_ids`. It travels as
+  `StickySelectionOutcome.hard_affinity_owner_excluded` →
+  `AccountSelection.hard_affinity_owner_excluded`. The flag is a boolean, not
+  the owner id, so no new surface has to redact an account id, and it answers
+  exactly the question every caller asks.
+- **Callers refuse the futile wait.**
+  `_account_selection_recovery_sleep_seconds` returns `None` for such a
+  selection, so `_sleep_for_account_selection_recovery` returns `False` without
+  sleeping once and every transport (HTTP bridge reconnect and creation, direct
+  WebSocket, SSE retry) fails closed on its first saturated re-selection
+  instead of spinning to its request budget. One guard, shared by all
+  surfaces, so the bridge and the WebSocket path cannot drift.
+- **Nothing about selection changes.** No exclusion is dropped, no row is
+  rebound or deleted, no alternate account is served, no error code, status or
+  payload changes. Only the delay before the failure main already produced.
+
+## Why not the same-owner retry (rejected)
+
+The issue's other direction — mirror the SSE path's
+`hard_affinity_same_owner_retry` and reconnect the created-only /
+model-fallback replay on the owner instead of excluding it — was rejected:
+
+- The pre-selection predicate available to the retry
+  (`_affinity_may_resolve_hard_owner`) is true for **every** `CODEX_SESSION`
+  affinity, not only the ones that really resolve a raw legacy row. Using it
+  here would disable the fresh-hard-request account switch for all native
+  sessions, including the common case where the switch is the intended
+  recovery from a dying account.
+- Deciding it late, from this change's selector evidence, is worse: the retry
+  path already cleared the session's `x-codex-turn-state` (and the session
+  turn-state fields) because the account was excluded, so a resurrected
+  same-owner reconnect would hand the owner a handshake stripped of the turn
+  state #2150 went out of its way to preserve.
+- For the model-fallback shape retrying the owner is futile by construction:
+  it just rejected the requested model.
+- It also needs a once-only flag inside the selection loop of
+  `http_bridge/mixin.py`, which is at its architecture line ceiling.
+
+Failing closed fast is `main`-parity-or-better: the wrong account is never
+served, the hard-affinity contract is untouched, and the client's own retry
+reaches the owner with no exclusion in seconds instead of hours. It is also
+the behaviour `main` already has for the neighbouring shape — a 1011 close on
+a hard key binds the reconnect to the session's account and
+`_require_http_bridge_bound_account_not_excluded` fails it closed immediately
+when the request excluded that account.
+
+## Impact
+
+- Specs: `sticky-session-operations` (ADDED: self-inflicted hard-affinity
+  saturation is not waited on).
+- Code: `_load_balancer/sticky_selection.py`, `load_balancer.py`,
+  `_service/support.py`. No migration, no new setting, no dashboard change, no
+  new metric.
+- Tests: `tests/unit/test_load_balancer_concurrency.py` (3),
+  `tests/unit/test_proxy_utils.py` (1),
+  `tests/unit/test_proxy_http_bridge.py` (2),
+  `tests/integration/test_http_responses_bridge.py` (2).
+- Known limitation: a self-excluded hard owner that becomes *unavailable*
+  during the wait could, on `main`, have had its raw row tombstoned by the
+  legacy-owner abandonment path on a later attempt and then spilled. That
+  lottery (median wait unbounded, up to 7200s) is now reached by the client's
+  next request instead.

--- a/openspec/changes/bound-self-excluded-hard-owner-saturation/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/bound-self-excluded-hard-owner-saturation/specs/sticky-session-operations/spec.md
@@ -1,0 +1,55 @@
+# sticky-session-operations Delta
+
+## ADDED Requirements
+
+### Requirement: A hard-affinity saturation caused by the caller's own exclusion is not waited on
+
+When account selection fails with `hard_affinity_saturated`, the selector MUST
+report whether the resolved hard `CODEX_SESSION` owner is one of the account
+ids the caller asked to exclude from that selection. The report MUST be true
+only for that combination: a saturation whose owner the caller did not exclude,
+and any other selection outcome, MUST NOT be reported as caller-excluded.
+
+A hard row is ownership evidence, so selection narrows to its owner and never
+spills to another account, and the exclusion filter removes the owner from the
+candidate pool before that narrowing. A caller that excluded the owner
+therefore cannot be served by any re-selection while its exclusion holds. When
+the selector reports that cause, the caller MUST NOT take the short
+owner-recovery wait that a briefly unavailable owner earns, and MUST fail the
+request closed on that first saturated selection instead of re-selecting until
+its request budget is spent. The failure's error code, HTTP status and payload
+MUST be unchanged from the same failure surfaced after the wait.
+
+The rule MUST hold for every transport that waits on selection recovery — the
+HTTP responses session bridge (session creation and reconnect), the direct
+WebSocket surface, and the SSE retry path — so no surface keeps spinning after
+another stops. It MUST NOT change any selection decision: the exclusion stands,
+the sticky row is neither rebound nor deleted, no alternate account is served
+for a resolved hard owner, and an owner the caller did not exclude keeps both
+its recovery wait and its retry.
+
+#### Scenario: Raw legacy hard owner excluded by the requesting replay
+
+- **GIVEN** a native Codex session whose bare session header still resolves a raw legacy `CODEX_SESSION` row naming account A as the hard owner, and no namespaced row
+- **AND** a healthy alternate account B is selectable
+- **WHEN** selection runs with that affinity and `exclude_account_ids` containing A
+- **THEN** selection fails with `hard_affinity_saturated` and never returns B
+- **AND** the failure reports that the resolved hard owner is one of the caller's own exclusions
+- **AND** the sticky row still names A, unrewritten and undeleted
+
+#### Scenario: Bridge replay that excluded its own hard owner fails closed at once
+
+- **GIVEN** the HTTP responses session bridge is enabled and a native Codex request carries a `session_id` header whose raw legacy row names the serving account as the hard owner
+- **AND** the turn fails before `response.created` reaches the client (the created-only pre-created replay) or the account rejects the requested model (the model-fallback replay), so the replay excludes that account to move the turn
+- **WHEN** the reconnect re-selects and selection reports the caller-excluded hard owner
+- **THEN** the reconnect fails the request closed on that first re-selection without waiting for the owner to recover
+- **AND** the turn is not sent to another account, and the owner is not reconnected behind the client's back
+- **AND** the client observes the resulting failure immediately instead of keepalives until the bridge request budget
+
+#### Scenario: Unavailable owner the caller did not exclude keeps its recovery wait
+
+- **GIVEN** the same session whose raw legacy row names account A as the hard owner
+- **AND** A is temporarily unselectable through a status or health transition while the caller excludes nothing
+- **WHEN** selection fails with `hard_affinity_saturated`
+- **THEN** the failure is not reported as caller-excluded
+- **AND** the caller takes its short owner-recovery wait and re-selects, so the owner may serve the turn once it recovers

--- a/openspec/changes/bound-self-excluded-hard-owner-saturation/tasks.md
+++ b/openspec/changes/bound-self-excluded-hard-owner-saturation/tasks.md
@@ -1,0 +1,30 @@
+## 1. Selector evidence
+
+- [x] 1.1 Add `_hard_affinity_owner_excluded_by_caller` to
+      `_load_balancer/sticky_selection.py`
+- [x] 1.2 Carry it on `StickySelectionOutcome` and report it from
+      `run_sticky_selection_path`
+- [x] 1.3 Surface it as `AccountSelection.hard_affinity_owner_excluded` from
+      `LoadBalancer.select_account`
+
+## 2. Recovery wait
+
+- [x] 2.1 `_account_selection_recovery_sleep_seconds` returns `None` for a
+      self-excluded hard owner, so every transport fails closed on the first
+      saturated re-selection
+
+## 3. Spec + tests
+
+- [x] 3.1 ADDED `sticky-session-operations` requirement + scenarios
+- [x] 3.2 Selection-level: raw legacy row + owner excluded reports the flag;
+      unexcluded control resolves the owner; owner unavailable without an
+      exclusion keeps its recovery wait
+- [x] 3.3 Support-level: the wait is refused without sleeping once
+- [x] 3.4 Reconnect-level bound: one selection attempt, no sleep, fail closed;
+      control still waits once and retries
+- [x] 3.5 Relay-level: created-only and model-fallback replays on a raw legacy
+      hard owner fail closed within one re-selection (both shapes spun 294/295
+      attempts to the budget before this change)
+- [x] 3.6 Mutants: drop the error-code condition, drop the exclusion-set
+      condition, drop the support guard, and stub the load-balancer plumbing —
+      each caught by a listed test

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -487,9 +487,13 @@ class _ClosingBridgeUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
 
 
 class _PrecreatedCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    def __init__(self, response_id_prefix: str = "resp_bridge", *, close_code: int = 1011) -> None:
+        super().__init__(response_id_prefix)
+        self.close_code = close_code
+
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
-        await self._messages.put(_FakeUpstreamMessage("close", close_code=1011))
+        await self._messages.put(_FakeUpstreamMessage("close", close_code=self.close_code))
 
 
 class _PrecreatedOverloadUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
@@ -17050,6 +17054,10 @@ def _install_two_account_bridge_failover_with_hard_owner(
                     account=None,
                     error_message="Hard affinity owner account is unavailable",
                     error_code="hard_affinity_saturated",
+                    # The production selector reports that the hard owner it
+                    # resolved is one of this caller's own exclusions, so the
+                    # owner-recovery wait cannot clear it (#2163).
+                    hard_affinity_owner_excluded=True,
                 )
             return AccountSelection(account=owner, error_message=None, error_code=None)
         chosen = alternate if owner.id in excluded else owner
@@ -17316,6 +17324,128 @@ async def test_backend_responses_http_bridge_accepted_replay_moved_by_a_soft_row
     # handshake carries none of it.
     assert "x-codex-turn-state" not in connects[0][1]
     assert "x-codex-turn-state" not in connects[1][1], connects[1][1]["x-codex-turn-state"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shape", ["created_only", "model_fallback"])
+async def test_backend_responses_http_bridge_fails_a_self_excluded_hard_owner_replay_closed(
+    async_client,
+    monkeypatch,
+    shape,
+):
+    """#2163 (residual of #2150): the two replays that still exclude the
+    account they are moving off -- the created-only pre-created replay
+    (upstream died before ``response.created`` reached the client) and the
+    model-fallback replay (the account rejected the requested model) -- on a
+    native Codex session whose affinity resolves a raw legacy hard
+    ``CODEX_SESSION`` owner. That owner is the only account selection may
+    return, so the exclusion makes every re-selection report
+    ``hard_affinity_saturated``; the reconnect read that as a transient owner
+    outage and slept ``_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS`` per attempt
+    until the bridge request budget was spent (measured on the pre-fix tree
+    with the budget bounded to 15s and the sleep to 50ms: 294 and 295 saturated
+    re-selections over the full 15s; production defaults are 2s per attempt to
+    a 7200s budget, ~3600 attempts before the client sees anything).
+
+    The selector now reports that the saturation is this request's own
+    exclusion, so the wait is refused and the failure is immediate. The turn is
+    never handed to the alternate account: a resolved hard row is ownership
+    evidence, and the client's own retry reaches the owner unexcluded."""
+    legacy_session_key = f"sid-http-bridge-self-excluded-{shape}"
+    model = "gpt-5.3-codex-spark" if shape == "model_fallback" else "gpt-5.1"
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=_make_app_settings(enabled=True).model_copy(
+            update={"http_responses_session_bridge_request_budget_seconds": 15.0}
+        ),
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    monkeypatch.setattr(proxy_support, "_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS", 0.05)
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS", 0.01)
+    owner_id = await _import_account(
+        async_client,
+        f"acc_self_excluded_owner_{shape}",
+        f"self-excluded-owner-{shape}@example.com",
+    )
+    alternate_id = await _import_account(
+        async_client,
+        f"acc_self_excluded_alternate_{shape}",
+        f"self-excluded-alternate-{shape}@example.com",
+    )
+    owner = await _get_account(owner_id)
+    alternate = await _get_account(alternate_id)
+    failing_upstream = (
+        _ErrorOnlyUpstreamWebSocket("resp_self_excluded_model_rejected")
+        if shape == "model_fallback"
+        else _PrecreatedCloseUpstreamWebSocket("resp_self_excluded_created_only", close_code=1006)
+    )
+    owner_second_upstream = _FakeBridgeUpstreamWebSocket("resp_self_excluded_owner_second")
+    alternate_upstream = _FakeBridgeUpstreamWebSocket("resp_self_excluded_alternate")
+    connect_account_ids, selection_exclusions, selection_legacy_keys = (
+        _install_two_account_bridge_failover_with_hard_owner(
+            monkeypatch,
+            owner=owner,
+            alternate=alternate,
+            legacy_session_key=legacy_session_key,
+            upstreams_by_account_header={
+                f"acc_self_excluded_owner_{shape}": [failing_upstream, owner_second_upstream],
+                f"acc_self_excluded_alternate_{shape}": [alternate_upstream],
+            },
+        )
+    )
+
+    started_at = time.monotonic()
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": model,
+            "instructions": "Return exactly OK.",
+            "input": "self-excluded-hard-owner-replay",
+            "stream": True,
+        },
+        headers={"session_id": legacy_session_key},
+    )
+    body = response.text
+    elapsed_seconds = time.monotonic() - started_at
+
+    # The bound: ONE saturated re-selection, not one per recovery sleep until
+    # the request budget. 5s is two orders of magnitude below the 15s budget
+    # this test allows, so a reintroduced spin fails here instead of hanging.
+    saturated_selections = [excluded for excluded in selection_exclusions if owner.id in excluded]
+    assert len(saturated_selections) == 1, (
+        f"the reconnect must not spin on a self-excluded hard owner: {len(saturated_selections)} attempts "
+        f"in {elapsed_seconds:.2f}s"
+    )
+    assert elapsed_seconds < 5.0
+    assert selection_legacy_keys[-1] == legacy_session_key
+    # The hard owner keeps its turns: the excluded replay is not served by the
+    # alternate account, and the owner is not reconnected behind the client's
+    # back either -- the request fails closed on its first re-selection.
+    assert connect_account_ids == [f"acc_self_excluded_owner_{shape}"]
+    assert len(failing_upstream.sent_text) == 1
+    assert owner_second_upstream.sent_text == []
+    assert alternate_upstream.sent_text == []
+    if shape == "created_only":
+        # Nothing was visible downstream yet, so the selection failure is the
+        # response: a 503 instead of 7200s of keepalives and a 502.
+        assert response.status_code == 503
+        assert json.loads(body)["error"]["code"] == "hard_affinity_saturated"
+        return
+    # The model-fallback replay surfaces the upstream rejection that started
+    # it, which is the actionable error for a hard owner that cannot serve the
+    # requested model.
+    assert response.status_code == 200
+    events = [
+        event
+        for line in body.splitlines()
+        if line.startswith("data: ") and line[6:] != "[DONE]"
+        if (event := json.loads(line[6:])).get("type") != "codex.keepalive"
+    ]
+    assert [event["type"] for event in events] == ["error"]
+    assert events[0]["error"]["code"] == "invalid_request_error"
+    assert events[0]["error"]["message"] == (
+        f"The '{model}' model is not supported when using Codex with a ChatGPT account."
+    )
 
 
 class _AcceptedOutputItemCapacityErrorUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -2927,6 +2927,150 @@ async def test_bare_codex_session_keeps_unsaturated_owner(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("owner_excluded", [True, False])
+async def test_raw_legacy_codex_session_owner_excluded_by_the_caller_reports_a_self_inflicted_saturation(
+    owner_excluded: bool,
+) -> None:
+    """#2163: a raw legacy ``CODEX_SESSION`` row (the un-namespaced
+    compatibility row an old replica persisted for a bare session header,
+    consulted through ``legacy_sticky_key`` and never aged out) is hard
+    ownership evidence, so selection narrows to its owner and never spills --
+    not even to a healthy alternate. A caller that excluded that owner, which
+    is what the HTTP bridge's created-only and model-fallback replays do to
+    move a fresh turn off a failing account, therefore cannot be served by any
+    re-selection while the exclusion holds. ``hard_affinity_saturated`` alone
+    does not say that: the same code covers a briefly unavailable owner that a
+    short recovery wait may recover. Only the selector knows which account the
+    row resolved to, so it reports the distinction."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer(
+        f"legacy-hard-owner-{'excluded' if owner_excluded else 'eligible'}"
+    )
+    assert alternate is not None
+    raw_session = "legacy-process"
+    # Raw row only: no namespaced row exists for this session (pre-v1.22.0 /
+    # #1382 shape), so the raw owner is the hard owner.
+    sticky_repo.account_ids_by_key = {raw_session: owner.id}
+
+    selected = await balancer.select_account(
+        sticky_key=_codex_session_selection_key(raw_session),
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        sticky_source="session_header",
+        legacy_sticky_key=raw_session,
+        spill_bare_session_on_account_cap=True,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+        exclude_account_ids={owner.id} if owner_excluded else set(),
+    )
+
+    if not owner_excluded:
+        # Control: unexcluded, the same raw row resolves to its owner.
+        assert selected.account is not None
+        assert selected.account.id == owner.id
+        assert selected.hard_affinity_owner_excluded is False
+        await balancer.release_account_lease(selected.lease)
+        return
+    assert selected.account is None
+    assert selected.error_code == "hard_affinity_saturated"
+    assert selected.hard_affinity_owner_excluded is True
+    # Ownership is untouched: the exclusion is request-local evidence, never a
+    # reason to rebind or delete the row the alternate would inherit.
+    assert sticky_repo.account_ids_by_key == {raw_session: owner.id}
+    assert sticky_repo.upserts == []
+    assert sticky_repo.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_soft_bare_session_owner_excluded_by_the_caller_is_not_a_hard_affinity_saturation() -> None:
+    """Scope guard for #2163: only ``hard_affinity_saturated`` may be reported
+    as caller-excluded. A namespaced soft row for the same bare session header
+    (no raw legacy row) is a preference, so excluding its owner spills to the
+    alternate and the selection succeeds -- nothing for a caller to stop
+    waiting on."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("soft-owner-excluded")
+    assert alternate is not None
+    raw_session = "soft-bare-session-excluded"
+    sticky_repo.account_ids_by_key = {_codex_session_selection_key(raw_session): owner.id}
+
+    selected = await balancer.select_account(
+        sticky_key=_codex_session_selection_key(raw_session),
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        sticky_source="session_header",
+        legacy_sticky_key=raw_session,
+        spill_bare_session_on_account_cap=True,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+        exclude_account_ids={owner.id},
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == alternate.id
+    assert selected.error_code is None
+    assert selected.hard_affinity_owner_excluded is False
+    await balancer.release_account_lease(selected.lease)
+
+
+@pytest.mark.asyncio
+async def test_account_cap_failure_with_an_excluded_sticky_owner_is_not_a_hard_affinity_saturation() -> None:
+    """Scope guard for #2163: the caller-excluded report is scoped to
+    ``hard_affinity_saturated``. Here the same excluded sticky owner ends in a
+    local account-cap failure instead, whose own recovery wait must survive:
+    the cap clears on its own, unlike an exclusion."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("soft-owner-excluded-capped")
+    assert alternate is not None
+    raw_session = "soft-bare-session-excluded-capped"
+    sticky_repo.account_ids_by_key = {_codex_session_selection_key(raw_session): owner.id}
+    saturated_leases = [await balancer.acquire_account_lease(alternate.id, kind="stream") for _ in range(8)]
+
+    selected = await balancer.select_account(
+        sticky_key=_codex_session_selection_key(raw_session),
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        sticky_source="session_header",
+        legacy_sticky_key=raw_session,
+        spill_bare_session_on_account_cap=True,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+        exclude_account_ids={owner.id},
+    )
+
+    assert selected.account is None
+    assert selected.error_code == "account_stream_cap"
+    assert selected.hard_affinity_owner_excluded is False
+
+    for lease in saturated_leases:
+        await balancer.release_account_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_hard_codex_session_owner_unavailable_without_an_exclusion_keeps_its_recovery_wait() -> None:
+    """Parity guard for #2163: an owner the caller did NOT exclude may be
+    unselectable only for as long as its status/health transition lasts, so the
+    saturation is not self-inflicted and the caller's short owner-recovery wait
+    must stay intact."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("legacy-hard-owner-unavailable")
+    assert alternate is not None
+    owner.status = AccountStatus.RATE_LIMITED
+    owner.reset_at = int(datetime.now(tz=timezone.utc).timestamp()) + 3600
+    raw_session = "legacy-process-unavailable"
+    sticky_repo.account_ids_by_key = {raw_session: owner.id}
+
+    selected = await balancer.select_account(
+        sticky_key=_codex_session_selection_key(raw_session),
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        sticky_source="session_header",
+        legacy_sticky_key=raw_session,
+        spill_bare_session_on_account_cap=True,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert selected.account is None
+    assert selected.error_code == "hard_affinity_saturated"
+    assert selected.hard_affinity_owner_excluded is False
+    assert sticky_repo.upserts == []
+    assert sticky_repo.deleted == []
+
+
+@pytest.mark.asyncio
 async def test_bare_codex_stream_avoids_owner_at_response_create_cap() -> None:
     balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("cap-second-stage")
     assert alternate is not None

--- a/tests/unit/test_load_balancer_contract.py
+++ b/tests/unit/test_load_balancer_contract.py
@@ -591,6 +591,9 @@ async def test_required_continuity_owner_preserves_transient_hard_affinity_satur
             error_code="hard_affinity_saturated",
             resets_at=None,
             disposition="shared_result",
+            # This caller excluded nothing, so the saturation is a transient
+            # owner outage and keeps its recovery wait (#2163).
+            hard_affinity_owner_excluded=False,
         )
 
     monkeypatch.setattr(load_balancer_module, "run_sticky_selection_path", saturated_selection)
@@ -606,6 +609,7 @@ async def test_required_continuity_owner_preserves_transient_hard_affinity_satur
     assert selection.account is None
     assert selection.error_message == "Hard affinity owner account is unavailable"
     assert selection.error_code == "hard_affinity_saturated"
+    assert selection.hard_affinity_owner_excluded is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -13146,6 +13146,106 @@ async def test_reconnect_http_bridge_session_retries_transient_file_pin_owner_sa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("owner_excluded_by_us", [True, False])
+async def test_reconnect_http_bridge_session_bounds_a_self_excluded_hard_owner_saturation(
+    monkeypatch: pytest.MonkeyPatch,
+    owner_excluded_by_us: bool,
+) -> None:
+    """#2163: the created-only and model-fallback replays of a fresh turn on a
+    hard ``session_header`` session exclude the failing account to move the
+    turn. When the session affinity resolves a raw legacy hard
+    ``CODEX_SESSION`` owner that account is the only one selection may return,
+    so every re-selection reports ``hard_affinity_saturated`` -- and the
+    reconnect used to read that as a transient owner outage and sleep
+    ``_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS`` per attempt until the bridge
+    request budget (7200s by default, ~3600 attempts) was spent.
+
+    The selector now proves the saturation is the caller's own exclusion, and
+    the recovery wait is refused: ONE attempt, no sleep, fail closed -- the
+    bound this test pins. A saturation without that proof keeps its single
+    recovery wait and its retry, so a briefly unavailable owner is unaffected."""
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-self-excluded-hard-owner", None),
+        key_value="sid-self-excluded-hard-owner",
+    )
+    assert session.key.strength == "hard"
+    # Abrupt 1006, not 1011: a 1011 close binds the reconnect to the session's
+    # account and already fails closed at
+    # ``_require_http_bridge_bound_account_not_excluded``. 1006 is the shape
+    # that reaches selection with the account excluded.
+    session.last_upstream_close_code = 1006
+    selections: list[dict[str, object]] = []
+    recovery_waits: list[proxy_service.AccountSelection] = []
+    recovery_sleeps: list[float] = []
+    alternate_account = cast(
+        Any, SimpleNamespace(id="acc-self-excluded-alternate", status=AccountStatus.ACTIVE, plan_type="plus")
+    )
+
+    async def select_account(_deadline: float, **kwargs: object) -> proxy_service.AccountSelection:
+        selections.append(kwargs)
+        if len(selections) == 1:
+            return proxy_service.AccountSelection(
+                account=None,
+                error_message="Hard affinity owner account is unavailable",
+                error_code="hard_affinity_saturated",
+                hard_affinity_owner_excluded=owner_excluded_by_us,
+            )
+        return proxy_service.AccountSelection(account=alternate_account, error_message=None)
+
+    async def recording_sleep(seconds: float) -> None:
+        recovery_sleeps.append(seconds)
+
+    async def sleep_for_recovery(selection: proxy_service.AccountSelection, **kwargs: Any) -> bool:
+        # The real recovery wait, on a scheduler that records instead of
+        # sleeping: the decision under test belongs to support, not to a stub.
+        recovery_waits.append(selection)
+        kwargs["scheduler"] = cast(Any, SimpleNamespace(sleep=recording_sleep))
+        return await proxy_support_module._sleep_for_account_selection_recovery(selection, **kwargs)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-self-excluded-hard-owner",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    request_state.excluded_account_ids.add(session.account.id)
+    upstream = cast(Any, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=_bridge_selection_settings())),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(http_bridge_mixin_module, "_sleep_for_account_selection_recovery", sleep_for_recovery)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=alternate_account))
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=upstream))
+
+    if owner_excluded_by_us:
+        with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+            await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.payload["error"]["code"] == "hard_affinity_saturated"
+        assert len(selections) == 1
+        assert session.account.id in cast(Any, selections[0]["exclude_account_ids"])
+        assert recovery_sleeps == []
+        assert session.closed is True
+        return
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert len(selections) == 2
+    assert recovery_waits and recovery_waits[0].error_code == "hard_affinity_saturated"
+    assert recovery_sleeps == [proxy_support_module._HARD_AFFINITY_RECOVERY_SLEEP_SECONDS]
+    assert session.account is alternate_account
+    assert session.closed is False
+
+
+@pytest.mark.asyncio
 async def test_reconnect_http_bridge_session_maps_nonexistent_file_pin_owner_without_sleep(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -29765,6 +29865,7 @@ async def test_http_bridge_reconnect_failure_keeps_reader_handoff_session_closed
             account=None,
             error_code="no_accounts",
             error_message="No active accounts available",
+            hard_affinity_owner_excluded=False,
         )
 
     monkeypatch.setattr(service, "_select_account_with_budget_for_stream", AsyncMock(side_effect=select_no_account))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1377,6 +1377,43 @@ def test_account_selection_recovery_sleep_retries_hard_affinity_owner_briefly():
     assert _account_selection_recovery_sleep_seconds(selection) == 2.0
 
 
+@pytest.mark.asyncio
+async def test_account_selection_recovery_sleep_refuses_a_self_excluded_hard_affinity_owner():
+    """#2163: the selector reports that the hard ``CODEX_SESSION`` owner it
+    resolved is one of the caller's own ``exclude_account_ids``. That owner
+    cannot become selectable while the exclusion holds and a hard row never
+    spills, so the 2s owner-recovery window buys nothing: repeating it burns
+    the whole request budget (7200s on the HTTP bridge) before the same
+    failure surfaces. The wait is refused without sleeping once, and the same
+    ``hard_affinity_saturated`` without that proof keeps its recovery wait
+    (``test_account_selection_recovery_sleep_retries_hard_affinity_owner_briefly``)."""
+    selection = AccountSelection(
+        account=None,
+        error_message="Hard affinity owner account is unavailable",
+        error_code="hard_affinity_saturated",
+        hard_affinity_owner_excluded=True,
+    )
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    assert _account_selection_recovery_sleep_seconds(selection) is None
+    waited = await _sleep_for_account_selection_recovery(
+        selection,
+        request_id="req_self_excluded_hard_owner",
+        kind="http_bridge",
+        request_stage="reattach",
+        model="gpt-5.1",
+        max_sleep_seconds=7200.0,
+        scheduler=cast(Any, SimpleNamespace(sleep=fake_sleep)),
+        clock=REAL_CLOCK,
+    )
+
+    assert waited is False
+    assert sleeps == []
+
+
 def test_account_selection_recovery_sleep_ignores_generic_no_available_accounts():
     selection = AccountSelection(account=None, error_message="No available accounts", error_code="no_accounts")
 


### PR DESCRIPTION
## Summary

`hard_affinity_saturated` is reported for two different causes, and the callers' short owner-recovery wait (`_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS`, 2s/attempt) can only help one of them. The sticky selector now reports which cause it hit, and the recovery wait is refused when the hard `CODEX_SESSION` owner it resolved is one of the **caller's own** `exclude_account_ids` — so the HTTP bridge's created-only and model-fallback replays on a raw legacy hard owner fail closed on their first re-selection instead of re-selecting every 2s until the 7200s bridge request budget.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Fixes #2163

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (request/response shape, SSE framing) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/bound-self-excluded-hard-owner-saturation/`

(#2150's change folder is already archived as `openspec/changes/archive/2026-09-09-keep-accepted-bridge-replay-on-hard-owner/`, so this is a new small change rather than an extension. `openspec validate bound-self-excluded-hard-owner-saturation --strict` → valid.)

## Reproduction (measured before / after)

Relay level, `tests/integration/test_http_responses_bridge.py::test_backend_responses_http_bridge_fails_a_self_excluded_hard_owner_replay_closed`, on a native Codex session (`session_id` header) whose affinity resolves a **raw legacy** `CODEX_SESSION` row naming the serving account as the hard owner, with a healthy alternate available. Bridge budget bounded to 15s and the recovery sleep to 50ms so the pre-fix mode terminates in seconds instead of 2 hours:

| shape | main (`7f792970d`) | this PR |
|---|---|---|
| created-only pre-created replay (upstream dies with 1006 before `response.created` reaches the client) | **294** saturated re-selections, **15.14s** (the whole budget), then `response.failed` `hard_affinity_saturated` after 15s of `codex.keepalive` | **1** re-selection, **0.36s**, HTTP `503 hard_affinity_saturated` |
| model-fallback replay (owner rejects the requested model) | **295** saturated re-selections, **15.10s**, same keepalives-then-failure | **1** re-selection, **0.29s**, the upstream `400 invalid_request_error` (“The 'gpt-5.3-codex-spark' model is not supported…”) delivered at once |

At production defaults (`http_responses_session_bridge_request_budget_seconds=7200`, sleep 2s) the pre-fix loop is ~3600 re-selections over ~2 hours before the client sees anything.

Selection level, `tests/unit/test_load_balancer_concurrency.py` with `_make_cap_spillover_balancer` and a raw sticky row `{"legacy-process": owner}` (no namespaced row): selecting with `exclude_account_ids={owner}` while an alternate is healthy returns `hard_affinity_saturated` (unchanged) and now also reports `hard_affinity_owner_excluded=True`; unexcluded, the same row resolves to the owner.

Note: the neighbouring 1011-close shape already fails closed immediately on `main` (`_require_http_bridge_bound_account_not_excluded`, “continuity account is excluded”, measured 0.39s) for exactly this “the request excluded its own bound account” situation — the created-only spin needs a close code outside `_UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY` (1006 here) to reach selection.

## Changes

- `_load_balancer/sticky_selection.py`: new `_hard_affinity_owner_excluded_by_caller` — true only when the failure is `hard_affinity_saturated` **and** the resolved sticky owner is in the caller's `exclude_account_ids`; carried on `StickySelectionOutcome.hard_affinity_owner_excluded`.
- `load_balancer.py`: `AccountSelection.hard_affinity_owner_excluded`, plumbed from the sticky outcome to the no-account return.
- `_service/support.py`: `_account_selection_recovery_sleep_seconds` returns `None` for such a selection, so `_sleep_for_account_selection_recovery` returns `False` without sleeping once and every transport that waits on selection recovery (bridge reconnect + creation, direct WebSocket, SSE retry) fails closed on the first saturated re-selection. One guard for all surfaces, so the bridge and `_websocket_affinity_may_resolve_hard_owner`'s surface cannot drift.
- No new setting, no migration, no metric, no dashboard change. Error code, HTTP status and payload are the ones `main` already produced — only the delay is gone.

## Chosen direction, and the one rejected

**Chosen — the issue's direction 2 (precise cap).** A boolean, not the owner id: the selector already holds the caller's exclusion set, so it can answer “is my own exclusion the reason?” itself, which keeps an account id out of surfaces that would have to redact it and needs **no** change to `http_bridge/mixin.py` (at its 2436-line architecture ceiling).

**Rejected — direction 1 (SSE-style same-owner retry) for the bridge:**
- The only predicate available *before* selection, `_affinity_may_resolve_hard_owner`, is true for **every** `CODEX_SESSION` affinity, not just the ones that really resolve a raw legacy row. Using it in `_retry_http_bridge_precreated_request` would disable the fresh-hard-request account switch for all native sessions — including the common case where that switch is the intended recovery from a dying account.
- Deciding it *late* (dropping the exclusion once this PR's evidence arrives) is worse: the retry path has already stripped `x-codex-turn-state` from the session and cleared its turn-state fields precisely because the account was excluded, so the resurrected same-owner reconnect would hand the owner a handshake without the turn state #2150 went out of its way to preserve.
- For the model-fallback shape retrying the owner is futile by construction — it just rejected the requested model. The fast failure surfaces that actionable 400 instead.
- It would also need a once-only flag inside the selection loop of `http_bridge/mixin.py`, which has no line budget.

## Main-parity argument

- **Same outcome, sooner.** The pre-fix path ends in the same failure after the budget; nothing that succeeded on `main` now fails. The wrong account is never served: selection returned no account, and no exclusion is dropped, no sticky row is rebound or deleted.
- **Hard affinity is untouched.** A resolved hard owner keeps its turns; the alternate account never receives the turn (asserted at the relay level: one connect, to the owner, and the alternate socket gets nothing).
- **The legitimate wait survives.** An owner the caller did *not* exclude still gets its 2s wait and its retry (pinned by unit + reconnect-level controls), because the flag requires the owner to be in the caller's own exclusion set.
- **Consistent with existing fail-closed.** `main` already fails this exact “I excluded my own bound account” situation closed immediately on a 1011 close; this extends that to the case where only the selector can prove it.
- **Recovery still exists.** The client's own retry reaches the owner unexcluded within seconds. Known limitation below covers the one `main` path this trades away.

## Test plan

```
# unit (new tests)
tests/unit/test_load_balancer_concurrency.py -k "self_inflicted_saturation or not_a_hard_affinity_saturation or keeps_its_recovery_wait"   # 5 passed
tests/unit/test_proxy_utils.py -k "recovery_sleep"                                                                                          # 16 passed
tests/unit/test_proxy_http_bridge.py -k "bounds_a_self_excluded_hard_owner_saturation"                                                      # 2 passed
tests/integration/test_http_responses_bridge.py -k "fails_a_self_excluded_hard_owner_replay_closed"                                         # 2 passed

# regression suites
tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py tests/unit/test_fair_share.py \
  tests/unit/test_overload_backoff.py tests/unit/test_proxy_support_virtual_time.py                                                         # 2531 passed, 1 deselected
tests/unit/test_load_balancer_concurrency.py tests/unit/test_load_balancer_contract.py                                                      # 179 passed
tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_sticky_sessions.py                                             # green

# gates
ruff check . / ruff format --check .        # clean
ty check                                    # All checks passed!
scripts/check_proxy_architecture.py         # passed (load_balancer.py 3007/3021, http_bridge/mixin.py untouched)
scripts/check_cancellation_safety.py        # passed
scripts/check_proxy_timing_seams.py         # passed
scripts/check_settings_tiers.py             # ok (96/96, unchanged)
openspec validate bound-self-excluded-hard-owner-saturation --strict   # valid
```

New tests, by level:
- **Selection** (`test_load_balancer_concurrency.py`): raw legacy row + excluded owner reports the flag while never spilling to the healthy alternate; unexcluded control resolves the owner; a soft namespaced row with the same excluded owner spills and reports nothing; an account-cap failure with the same excluded owner reports nothing; a `RATE_LIMITED` owner with no exclusion reports nothing.
- **Support** (`test_proxy_utils.py`): the wait is refused and `_sleep_for_account_selection_recovery` returns `False` having called `scheduler.sleep` zero times, with a 7200s budget offered.
- **Reconnect bound** (`test_proxy_http_bridge.py`): `_reconnect_http_bridge_session` on a hard `session_header` session that excluded its own account raises `503 hard_affinity_saturated` after exactly **one** selection and zero sleeps; the control (same saturation, flag off) waits exactly one `_HARD_AFFINITY_RECOVERY_SLEEP_SECONDS` and succeeds on the second selection.
- **Relay** (`test_http_responses_bridge.py`): both shapes, asserting one saturated selection, <5s against a 15s budget, one connect (to the owner, never the alternate), and the terminal the client sees.

Two pre-existing `SimpleNamespace` selection stubs (`test_load_balancer_contract.py`, `test_proxy_http_bridge.py`) gained the new field so they keep mirroring `AccountSelection`.

### Mutants planted (each caught)

| mutant | caught by |
|---|---|
| `_hard_affinity_owner_excluded_by_caller` drops the `error_code == "hard_affinity_saturated"` condition | `test_account_cap_failure_with_an_excluded_sticky_owner_is_not_a_hard_affinity_saturation` |
| …drops the `owner in exclude_account_ids` condition (report any hard saturation) | `test_hard_codex_session_owner_unavailable_without_an_exclusion_keeps_its_recovery_wait` |
| `_account_selection_recovery_sleep_seconds` loses the `hard_affinity_owner_excluded` guard | `test_account_selection_recovery_sleep_refuses_a_self_excluded_hard_affinity_owner`, `test_reconnect_http_bridge_session_bounds_a_self_excluded_hard_owner_saturation[True]`, and **both** relay tests |
| `select_account` stops reading the flag off the sticky outcome | `test_raw_legacy_codex_session_owner_excluded_by_the_caller_reports_a_self_inflicted_saturation[True]` |

## Known limitations

- A self-excluded hard owner that becomes *unavailable* during the pre-fix wait could, on `main`, have had its raw legacy row tombstoned by the legacy-owner abandonment CAS on a later attempt and then spilled to an alternate. That path is now reached by the client's next request instead of by an unbounded (up to 7200s) in-request lottery the client has long abandoned.
- The created-only and model-fallback replays still **exclude** the account they move off (`main` parity, as #2150 left them): this PR bounds the wait, it does not serve the turn on the owner. Serving it would be the same-owner retry rejected above; a narrower version (a raw-legacy-row-specific pre-selection predicate) remains possible as a follow-up.
- The flag is only reported by the sticky selection path. The preferred-owner pre-selection inside `_select_account_with_budget` passes no `exclude_account_ids` (and requires the preferred account not to be excluded), so it cannot produce this cause.
- Only the `hard_affinity_saturated` wait is addressed. Other selection-recovery waits (account caps, rate-limit hints) are unchanged, including cases where the caller's exclusion set is what keeps the pool empty for a *soft* owner.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant lint/type/architecture/openspec gates locally (listed above; `uv` targets avoided on this host, same commands run through the project venv).
- [x] If touching specs: strict OpenSpec validation passes for the new change.
- [x] Simplicity gates reviewed: no new setting, no README section, no dashboard surface, no default changed.
- [x] CHANGELOG is not edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
