### PR TITLE
refactor(db): give the SQLite lock report one owner and state the driver-evidence rule

### DIFF
--- a/app/db/sqlite_lock_retry.py
+++ b/app/db/sqlite_lock_retry.py
@@ -95,6 +95,27 @@ def sqlite_error_name(exc: BaseException) -> str | None:
     return getattr(driver_exc, "sqlite_errorname", None)
 
 
+def _report_lock_attempt(exc: BaseException, *, what: str, giving_up: bool, **extra: object) -> None:
+    """Emit the one report format both retry helpers share.
+
+    Each helper reports the same two facts — which write contended and which
+    mechanism the driver named — and differs only in the attempt/timing fields
+    it can supply, which are appended as trailing ``key=value`` pairs. Emitting
+    from here gives that format a single owner, so a field added for one helper
+    cannot silently drift from the other's. The helpers keep their own budgets;
+    only the report is shared.
+    """
+    trailer = "".join(f" {name}={value}" for name, value in extra.items())
+    logger.log(
+        logging.WARNING if giving_up else logging.DEBUG,
+        "%s what=%s sqlite_errorname=%s%s",
+        "sqlite lock retry budget exhausted" if giving_up else "retrying sqlite lock failure",
+        what,
+        sqlite_error_name(exc),
+        trailer,
+    )
+
+
 async def should_retry_after_sqlite_lock(
     exc: BaseException,
     *,
@@ -115,19 +136,9 @@ async def should_retry_after_sqlite_lock(
     if not is_sqlite_lock_error(exc):
         return False
     if attempt >= max_attempts - 1:
-        logger.warning(
-            "sqlite lock retry budget exhausted what=%s sqlite_errorname=%s attempts=%d",
-            what,
-            sqlite_error_name(exc),
-            max_attempts,
-        )
+        _report_lock_attempt(exc, what=what, giving_up=True, attempts=max_attempts)
         return False
-    logger.debug(
-        "retrying sqlite lock failure what=%s sqlite_errorname=%s attempt=%d",
-        what,
-        sqlite_error_name(exc),
-        attempt,
-    )
+    _report_lock_attempt(exc, what=what, giving_up=False, attempt=attempt)
     await asyncio.sleep(base_delay_seconds * (2**attempt))
     return True
 
@@ -157,23 +168,21 @@ async def retry_on_sqlite_lock(
             attempt_seconds = time.monotonic() - attempt_started_at
             total_seconds = time.monotonic() - started_at
             if delay_seconds is None:
-                logger.warning(
-                    "sqlite lock retry budget exhausted what=%s sqlite_errorname=%s "
-                    "attempt_seconds=%.3f total_seconds=%.3f",
-                    what,
-                    sqlite_error_name(exc),
-                    attempt_seconds,
-                    total_seconds,
+                _report_lock_attempt(
+                    exc,
+                    what=what,
+                    giving_up=True,
+                    attempt_seconds=f"{attempt_seconds:.3f}",
+                    total_seconds=f"{total_seconds:.3f}",
                 )
                 raise
-            logger.debug(
-                "retrying sqlite lock failure what=%s sqlite_errorname=%s "
-                "attempt_seconds=%.3f total_seconds=%.3f next_delay_seconds=%.3f",
-                what,
-                sqlite_error_name(exc),
-                attempt_seconds,
-                total_seconds,
-                delay_seconds,
+            _report_lock_attempt(
+                exc,
+                what=what,
+                giving_up=False,
+                attempt_seconds=f"{attempt_seconds:.3f}",
+                total_seconds=f"{total_seconds:.3f}",
+                next_delay_seconds=f"{delay_seconds:.3f}",
             )
             if before_retry is not None:
                 await before_retry()

--- a/openspec/changes/unify-sqlite-lock-classification/proposal.md
+++ b/openspec/changes/unify-sqlite-lock-classification/proposal.md
@@ -26,7 +26,9 @@ retry budget is beside the point).
 
 - Route all three remaining sites through the shared predicate and delete the
   duplicated helpers; the predicate now matches the union of what the sites
-  matched, and matches the driver exception rather than the rendered SQL.
+  matched, and matches the driver exception rather than the rendered SQL — a
+  wrapper carrying no driver exception is not contention either, since the only
+  text left to match there is the statement and parameters just excluded.
 - Report `sqlite_errorname` wherever a lock failure is retried, swallowed, or
   given up on, so the next occurrence classifies itself.
 - Change no control flow: leader election's two best-effort shutdown lease
@@ -44,6 +46,24 @@ retry budget is beside the point).
 - scheduler-coordination: the best-effort shutdown lease writes classify
   contention with the shared predicate, keep failing fast by design, and name
   the driver result code in their debug report.
+
+### Unchanged Capabilities
+
+- api-keys: *Requirement: API Key update* already requires that "a transient
+  SQLite lock or snapshot conflict during the update MUST roll back and retry
+  the complete read/build/write transaction, including rereading existing
+  limits, before returning an error", with the scenario *Retry API-key PATCH
+  after a transient SQLite snapshot conflict*. `update_key` is one of the sites
+  rewired here, and the one whose haystack this change narrows most, so that
+  requirement was re-read against the rewiring. The promise does not move and
+  needs no delta: the rollback, the reread of existing limits, the recursive
+  whole-transaction retry, the four-attempt budget and the eventual error are
+  all untouched. Only which driver failures enter that branch changes, and both
+  directions move the code toward the requirement rather than away from it —
+  `database is busy` is a transient SQLite lock the old local predicate refused
+  to retry (the requirement already demanded it), and a non-lock failure whose
+  lock text lived only in the rendered statement or a bound parameter is not "a
+  transient SQLite lock or snapshot conflict" and was never owed a retry.
 
 ## Impact
 

--- a/openspec/changes/unify-sqlite-lock-classification/specs/database-backends/spec.md
+++ b/openspec/changes/unify-sqlite-lock-classification/specs/database-backends/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: SQLite write-lock contention is classified in one place
 
-Every site that decides whether a failure is transient SQLite write-lock contention MUST reach that decision through one shared predicate rather than its own substring match, so a message SQLite emits for contention is never transient in one module and fatal in another. That predicate MUST accept only an `OperationalError`, MUST inspect the DRIVER exception rather than the rendered statement and bound parameters (the rendered form would classify an unrelated failure as transient whenever the SQL or a parameter value contained the lock text), and MUST match SQLITE_BUSY's `database is locked` and `database is busy`, SQLITE_LOCKED's `database table is locked` and `database schema is locked`, and a `busy_snapshot` extended result-code name appearing in the message.
+Every site that decides whether a failure is transient SQLite write-lock contention MUST reach that decision through one shared predicate rather than its own substring match, so a message SQLite emits for contention is never transient in one module and fatal in another. That predicate MUST accept only an `OperationalError`, and MUST match SQLITE_BUSY's `database is locked` and `database is busy`, SQLITE_LOCKED's `database table is locked` and `database schema is locked`, and a `busy_snapshot` extended result-code name appearing in the message.
+
+The predicate MUST match that message set against the DRIVER exception the wrapper carries, and MUST NOT classify on the rendered statement and bound parameters: the rendered form would treat an unrelated failure as transient whenever the SQL or a parameter value contained the lock text. A wrapper carrying no driver exception therefore MUST NOT be classified as contention — it offers no driver evidence, and the only text left to match is the statement and parameters this rule excludes. That is not a reachable narrowing of any call site today: the lock failures every site retries are raised by the driver and arrive wrapped.
 
 Wherever such a failure is reported, retried, or swallowed, the report MUST name the driver's extended result code (`sqlite_errorname`, or its absence) alongside an identifier for the write. `database is locked` is emitted both for an instant `SQLITE_BUSY_SNAPSHOT`, where retrying on a fresh transaction is the whole fix, and for a `SQLITE_BUSY` returned only after the full busy timeout, where another writer held the slot that long and no retry budget helps; without the result-code name an occurrence cannot be told apart after the fact. These reports MUST NOT include the values being written.
 
@@ -21,6 +23,14 @@ Unifying the predicate MUST NOT change any site's control flow: a site that retr
 - **WHEN** the shared predicate classifies it
 - **THEN** it is not treated as transient write-lock contention
 - **AND** it propagates with the call site's existing non-lock outcome
+
+#### Scenario: A wrapper with no driver exception is not contention
+
+- **GIVEN** an `OperationalError` carrying no driver exception, whose rendered statement or bound parameters contain the text `database is locked`
+- **WHEN** the shared predicate classifies it
+- **THEN** it is not treated as transient write-lock contention
+- **AND** the predicate does not fall back to matching the rendered statement and parameters
+- **AND** the call site raises it rather than spending a retry attempt on it
 
 #### Scenario: A reported lock failure names its mechanism
 

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -1983,6 +1983,41 @@ async def test_update_key_retries_after_sqlite_snapshot_conflict(lock_message: s
 
 
 @pytest.mark.asyncio
+async def test_update_key_does_not_retry_a_wrapper_without_driver_evidence() -> None:
+    # The spec-governed PATCH retry (api-keys "API Key update") owes a retry to
+    # "a transient SQLite lock or snapshot conflict". A wrapper with no driver
+    # exception carries no such evidence: the only text left to match is the
+    # rendered statement and its bound parameters, and matching those is exactly
+    # the false positive the shared predicate exists to remove. So this must
+    # propagate on the first attempt instead of spending the budget on it.
+    class _OrigLessPatchRepo(_FakeApiKeysRepository):
+        fail_commits = False
+        failed_commits = 0
+
+        async def commit(self) -> None:
+            if self.fail_commits:
+                self.failed_commits += 1
+                raise OperationalError(
+                    "UPDATE api_keys SET name = ?",
+                    {"name": "database is locked"},
+                    cast(BaseException, None),
+                )
+            await super().commit()
+
+    repo = _OrigLessPatchRepo()
+    service = ApiKeysService(repo)
+    created = await service.create_key(ApiKeyCreateData(name="orig-less-key", allowed_models=None))
+    repo.fail_commits = True
+
+    with pytest.raises(OperationalError):
+        await service.update_key(created.id, ApiKeyUpdateData(name="retried-key", name_set=True))
+
+    # One attempt, not the four a classified lock failure would have spent.
+    assert repo.failed_commits == 1
+    assert repo.rollback_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_update_key_limit_reset_still_clears_matched_usage() -> None:
     repo = _FakeApiKeysRepository()
     service = ApiKeysService(repo)


### PR DESCRIPTION
## Summary

Follow-up to #2361, which merged (`e715165e8`) while these three review items were still being applied. The work is unchanged in intent from that PR — it only makes the merged change's spec match its code exactly, records the one spec requirement #2361's description wrongly said did not exist, and gives the shared lock report a single owner.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [x] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none; follows #2361 (relates to #1949).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/unify-sqlite-lock-classification/` (still active on `main`; this edits its delta and proposal in place, so `openspec archive` still applies with `+1 added, ~1 modified`).

## Changes

### 1. The ADDED requirement stated an absolute the code did not hold

`openspec/changes/unify-sqlite-lock-classification/specs/database-backends/spec.md` said classification "MUST inspect the DRIVER exception rather than the rendered statement and bound parameters" — but left the `exc.orig is None` case implied, where the natural reading of a fallback to `str(exc)` is exactly the rendered statement and bound parameters the requirement forbids (a bound parameter containing the phrase would be a false positive).

Resolved by **making the spec state what the code enforces**, not by softening the rule, because nothing real depends on a fallback:

- `grep -rn "OperationalError(" app/` returns **zero** hits — no application path constructs one.
- Every test double in `tests/` passes a driver exception as the third argument; the only orig-less construction in the tree is the regression test for this rule.
- SQLAlchemy cannot produce one either: `DBAPIError.instance()` is the sole wrapping path and only builds a wrapper when `orig is not None`.

So the requirement now says a wrapper carrying no driver exception MUST NOT be classified as contention, notes that this narrows no reachable call site today, and adds the scenario *A wrapper with no driver exception is not contention*.

Covered at the predicate (`test_wrapper_without_a_driver_exception_is_not_a_lock_failure`, already present) **and**, new here, at the spec-governed product path: `test_update_key_does_not_retry_a_wrapper_without_driver_evidence` asserts one commit attempt and one rollback, then propagation — not the four attempts a classified lock failure would spend.

### 2. `api-keys` does name the `update_key` lock retry — recorded, no delta

#2361's description said "Nothing in `api-keys` or the account specs names the refresh-claim or usage-reservation lock retry". That was wrong. `openspec/specs/api-keys/spec.md` → *Requirement: API Key update* says:

> A transient SQLite lock or snapshot conflict during the update MUST roll back and retry the complete read/build/write transaction, including rereading existing limits, before returning an error.

with the scenario *Retry API-key PATCH after a transient SQLite snapshot conflict*. `update_key` is one of the rewired sites, and the one whose predicate haystack #2361 narrowed most.

**The promise does not move, so there is still no delta** — but the reasoning now lives in the change's `proposal.md` under **Unchanged Capabilities** instead of in a PR description that says the requirement does not exist. Everything the requirement binds is untouched: the `rollback()` still precedes the retry, the retry is still the recursive whole-method call that rereads existing limits, the budget is still four attempts at `0.1 * 2**attempt`, and an exhausted budget still returns the error. Only which driver failures enter that branch changed, and both directions move the code *toward* the requirement:

- `database is busy` is a transient SQLite lock (SQLITE_BUSY) that the deleted local predicate did **not** match — the old code under-delivered a retry the requirement already demanded.
- A non-lock failure whose lock text lived only in the rendered statement or a bound parameter is not "a transient SQLite lock or snapshot conflict", so it was never owed a retry.

Recording either correction as a MODIFIED requirement would be wrong: the normative text does not change, only the code's fidelity to it.

### 3. One owner for the lock report

`app/db/sqlite_lock_retry.py` held two retry-diagnostic implementations with duplicated log strings. Both now emit through one private `_report_lock_attempt(exc, *, what, giving_up, **extra)`, which appends each helper's own timing/attempt fields as trailing `key=value` pairs.

**The budgets are deliberately not unified** — that is the behaviour change #2361 avoided, and it stays avoided. `retry_on_sqlite_lock` keeps its 3 retries at 0.05/0.1/0.2s; `should_retry_after_sqlite_lock` keeps returning the decision to a caller that owns its own attempt count and `raise`. Only the report format is shared, and every emitted line is byte-identical to before:

```
sqlite lock retry budget exhausted what=touch_usage_reservation sqlite_errorname=SQLITE_BUSY attempts=4
retrying sqlite lock failure what=encryption-key fingerprint stamp sqlite_errorname=SQLITE_BUSY_SNAPSHOT attempt_seconds=0.001 total_seconds=0.002 next_delay_seconds=0.050
```

## Test plan

```
make lint                                                   # pass
uv run ty check                                             # pass
make migration-check                                        # migration_policy=ok schema_drift=none
python3 .github/scripts/check_simplicity_budgets.py         # all within budget

uv run pytest tests/unit/test_sqlite_lock_classification.py \
              tests/unit/test_api_keys_service.py \
              tests/unit/test_refresh_claims.py \
              tests/unit/test_startup_sentinel_lock_retry.py \
              tests/unit/test_leader_election.py -q         # 168 passed
uv run pytest tests/unit -q -x                              # 9958 passed, 4 skipped

openspec validate --specs --strict                          # 65 passed, 0 failed
openspec validate unify-sqlite-lock-classification --strict  # valid
# archive simulated on a clean copy of main's openspec/: +1 added, ~1 modified;
# only database-backends + scheduler-coordination differ afterwards; re-validates 65/65
```

## Screenshots / output

No user-visible surface; log lines are unchanged.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related PR above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs --strict` passes and the change validates strict; archive simulated against `main`.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6). No new setting, no README/nav/.env change; net effect is one fewer duplicated report format.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
