### PR TITLE
fix(proxy): attribute refused cross-account continuity replays

### DIFF
--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -224,6 +224,12 @@ if PROMETHEUS_AVAILABLE:
         ["surface", "source", "outcome"],
         registry=REGISTRY,
     )
+    continuity_replay_rejected_total = Counter(
+        "codex_lb_continuity_replay_rejected_total",
+        "Total cross-account continuity replays refused by surface and refusing proof",
+        ["surface", "reason"],
+        registry=REGISTRY,
+    )
     continuity_fail_closed_total = Counter(
         "codex_lb_continuity_fail_closed_total",
         "Total continuity fail-closed or masked retryable outcomes by surface and reason",
@@ -508,6 +514,7 @@ else:
     bridge_forward_latency_seconds: HistogramLike | None = None
     bridge_public_contract_error_total: CounterLike | None = None
     continuity_owner_resolution_total: CounterLike | None = None
+    continuity_replay_rejected_total: CounterLike | None = None
     continuity_fail_closed_total: CounterLike | None = None
     account_lease_acquired_total: CounterLike | None = None
     account_lease_released_total: CounterLike | None = None
@@ -587,6 +594,7 @@ __all__ = [
     "event_loop_lag_seconds",
     "event_loop_lag_warnings_total",
     "continuity_owner_resolution_total",
+    "continuity_replay_rejected_total",
     "http_bridge_prewarm_total",
     "http_bridge_retry_circuit_total",
     "http_bridge_spool_cleanup_backlog_likely",

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -121,6 +121,9 @@ from app.modules.proxy._service.observability import (
     _record_continuity_owner_resolution as _record_continuity_owner_resolution,
 )
 from app.modules.proxy._service.observability import (
+    _record_continuity_replay_rejected as _record_continuity_replay_rejected,
+)
+from app.modules.proxy._service.observability import (
     _summarize_input as _summarize_input,
 )
 from app.modules.proxy._service.observability import (
@@ -3837,6 +3840,7 @@ def _log_http_bridge_event(
         "capacity_exhausted_active_sessions",
         "owner_mismatch",
         "owner_forward_fail",
+        "owner_unavailable_replay_rejected",
         "missing_response_created_timeout",
         "prompt_cache_locality_miss",
         "reallocation_orphan",

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -6,7 +6,7 @@ import json
 import logging
 import math
 from collections.abc import AsyncGenerator, Callable
-from typing import Any, AsyncIterator, Mapping, TypeVar, cast
+from typing import Any, AsyncIterator, Literal, Mapping, TypeVar, cast, get_args
 from uuid import uuid4
 
 import anyio
@@ -116,6 +116,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _proxy_admission_wait_timeout_seconds,
     _record_bridge_reattach,
     _record_continuity_fail_closed,
+    _record_continuity_replay_rejected,
     _release_http_bridge_denied_anchor_fences,
     _release_http_bridge_unanchored_handoff,
     _release_http_bridge_unanchored_handoffs_for_request,
@@ -197,6 +198,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _is_local_account_cap_code,
+    _request_log_client_fields,
     _signal_propagated_capacity_startup_ready,
     _signal_propagated_capacity_startup_wait,
     _signal_propagated_responses_service_cleanup_ready,
@@ -278,6 +280,61 @@ T = TypeVar("T")
 _REQUEST_TRANSPORT_HTTP = "http"
 
 _RESPONSE_CREATE_GATE_RETRY_SLEEP_SECONDS = 10.0
+
+# Why a cross-account replay of an unavailable owner's turn was refused. The
+# recovery gate is a conjunction of independent proofs, so a bare ``False``
+# cannot say which one held; these name them for
+# ``owner_unavailable_replay_rejected``.
+_AccountNeutralReplayRejection = Literal[
+    "file_bound",
+    "no_durable_lookup",
+    "payload_not_full_resend",
+    "anchor_metadata_missing",
+    "prefix_fingerprint_mismatch",
+    "input_not_itemized",
+    "missing_prior_output",
+    "account_scoped_input",
+]
+ACCOUNT_NEUTRAL_REPLAY_REJECTIONS: frozenset[str] = frozenset(
+    get_args(_AccountNeutralReplayRejection),
+)
+# Bridge pre-submit failures that name an account-scoped continuity owner. These
+# get a request-log row; other pre-submit codes keep their existing behaviour.
+_HTTP_BRIDGE_CONTINUITY_OWNER_ERROR_CODES = frozenset(
+    {
+        "previous_response_owner_unavailable",
+        "continuity_owner_conflict",
+    }
+)
+
+
+def _durable_full_resend_anchor_rejection(
+    payload: ResponsesRequest,
+    lookup: DurableBridgeLookup,
+    *,
+    payload_looks_like_full_resend: bool,
+) -> _AccountNeutralReplayRejection | None:
+    """Return which stored-anchor proof refuses this body, or None when all hold.
+
+    Each of these clears the anchor fields, which downstream cannot tell apart
+    even though they call for different fixes: a client that never sends full
+    history, a durable row written before the anchor metadata existed, and a
+    body whose prefix diverged from the stored turn.
+    """
+    if not payload_looks_like_full_resend:
+        return "payload_not_full_resend"
+    stored_count = lookup.latest_input_item_count
+    if stored_count is None:
+        return "anchor_metadata_missing"
+    if not _input_prefix_matches_stored_context(
+        payload.input,
+        stored_count=stored_count,
+        stored_fingerprint=lookup.latest_input_full_fingerprint,
+    ):
+        return "prefix_fingerprint_mismatch"
+    if not isinstance(payload.input, list):
+        return "input_not_itemized"
+    return None
 
 
 def _http_bridge_verified_stale_anchor_replay_is_operation_fenced(
@@ -1025,6 +1082,7 @@ class _HTTPBridgeStreamingMixin:
         deferred_account_backoff_tracker = _DeferredAccountBackoffTracker()
         bridge_yielded_any = False
         bridge_transport_unavailable = False
+        bridge_attempt_started_at = clock_for(self).monotonic()
         try:
             try:
                 async for line in self._stream_via_http_bridge(
@@ -1109,6 +1167,33 @@ class _HTTPBridgeStreamingMixin:
                     or getattr(exc, _HTTP_BRIDGE_PREPARED_ANCHOR_ATTR, False)
                     or (transport_failure_code is None and not cooldown_suppression)
                 ):
+                    # Continuity-owner failures are raised out of bridge session
+                    # creation, the one proxy surface with no request-log write
+                    # of its own: the direct-websocket and raw-HTTP surfaces
+                    # both log this code, so a bridged thread's outage was
+                    # visible only in a rotating container log. Record it on the
+                    # propagating path only — the branch below hands the turn to
+                    # the raw-HTTP upstream, which settles its own outcome, and
+                    # an error row for a turn that then succeeded would corrupt
+                    # the very error rate this row exists to show.
+                    bridge_error_code, bridge_error_message = _proxy_error_code_message(exc)
+                    if bridge_error_code in _HTTP_BRIDGE_CONTINUITY_OWNER_ERROR_CODES:
+                        useragent, useragent_group, conversation_id = _request_log_client_fields(headers)
+                        await self._write_stream_preflight_error(
+                            account_id=None,
+                            api_key=api_key,
+                            request_id=request_id,
+                            model=payload.model,
+                            start=bridge_attempt_started_at,
+                            error_code=bridge_error_code,
+                            error_message=bridge_error_message or "Continuity owner account is unavailable",
+                            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                            service_tier=payload.service_tier,
+                            useragent=useragent,
+                            useragent_group=useragent_group,
+                            conversation_id=conversation_id,
+                            client_ip=client_ip,
+                        )
                     raise
                 if transport_failure_code is not None:
                     # Bridge session creation runs its own pre-dispatch
@@ -1472,6 +1557,12 @@ class _HTTPBridgeStreamingMixin:
         durable_full_resend_fresh_payload: ResponsesRequest | None = None
         durable_full_resend_is_account_neutral: bool | None = None
         durable_full_resend_has_safe_fresh_context = False
+        # Set only when a durable lookup existed but failed one of the anchor
+        # proofs; ``no_durable_lookup`` covers the absent-lookup case instead.
+        durable_full_resend_anchor_reason: _AccountNeutralReplayRejection | None = None
+        # Why the folded anchor/prior-output proof last refused, so the
+        # classifier can report it without re-deriving the conjunction.
+        durable_full_resend_context_rejection: _AccountNeutralReplayRejection | None = None
         durable_full_resend_retains_required_context_cache: bool | None = None
         durable_full_resend_proof = _verify_durable_full_resend(payload, durable_lookup)
         durable_full_resend_fresh_bridge_proof: _VerifiedDurableFullResend | None = None
@@ -1513,19 +1604,15 @@ class _HTTPBridgeStreamingMixin:
 
         def classify_durable_full_resend(
             lookup: DurableBridgeLookup,
-        ) -> tuple[int | None, str | None, bool]:
+        ) -> tuple[int | None, str | None, bool, _AccountNeutralReplayRejection | None]:
+            anchor_rejection = _durable_full_resend_anchor_rejection(
+                payload,
+                lookup,
+                payload_looks_like_full_resend=payload_looks_like_full_resend,
+            )
             stored_count = lookup.latest_input_item_count
-            if (
-                not payload_looks_like_full_resend
-                or stored_count is None
-                or not _input_prefix_matches_stored_context(
-                    payload.input,
-                    stored_count=stored_count,
-                    stored_fingerprint=lookup.latest_input_full_fingerprint,
-                )
-                or not isinstance(payload.input, list)
-            ):
-                return None, None, False
+            if anchor_rejection is not None or stored_count is None or not isinstance(payload.input, list):
+                return None, None, False, anchor_rejection or "anchor_metadata_missing"
             replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                 cast(list[JsonValue], payload.input),
                 stored_count=stored_count,
@@ -1538,13 +1625,14 @@ class _HTTPBridgeStreamingMixin:
             safe_fresh_context = False
             if replay_projection is not None:
                 safe_fresh_context = replay_projection_retains_required_context(replay_projection, lookup)
-            return stored_count, lookup.latest_input_full_fingerprint, safe_fresh_context
+            return stored_count, lookup.latest_input_full_fingerprint, safe_fresh_context, None
 
         if durable_lookup is not None:
             (
                 durable_full_resend_anchor_count,
                 durable_full_resend_anchor_fingerprint,
                 durable_full_resend_has_safe_fresh_context,
+                durable_full_resend_anchor_reason,
             ) = classify_durable_full_resend(durable_lookup)
         if (
             durable_full_resend_has_safe_fresh_context
@@ -1988,12 +2076,15 @@ class _HTTPBridgeStreamingMixin:
 
         def durable_full_resend_retains_required_context() -> bool:
             nonlocal durable_full_resend_retains_required_context_cache
+            nonlocal durable_full_resend_context_rejection
 
-            if (
-                durable_full_resend_anchor_count is None
-                or durable_full_resend_anchor_fingerprint is None
-                or not isinstance(payload.input, list)
-            ):
+            if durable_full_resend_anchor_count is None or durable_full_resend_anchor_fingerprint is None:
+                # Either no durable row was supplied, or classification already
+                # cleared the anchor fields and named its own reason.
+                durable_full_resend_context_rejection = durable_full_resend_anchor_reason or "no_durable_lookup"
+                return False
+            if not isinstance(payload.input, list):
+                durable_full_resend_context_rejection = "input_not_itemized"
                 return False
             if durable_full_resend_retains_required_context_cache is None:
                 eligibility_projection = project_responses_input_for_account_neutral_fresh_replay(
@@ -2002,28 +2093,46 @@ class _HTTPBridgeStreamingMixin:
                     preserve_developer_message_ids=True,
                 )
                 if eligibility_projection is None or durable_lookup is None:
+                    # A body the projection cannot rebuild carries state that
+                    # is not ours to move; a missing lookup is the pinned-owner
+                    # case. They are different fixes, so keep them distinct.
+                    durable_full_resend_context_rejection = (
+                        "account_scoped_input" if durable_lookup is not None else "no_durable_lookup"
+                    )
                     return False
                 durable_full_resend_retains_required_context_cache = replay_projection_retains_required_context(
                     eligibility_projection,
                     durable_lookup,
                 )
-            return bool(durable_full_resend_retains_required_context_cache)
+            if not durable_full_resend_retains_required_context_cache:
+                durable_full_resend_context_rejection = "missing_prior_output"
+                return False
+            return True
 
-        def durable_full_resend_allows_account_neutral_replay() -> bool:
+        def classify_account_neutral_replay_rejection() -> _AccountNeutralReplayRejection | None:
+            """Return why this turn cannot move accounts, or None when it can.
+
+            Evaluation order matches the conjunction this replaces, so the
+            reported reason is the first proof that refused.
+            """
             nonlocal durable_full_resend_fresh_payload
             nonlocal durable_full_resend_is_account_neutral
 
-            if rewritten_file_account_id is not None or not durable_full_resend_retains_required_context():
-                return False
+            if rewritten_file_account_id is not None:
+                return "file_bound"
+            if not durable_full_resend_retains_required_context():
+                return durable_full_resend_context_rejection or "no_durable_lookup"
             if durable_full_resend_fresh_payload is None:
-                assert isinstance(payload.input, list)
-                assert durable_full_resend_anchor_count is not None
+                if not isinstance(payload.input, list) or durable_full_resend_anchor_count is None:
+                    # Unreachable while the proof above holds; kept explicit so
+                    # a future caller cannot turn it into an AssertionError.
+                    return "no_durable_lookup"
                 replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                     cast(list[JsonValue], payload.input),
                     stored_count=durable_full_resend_anchor_count,
                 )
                 if replay_projection is None:
-                    return False
+                    return "account_scoped_input"
                 durable_full_resend_fresh_payload = _http_bridge_payload_without_previous_response_id(
                     payload
                 ).model_copy(update={"input": replay_projection.input_items})
@@ -2031,13 +2140,34 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
                 )
-            return durable_full_resend_is_account_neutral
+            return None if durable_full_resend_is_account_neutral else "account_scoped_input"
+
+        def durable_full_resend_allows_account_neutral_replay() -> bool:
+            return classify_account_neutral_replay_rejection() is None
+
+        def record_account_neutral_replay_rejection(
+            rejection: _AccountNeutralReplayRejection,
+        ) -> None:
+            _record_continuity_replay_rejected(surface="http_bridge", reason=rejection)
+            _log_http_bridge_event(
+                "owner_unavailable_replay_rejected",
+                bridge_session_key,
+                account_id=request_state.preferred_account_id,
+                model=payload.model,
+                detail=f"reason={rejection}",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(payload.model) if payload.model else None,
+                owner_check_applied=True,
+            )
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
-            return (
-                _http_bridge_is_previous_response_owner_unavailable(exc)
-                and durable_full_resend_allows_account_neutral_replay()
-            )
+            if not _http_bridge_is_previous_response_owner_unavailable(exc):
+                return False
+            rejection = classify_account_neutral_replay_rejection()
+            if rejection is None:
+                return True
+            record_account_neutral_replay_rejection(rejection)
+            return False
 
         def switch_to_account_neutral_replay(
             *,
@@ -2052,6 +2182,8 @@ class _HTTPBridgeStreamingMixin:
             nonlocal dead_owner_process_epoch_mismatch
             nonlocal durable_full_resend_anchor_count
             nonlocal durable_full_resend_anchor_fingerprint
+            nonlocal durable_full_resend_anchor_reason
+            nonlocal durable_full_resend_context_rejection
             nonlocal durable_full_resend_fresh_payload
             nonlocal durable_full_resend_is_account_neutral
             nonlocal durable_lookup
@@ -2135,6 +2267,8 @@ class _HTTPBridgeStreamingMixin:
             previous_response_trimmed_input_fingerprint = None
             durable_full_resend_anchor_count = None
             durable_full_resend_anchor_fingerprint = None
+            durable_full_resend_anchor_reason = None
+            durable_full_resend_context_rejection = None
             durable_full_resend_fresh_payload = None
             durable_full_resend_is_account_neutral = None
             durable_lookup = None
@@ -2176,6 +2310,13 @@ class _HTTPBridgeStreamingMixin:
                 session_id=request_state.session_id,
                 upstream_error_code="owner_lookup_miss",
             )
+            # This exit has no exception to classify, so the funnel in
+            # ``owner_unavailable_allows_account_neutral_replay`` never sees it.
+            # Attribute it here for the same reason: a refusal that names no
+            # proof cannot be acted on.
+            replay_rejection = classify_account_neutral_replay_rejection()
+            if replay_rejection is not None:
+                record_account_neutral_replay_rejection(replay_rejection)
             raise owner_unavailable
 
         while True:
@@ -2393,15 +2534,18 @@ class _HTTPBridgeStreamingMixin:
                         else:
                             if _http_bridge_durable_lookup_allows_turn_state_takeover(fresh_turn_state_lookup):
                                 durable_lookup = fresh_turn_state_lookup
+                                durable_full_resend_context_rejection = None
                                 if fresh_turn_state_lookup is None:
                                     durable_full_resend_anchor_count = None
                                     durable_full_resend_anchor_fingerprint = None
                                     durable_full_resend_has_safe_fresh_context = False
+                                    durable_full_resend_anchor_reason = None
                                 else:
                                     (
                                         durable_full_resend_anchor_count,
                                         durable_full_resend_anchor_fingerprint,
                                         durable_full_resend_has_safe_fresh_context,
+                                        durable_full_resend_anchor_reason,
                                     ) = classify_durable_full_resend(fresh_turn_state_lookup)
                                     continuity_preferred_account_id = fresh_turn_state_lookup.account_id
                                     request_state.preferred_account_id = resolve_required_account_id(

--- a/app/modules/proxy/_service/observability.py
+++ b/app/modules/proxy/_service/observability.py
@@ -12,6 +12,7 @@ from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
     continuity_fail_closed_total,
     continuity_owner_resolution_total,
+    continuity_replay_rejected_total,
     http_bridge_routing_total,
     upstream_reasoning_replay_400_total,
     upstream_transport_decisions_total,
@@ -248,6 +249,19 @@ def _record_continuity_owner_resolution(
         _hash_identifier_or_none(previous_response_id),
         _hash_identifier_or_none(session_id),
     )
+
+
+def _record_continuity_replay_rejected(*, surface: str, reason: str) -> None:
+    """Count one refusal to move an unavailable owner's turn to another account.
+
+    The recovery gate is a conjunction of independent proofs, so the caller
+    reports the first one that refused; the paired ``owner_unavailable_replay_rejected``
+    bridge event carries the request-scoped identifiers.
+    """
+    prometheus_available = bool(_service_global("PROMETHEUS_AVAILABLE", PROMETHEUS_AVAILABLE))
+    counter = _service_global("continuity_replay_rejected_total", continuity_replay_rejected_total)
+    if prometheus_available and counter is not None:
+        counter.labels(surface=surface, reason=reason).inc()
 
 
 def _format_continuity_fail_closed_diagnostics(

--- a/openspec/changes/trace-continuity-owner-replay-rejection/.openspec.yaml
+++ b/openspec/changes/trace-continuity-owner-replay-rejection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/trace-continuity-owner-replay-rejection/context.md
+++ b/openspec/changes/trace-continuity-owner-replay-rejection/context.md
@@ -1,0 +1,119 @@
+# Context
+
+## Purpose and scope
+
+Make one production failure attributable: a Codex thread whose upstream owner account
+became unroutable returns 502 `previous_response_owner_unavailable` on every resume, and
+today nothing says why the proxy refused to move that turn to a healthy account.
+
+In scope: a typed refusal reason, one bridge event, one Prometheus counter, and a
+request-log row for the bridge surface. Out of scope: changing whether any turn recovers.
+That is the behavior work tracked in #1707 and it depends on the evidence this change
+produces.
+
+## Production evidence (`1.25.0-beta.7`, 24 accounts, 2026-09-11)
+
+| Observation | Value |
+|---|---|
+| `previous_response_owner_unavailable` request-log rows | 1,480 / 36h |
+| ... by owner account status | `reauth_required` 1,361; `paused` 22; `rate_limited` 3; owner now `active` again ~94 |
+| ... by `transport` | `websocket` 1,491 / 48h; `http` **0** |
+| `owner_unavailable_fresh_resend` bridge events | **0** / 24h |
+| `dead_owner_fresh_resend` bridge events | **0** / 24h |
+| Bridge 502s present in `request_logs` over the last 6h | **0** of 14,555 rows |
+
+Two readings matter. First, the recovery path that exists
+(`switch_to_account_neutral_replay`) has never fired in production, so the refusal is
+systematic rather than incidental. Second, the bridge surface's failures are absent from
+`request_logs` entirely, so the only record is a rotating container log (3x50MB, roughly
+8 hours) — which is why the 2026-09-04 recurrence of this class had to be reconstructed
+from `haproxy` logs and DB `updated_at` clusters.
+
+## Decisions
+
+**Why a reason instead of a boolean.** `durable_full_resend_allows_account_neutral_replay`
+is a conjunction of six independent proofs. `no_durable_lookup` and
+`prefix_fingerprint_mismatch` call for different fixes — the first means owner resolution
+handed us a pin with no anchor context (request-log index, in-process registry), the
+second means the client's body diverged from the stored turn. Collapsing them to `False`
+makes the next PR a guess.
+
+**Why the reason is reported at the first refusing proof.** Reporting every failed proof
+would need all six evaluated, which costs a projection rebuild on the hot path for no
+operational gain. Evaluation order is preserved from the conjunction it replaces, so the
+reported reason is deterministic for a given request.
+
+**Why one funnel.** `owner_unavailable_allows_account_neutral_replay` already gates all
+three recovery attempt sites (session creation, owner forward, capacity retry). Emitting
+there instead of at each raise site keeps "exactly one reason per refusal" structural
+rather than a convention every future raise site must remember. The
+`required_continuity_owner_missing` exit is the one case with no exception to classify, so
+it calls the classifier directly.
+
+**Why only two error codes get a request-log row.** Widening the bridge's request-log
+coverage to every pre-submit failure is a bigger behavioral question (capacity waits,
+cooldown suppressions, and transport failovers each have their own settlement story). The
+two continuity-owner codes are the ones the other two surfaces already log, so this is
+parity, not a new policy.
+
+**Why no `service.py` re-export.** The `_service_global` indirection in
+`_record_continuity_replay_rejected` falls back to the module global, so the recorder works
+without one, and `app/modules/proxy/service.py` sits exactly at its 2600-line architecture
+ratchet. Tests patch `app.modules.proxy.service` with `raising=False`, matching the
+existing continuity-counter tests.
+
+## Constraints
+
+- No ceiling-guarded proxy file may grow: `service.py` (2600/2600),
+  `load_balancer.py` (3000/3021), `_service/http_bridge/mixin.py` (2435/2436),
+  `_service/streaming/mixin.py` (1097/1100). This change touches none of them.
+- `_service/http_bridge/**` may only import from the `_service` domains
+  `{api_key_usage, compact, http_bridge, observability, support, warmup}`;
+  `_request_log_client_fields` comes from `support`.
+- Observational only: no forwarded byte, routing decision, selection outcome, or settlement
+  path changes. The predicate's truth value is identical at every existing call site.
+
+## Failure modes
+
+- **`input_not_itemized` is a guard, not an outcome.** A non-list body can never satisfy
+  the stored-prefix proof, so the prefix check always refuses first. It stays in the closed
+  set because the code path exists; `test_string_input_refuses_on_the_prefix_proof` pins
+  that ordering so a future caller that admits a non-list body past the prefix proof shows
+  up as a test change rather than a silent mislabel.
+- **Reason drift after a replay switch.** `switch_to_account_neutral_replay` clears the
+  anchor request-locals; both new locals are cleared with them, so a refusal after a switch
+  reports `no_durable_lookup` rather than a stale pre-switch reason.
+- **Double emission.** The connect loop can re-enter after a cap spill or a capacity wait.
+  The funnel emits once per classifier refusal, and the integration test asserts exactly
+  one line for one failing resume.
+- **Counter cardinality.** Both labels are closed sets (`surface` is
+  `http_bridge`; `reason` is the eight-value literal), asserted in
+  `test_closed_reason_set_matches_the_literal` and `tests/unit/test_metrics.py`.
+- **No error row for a turn that then succeeded.** The write sits inside the propagating
+  branch, so the transport-failover branch (which hands the turn to the raw-HTTP upstream and
+  lets it settle its own outcome) cannot produce one. That combination —
+  `previous_response_owner_unavailable` carrying websocket connect-transport provenance — is
+  not reachable today, because the code comes from a selection failure and the provenance from
+  a handshake, so the constraint is stated in the spec to hold future code rather than covered
+  by a test that would have to fabricate the attribute.
+
+## Example
+
+An OpenCode session pinned to a manually paused account, resumed (the shape reported on
+#1707 on 2026-09-09):
+
+```text
+continuity_owner_resolution surface=http_bridge source=request_logs outcome=hit
+Proxy account selection start request_stage=follow_up preferred_account_id=<A>
+No account selected error=No available accounts
+Proxy preferred account unavailable error_code=continuity_owner_unavailable
+http_bridge_event event=owner_unavailable_replay_rejected bridge_kind=thread_header
+  bridge_key=sha256:… account_id=<A> detail=reason=no_durable_lookup key_strength=hard
+proxy_error_response status=502 code="previous_response_owner_unavailable"
+```
+
+The new line is the fifth. `reason=no_durable_lookup` says the owner was pinned from the
+request-log index with no durable anchor context, so no fingerprint proof could ever have
+been satisfied — which identifies the fix as decoupling the replay gate from the durable
+lookup rather than loosening the fingerprint check. A row for the same `request_id` now
+also exists in `request_logs`, so the dashboard shows the outage.

--- a/openspec/changes/trace-continuity-owner-replay-rejection/proposal.md
+++ b/openspec/changes/trace-continuity-owner-replay-rejection/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+`previous_response_owner_unavailable` is the user-visible face of #1707: an existing Codex
+thread whose upstream owner account became unroutable fails with 502 on every resume while
+healthy accounts sit idle in the pool. The proxy already contains the cure —
+`switch_to_account_neutral_replay` in `app/modules/proxy/_service/http_bridge/streaming.py`
+projects reasoning out of the history and re-sends plaintext context on a fresh account — and
+its gate, `durable_full_resend_allows_account_neutral_replay`, is a conjunction of six
+independent proofs. It returns a bare `bool`.
+
+That makes the failure unattributable. A 36-hour window on a production deployment
+(`1.25.0-beta.7`, 24 accounts) recorded **1,480** `previous_response_owner_unavailable`
+request-log rows, and **zero** `owner_unavailable_fresh_resend` or `dead_owner_fresh_resend`
+bridge events in the same period: the recovery path never fired once, and nothing on the
+failing request says which of the six proofs refused it. The maintainer's 2026-09-08 status
+note on #1707 asks reporters for exactly this attribution and the current logs cannot supply
+it.
+
+The same window also shows the failure is invisible where operators look for it. All 1,491
+`previous_response_owner_unavailable` rows over 48 hours carry `transport="websocket"` — every
+one came from the direct WebSocket surface, which logs the code itself. Not one carries
+`transport="http"`: the HTTP session bridge raises the identical envelope from session
+creation, before any request-log write, and `app/modules/proxy/_service/http_bridge/` contains
+no request-log write at all (`_write_request_log` appears only as an unused protocol
+declaration). Over the most recent 6 hours the container log carried the bridge's 502s while
+`request_logs` held **0** of them out of 14,555 rows. The dashboard shows nothing, so a bridge
+incident is only reachable by reading a rotating container log (3x50MB, roughly 8 hours of
+retention) — which is how the 2026-09-04 recurrence of this same class had to be
+reconstructed.
+
+## What Changes
+
+- **Typed rejection reason.** `durable_full_resend_allows_account_neutral_replay` becomes a
+  thin `is None` wrapper over a new `classify_account_neutral_replay_rejection()` that returns
+  `None` when a cross-account replay is allowed and otherwise one of a closed set:
+  `file_bound`, `no_durable_lookup`, `payload_not_full_resend`, `anchor_metadata_missing`,
+  `prefix_fingerprint_mismatch`, `input_not_itemized`, `missing_prior_output`,
+  `account_scoped_input`. The stored-anchor half moves to a new module-level
+  `_durable_full_resend_anchor_rejection(payload, lookup, *, payload_looks_like_full_resend)`
+  — pure, and the seam the unit tests drive — and `classify_durable_full_resend` gains a fourth
+  tuple element carrying its verdict, so the three causes it collapses today
+  (`payload_not_full_resend`, `anchor_metadata_missing`, `prefix_fingerprint_mismatch`) stop
+  being indistinguishable. `input_not_itemized` is the fourth branch and stays a guard: a
+  non-list body cannot satisfy the stored-prefix proof, so the prefix check always refuses
+  first. The predicate's truth value is unchanged at every existing call site.
+- **One emission point.** `owner_unavailable_allows_account_neutral_replay` emits the new
+  bridge event `owner_unavailable_replay_rejected` (WARNING, `detail=reason=<reason>`) when the
+  raised error is an owner-unavailable failure and the classifier refuses. It is the single
+  funnel for all three of its call sites (session creation, owner forward, capacity retry), so
+  no raise site is instrumented individually. The `required_continuity_owner_missing`
+  fail-closed raise has no exception to classify, so it calls the classifier directly and
+  emits the same event with whichever reason applies.
+- **Metric.** New counter `codex_lb_continuity_replay_rejected_total{surface, reason}`
+  registered in `app/core/metrics/prometheus.py` with the usual `None` fallback, recorded
+  through a new `_record_continuity_replay_rejected` in
+  `app/modules/proxy/_service/observability.py` next to the existing
+  `_record_continuity_owner_resolution` and `_record_continuity_fail_closed`.
+- **Request-log parity for the bridge surface.** `_stream_http_bridge_or_retry` writes one
+  `_write_stream_preflight_error` row before re-raising a pre-submit `ProxyResponseError` whose
+  code is a continuity-owner code (`previous_response_owner_unavailable`,
+  `continuity_owner_conflict`). This mirrors what `retry.py` already does for the `http_stream`
+  surface at its own owner-unavailable exit, and uses the request id the container log prints
+  (both sites resolve the same `ensure_request_id()` contextvar), so log and row are joinable.
+  The write sits on the propagating branch only: when the bridge instead hands the turn to the
+  raw-HTTP upstream, that path settles its own outcome, and an error row for a turn that then
+  succeeded would corrupt the error rate this row exists to expose. Only those codes are
+  logged; widening the bridge's request-log coverage to every pre-submit failure is a separate
+  concern.
+
+No new `CODEX_LB_*` setting, no migration, no `.env.example` change, no README growth. No
+routing, selection, or failover decision changes: the classifier is a pure refactor of an
+existing conjunction, and the counter and log line are observational. None of the four
+ceiling-guarded proxy files (`service.py`, `load_balancer.py`,
+`_service/http_bridge/mixin.py`, `_service/streaming/mixin.py`) is touched.
+
+## Why observability first
+
+The follow-up work in #1707 is a behavior change: retiring an unroutable continuity owner so
+the thread rebinds. Which mechanism to build depends on which proof is actually refusing the
+existing recovery in production, and `no_durable_lookup` versus `prefix_fingerprint_mismatch`
+point at different fixes. Landing the attribution first makes that choice evidence-based and
+gives the later PRs a before/after signal that is not a rotating container log.
+
+## Impact
+
+- Affected specs: `proxy-runtime-observability` (ADDED — rejection attribution requirement,
+  alongside the existing continuity fail-closed contracts).
+- Affected code: `app/modules/proxy/_service/http_bridge/streaming.py`,
+  `app/modules/proxy/_service/http_bridge/helpers.py` (one event name added to the WARNING
+  set), `app/modules/proxy/_service/observability.py`, `app/core/metrics/prometheus.py`.
+- Tests: `tests/unit/test_http_bridge_replay_rejection.py` (new; the anchor-proof reasons,
+  the counter's closed label set, the event's WARNING level), `tests/unit/test_metrics.py`,
+  `tests/integration/test_http_responses_bridge.py` (an owner-unavailable 502 through the real
+  bridge emits the event and leaves exactly one `request_logs` row carrying the ingress request
+  id).
+- Partial fix for #1707; it does not by itself let any thread recover.

--- a/openspec/changes/trace-continuity-owner-replay-rejection/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/trace-continuity-owner-replay-rejection/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Refused cross-account continuity replays are attributable
+
+When a continuity owner account is unavailable and the proxy refuses to move the turn to
+another account, it MUST record which proof refused it. The reason MUST come from the closed
+set `file_bound`, `no_durable_lookup`, `payload_not_full_resend`, `anchor_metadata_missing`,
+`prefix_fingerprint_mismatch`, `input_not_itemized`, `missing_prior_output`,
+`account_scoped_input`, and MUST be exposed both as the Prometheus counter
+`codex_lb_continuity_replay_rejected_total{surface, reason}` and as one bridge event log line
+`owner_unavailable_replay_rejected` at WARNING carrying the reason, the hashed bridge key, the
+affinity kind, the model, and the failed owner account id. Exactly one reason MUST be reported
+per refusal, and it MUST be the first proof that refused in evaluation order. Recording MUST
+NOT change whether the replay is attempted, MUST NOT alter any routing, selection, or failover
+decision, and MUST degrade to the log line alone when the Prometheus client is absent.
+
+#### Scenario: Owner pinned without durable anchor context
+
+- **GIVEN** the continuity owner was resolved from the request-log index, the in-process bridge
+  registry, or a durable row that carries no stored input item count
+- **WHEN** that owner is unavailable and the turn fails closed
+- **THEN** the counter is incremented once with `reason="no_durable_lookup"` or
+  `reason="anchor_metadata_missing"` according to which condition held
+- **AND** one `owner_unavailable_replay_rejected` line is logged for the same refusal
+
+#### Scenario: Stored prefix does not match the incoming body
+
+- **GIVEN** a durable row carries a stored input item count and full-input fingerprint
+- **WHEN** the incoming body is full-resend shaped but its prefix does not match that
+  fingerprint, and the unavailable owner makes the turn fail closed
+- **THEN** the reason reported is `prefix_fingerprint_mismatch`, distinct from the reason
+  reported when the body is not full-resend shaped (`payload_not_full_resend`) and from the
+  reason reported when the row has no stored count (`anchor_metadata_missing`)
+
+#### Scenario: History cannot leave the account
+
+- **WHEN** the projected body still carries account-scoped state, or the projection cannot be
+  built at all
+- **THEN** the reason reported is `account_scoped_input`
+- **WHEN** the request is pinned to an account by an uploaded input file
+- **THEN** the reason reported is `file_bound`
+- **WHEN** the projected body loses the prior upstream output and does not match the row's
+  pending tool calls
+- **THEN** the reason reported is `missing_prior_output`
+
+#### Scenario: Replay is allowed
+
+- **WHEN** every proof passes and the turn is re-anchored on another account
+- **THEN** no reason is recorded and the counter is not incremented
+- **AND** the existing `owner_unavailable_fresh_resend` event is logged as before
+
+### Requirement: Bridge continuity-owner failures reach the request log
+
+A pre-submit HTTP session bridge failure whose error code is `previous_response_owner_unavailable`
+or `continuity_owner_conflict` MUST write exactly one `request_logs` row before the error is
+returned to the client, carrying `status="error"`, that error code, the request model, and the
+ingress request id also printed by the proxy's error log line, so the row and the log line are
+joinable on that id. The row MUST NOT be written when the bridge instead hands the turn to the
+plain HTTP upstream transport, which settles its own outcome — an error row for a turn that
+then succeeded would misstate the error rate the row exists to expose. A bridge failure
+carrying any other error code MUST NOT gain a request-log row from this requirement.
+
+#### Scenario: Unroutable owner on the bridge surface
+
+- **GIVEN** an existing bridged thread whose owner account is not selectable
+- **WHEN** session creation fails with `previous_response_owner_unavailable`
+- **THEN** one `request_logs` row exists for that request id with `status="error"` and
+  `error_code="previous_response_owner_unavailable"`
+- **AND** the client still receives the same 502 envelope as before
+
+#### Scenario: Unrelated pre-submit failure
+
+- **WHEN** bridge session creation fails with a capacity, transport, or cooldown error code
+- **THEN** no request-log row is written by this requirement and the existing behaviour of that
+  path is unchanged

--- a/openspec/changes/trace-continuity-owner-replay-rejection/tasks.md
+++ b/openspec/changes/trace-continuity-owner-replay-rejection/tasks.md
@@ -1,0 +1,69 @@
+## 1. Implementation
+
+- [x] 1.1 Add the closed reason set to `app/modules/proxy/_service/http_bridge/streaming.py` as
+  a module-level `Literal` alias plus a `frozenset` used by the tests, and give
+  `classify_durable_full_resend` a fourth tuple element carrying the reason it cleared the
+  anchor fields (`payload_not_full_resend`, `anchor_metadata_missing`,
+  `prefix_fingerprint_mismatch`, `input_not_itemized`). Store it in a new
+  `durable_full_resend_anchor_reason` request-local.
+- [x] 1.2 Introduce `classify_account_neutral_replay_rejection()` in
+  `_stream_via_http_bridge_impl`, evaluated in the same order as today's conjunction:
+  `file_bound` -> anchor-reason (or `no_durable_lookup` when no durable lookup was supplied) ->
+  `missing_prior_output` -> `account_scoped_input`. Reduce
+  `durable_full_resend_allows_account_neutral_replay()` to
+  `classify_account_neutral_replay_rejection() is None`; the two `assert`s it carries today are
+  subsumed by the explicit early checks and are removed. Leave its three other call sites
+  (`streaming.py` dead-owner fresh resend and the two stale-anchor gates) untouched.
+- [x] 1.3 Emit `owner_unavailable_replay_rejected` from
+  `owner_unavailable_allows_account_neutral_replay` when the error is an owner-unavailable
+  failure and the classifier refuses, and from the `required_continuity_owner_missing` raise
+  (which has no exception to classify). One emission per refusal; assert no double emission
+  when the connect loop re-enters.
+- [x] 1.4 Add `owner_unavailable_replay_rejected` to the WARNING event set in
+  `app/modules/proxy/_service/http_bridge/helpers.py::_log_http_bridge_event`.
+- [x] 1.5 Register `continuity_replay_rejected_total`
+  (`codex_lb_continuity_replay_rejected_total{surface,reason}`) in
+  `app/core/metrics/prometheus.py` with the `None` fallback and the `__all__` entry, and add
+  `_record_continuity_replay_rejected` to `app/modules/proxy/_service/observability.py`
+  following `_record_continuity_owner_resolution`'s `_service_global` indirection.
+- [x] 1.6 In `_stream_http_bridge_or_retry`, capture a monotonic start alongside `request_id`
+  and, in the `except ProxyResponseError` branch before the `raise`, write one
+  `_write_stream_preflight_error` row when the sanitized error code is
+  `previous_response_owner_unavailable` or `continuity_owner_conflict`. Derive
+  `useragent`/`useragent_group`/`conversation_id` with
+  `_request_log_client_fields` from `app/modules/proxy/_service/support.py` (an allowed import
+  domain for `_service/http_bridge/**`). Write inside the propagating branch, not before it: the
+  transport-failover branch hands the turn to raw HTTP, which settles its own outcome.
+
+## 2. Regression coverage
+
+- [x] 2.1 New `tests/unit/test_http_bridge_replay_rejection.py`: the anchor-proof reasons via
+  the module-level `_durable_full_resend_anchor_rejection`, a case proving the allowed path
+  reports no reason, a case proving `payload_not_full_resend`, `anchor_metadata_missing` and
+  `prefix_fingerprint_mismatch` are reported distinctly where today all three collapse to one
+  `False`, and a case pinning that `input_not_itemized` stays unreachable behind the prefix
+  proof. The event's WARNING level is asserted through `caplog`, not bytecode introspection.
+- [x] 2.2 `tests/integration/test_http_responses_bridge.py`: an end-to-end bridged resume whose
+  owner account is not selectable returns the unchanged 502 envelope, logs exactly one
+  `owner_unavailable_replay_rejected` with a reason from the closed set, and leaves exactly one
+  `request_logs` row for the ingress request id with
+  `error_code="previous_response_owner_unavailable"`. A sibling case proves a capacity-coded
+  pre-submit failure still writes no row.
+- [x] 2.3 Assert the counter's label set is closed and that the recorder no-ops without
+  `prometheus_client`, matching the existing continuity-counter tests; add the name/label
+  assertion to `tests/unit/test_metrics.py` next to the sibling continuity counters.
+- [x] 2.4 Keep `tests/unit/test_proxy_http_bridge.py` (which pins the 502/503 owner-unavailable
+  envelopes) and `tests/unit/test_otel.py` green.
+
+## 3. Validation
+
+- [x] 3.1 `make lint` (includes `scripts/check_proxy_architecture.py`: no ceiling-guarded file
+  grew, no cross-domain import added), `make typecheck`.
+- [x] 3.2 `make test-unit` (9,984 passed), `make test-integration-bridge` (341),
+  `make test-integration-core-1` (889), `-2` (873), `-3` (774), `tests/e2e` (27). Shards 2 and 3
+  also reported sqlite `unable to open database file` on unrelated files (444 occurrences)
+  from a 96%-full host partition shared with concurrent suites; those files pass in
+  isolation (103 + 247).
+- [x] 3.3 `openspec validate trace-continuity-owner-replay-rejection --strict` and
+  `openspec validate --specs`.
+- [x] 3.4 `codex review --base origin/main` — no findings.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8483,6 +8483,189 @@ async def test_v1_responses_http_bridge_reports_unavailable_required_owner_when_
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_attributes_and_logs_unavailable_required_owner(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """An unroutable continuity owner must name the refusing proof and leave a row.
+
+    Before this, the bridge surface raised this 502 out of session creation with
+    no request-log write and no reason, so the only evidence was a rotating
+    container log.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    owner_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_owner_attribution",
+        "http-bridge-owner-attribution@example.com",
+    )
+    alternate_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_owner_attribution_other",
+        "http-bridge-owner-attribution-other@example.com",
+    )
+    owner_account = await _get_account(owner_account_id)
+    alternate_account = await _get_account(alternate_account_id)
+    upstream = _ClosingBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        preferred_account_id = cast(str | None, kwargs.get("preferred_account_id"))
+        fallback_enabled = bool(kwargs.get("fallback_on_preferred_account_unavailable", True))
+        if preferred_account_id is None:
+            return AccountSelection(account=owner_account, error_message=None, error_code=None)
+        if fallback_enabled:
+            return AccountSelection(account=alternate_account, error_message=None, error_code=None)
+        return AccountSelection(
+            account=None,
+            error_message="No available accounts",
+            error_code=CONTINUITY_OWNER_UNAVAILABLE,
+        )
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    first = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "hello",
+                "prompt_cache_key": "http-bridge-owner-attribution",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+    assert first.status_code == 200
+
+    caplog.set_level(logging.INFO, logger="app.modules.proxy.service")
+    second = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "continue",
+                "prompt_cache_key": "http-bridge-owner-attribution",
+                "previous_response_id": first.json()["id"],
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    # The client contract is unchanged; only the evidence trail is new.
+    assert second.status_code == 502
+    assert second.json()["error"]["code"] == "previous_response_owner_unavailable"
+
+    rejections = [
+        record.getMessage() for record in caplog.records if "owner_unavailable_replay_rejected" in record.getMessage()
+    ]
+    assert len(rejections) == 1
+    assert any(
+        f"detail=reason={reason}" in rejections[0]
+        for reason in http_bridge_streaming_module.ACCOUNT_NEUTRAL_REPLAY_REJECTIONS
+    )
+    assert "detail=reason=payload_not_full_resend" in rejections[0]
+
+    service = get_proxy_service_for_app(app_instance)
+    rows: list[RequestLog] = []
+    deadline = time.monotonic() + _TEST_SYNC_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        assert await service.drain_persistence_tasks(timeout_seconds=10)
+        async with SessionLocal() as session:
+            rows = list(
+                (
+                    await session.execute(
+                        select(RequestLog).where(RequestLog.error_code == "previous_response_owner_unavailable")
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        if rows:
+            break
+        await asyncio.sleep(0.05)
+    assert len(rows) == 1
+    assert rows[0].status == "error"
+    assert rows[0].model == "gpt-5.1"
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_capacity_failure_writes_no_owner_request_log(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    """Only continuity-owner codes gain a row; other pre-submit codes are unchanged."""
+    _install_bridge_settings(monkeypatch, enabled=True)
+    await _import_account(
+        async_client,
+        "acc_http_bridge_owner_row_scope",
+        "http-bridge-owner-row-scope@example.com",
+    )
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline, kwargs
+        # ``capacity_exhausted_active_sessions`` is the one local cap code the
+        # bridge treats as terminal rather than waiting out the request budget,
+        # so this exercises the no-row path without a capacity sleep.
+        return AccountSelection(
+            account=None,
+            error_message="HTTP bridge capacity exhausted",
+            error_code="capacity_exhausted_active_sessions",
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+
+    response = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "hello",
+                "prompt_cache_key": "http-bridge-owner-row-scope",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+    assert response.status_code != 200
+
+    service = get_proxy_service_for_app(app_instance)
+    assert await service.drain_persistence_tasks(timeout_seconds=10)
+    async with SessionLocal() as session:
+        owner_rows = list(
+            (
+                await session.execute(
+                    select(RequestLog).where(RequestLog.error_code == "previous_response_owner_unavailable")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert owner_rows == []
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_soft_prompt_cache_follow_up_uses_durable_owner_over_stale_local_lane(
     async_client,
     app_instance,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8648,7 +8648,10 @@ async def test_v1_responses_http_bridge_capacity_failure_writes_no_owner_request
         ),
         timeout=_TEST_SYNC_TIMEOUT_SECONDS,
     )
-    assert response.status_code != 200
+    # ``capacity_exhausted_active_sessions`` is a local overload code, so this
+    # is the stable 429 contract rather than merely "not 200" — a broad check
+    # would also pass if the request failed for an unrelated reason.
+    assert response.status_code == 429
 
     service = get_proxy_service_for_app(app_instance)
     assert await service.drain_persistence_tasks(timeout_seconds=10)

--- a/tests/unit/test_http_bridge_replay_rejection.py
+++ b/tests/unit/test_http_bridge_replay_rejection.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+import pytest
+
+from app.core.openai.requests import ResponsesRequest
+from app.core.types import JsonValue
+from app.db.models import HttpBridgeSessionState
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service import observability as observability_module
+from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers
+from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
+from app.modules.proxy._service.response_create import _fingerprint_input_items
+from app.modules.proxy.durable_bridge_coordinator import DurableBridgeLookup
+
+pytestmark = pytest.mark.unit
+
+_STORED_ITEMS: list[JsonValue] = [
+    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "first"}]},
+    {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "answer"}]},
+]
+_FRESH_ITEM: JsonValue = {
+    "type": "message",
+    "role": "user",
+    "content": [{"type": "input_text", "text": "second"}],
+}
+
+
+def _payload(input_value: object) -> ResponsesRequest:
+    return ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "be brief", "input": input_value})
+
+
+def _lookup(
+    *,
+    latest_input_item_count: int | None,
+    latest_input_full_fingerprint: str | None,
+) -> DurableBridgeLookup:
+    return DurableBridgeLookup(
+        session_id="session-1",
+        canonical_kind="thread_header",
+        canonical_key="thread-1",
+        api_key_scope="global",
+        account_id="account-1",
+        owner_instance_id="codex-lb",
+        owner_epoch=1,
+        lease_expires_at=None,
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id="resp-1",
+        latest_input_item_count=latest_input_item_count,
+        latest_input_full_fingerprint=latest_input_full_fingerprint,
+    )
+
+
+def _matching_lookup() -> DurableBridgeLookup:
+    return _lookup(
+        latest_input_item_count=len(_STORED_ITEMS),
+        latest_input_full_fingerprint=_fingerprint_input_items(list(_STORED_ITEMS)),
+    )
+
+
+def _full_resend_payload() -> ResponsesRequest:
+    return _payload([*_STORED_ITEMS, _FRESH_ITEM])
+
+
+def _anchor_rejection(
+    payload: ResponsesRequest,
+    lookup: DurableBridgeLookup,
+    *,
+    payload_looks_like_full_resend: bool = True,
+) -> str | None:
+    return http_bridge_streaming_module._durable_full_resend_anchor_rejection(
+        payload,
+        lookup,
+        payload_looks_like_full_resend=payload_looks_like_full_resend,
+    )
+
+
+def test_matching_full_resend_has_no_anchor_rejection() -> None:
+    assert _anchor_rejection(_full_resend_payload(), _matching_lookup()) is None
+
+
+def test_non_full_resend_payload_is_reported_distinctly() -> None:
+    # The body carries only the new turn, so there is no history to move.
+    assert (
+        _anchor_rejection(
+            _payload([_FRESH_ITEM]),
+            _matching_lookup(),
+            payload_looks_like_full_resend=False,
+        )
+        == "payload_not_full_resend"
+    )
+
+
+def test_row_without_stored_count_is_reported_distinctly() -> None:
+    # A durable row written before the anchor metadata existed, or one whose
+    # owner was pinned from the request-log index.
+    assert (
+        _anchor_rejection(
+            _full_resend_payload(),
+            _lookup(latest_input_item_count=None, latest_input_full_fingerprint="deadbeef"),
+        )
+        == "anchor_metadata_missing"
+    )
+
+
+def test_diverged_prefix_is_reported_distinctly() -> None:
+    assert (
+        _anchor_rejection(
+            _full_resend_payload(),
+            _lookup(
+                latest_input_item_count=len(_STORED_ITEMS),
+                latest_input_full_fingerprint="0" * 64,
+            ),
+        )
+        == "prefix_fingerprint_mismatch"
+    )
+
+
+def test_missing_fingerprint_is_a_prefix_mismatch() -> None:
+    assert (
+        _anchor_rejection(
+            _full_resend_payload(),
+            _lookup(latest_input_item_count=len(_STORED_ITEMS), latest_input_full_fingerprint=None),
+        )
+        == "prefix_fingerprint_mismatch"
+    )
+
+
+def test_stored_prefix_without_a_fresh_suffix_is_a_prefix_mismatch() -> None:
+    # The stored prefix consumes the whole body, so nothing new was sent.
+    assert _anchor_rejection(_payload(list(_STORED_ITEMS)), _matching_lookup()) == "prefix_fingerprint_mismatch"
+
+
+def test_string_input_refuses_on_the_prefix_proof() -> None:
+    # A non-list body cannot match a stored prefix, so the prefix proof always
+    # refuses first. ``input_not_itemized`` therefore stays a guard rather than
+    # an observable outcome: it is only reachable if some future caller admits
+    # a non-list body past the prefix proof.
+    assert (
+        _anchor_rejection(
+            _payload("plain string input"),
+            _matching_lookup(),
+            payload_looks_like_full_resend=True,
+        )
+        == "prefix_fingerprint_mismatch"
+    )
+
+
+def test_every_anchor_rejection_is_in_the_closed_set() -> None:
+    matching = _matching_lookup()
+    observed = {
+        _anchor_rejection(_payload([_FRESH_ITEM]), matching, payload_looks_like_full_resend=False),
+        _anchor_rejection(
+            _full_resend_payload(),
+            _lookup(latest_input_item_count=None, latest_input_full_fingerprint="deadbeef"),
+        ),
+        _anchor_rejection(
+            _full_resend_payload(),
+            _lookup(latest_input_item_count=len(_STORED_ITEMS), latest_input_full_fingerprint="0" * 64),
+        ),
+    }
+    assert observed <= http_bridge_streaming_module.ACCOUNT_NEUTRAL_REPLAY_REJECTIONS
+    # The three causes that used to collapse into one ``False``.
+    assert len(observed) == 3
+
+
+def test_closed_reason_set_matches_the_literal() -> None:
+    assert http_bridge_streaming_module.ACCOUNT_NEUTRAL_REPLAY_REJECTIONS == frozenset(
+        {
+            "file_bound",
+            "no_durable_lookup",
+            "payload_not_full_resend",
+            "anchor_metadata_missing",
+            "prefix_fingerprint_mismatch",
+            "input_not_itemized",
+            "missing_prior_output",
+            "account_scoped_input",
+        }
+    )
+
+
+class _RecordingCounter:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+        self.increments = 0
+
+    def labels(self, **kwargs: str) -> "_RecordingCounter":
+        self.calls.append(kwargs)
+        return self
+
+    def inc(self, amount: float = 1) -> None:
+        self.increments += 1
+
+
+def test_replay_rejection_counter_uses_the_closed_label_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    counter = _RecordingCounter()
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_service, "continuity_replay_rejected_total", counter, raising=False)
+
+    observability_module._record_continuity_replay_rejected(
+        surface="http_bridge",
+        reason="no_durable_lookup",
+    )
+
+    assert counter.calls == [{"surface": "http_bridge", "reason": "no_durable_lookup"}]
+    assert counter.increments == 1
+
+
+def test_replay_rejection_recorder_no_ops_without_prometheus(monkeypatch: pytest.MonkeyPatch) -> None:
+    counter = _RecordingCounter()
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", False)
+    monkeypatch.setattr(proxy_service, "continuity_replay_rejected_total", counter, raising=False)
+
+    observability_module._record_continuity_replay_rejected(surface="http_bridge", reason="file_bound")
+
+    assert counter.calls == []
+    assert counter.increments == 0
+
+
+def test_replay_rejection_event_is_logged_at_warning(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="app.modules.proxy.service")
+    key = proxy_service._HTTPBridgeSessionKey("thread_header", "thread-1", None)
+
+    http_bridge_helpers._log_http_bridge_event(
+        "owner_unavailable_replay_rejected",
+        key,
+        account_id="account-1",
+        model="gpt-5.4",
+        detail="reason=no_durable_lookup",
+        cache_key_family="thread_header",
+        owner_check_applied=True,
+    )
+
+    records = [record for record in caplog.records if "owner_unavailable_replay_rejected" in record.getMessage()]
+    assert len(records) == 1
+    # A refusal nobody can find in the logs is the failure this change exists
+    # to fix, so the level is part of the contract.
+    assert records[0].levelno == logging.WARNING
+    assert "reason=no_durable_lookup" in records[0].getMessage()
+    assert "account_id=account-1" in records[0].getMessage()
+    assert "key_strength=hard" in records[0].getMessage()
+
+
+def test_lookup_field_rename_fails_here() -> None:
+    # The anchor proof reads only these two lookup fields, so a rename must
+    # fail here rather than silently degrade every refusal to one reason.
+    lookup = replace(_matching_lookup(), latest_input_item_count=None)
+    assert _anchor_rejection(_full_resend_payload(), lookup) == "anchor_metadata_missing"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -142,6 +142,8 @@ def test_prometheus_metrics_defined_when_dependency_available(monkeypatch: pytes
     assert prometheus_module.continuity_owner_resolution_total.labelnames == ("surface", "source", "outcome")
     assert prometheus_module.continuity_fail_closed_total.name == "codex_lb_continuity_fail_closed_total"
     assert prometheus_module.continuity_fail_closed_total.labelnames == ("surface", "reason")
+    assert prometheus_module.continuity_replay_rejected_total.name == "codex_lb_continuity_replay_rejected_total"
+    assert prometheus_module.continuity_replay_rejected_total.labelnames == ("surface", "reason")
     assert prometheus_module.upstream_reasoning_replay_400_total.name == "codex_lb_upstream_reasoning_replay_400_total"
     assert prometheus_module.upstream_reasoning_replay_400_total.labelnames == ()
     assert prometheus_module.account_inflight_leases.name == "codex_lb_account_inflight_leases"


### PR DESCRIPTION
## Why

`previous_response_owner_unavailable` is the user-visible face of #1707: an existing Codex thread whose upstream owner account became unroutable fails with 502 on every resume while healthy accounts sit idle in the pool.

The proxy already contains the cure. `switch_to_account_neutral_replay` projects reasoning out of the history and re-sends plaintext context on a fresh account. Its gate, `durable_full_resend_allows_account_neutral_replay`, is a conjunction of six independent proofs — and it returns a bare `bool`.

That makes the failure unattributable. A 36-hour window on a production deployment (`1.25.0-beta.7`, 24 accounts) recorded:

| Observation | Value |
|---|---|
| `previous_response_owner_unavailable` request-log rows | **1,480** / 36h |
| … by owner account status | `reauth_required` 1,361; `paused` 22; `rate_limited` 3; owner now `active` again ~94 |
| … by `transport` | `websocket` 1,491 / 48h; `http` **0** |
| `owner_unavailable_fresh_resend` bridge events | **0** / 24h |
| `dead_owner_fresh_resend` bridge events | **0** / 24h |
| Bridge 502s present in `request_logs` over the last 6h | **0** of 14,555 rows |

Two readings matter:

1. **The recovery path has never fired in production.** Zero `owner_unavailable_fresh_resend` events against 1,480 failures means the refusal is systematic, not incidental — and nothing on the failing request says which of the six proofs refused it. The 2026-09-08 status note on #1707 asks reporters for exactly this attribution; the current logs cannot supply it.

2. **The bridge surface's failures are invisible where operators look.** Every logged row carries `transport="websocket"` — the direct-WebSocket surface logs the code itself. Not one carries `transport="http"`: the HTTP session bridge raises the identical envelope from session creation, before any request-log write, and `app/modules/proxy/_service/http_bridge/` contains no request-log write at all (`_write_request_log` appears only as an unused protocol declaration). The dashboard shows nothing, so a bridge incident is only reachable by reading a rotating container log (3×50MB, ~8h retention) — which is how the 2026-09-04 recurrence of this same class had to be reconstructed.

## What changes

- **Typed rejection reason.** `durable_full_resend_allows_account_neutral_replay` becomes a thin `is None` wrapper over a new `classify_account_neutral_replay_rejection()` returning `None` when a cross-account replay is allowed, else one of a closed set: `file_bound`, `no_durable_lookup`, `payload_not_full_resend`, `anchor_metadata_missing`, `prefix_fingerprint_mismatch`, `input_not_itemized`, `missing_prior_output`, `account_scoped_input`.

  The stored-anchor half moves to a new module-level, pure `_durable_full_resend_anchor_rejection(payload, lookup, *, payload_looks_like_full_resend)` — the seam the unit tests drive — so the three causes `classify_durable_full_resend` collapses today (`payload_not_full_resend`, `anchor_metadata_missing`, `prefix_fingerprint_mismatch`) stop being indistinguishable. **The predicate's truth value is unchanged at every existing call site**; evaluation order is preserved from the conjunction, so the reported reason is the first proof that refused.

- **One emission point.** `owner_unavailable_allows_account_neutral_replay` emits the new bridge event `owner_unavailable_replay_rejected` (WARNING, `detail=reason=<reason>`). It already gates all three recovery attempt sites (session creation, owner forward, capacity retry), so "exactly one reason per refusal" is structural rather than a convention each future raise site must remember. The `required_continuity_owner_missing` exit has no exception to classify and calls the classifier directly.

- **Metric.** `codex_lb_continuity_replay_rejected_total{surface, reason}` with the usual `None` fallback, recorded via `_record_continuity_replay_rejected` beside the existing `_record_continuity_owner_resolution` / `_record_continuity_fail_closed`.

- **Request-log parity for the bridge surface.** `_stream_http_bridge_or_retry` writes one `_write_stream_preflight_error` row before re-raising a pre-submit `ProxyResponseError` coded `previous_response_owner_unavailable` or `continuity_owner_conflict`, mirroring what `retry.py` already does at its own owner-unavailable exit. Both sites resolve the same `ensure_request_id()` contextvar, so the container log line and the row are joinable on that id.

  The write sits **inside the propagating branch only**: when the bridge instead hands the turn to the raw-HTTP upstream, that path settles its own outcome, and an error row for a turn that then succeeded would corrupt the very error rate this row exists to expose.

## Why observability first

The follow-up work in #1707 is a behavior change: retiring an unroutable continuity owner so the thread rebinds. Which mechanism to build depends on which proof is actually refusing the existing recovery in production — `no_durable_lookup` (owner pinned from the request-log index with no anchor context) and `prefix_fingerprint_mismatch` (client body diverged from the stored turn) point at different fixes. Landing the attribution first makes that choice evidence-based and gives the later PRs a before/after signal that is not a rotating container log.

## Scope and safety

No new `CODEX_LB_*` setting, no migration, no `.env.example` change, no README growth. No routing, selection, or failover decision changes — the classifier is a pure refactor of an existing conjunction, and the counter and log line are observational.

None of the four ceiling-guarded proxy files is touched: `service.py` (2600/2600), `load_balancer.py` (3000/3021), `_service/http_bridge/mixin.py` (2435/2436), `_service/streaming/mixin.py` (1097/1100). The recorder deliberately skips a `service.py` re-export — `_service_global` falls back to the module global, and that file sits exactly at its ratchet.

Two closed-set notes:
- `input_not_itemized` is a **guard, not an outcome**: a non-list body can never satisfy the stored-prefix proof, so the prefix check always refuses first. `test_string_input_refuses_on_the_prefix_proof` pins that ordering so a future caller admitting a non-list body past the prefix proof shows up as a test change rather than a silent mislabel.
- Both counter labels are closed (`surface` is `http_bridge`; `reason` is the eight-value literal), asserted in `test_closed_reason_set_matches_the_literal` and `tests/unit/test_metrics.py`.

## Test plan

Local, all green:

| Gate | Result |
|---|---|
| `make lint` (incl. `check_proxy_architecture.py`, `check_cancellation_safety.py`, `check_proxy_timing_seams.py`, `check_settings_tiers.py`) | pass |
| `make typecheck` (`ty`) | pass |
| `make test-unit` | **9,984 passed**, 6 skipped, 1 xfailed |
| `make test-integration-bridge` | **341 passed** |
| `make test-integration-core-1` | **889 passed**, 332 skipped |
| `make test-integration-core-2` | **873 passed**, 31 skipped |
| `make test-integration-core-3` | **774 passed**, 34 skipped |
| `uv run pytest tests/e2e` | **27 passed**, 1 skipped |
| `openspec validate trace-continuity-owner-replay-rejection --strict` | valid |
| `codex review --base origin/main` | no findings |
| `openspec validate --specs` | 65 passed, 0 failed |

New coverage:
- `tests/unit/test_http_bridge_replay_rejection.py` (new) — the anchor-proof reasons via the pure module-level seam, the allowed path reporting no reason, the three previously-collapsed causes reported distinctly, `input_not_itemized` pinned as unreachable behind the prefix proof, the counter's closed label set, the recorder's no-prometheus no-op, and the event's WARNING level asserted through `caplog`.
- `tests/integration/test_http_responses_bridge.py` — a bridged resume whose owner is not selectable returns the unchanged 502 envelope, logs exactly one `owner_unavailable_replay_rejected` with a reason from the closed set, and leaves exactly one `request_logs` row with `error_code="previous_response_owner_unavailable"`. A sibling case proves a capacity-coded pre-submit failure still writes no row.
- `tests/unit/test_metrics.py` — name/label assertion beside the sibling continuity counters.

## OpenSpec

`openspec/changes/trace-continuity-owner-replay-rejection/` — proposal, context, tasks, and a `proxy-runtime-observability` delta with two ADDED requirements (rejection attribution; bridge continuity-owner failures reach the request log).

Partial fix for #1707 — it does not by itself let any thread recover.

> Shards 2 and 3 additionally reported sqlite `unable to open database file` (444 occurrences) on files unrelated to this change — `test_v1_reset_credit`, `test_subscription_overflow_*`, `test_usage_*`, `test_proxy_api_extended`, `test_proxy_images`, `test_proxy_realtime_live`, `test_proxy_sticky_sessions`. The host root partition was at 96% with several test suites running concurrently. All of those files pass in isolation on this branch (103 + 247 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
