### PR TITLE
fix(proxy): narrow the input-image upstream transport pin

### DIFF
--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -223,6 +223,10 @@ def _responses_request_uses_image_generation(*args: Any, **kwargs: Any) -> Any:
     return _service_global("_responses_request_uses_image_generation")(*args, **kwargs)
 
 
+def _input_image_request_requires_http_upstream(*args: Any, **kwargs: Any) -> Any:
+    return _service_global("_input_image_request_requires_http_upstream")(*args, **kwargs)
+
+
 def _input_prefix_matches_stored_context(*args: Any, **kwargs: Any) -> Any:
     return _service_global("_input_prefix_matches_stored_context")(*args, **kwargs)
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -141,6 +141,7 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _header_value_case_insensitive,
     _http_bridge_startup_keepalive_grace_seconds,
     _inject_missing_interrupted_function_call_outputs,
+    _input_image_request_requires_http_upstream,
     _input_prefix_matches_stored_context,
     _is_previous_response_not_found_error,
     _maybe_log_proxy_request_payload,
@@ -963,7 +964,20 @@ class _HTTPBridgeStreamingMixin:
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
         image_request = _responses_request_contains_input_image(payload)
         image_generation_request = _responses_request_uses_image_generation(payload)
-        force_upstream_stream_transport = "http" if image_request else None
+        # The bridge bypass below is about bridge pending slots; it must not also
+        # decide the upstream transport. An inline ``data:`` image rides the
+        # upstream websocket unchanged, so only the two websocket-specific
+        # hazards keep the pin (#2363). ``image_request`` gates the predicate
+        # because the predicate's own first check is that same walk of the whole
+        # input, and this runs on every request on the hot path.
+        force_upstream_stream_transport = (
+            "http"
+            if image_request
+            and _input_image_request_requires_http_upstream(
+                payload, payload_size_estimate_bytes=payload_size_estimate_bytes
+            )
+            else None
+        )
         if runtime_config.enabled and (image_request or image_generation_request):
             record_http_bridge_routing(stage="bypass", reason="image")
             logger.info(

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -194,7 +194,11 @@ def _json_value_contains_external_input_image(value: JsonValue) -> bool:
     """
     if _input_part_is_image(value):
         image_url = value.get("image_url") if is_json_mapping(value) else None
-        return isinstance(image_url, str) and image_url.startswith(("http://", "https://"))
+        # URL schemes are case-insensitive, and this decision is the fail-safe
+        # direction: missing one sends a raw external URL to a websocket that
+        # only accepts ``data:``. ``_count_external_image_urls`` still matches
+        # case-sensitively; that is the bridge's own guard and out of scope here.
+        return isinstance(image_url, str) and image_url.lower().startswith(("http://", "https://"))
     if isinstance(value, list):
         return any(_json_value_contains_external_input_image(item) for item in value)
     if is_json_mapping(value):

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -181,6 +181,27 @@ def _responses_request_contains_input_image(payload: ResponsesRequest) -> bool:
     return any(_json_value_contains_input_image_part(item) for item in input_value)
 
 
+def _json_value_contains_external_input_image(value: JsonValue) -> bool:
+    """Whether ``value`` holds an ``input_image`` part that still names an external URL.
+
+    Recurses the same way :func:`_json_value_contains_input_image_part` does,
+    rather than walking the two shapes ``_count_external_image_urls`` knows
+    (a top-level item and its ``content`` array). The transport decision has to
+    see every external URL the payload carries, including one nested in a
+    ``function_call_output`` output array, because an image the URL inliner
+    never visits is precisely the one that is still external when the request
+    reaches the upstream websocket.
+    """
+    if _input_part_is_image(value):
+        image_url = value.get("image_url") if is_json_mapping(value) else None
+        return isinstance(image_url, str) and image_url.startswith(("http://", "https://"))
+    if isinstance(value, list):
+        return any(_json_value_contains_external_input_image(item) for item in value)
+    if is_json_mapping(value):
+        return any(_json_value_contains_external_input_image(child) for child in value.values())
+    return False
+
+
 def _input_image_request_requires_http_upstream(
     payload: ResponsesRequest,
     *,
@@ -197,12 +218,22 @@ def _input_image_request_requires_http_upstream(
     historical inline image with an omission notice. An external ``http(s)``
     image URL may still be there after ``_inline_content_images`` gives up on a
     failed fetch, and the upstream websocket does not accept one.
+
+    The external-URL check recurses the whole input rather than reusing
+    ``_count_external_image_urls``, whose traversal stops at an item's
+    ``content`` array. An ``input_image`` nested deeper — in a
+    ``function_call_output`` output array, a routine Codex tool-result shape —
+    is exactly the one the URL inliner also never visits, so it is still
+    external at the upstream and must keep the pin.
     """
-    if not _responses_request_contains_input_image(payload):
+    input_value = payload.input
+    if not isinstance(input_value, list):
+        return False
+    if not any(_json_value_contains_input_image_part(item) for item in input_value):
         return False
     if payload_size_estimate_bytes > _ws_transport_payload_budget_bytes():
         return True
-    return _count_external_image_urls({"input": payload.input}) > 0
+    return any(_json_value_contains_external_input_image(item) for item in input_value)
 
 
 def _responses_request_uses_image_generation(payload: ResponsesRequest) -> bool:

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -33,6 +33,7 @@ from app.core.clients.proxy import (
     _response_create_too_large_error_envelope,
     _should_slim_historical_tool_output,
     _slim_historical_response_content,
+    _ws_transport_payload_budget_bytes,
     apply_codex_installation_metadata,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, get_settings
@@ -178,6 +179,30 @@ def _responses_request_contains_input_image(payload: ResponsesRequest) -> bool:
     if not isinstance(input_value, list):
         return False
     return any(_json_value_contains_input_image_part(item) for item in input_value)
+
+
+def _input_image_request_requires_http_upstream(
+    payload: ResponsesRequest,
+    *,
+    payload_size_estimate_bytes: int,
+) -> bool:
+    """Return whether an ``input_image`` request must stay on the upstream HTTP transport.
+
+    Inline ``data:`` images ride the upstream websocket unchanged, so carrying one
+    is not by itself a reason to pin upstream HTTP; the bridge bypass exists to
+    free bridge pending slots (#903), not to avoid the websocket. Two
+    websocket-specific hazards survive, and only those keep the pin (#2363). A
+    payload over the websocket frame budget would reach
+    ``_prepare_websocket_response_create_payload``, which replaces every
+    historical inline image with an omission notice. An external ``http(s)``
+    image URL may still be there after ``_inline_content_images`` gives up on a
+    failed fetch, and the upstream websocket does not accept one.
+    """
+    if not _responses_request_contains_input_image(payload):
+        return False
+    if payload_size_estimate_bytes > _ws_transport_payload_budget_bytes():
+        return True
+    return _count_external_image_urls({"input": payload.input}) > 0
 
 
 def _responses_request_uses_image_generation(payload: ResponsesRequest) -> bool:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -378,19 +378,28 @@ class _StreamingRetryMixin:
         upstream_stream_transport = upstream_stream_transport_override
         if upstream_stream_transport is None:
             configured_transport, explicit_transport = _resolved_configured_stream_transport(settings)
-            image_bypass = _facade()._responses_request_uses_image_generation(
-                payload
-            ) or _facade()._responses_request_contains_input_image(payload)
+            # ``has_image_generation_tool`` means exactly that: folding
+            # ``input_image`` into it pinned every image turn to upstream HTTP
+            # from inside _resolve_stream_transport, where no log or counter
+            # records the decision (#2363). An ``input_image`` request is pinned
+            # only by the narrow predicate below.
+            image_generation_bypass = _facade()._responses_request_uses_image_generation(payload)
+            payload_size_estimate = _payload_size_estimate_bytes(payload)
             resolved_base_transport = _resolve_stream_transport(
                 transport=configured_transport,
                 transport_override=None,
                 model=payload.model,
                 headers=headers,
-                has_image_generation_tool=image_bypass,
-                payload_size_estimate_bytes=_payload_size_estimate_bytes(payload),
+                has_image_generation_tool=image_generation_bypass,
+                payload_size_estimate_bytes=payload_size_estimate,
             )
             upstream_stream_transport = resolved_base_transport
-            if not explicit_transport and image_bypass:
+            if not explicit_transport and (
+                image_generation_bypass
+                or _facade()._input_image_request_requires_http_upstream(
+                    payload, payload_size_estimate_bytes=payload_size_estimate
+                )
+            ):
                 upstream_stream_transport = "http"
             if (
                 not explicit_transport

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -444,6 +444,11 @@ from app.modules.proxy._service.response_create import (
     _inline_top_level_input_image_urls as _inline_top_level_input_image_urls,
 )
 from app.modules.proxy._service.response_create import (
+    _input_image_request_requires_http_upstream,  # noqa: F401
+    _responses_request_contains_input_image,  # noqa: F401
+    _responses_request_uses_image_generation,  # noqa: F401
+)
+from app.modules.proxy._service.response_create import (
     _input_part_is_image as _input_part_is_image,
 )
 from app.modules.proxy._service.response_create import (
@@ -478,12 +483,6 @@ from app.modules.proxy._service.response_create import (
 )
 from app.modules.proxy._service.response_create import (
     _response_output_item_done_tool_call as _response_output_item_done_tool_call,
-)
-from app.modules.proxy._service.response_create import (
-    _responses_request_contains_input_image as _responses_request_contains_input_image,
-)
-from app.modules.proxy._service.response_create import (
-    _responses_request_uses_image_generation as _responses_request_uses_image_generation,
 )
 from app.modules.proxy._service.response_create import (
     _safe_dump_slug as _safe_dump_slug,

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -150,7 +150,11 @@ this policy too; their User-Agent alone does not indicate a WebSocket failure.
 
 Real recent upstream WS failures temporarily keep requests on HTTP (the existing
 60-second cooldown). Explicit HTTP policy, image-capable requests and oversized
-payloads also bypass the bridge. Source-routed Chat requests keep their source.
+payloads also bypass the bridge. Bypassing the bridge does not force upstream
+HTTP: an `input_image` request keeps upstream HTTP only when its payload exceeds
+the WebSocket frame budget or still carries an external image URL, and otherwise
+follows the ordinary transport precedence. Source-routed Chat requests keep
+their source.
 
 Clients resending full history need not retain response headers to reuse a
 connection. Inferred locality uses complete initial user input and instructions,

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/.openspec.yaml
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/context.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/context.md
@@ -64,38 +64,15 @@ hang on a path nobody watches.
 
 ## Known bounds
 
-- `_count_external_image_urls` sees top-level `input_image` items and one level
-  of `content`, exactly the shapes `_inline_input_image_urls` can rewrite. An
-  external URL nested deeper (for example inside a `function_call_output`
-  content array) is invisible to both, so such a request can now reach the
-  upstream WebSocket with a raw `https://` URL. The blind spot is identical to
-  the existing HTTP bridge guard's; no deployment gains a hazard the bridge path
-  did not already have, but the raw path had been masked by the pin until now.
-  Widening that traversal is deliberately out of scope, so the spec's "external
-  image URL still forces HTTP" scenario names the two shapes the guard actually
-  reads rather than promising coverage it does not have, and the capability
-  `context.md` records the same bound.
-- The residual pin still overrides an explicit operator
-  `upstream_stream_transport = "websocket"`, so precedence item 2 still beats
-  item 1 for these two cases. This inversion is deliberate rather than
-  overlooked: with an explicit WebSocket pin `_resolve_stream_transport`
-  short-circuits and no size gate runs, so removing the override would turn an
-  oversized image payload into a local 400 `payload_too_large` that operators do
-  not get today. The spec text now states the wart instead of leaving it
-  implicit. It is site A that inverts the precedence, so it applies to every
-  request that reaches the bridge routing decision — all of `/v1/responses` and
-  `/backend-api/codex/responses`. Site B keeps both residual clauses behind its
-  pre-existing `not explicit_transport` gate, so a `/v1/chat/completions`
-  request whose bridge admission already declined the bridge follows the
-  explicit override instead. That asymmetry predates this change and widening
-  site B would be a separate behaviour change; the spec text scopes the claim
-  rather than asserting a rule the code does not implement.
-- There is no image marker on `request_logs`, so the production error-rate split
-  between image and non-image traffic is not derivable from LB telemetry. This
-  change is verifiable as a ratio shift on
-  `codex_lb_upstream_transport_decisions_total` (`policy="explicit"` falling,
-  `"auto"` rising) with `http_bridge_routing{reason="image"}` flat — not as a
-  direct WebSocket count.
+- The transport predicate's external-URL check recurses the whole input, so an
+  external URL nested inside a tool-output array keeps the pin. It deliberately
+  does not reuse `_count_external_image_urls`, whose traversal stops at one
+  level of `content`.
+- `_inline_input_image_urls` and the HTTP bridge's post-inline guard
+  (`_count_external_image_urls`) still read only those two shallow shapes, so a
+  bridged request carrying an external URL nested deeper is neither inlined nor
+  rejected and reaches the upstream WebSocket raw. That is pre-existing and
+  unchanged by this PR; widening the inliner is a separate change.
 
 ## Example
 

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/context.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/context.md
@@ -1,0 +1,128 @@
+# Context: narrow-input-image-upstream-transport-pin
+
+## Provenance: how a bridge bypass became a transport pin
+
+`bcd63c827` introduced the `input_image` bypass. Its proposal text is entirely
+about HTTP bridge pending slots: an image request that sat in the bridge
+occupied a pending slot until it timed out (#903), so image requests were routed
+to the raw (non-bridge) Responses path. The commit implemented that by setting
+`force_upstream_stream_transport = "http"` alongside the bypass, conflating two
+separate decisions — *which local path serves the request* and *which upstream
+transport it opens*. The spec sentence "and send the request over the raw HTTP
+Responses stream path" is the textual origin of the same conflation; it now
+reads "the raw (non-bridge) Responses stream path".
+
+Later, `2e124df8f` (#1093) folded `input_image` into the `image_bypass` variable
+at the second site, so the same conflation reached the raw path's own transport
+resolution.
+
+## Why two sites, and why both had to change
+
+Site A is `_stream_http_bridge_or_retry`
+(`app/modules/proxy/_service/http_bridge/streaming.py`). It computes the pin
+unconditionally — not gated on `runtime_config.enabled`, unlike the bridge
+bypass on the next line — and forwards it to `_stream_with_retry` as
+`upstream_stream_transport_override`. It governs `/v1/responses`,
+`/backend-api/codex/responses`, and bridge-active `/v1/chat/completions`.
+
+Site B is `_stream_with_retry` (`app/modules/proxy/_service/streaming/retry.py`),
+which runs exactly when that override is `None`. It governs everything site A
+never touches: `/v1/chat/completions` with the bridge inactive,
+`_collect_responses`, and `prefer_http_bridge=False` callers.
+
+At site B the effective pin was the `has_image_generation_tool=image_bypass`
+argument, not the explicit re-pin two lines below it. Under the default
+`upstream_stream_transport = "auto"`, `_resolve_stream_transport` returns
+`"http"` on that argument before the explicit re-pin runs, so a patch touching
+only the re-pin would have shipped a no-op. Both sub-edits are load-bearing.
+Passing only `image_generation` also restores that parameter's original meaning,
+matching its one in-core caller.
+
+## Why the two residual clauses
+
+**Frame budget.** A payload over `_ws_transport_payload_budget_bytes()` (14 MiB)
+that reaches the upstream WebSocket goes through
+`_prepare_websocket_response_create_payload`, whose slimmer is all-or-nothing:
+crossing the budget by one byte replaces *every* historical inline image with
+`[codex-lb omitted historical inline image to fit upstream websocket budget]`.
+14 MiB, not the 15 MiB `upstream_response_create_max_bytes`, is deliberate:
+under `auto` the 14 MiB gate inside `_resolve_stream_transport` already fires
+first, so a 15 MiB clause would be unreachable there, and two thresholds for one
+routing decision is the drift this change exists to remove. 14 MiB is also
+strictly conservative with respect to the 15 MiB slimming trigger.
+
+**External image URL.** `_inline_content_images` silently leaves an external
+`http(s)` image URL in place when the fetch fails — non-https, SSRF-blocked
+host, non-200, over 8 MiB, or the 8 s timeout — and the raw path has no
+fail-closed guard for that, while the HTTP bridge fails closed with a 400
+`image_download_failed`. **The evidence that the upstream WebSocket cannot
+accept such a URL is a code comment in `request_submit.py` ("silently reject or
+hang"), not a captured trace or upstream document.** The clause is kept anyway
+because the reported production shape is a pasted screenshot — a `data:` URL,
+unaffected — so the clause costs nothing, while dropping it risks an unbounded
+hang on a path nobody watches.
+
+## Known bounds
+
+- `_count_external_image_urls` sees top-level `input_image` items and one level
+  of `content`, exactly the shapes `_inline_input_image_urls` can rewrite. An
+  external URL nested deeper (for example inside a `function_call_output`
+  content array) is invisible to both, so such a request can now reach the
+  upstream WebSocket with a raw `https://` URL. The blind spot is identical to
+  the existing HTTP bridge guard's; no deployment gains a hazard the bridge path
+  did not already have, but the raw path had been masked by the pin until now.
+  Widening that traversal is deliberately out of scope, so the spec's "external
+  image URL still forces HTTP" scenario names the two shapes the guard actually
+  reads rather than promising coverage it does not have, and the capability
+  `context.md` records the same bound.
+- The residual pin still overrides an explicit operator
+  `upstream_stream_transport = "websocket"`, so precedence item 2 still beats
+  item 1 for these two cases. This inversion is deliberate rather than
+  overlooked: with an explicit WebSocket pin `_resolve_stream_transport`
+  short-circuits and no size gate runs, so removing the override would turn an
+  oversized image payload into a local 400 `payload_too_large` that operators do
+  not get today. The spec text now states the wart instead of leaving it
+  implicit. It is site A that inverts the precedence, so it applies to every
+  request that reaches the bridge routing decision — all of `/v1/responses` and
+  `/backend-api/codex/responses`. Site B keeps both residual clauses behind its
+  pre-existing `not explicit_transport` gate, so a `/v1/chat/completions`
+  request whose bridge admission already declined the bridge follows the
+  explicit override instead. That asymmetry predates this change and widening
+  site B would be a separate behaviour change; the spec text scopes the claim
+  rather than asserting a rule the code does not implement.
+- There is no image marker on `request_logs`, so the production error-rate split
+  between image and non-image traffic is not derivable from LB telemetry. This
+  change is verifiable as a ratio shift on
+  `codex_lb_upstream_transport_decisions_total` (`policy="explicit"` falling,
+  `"auto"` rising) with `http_bridge_routing{reason="image"}` flat — not as a
+  direct WebSocket count.
+
+## Example
+
+Thread turn 7 of a Codex conversation whose turn 1 contained a pasted
+screenshot:
+
+```json
+{"model": "gpt-5.4", "input": [
+  {"role": "user", "content": [{"type": "input_image", "image_url": "data:image/png;base64,..."}]},
+  {"role": "assistant", "content": "first answer"},
+  {"role": "user", "content": "continue"}
+]}
+```
+
+Before: the bridge bypass fired *and* `upstream_stream_transport_override` was
+`"http"`, so the raw path opened an upstream HTTP POST. After: the bridge bypass
+still fires, the override is `None`, and the `smart` policy sees the
+assistant-to-user continuation signal and keeps upstream WebSocket with the base
+`"auto"` transport mode intact.
+
+## Repository-gate note
+
+`app/modules/proxy/service.py` sits exactly on its 2600-line architecture
+ratchet (`openspec/specs/proxy-architecture/spec.md`), which may only be
+restored or lowered, and `streaming`/`http_bridge` may not import
+`response_create` directly — the façade is the only legal seam. The three
+`response_create` image-predicate re-exports were therefore folded into one
+plain `# noqa: F401` block, the form this file already uses for its `support`
+and `http_bridge.helpers` re-exports. That frees one line, so the file lands at
+2599 with the new façade name added.

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/proposal.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/proposal.md
@@ -1,0 +1,54 @@
+# Change: narrow-input-image-upstream-transport-pin
+
+## Why
+
+Any Responses request whose `input` carries an `input_image` part was forced
+onto the upstream HTTP transport, whatever the operator configured. Codex keeps
+earlier screenshots in the thread history, so a single pasted image dragged
+every later turn of that conversation onto upstream HTTP for the rest of the
+thread — losing upstream WebSocket connection reuse and prompt-cache affinity
+for that traffic (#2363).
+
+The pin was never required for correctness. It arrived in `bcd63c827` as the
+transport half of a bridge bypass whose stated purpose was freeing HTTP bridge
+pending slots (#903), and native downstream WebSocket clients already send
+inline `data:` images over the upstream WebSocket today with no bypass at all.
+Only two WebSocket-specific hazards actually need upstream HTTP: a payload over
+the WebSocket frame budget, where the oversize slimmer strips every historical
+inline image, and an external `http(s)` image URL, which the image inliner
+leaves in place when its fetch fails.
+
+## What Changes
+
+- One shared predicate, `_input_image_request_requires_http_upstream`, decides
+  whether an `input_image` request keeps the upstream HTTP pin: only when the
+  serialized payload exceeds the WebSocket frame budget
+  (`_ws_transport_payload_budget_bytes()`), or when the payload still carries an
+  external `http(s)` image URL.
+- Both pin sites call it. `_stream_http_bridge_or_retry` no longer computes
+  `force_upstream_stream_transport = "http" if image_request else None`, and
+  `_stream_with_retry` no longer folds `input_image` into the
+  `has_image_generation_tool` argument of `_resolve_stream_transport`.
+- The HTTP bridge bypass is unchanged: an image request still bypasses the
+  bridge, still records `http_bridge_routing{stage="bypass",reason="image"}`,
+  and still logs the same line. The `image_generation` pin is unchanged.
+- No new setting, metric, or metric label.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: the image bridge bypass no longer pins the upstream
+  stream transport, and the downstream-HTTP transport precedence narrows its
+  `input_image` clause to oversized payloads and external image URLs.
+
+## Impact
+
+- Image threads rejoin the sticky WebSocket/promotion population, which changes
+  prompt-cache affinity and account stickiness for that traffic.
+- With the pin cleared, an image request during an upstream WebSocket outage now
+  falls into the existing `recent_ws_failure` branch and is degraded to HTTP
+  there, with the bypass counter and log that branch already emits.
+- `codex_lb_upstream_transport_decisions_total` will show
+  `upstream_transport="http",policy="explicit"` falling and `"auto"` rising for
+  image traffic; `http_bridge_routing{reason="image"}` stays flat.

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
@@ -172,10 +172,21 @@ through to the global `http_downstream_transport_policy`.
 
 - **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
 - **AND** no recent upstream WS failure marker is active
-- **WHEN** a single-shot downstream HTTP request with no sticky signals
-  resolves the upstream transport under any policy
+- **WHEN** a single-shot downstream HTTP request with no sticky signals, and
+  which trips none of the precedence item 2 bypasses, resolves the upstream
+  transport under any policy
 - **THEN** the explicit override MUST win and the request MUST use
   upstream WebSocket
+
+#### Scenario: external image URL still forces HTTP under an explicit websocket override
+
+- **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
+- **AND** a request passing through the HTTP bridge routing decision carries an
+  `input_image` part whose `image_url` is an external `http(s)` URL
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`, because the
+  override would otherwise short-circuit the residual pin and hand the upstream
+  WebSocket a URL it does not accept
 
 #### Scenario: oversized payload bypass still forces HTTP under always_websocket
 

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
@@ -198,8 +198,8 @@ through to the global `http_downstream_transport_policy`.
 
 - **GIVEN** `upstream_stream_transport` is `"auto"`
 - **AND** a request carries an `input_image` part whose `image_url` is an
-  external `http(s)` URL, in a top-level input item or in that item's
-  `content` array
+  external `http(s)` URL, anywhere in the input — including inside a
+  tool-output array, which the image inliner never rewrites
 - **WHEN** the proxy resolves the upstream transport
 - **THEN** the request MUST be sent over upstream HTTP `POST`
 

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/specs/responses-api-compat/spec.md
@@ -1,0 +1,212 @@
+# responses-api-compat delta
+
+## MODIFIED Requirements
+
+### Requirement: Responses input images bypass the HTTP bridge
+
+The service MUST bypass the HTTP responses bridge when a `/v1/responses`,
+`/backend-api/codex/responses`, `/responses/compact`, or `/v1/responses/compact`
+request contains any `input_image` part in top-level input items, nested
+message content, or tool output content, and send the request over the raw
+(non-bridge) Responses stream path. This bypass MUST happen after rejecting
+unsupported uploaded-image references and MUST be limited to the current
+request; subsequent text-only requests MAY continue using the HTTP responses
+bridge.
+
+The raw (non-bridge) path is the source of truth for image validation and
+upstream image error semantics. The bridge MUST NOT hold image requests waiting
+for `response.created` when upstream rejects an invalid inline image payload.
+
+This bridge bypass MUST NOT by itself pin the upstream stream transport. The
+upstream transport for a bypassed image request MUST be resolved by the ordinary
+upstream-transport precedence.
+
+#### Scenario: Nested input_image bypasses bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a Responses request contains a nested content part with `type = "input_image"`
+- **THEN** the request is sent through the raw (non-bridge) stream path
+- **AND** the HTTP responses bridge is not used for that request
+
+#### Scenario: Image bypass does not disable future text bridge use
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** an image-bearing request bypasses the bridge
+- **THEN** the bypass applies only to that request
+- **AND** a later text-only request can still use the HTTP responses bridge
+
+#### Scenario: Image bypass does not pin the upstream transport
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **AND** `upstream_stream_transport` is `"auto"`
+- **WHEN** a Responses request carrying an inline `data:` image below the
+  WebSocket frame budget bypasses the bridge
+- **THEN** the request MUST NOT be forced onto upstream HTTP
+- **AND** the configured transport policy MUST decide its upstream transport
+
+### Requirement: Downstream-HTTP upstream transport follows a configurable policy
+
+When a downstream HTTP/SSE request (`request_transport == "http"`) resolves its base upstream transport to `"websocket"`, the proxy MUST decide the final upstream transport using the configured `http_downstream_transport_policy`, after all higher-precedence rails have been applied, and the policy MUST NOT affect native WebSocket clients (`request_transport == "websocket"`), which keep their dedicated upstream WebSocket path.
+
+Precedence (highest first), evaluated before the policy:
+
+1. Outside the existing recent upstream WS failure cooldown, an explicit
+   `upstream_stream_transport` override of `"http"` or `"websocket"` wins.
+2. Oversized-payload bypass and the `image_generation` bypass force upstream
+   HTTP. A request carrying `input_image` parts forces upstream HTTP only when
+   its serialized payload exceeds the WebSocket frame budget, or when the
+   payload still carries an external `http(s)` image URL that the proxy may be
+   unable to inline; an inline `data:` image alone MUST NOT force upstream HTTP.
+   These two residual `input_image` pins are deliberately evaluated ahead of an
+   explicit `"websocket"` override wherever the request passes through the HTTP
+   bridge routing decision — every `/v1/responses` and
+   `/backend-api/codex/responses` request does — because that override
+   short-circuits the size gate and an oversized image payload would otherwise
+   fail locally with `400 payload_too_large`. A request that never reaches that
+   decision, such as a `/v1/chat/completions` request whose bridge admission has
+   already declined the bridge, follows item 1 instead.
+3. The effective policy (per-API-key `transport_policy_override` when
+   set, otherwise the global `http_downstream_transport_policy`) decides.
+
+Policy values and behavior:
+
+- `always_http` (and its alias `pinned`): the request MUST be sent over
+  upstream HTTP `POST`, preserving the legacy unconditional pin.
+- `always_websocket`: the request MUST keep upstream WebSocket whenever
+  the base transport resolved to `"websocket"` without replacing a base
+  `"auto"` transport mode with a hard `"websocket"` override.
+- `smart` (default): the request MUST keep upstream WebSocket **iff** at
+  least one sticky-continuation signal is present on the request, and
+  MUST otherwise fall back to upstream HTTP. The sticky-continuation
+  signals are:
+  - a non-null `previous_response_id` on the request payload, **OR**
+  - a `prompt_cache_key` present on the request model, **OR**
+  - a Codex session header (`session_id`, `x-codex-session-id`, or
+    `x-codex-conversation-id`), **OR**
+  - an `x-codex-turn-state` continuity header, **OR**
+  - a non-empty `conversation` identifier, **OR**
+  - a structured tool-result input item (`function_call_output`,
+    `custom_tool_call_output`, or `apply_patch_call_output`), **OR**
+  - an assistant message followed by new user input in the supplied history.
+
+Tool declarations, instruction messages, and user-only input sequences MUST NOT
+alone count as continuation evidence. The existing recent upstream WS failure
+cooldown MUST force upstream HTTP before these policy choices, including an
+explicit WebSocket preference; clearing or expiring the marker restores normal
+eligibility.
+
+When a policy decision keeps upstream WebSocket, the proxy MUST preserve
+the configured/base downstream transport mode passed to the upstream
+client. In particular, a base `"auto"` mode MUST remain `"auto"` so the
+existing WebSocket-handshake rejection fallback to upstream HTTP remains
+available. The policy MAY force a concrete transport override only when
+the decision is to downgrade to upstream HTTP.
+
+The per-API-key `transport_policy_override`, when non-null, MUST be used
+as the effective policy for requests authenticated by that key and MUST
+take precedence over the global default. A null override MUST fall
+through to the global `http_downstream_transport_policy`.
+
+#### Scenario: single-shot downstream-HTTP request falls back to HTTP under smart policy
+
+- **GIVEN** `http_downstream_transport_policy` is `"smart"` and the base
+  upstream transport resolves to `"websocket"`
+- **AND** a downstream HTTP request carries no `previous_response_id`, no
+  `prompt_cache_key`, no Codex session header, and no `x-codex-turn-state`
+  header, conversation identifier, tool result, or assistant-to-user history
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`
+
+#### Scenario: sticky downstream-HTTP request keeps WebSocket under smart policy
+
+- **GIVEN** `http_downstream_transport_policy` is `"smart"` and the base
+  upstream transport mode is `"auto"` and resolves to `"websocket"`
+- **AND** a downstream HTTP request carries any one of
+  `previous_response_id`, `prompt_cache_key`, a Codex session header, or
+  an `x-codex-turn-state` header
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket without converting
+  the downstream transport mode from `"auto"` to `"websocket"`
+- **AND** an upstream WebSocket handshake rejection status eligible for
+  auto fallback MUST transparently retry over upstream HTTP
+
+#### Scenario: always_http policy preserves the legacy pin
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_http"` (or
+  `"pinned"`) and the base upstream transport resolves to `"websocket"`
+- **WHEN** a downstream HTTP request resolves the upstream transport,
+  regardless of sticky signals
+- **THEN** the request MUST be sent over upstream HTTP `POST`
+
+#### Scenario: always_websocket policy never downgrades sticky-less HTTP
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+  and the base upstream transport mode is `"auto"` and resolves to
+  `"websocket"`
+- **WHEN** a downstream HTTP request with no sticky signals resolves the
+  upstream transport
+- **THEN** the request MUST keep upstream WebSocket without converting
+  the downstream transport mode from `"auto"` to `"websocket"`
+
+#### Scenario: per-key override wins over the global policy
+
+- **GIVEN** the global `http_downstream_transport_policy` is `"smart"`
+- **AND** the authenticating API key has
+  `transport_policy_override = "always_http"`
+- **WHEN** a sticky downstream HTTP request authenticated by that key
+  resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`,
+  because the per-key override takes precedence
+
+#### Scenario: null per-key override follows the global policy
+
+- **GIVEN** the global `http_downstream_transport_policy` is `"smart"`
+- **AND** the authenticating API key has `transport_policy_override =
+  null`
+- **WHEN** a sticky downstream HTTP request authenticated by that key
+  resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket, following the global
+  `smart` policy
+
+#### Scenario: explicit websocket override still beats the policy
+
+- **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
+- **AND** no recent upstream WS failure marker is active
+- **WHEN** a single-shot downstream HTTP request with no sticky signals
+  resolves the upstream transport under any policy
+- **THEN** the explicit override MUST win and the request MUST use
+  upstream WebSocket
+
+#### Scenario: oversized payload bypass still forces HTTP under always_websocket
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+- **AND** the serialized request payload exceeds the WebSocket frame
+  budget
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`, because the
+  oversized-payload bypass has higher precedence than the policy
+
+#### Scenario: inline image alone does not force HTTP under always_websocket
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+- **AND** a request carries an inline `data:` image below the WebSocket
+  frame budget
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket
+
+#### Scenario: external image URL still forces HTTP
+
+- **GIVEN** `upstream_stream_transport` is `"auto"`
+- **AND** a request carries an `input_image` part whose `image_url` is an
+  external `http(s)` URL, in a top-level input item or in that item's
+  `content` array
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`
+
+#### Scenario: native WebSocket clients are unaffected by the policy
+
+- **GIVEN** any value of `http_downstream_transport_policy`
+- **WHEN** a native WebSocket client (`request_transport == "websocket"`)
+  streams a request
+- **THEN** the client MUST keep its dedicated upstream WebSocket path and
+  the policy MUST NOT downgrade it to HTTP

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/tasks.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/tasks.md
@@ -1,0 +1,95 @@
+# Tasks: narrow-input-image-upstream-transport-pin
+
+## 1. Implementation
+
+- [x] 1.1 `app/modules/proxy/_service/response_create.py`: add the shared
+  predicate `_input_image_request_requires_http_upstream(payload, *,
+  payload_size_estimate_bytes)`, returning `True` only when the request carries
+  an `input_image` part **and** either the estimate exceeds
+  `_ws_transport_payload_budget_bytes()` or `_count_external_image_urls` finds a
+  surviving external `http(s)` image URL.
+- [x] 1.2 `app/modules/proxy/service.py` and
+  `app/modules/proxy/_service/http_bridge/service_stubs.py`: expose the
+  predicate through the façade seam both pin sites already use. The three
+  `response_create` image predicates now share one plain `# noqa: F401`
+  re-export block so `service.py` stays under its 2600-line architecture ratchet
+  (it lands at 2599).
+- [x] 1.3 **Pin site A** —
+  `app/modules/proxy/_service/http_bridge/streaming.py`
+  `_stream_http_bridge_or_retry`: replace
+  `force_upstream_stream_transport = "http" if image_request else None` with the
+  predicate, reusing the `payload_size_estimate_bytes` already computed for the
+  bridge size gate. The bridge bypass, its `reason="image"` counter, and its log
+  line are untouched.
+- [x] 1.4 **Pin site B** — `app/modules/proxy/_service/streaming/retry.py`
+  `_stream_with_retry`: stop folding `input_image` into
+  `has_image_generation_tool=` (this argument, not the explicit re-pin below it,
+  was the effective pin under `auto`), and gate the explicit re-pin on
+  `image_generation_bypass or _input_image_request_requires_http_upstream(...)`.
+- [x] 1.5 Sync `openspec/specs/responses-api-compat/spec.md` and its
+  `context.md`, and update `docs/routing.md` so the published page no longer
+  documents the removed pin. Precedence item 2 scopes the claim that the
+  residual pins outrank an explicit `"websocket"` override to requests that
+  reach the bridge routing decision, because site B keeps both clauses behind
+  its pre-existing `not explicit_transport` gate; the external-URL scenario
+  names the two shapes `_count_external_image_urls` actually reads.
+
+## 2. Regression coverage (failing product path)
+
+- [x] 2.1 `tests/integration/test_http_promotion_accounting.py::test_promoted_image_bypass_is_counted_without_pinning_http`
+  — real `/v1/responses` route: an inline `data:` image still records
+  `bypass/image` and `admission/smart_history` and still opens no upstream
+  WebSocket session, but the raw call now carries `upstream_transport == "auto"`.
+  The old parametrization is split so the `payload_size` leg keeps asserting
+  `"http"`.
+- [x] 2.2 `…::test_historical_image_does_not_pin_later_turns_to_http` — the
+  reported production shape: the image is in the *first* turn and the last turn
+  is plain text; the request must not be pinned.
+- [x] 2.3 `…::test_oversized_image_request_still_pins_http` and
+  `…::test_external_image_url_request_still_pins_http` — pin the two surviving
+  clauses at the route so a later refactor cannot delete them silently. The
+  oversize test pins `upstream_stream_transport = "websocket"` explicitly:
+  under `"auto"` the frame-budget gate inside `_resolve_stream_transport` would
+  satisfy the assertion on its own, so the test would have passed with the
+  predicate's size clause deleted. Deleting either clause now fails both its
+  route test and its unit test.
+- [x] 2.4 `tests/integration/test_proxy_responses.py::test_v1_responses_without_http_bridge_websocket_upstream_keeps_small_inline_images`
+  — route-level proof that an explicit operator `upstream_stream_transport =
+  "websocket"` now wins for an image turn, and that the inline image reaches the
+  upstream payload verbatim.
+- [x] 2.5 `tests/integration/test_proxy_responses.py::test_v1_responses_without_http_bridge_http_upstream_preserves_historical_inline_artifacts`
+  — repointed at an explicit `upstream_stream_transport = "http"`; its subject
+  is "the HTTP upstream does not slim", and it was reaching that upstream only
+  through the removed pin.
+- [x] 2.6 `tests/unit/test_proxy_utils.py`: rename
+  `…forces_http_for_input_image_when_bridge_disabled` to
+  `…keeps_unpinned_transport_for_small_input_image_when_bridge_disabled` and
+  assert the override is `None` (this is the population where the pin fired with
+  no log and no counter); add
+  `…forces_http_for_websocket_hostile_input_image` covering both residual
+  clauses at site A; update the two override tuples in
+  `…bypasses_bridge_for_input_image` to `None`.
+- [x] 2.7 `tests/unit/test_proxy_utils.py`: rename the `always_websocket` image
+  case to `test_http_downstream_small_input_image_follows_policy_under_always_websocket`
+  (now `"auto"`), add
+  `test_http_downstream_external_image_url_still_forces_http_under_always_websocket`,
+  and close the coverage gap on the site-B argument with
+  `test_stream_retry_passes_image_generation_{only_,tool_}to_resolve_stream_transport`
+  — the sibling tests stub `_resolve_stream_transport` away, so nothing verified
+  that argument before.
+
+## 3. Verification
+
+- [x] 3.1 Proved the key regressions fail on an unmodified tree: with only the
+  `app/` diff reverse-applied, 7 of the 14 new/changed tests fail (`'http' ==
+  'auto'`, `'http' is None`, `True is False`); with it restored, 14 pass.
+- [x] 3.2 `uv run pytest tests/unit/test_proxy_utils.py` (1,400 passed),
+  `tests/unit/test_proxy_http_bridge.py tests/unit/test_websocket_transport_fallback.py
+  tests/unit/test_http_bridge_safe_continuity.py tests/unit/test_http_continuation.py
+  tests/unit/test_proxy_api_responses_contract.py` (1,205 passed),
+  `tests/integration/test_proxy_responses.py tests/integration/test_http_promotion_accounting.py`
+  (108 passed), `tests/integration/test_http_responses_bridge.py` (185 passed).
+- [x] 3.3 `ruff format` / `ruff check app tests` / `ty check app`, and the proxy
+  architecture, cancellation-safety, timing-seam and settings-tier scripts.
+- [x] 3.4 `openspec validate narrow-input-image-upstream-transport-pin --strict`
+  and `openspec validate --specs`.

--- a/openspec/changes/narrow-input-image-upstream-transport-pin/verification.md
+++ b/openspec/changes/narrow-input-image-upstream-transport-pin/verification.md
@@ -1,0 +1,128 @@
+# Verification — 2026-09-11
+
+Base commit: `e24b57c93` (origin/main when implementation started). No runtime
+settings or production deployment were changed.
+
+## Failing-before-the-fix proof
+
+The `app/` diff was reverse-applied (`git apply -R`) with the test changes left
+in place, the regression set was run, and the diff was restored and rerun. Seven
+of the fifteen node ids fail without the `app/` change and pass with it; the
+other eight pass in both worlds by design — they pin the two residual clauses and
+the unchanged `image_generation` behaviour, so they must not be sensitive to the
+fix. Mutation testing covers those eight instead (see "Residual-clause mutation
+proof").
+
+Failures on the unmodified tree:
+
+- `tests/integration/test_http_promotion_accounting.py::test_historical_image_does_not_pin_later_turns_to_http`
+  — `AssertionError: assert 'http' == 'auto'`
+- `tests/integration/test_http_promotion_accounting.py::test_promoted_image_bypass_is_counted_without_pinning_http`
+  — `AssertionError: assert 'http' == 'auto'`
+- `tests/integration/test_proxy_responses.py::test_v1_responses_without_http_bridge_websocket_upstream_keeps_small_inline_images`
+  — `AssertionError: assert 'http' == 'websocket'`
+- `tests/unit/test_proxy_utils.py::test_stream_http_bridge_or_retry_keeps_unpinned_transport_for_small_input_image_when_bridge_disabled`
+  — `AssertionError: assert 'http' is None`
+- `tests/unit/test_proxy_utils.py::test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image`
+  — `assert [('retry', …, 'http')] == [('retry', …, None)]`
+- `tests/unit/test_proxy_utils.py::test_http_downstream_small_input_image_follows_policy_under_always_websocket`
+  — `AssertionError: assert 'http' == 'auto'`
+- `tests/unit/test_proxy_utils.py::test_stream_retry_passes_image_generation_only_to_resolve_stream_transport`
+  — `assert True is False`
+
+Totals: **7 failed, 8 passed** without the `app/` change; **15 passed** with it.
+
+The last failure is the one that proves both halves of the site-B edit are
+load-bearing: it asserts on the `has_image_generation_tool` argument handed to
+`_resolve_stream_transport`, which the sibling policy tests cannot see because
+they stub that resolver out. A patch that narrowed only the explicit re-pin
+would still fail it.
+
+## Residual-clause mutation proof
+
+The eight tests that pass in both worlds guard the two clauses the predicate
+keeps, so each clause was disabled in turn and the guard set rerun.
+
+- Size clause disabled: `test_oversized_image_request_still_pins_http` fails
+  (`assert not upstreams`, the request opened an upstream WebSocket) and
+  `test_stream_http_bridge_or_retry_forces_http_for_websocket_hostile_input_image[over_frame_budget]`
+  fails (`assert None == 'http'`). Before the route test was pinned to an
+  explicit `upstream_stream_transport = "websocket"` it survived this mutation,
+  because under `"auto"` the frame-budget gate inside `_resolve_stream_transport`
+  reaches the same outcome by itself.
+- External-URL clause disabled:
+  `test_external_image_url_request_still_pins_http`,
+  `…forces_http_for_websocket_hostile_input_image[external_url]` and
+  `test_http_downstream_external_image_url_still_forces_http_under_always_websocket`
+  all fail.
+
+## Passing checks
+
+- `tests/unit/test_proxy_utils.py`: **1,400 passed**.
+- `tests/unit/test_proxy_http_bridge.py`, `test_websocket_transport_fallback.py`,
+  `test_http_bridge_safe_continuity.py`, `test_http_continuation.py`,
+  `test_proxy_api_responses_contract.py`: **1,205 passed**.
+- `tests/integration/test_proxy_responses.py` +
+  `tests/integration/test_http_promotion_accounting.py`: **108 passed**.
+- `tests/integration/test_http_responses_bridge.py`: **185 passed**.
+- `uv run ruff format`, `uv run ruff check app tests`, `uv run ty check app`.
+- `scripts/check_proxy_architecture.py`, `check_cancellation_safety.py`,
+  `check_proxy_timing_seams.py`, `check_settings_tiers.py`.
+- `openspec validate narrow-input-image-upstream-transport-pin --strict`;
+  `openspec validate --specs` — **65 passed**.
+
+Suite counts overlap and should not be summed as unique coverage.
+
+## Corrections to the change design
+
+- The design expected an oversized `input_image` request to record both the
+  `payload_size` and the `image` bridge-bypass reasons. It records only
+  `payload_size`: the size gate disables the bridge first, so the image gate's
+  `runtime_config.enabled` guard is already false. That ordering is pre-existing
+  and unchanged here, and the test asserts the observed behaviour.
+- The design expected `test_v1_responses_without_http_bridge_http_upstream_preserves_historical_inline_artifacts`
+  to fail before the fix. It is repointed at an explicit
+  `upstream_stream_transport = "http"`, which makes it pass in both worlds —
+  correct for its subject ("the HTTP upstream does not slim"), which should not
+  depend on the transport pin at all.
+
+## Review repairs
+
+- Site A walked the whole input twice per request: `image_request` and then the
+  predicate's own identical first check. Measured on this host with an 830 KiB
+  text-only thread, one walk costs 2.66 ms against 5.87 ms for the
+  `to_payload()` + `json.dumps` the size gate already runs, so the second walk
+  was a ~45% add to that step on 100% of bridge-path traffic. `image_request`
+  now short-circuits the predicate; no test monkeypatches
+  `_responses_request_contains_input_image` on the façade, so the two seams
+  cannot disagree.
+- Precedence item 2 claimed the residual pins outrank an explicit
+  `"websocket"` override unconditionally. Only site A does that. Site B keeps
+  both clauses behind its pre-existing `not explicit_transport` gate, and a
+  `/v1/chat/completions` request whose bridge admission already declined the
+  bridge reaches site B without traversing site A. The text now scopes the claim
+  to requests that reach the bridge routing decision; the runtime asymmetry
+  predates this change and widening site B would be a separate behaviour change.
+- The "external image URL still forces HTTP" scenario was unconditional while
+  `_count_external_image_urls` reads only top-level `input_image` items and one
+  level of `content`. Confirmed: a `function_call_output` whose `output` array
+  holds an `https://` image returns `_responses_request_contains_input_image ==
+  True` but `_count_external_image_urls == 0`, so the predicate returns `False`.
+  Widening that traversal is out of scope, so the scenario now names the shapes
+  the guard reads and the capability `context.md` records the bound.
+- The bridge-bypass requirement reworded "raw HTTP Responses stream path" but
+  left "the raw HTTP path is the source of truth" and one scenario's "raw HTTP
+  stream path" behind, which re-introduced the bridge/transport conflation this
+  change exists to remove. All three now read "raw (non-bridge)".
+
+## Scope of evidence
+
+Integration tests exercise the real `/v1/responses` route, real bridge and
+admission code, and real request-log accounting with only upstream I/O faked. No
+live upstream traffic was sent, and the production error-rate claim in #2363 is
+not verifiable from this repository: `request_logs` carries no image marker, so
+the image/non-image split is not derivable from LB telemetry. After deploy the
+change shows up as a ratio shift on
+`codex_lb_upstream_transport_decisions_total` (`policy="explicit"` falling,
+`upstream_transport="auto"` rising) with
+`codex_lb_http_bridge_routing_total{reason="image"}` flat.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -276,10 +276,12 @@ pins and size bypasses remain effective. The image bypass keeps requests off the
 HTTP session bridge but no longer pins the upstream transport, which is resolved
 by ordinary precedence; an `input_image` request keeps upstream HTTP only when
 its payload exceeds the WebSocket frame budget or still carries an external
-image URL. External-URL detection reads top-level `input_image` items and one
-level of `content`, exactly the shapes the image inliner can rewrite, so a URL
-nested deeper — inside a tool-output array, say — is invisible to both and does
-not keep the pin. No new retry/session registry.
+image URL. External-URL detection for that decision recurses the whole input, so
+a URL nested inside a tool-output array keeps the pin even though the image
+inliner never rewrites it — that is the case where the URL is still external at
+the upstream. The inliner and the bridge's post-inline guard still read only
+top-level `input_image` items and one level of `content`; closing that is a
+separate change. No new retry/session registry.
 
 History-only locality is soft, scoped by the bridge's full API-key identifier,
 and hashes the complete first user item plus instructions and model. No client

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -272,7 +272,14 @@ OpenSpec change first.
 Healthy native HTTP requests use normal policy. The proxy cannot infer every
 client-local WebSocket failure from HTTP alone; it uses its existing 60-second
 upstream-connect failure marker as concrete failure evidence. Operator HTTP
-pins, image and size bypasses remain effective. No new retry/session registry.
+pins and size bypasses remain effective. The image bypass keeps requests off the
+HTTP session bridge but no longer pins the upstream transport, which is resolved
+by ordinary precedence; an `input_image` request keeps upstream HTTP only when
+its payload exceeds the WebSocket frame budget or still carries an external
+image URL. External-URL detection reads top-level `input_image` items and one
+level of `content`, exactly the shapes the image inliner can rewrite, so a URL
+nested deeper — inside a tool-output array, say — is invisible to both and does
+not keep the pin. No new retry/session registry.
 
 History-only locality is soft, scoped by the bridge's full API-key identifier,
 and hashes the complete first user item plus instructions and model. No client

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -3076,20 +3076,25 @@ account-owner requests whose upstream resource is bound to the selected account.
 The service MUST bypass the HTTP responses bridge when a `/v1/responses`,
 `/backend-api/codex/responses`, `/responses/compact`, or `/v1/responses/compact`
 request contains any `input_image` part in top-level input items, nested
-message content, or tool output content, and send the request over the raw HTTP
-Responses stream path. This bypass MUST happen after rejecting unsupported
-uploaded-image references and MUST be limited to the current request; subsequent
-text-only requests MAY continue using the HTTP responses bridge.
+message content, or tool output content, and send the request over the raw
+(non-bridge) Responses stream path. This bypass MUST happen after rejecting
+unsupported uploaded-image references and MUST be limited to the current
+request; subsequent text-only requests MAY continue using the HTTP responses
+bridge.
 
-The raw HTTP path is the source of truth for image validation and upstream image
-error semantics. The bridge MUST NOT hold image requests waiting for
-`response.created` when upstream rejects an invalid inline image payload.
+The raw (non-bridge) path is the source of truth for image validation and
+upstream image error semantics. The bridge MUST NOT hold image requests waiting
+for `response.created` when upstream rejects an invalid inline image payload.
+
+This bridge bypass MUST NOT by itself pin the upstream stream transport. The
+upstream transport for a bypassed image request MUST be resolved by the ordinary
+upstream-transport precedence.
 
 #### Scenario: Nested input_image bypasses bridge
 
 - **GIVEN** the HTTP responses bridge is enabled
 - **WHEN** a Responses request contains a nested content part with `type = "input_image"`
-- **THEN** the request is sent through the raw HTTP stream path
+- **THEN** the request is sent through the raw (non-bridge) stream path
 - **AND** the HTTP responses bridge is not used for that request
 
 #### Scenario: Image bypass does not disable future text bridge use
@@ -3098,6 +3103,15 @@ error semantics. The bridge MUST NOT hold image requests waiting for
 - **WHEN** an image-bearing request bypasses the bridge
 - **THEN** the bypass applies only to that request
 - **AND** a later text-only request can still use the HTTP responses bridge
+
+#### Scenario: Image bypass does not pin the upstream transport
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **AND** `upstream_stream_transport` is `"auto"`
+- **WHEN** a Responses request carrying an inline `data:` image below the
+  WebSocket frame budget bypasses the bridge
+- **THEN** the request MUST NOT be forced onto upstream HTTP
+- **AND** the configured transport policy MUST decide its upstream transport
 
 ### Requirement: Security-work authorization errors can route to authorized accounts
 
@@ -4557,8 +4571,19 @@ Precedence (highest first), evaluated before the policy:
 
 1. Outside the existing recent upstream WS failure cooldown, an explicit
    `upstream_stream_transport` override of `"http"` or `"websocket"` wins.
-2. Oversized-payload bypass and image / image-generation bypass force
-   upstream HTTP.
+2. Oversized-payload bypass and the `image_generation` bypass force upstream
+   HTTP. A request carrying `input_image` parts forces upstream HTTP only when
+   its serialized payload exceeds the WebSocket frame budget, or when the
+   payload still carries an external `http(s)` image URL that the proxy may be
+   unable to inline; an inline `data:` image alone MUST NOT force upstream HTTP.
+   These two residual `input_image` pins are deliberately evaluated ahead of an
+   explicit `"websocket"` override wherever the request passes through the HTTP
+   bridge routing decision — every `/v1/responses` and
+   `/backend-api/codex/responses` request does — because that override
+   short-circuits the size gate and an oversized image payload would otherwise
+   fail locally with `400 payload_too_large`. A request that never reaches that
+   decision, such as a `/v1/chat/completions` request whose bridge admission has
+   already declined the bridge, follows item 1 instead.
 3. The effective policy (per-API-key `transport_policy_override` when
    set, otherwise the global `http_downstream_transport_policy`) decides.
 
@@ -4679,6 +4704,23 @@ through to the global `http_downstream_transport_policy`.
 - **WHEN** the proxy resolves the upstream transport
 - **THEN** the request MUST be sent over upstream HTTP `POST`, because the
   oversized-payload bypass has higher precedence than the policy
+
+#### Scenario: inline image alone does not force HTTP under always_websocket
+
+- **GIVEN** `http_downstream_transport_policy` is `"always_websocket"`
+- **AND** a request carries an inline `data:` image below the WebSocket
+  frame budget
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST keep upstream WebSocket
+
+#### Scenario: external image URL still forces HTTP
+
+- **GIVEN** `upstream_stream_transport` is `"auto"`
+- **AND** a request carries an `input_image` part whose `image_url` is an
+  external `http(s)` URL, in a top-level input item or in that item's
+  `content` array
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`
 
 #### Scenario: native WebSocket clients are unaffected by the policy
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -4717,8 +4717,8 @@ through to the global `http_downstream_transport_policy`.
 
 - **GIVEN** `upstream_stream_transport` is `"auto"`
 - **AND** a request carries an `input_image` part whose `image_url` is an
-  external `http(s)` URL, in a top-level input item or in that item's
-  `content` array
+  external `http(s)` URL, anywhere in the input — including inside a
+  tool-output array, which the image inliner never rewrites
 - **WHEN** the proxy resolves the upstream transport
 - **THEN** the request MUST be sent over upstream HTTP `POST`
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -4691,10 +4691,21 @@ through to the global `http_downstream_transport_policy`.
 
 - **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
 - **AND** no recent upstream WS failure marker is active
-- **WHEN** a single-shot downstream HTTP request with no sticky signals
-  resolves the upstream transport under any policy
+- **WHEN** a single-shot downstream HTTP request with no sticky signals, and
+  which trips none of the precedence item 2 bypasses, resolves the upstream
+  transport under any policy
 - **THEN** the explicit override MUST win and the request MUST use
   upstream WebSocket
+
+#### Scenario: external image URL still forces HTTP under an explicit websocket override
+
+- **GIVEN** `upstream_stream_transport` is explicitly `"websocket"`
+- **AND** a request passing through the HTTP bridge routing decision carries an
+  `input_image` part whose `image_url` is an external `http(s)` URL
+- **WHEN** the proxy resolves the upstream transport
+- **THEN** the request MUST be sent over upstream HTTP `POST`, because the
+  override would otherwise short-circuit the residual pin and hand the upstream
+  WebSocket a URL it does not accept
 
 #### Scenario: oversized payload bypass still forces HTTP under always_websocket
 

--- a/tests/integration/test_http_promotion_accounting.py
+++ b/tests/integration/test_http_promotion_accounting.py
@@ -186,6 +186,43 @@ async def test_external_image_url_request_still_pins_http(async_client, promotio
 
 
 @pytest.mark.asyncio
+async def test_external_image_url_inside_a_tool_output_still_pins_http(async_client, promotion_transport):
+    # A ``function_call_output`` output array is a routine Codex tool-result
+    # shape, and the URL inliner never walks into it, so an external URL there
+    # is still external at the upstream. It has to keep the pin even though it
+    # is deeper than the shapes ``_count_external_image_urls`` visits.
+    upstreams, raw_calls, _ = promotion_transport
+    history = _promotion_history()
+    history[-1] = {
+        "type": "function_call_output",
+        "call_id": "call_shot",
+        "output": [{"type": "input_image", "image_url": "https://example.com/shot.png"}],
+    }
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+
+
+@pytest.mark.asyncio
+async def test_inline_image_inside_a_tool_output_does_not_pin_http(async_client, promotion_transport):
+    # The counterpart that makes the clause above narrow rather than a
+    # reinstatement of the old blanket pin: an inline image nested just as
+    # deeply is carried by the websocket unchanged, so it must not pin.
+    upstreams, raw_calls, _ = promotion_transport
+    history = _promotion_history()
+    history[-1] = {
+        "type": "function_call_output",
+        "call_id": "call_shot",
+        "output": [{"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="}],
+    }
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "auto"
+
+
+@pytest.mark.asyncio
 async def test_promotion_counts_reuse_separately_from_admission(async_client, promotion_transport, monkeypatch):
     routing_counter, connection_counter = Mock(), Mock()
     monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)

--- a/tests/integration/test_http_promotion_accounting.py
+++ b/tests/integration/test_http_promotion_accounting.py
@@ -205,6 +205,34 @@ async def test_external_image_url_inside_a_tool_output_still_pins_http(async_cli
 
 
 @pytest.mark.asyncio
+async def test_external_image_url_pins_http_under_an_explicit_websocket_override(async_client, promotion_transport):
+    # The residual pin is deliberately evaluated ahead of an explicit websocket
+    # override: the override short-circuits the transport resolver, so without
+    # the pin the upstream WebSocket would be handed a URL it does not accept.
+    upstreams, raw_calls, dashboard = promotion_transport
+    dashboard.upstream_stream_transport = "websocket"
+    history = _image_history("https://example.com/shot.png")
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scheme", ["https", "HTTPS", "HtTp"])
+async def test_external_image_url_scheme_match_is_case_insensitive(async_client, promotion_transport, scheme):
+    # URL schemes are case-insensitive, and this is the fail-safe direction:
+    # missing one sends a raw external URL to a websocket that accepts only
+    # ``data:``.
+    upstreams, raw_calls, _ = promotion_transport
+    history = _image_history(f"{scheme}://example.com/shot.png")
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+
+
+@pytest.mark.asyncio
 async def test_inline_image_inside_a_tool_output_does_not_pin_http(async_client, promotion_transport):
     # The counterpart that makes the clause above narrow rather than a
     # reinstatement of the old blanket pin: an inline image nested just as

--- a/tests/integration/test_http_promotion_accounting.py
+++ b/tests/integration/test_http_promotion_accounting.py
@@ -90,32 +90,99 @@ async def test_per_key_http_override_suppresses_native_history_promotion(async_c
     assert raw_calls[-1]["upstream_transport"] == "http"
 
 
+def _image_history(image_url, *, position=-1):
+    history = _promotion_history()
+    history[position] = {"role": "user", "content": [{"type": "input_image", "image_url": image_url}]}
+    return history
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize("bypass", ["image", "payload_size"])
-async def test_promoted_http_bypass_reasons_are_counted(async_client, promotion_transport, monkeypatch, bypass):
+async def test_promoted_oversized_payload_bypass_is_counted_and_pins_http(
+    async_client, promotion_transport, monkeypatch
+):
     upstreams, raw_calls, _ = promotion_transport
     routing_counter = Mock()
     monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
-    if bypass == "payload_size":
-        # The payload bypass compares against the fixed upstream frame budget
-        # (MAX_SSE_EVENT_BYTES - 2 MiB headroom, floored at 1 MiB): shrink it so
-        # a 1 MiB + 1 history trips the bypass.
-        monkeypatch.setattr(core_proxy_module, "MAX_SSE_EVENT_BYTES", 3 * 1024 * 1024)
-        history = _promotion_history("x" * (1024 * 1024 + 1))
-    else:
-        history = _promotion_history()
-        history[-1] = {
-            "role": "user",
-            "content": [
-                {"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="},
-            ],
-        }
+    # The payload bypass compares against the fixed upstream frame budget
+    # (MAX_SSE_EVENT_BYTES - 2 MiB headroom, floored at 1 MiB): shrink it so
+    # a 1 MiB + 1 history trips the bypass.
+    monkeypatch.setattr(core_proxy_module, "MAX_SSE_EVENT_BYTES", 3 * 1024 * 1024)
+    history = _promotion_history("x" * (1024 * 1024 + 1))
     response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
     assert response.status_code == 200, response.text
     assert not upstreams
     assert raw_calls[-1]["upstream_transport"] == "http"
     routing_counter.labels.assert_any_call(stage="admission", reason="smart_history")
-    routing_counter.labels.assert_any_call(stage="bypass", reason=bypass)
+    routing_counter.labels.assert_any_call(stage="bypass", reason="payload_size")
+
+
+@pytest.mark.asyncio
+async def test_promoted_image_bypass_is_counted_without_pinning_http(async_client, promotion_transport, monkeypatch):
+    # Regression for #2363: the image bypass frees bridge pending slots, and it
+    # must keep doing that, but an inline ``data:`` image below the frame budget
+    # must no longer drag the request onto the upstream HTTP transport.
+    upstreams, raw_calls, _ = promotion_transport
+    routing_counter = Mock()
+    monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
+    history = _image_history("data:image/png;base64,aGVsbG8=")
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "auto"
+    routing_counter.labels.assert_any_call(stage="admission", reason="smart_history")
+    routing_counter.labels.assert_any_call(stage="bypass", reason="image")
+
+
+@pytest.mark.asyncio
+async def test_historical_image_does_not_pin_later_turns_to_http(async_client, promotion_transport):
+    # The reported production shape: Codex keeps earlier screenshots in the
+    # input, so before #2363 one historical image pinned every later turn of the
+    # thread to the degraded upstream HTTP path.
+    upstreams, raw_calls, _ = promotion_transport
+    history = _image_history("data:image/png;base64,aGVsbG8=", position=0)
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_oversized_image_request_still_pins_http(async_client, promotion_transport, monkeypatch):
+    upstreams, raw_calls, dashboard = promotion_transport
+    routing_counter = Mock()
+    monkeypatch.setattr(observability, "http_bridge_routing_total", routing_counter)
+    monkeypatch.setattr(core_proxy_module, "MAX_SSE_EVENT_BYTES", 3 * 1024 * 1024)
+    # Pin the websocket explicitly so the size clause of the narrowed predicate
+    # is the only thing that can still produce "http" here: an explicit pin
+    # short-circuits _resolve_stream_transport before its own frame-budget gate,
+    # which would otherwise satisfy this assertion on its own. This is also the
+    # configuration the residual pin exists for, since that short-circuit is what
+    # would turn an oversized image payload into a local 400 payload_too_large.
+    dashboard.upstream_stream_transport = "websocket"
+    history = _image_history("data:image/png;base64," + "A" * (1024 * 1024 + 1))
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
+    # The size gate runs first and already disables the bridge, so only
+    # ``payload_size`` is counted; the image gate is skipped, as it is today for
+    # every oversized image request.
+    bypass_reasons = [
+        call.kwargs["reason"] for call in routing_counter.labels.call_args_list if call.kwargs["stage"] == "bypass"
+    ]
+    assert bypass_reasons == ["payload_size"]
+
+
+@pytest.mark.asyncio
+async def test_external_image_url_request_still_pins_http(async_client, promotion_transport):
+    # An external URL survives when ``_inline_content_images`` cannot fetch it,
+    # and the upstream websocket does not accept one, so this shape keeps the pin.
+    upstreams, raw_calls, _ = promotion_transport
+    history = _image_history("https://example.com/shot.png")
+    response = await async_client.post("/v1/responses", json={"model": "gpt-5.4", "input": history})
+    assert response.status_code == 200, response.text
+    assert not upstreams
+    assert raw_calls[-1]["upstream_transport"] == "http"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2218,7 +2218,11 @@ async def test_v1_responses_without_http_bridge_http_upstream_preserves_historic
     dashboard_settings = DashboardSettings(
         id=1,
         sticky_threads_enabled=False,
-        upstream_stream_transport="websocket",
+        # The subject here is "the HTTP upstream does not slim", so the HTTP
+        # upstream is pinned explicitly. Before #2363 this test reached it only
+        # through the input_image transport pin, which no longer fires for a
+        # small inline image.
+        upstream_stream_transport="http",
         prefer_earlier_reset_accounts=False,
         routing_strategy="usage_weighted",
         openai_cache_affinity_max_age_seconds=300,
@@ -2311,6 +2315,114 @@ async def test_v1_responses_without_http_bridge_http_upstream_preserves_historic
             "type": "input_image",
             "image_url": "data:image/png;base64," + ("B" * 1200),
         }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_without_http_bridge_websocket_upstream_keeps_small_inline_images(
+    async_client,
+    monkeypatch,
+):
+    # Regression for #2363: an operator's explicit websocket pin is precedence
+    # item 1, so a request carrying a small inline image must follow it instead
+    # of being forced onto upstream HTTP, and its image must survive verbatim.
+    email = "stream-ws-inline@example.com"
+    raw_account_id = "acc_stream_ws_inline"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    app_settings = Settings(
+        http_responses_session_bridge_enabled=False,
+        proxy_request_budget_seconds=75.0,
+        compact_request_budget_seconds=75.0,
+        transcription_request_budget_seconds=120.0,
+        stream_idle_timeout_seconds=300.0,
+        proxy_response_create_limit=64,
+    )
+    dashboard_settings = DashboardSettings(
+        id=1,
+        sticky_threads_enabled=False,
+        upstream_stream_transport="websocket",
+        prefer_earlier_reset_accounts=False,
+        routing_strategy="usage_weighted",
+        openai_cache_affinity_max_age_seconds=300,
+        import_without_overwrite=False,
+        totp_required_on_login=False,
+        api_key_auth_enabled=False,
+        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+        http_responses_session_bridge_gateway_safe_mode=False,
+        sticky_reallocation_budget_threshold_pct=95.0,
+        http_downstream_transport_policy="smart",
+    )
+
+    class _SettingsCache:
+        async def get(self) -> DashboardSettings:
+            return dashboard_settings
+
+    class _CoreProxySettings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        proxy_request_budget_seconds = 75.0
+        trace_channels = frozenset()
+
+    captured: dict[str, object] = {}
+
+    async def fail_open_upstream_websocket(**kwargs):
+        del kwargs
+        raise AssertionError("HTTP /v1/responses must not open upstream websocket")
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        upstream_stream_transport_override=None,
+    ):
+        del headers, access_token, account_id, base_url, raise_for_status
+        captured["transport"] = upstream_stream_transport_override
+        captured["payload"] = payload.to_payload()
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_ws_stream_inline","object":"response",'
+            '"status":"completed","output":[],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: app_settings)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _SettingsCache())
+    monkeypatch.setattr(proxy_client_module, "get_settings", lambda: _CoreProxySettings())
+    monkeypatch.setattr(proxy_client_module, "_open_upstream_websocket", fail_open_upstream_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    inline_image = "data:image/png;base64," + ("B" * 1200)
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe this"},
+                        {"type": "input_image", "image_url": inline_image},
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "resp_ws_stream_inline"
+    assert captured["transport"] == "websocket"
+    request_input = cast(dict[str, object], captured["payload"])["input"]
+    assert isinstance(request_input, list)
+    assert cast(dict[str, object], request_input[0])["content"] == [
+        {"type": "input_text", "text": "describe this"},
+        {"type": "input_image", "image_url": inline_image},
     ]
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4909,7 +4909,7 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monke
     ]
 
     assert output == ["data: retry\n\n"]
-    assert calls == [("retry", payload, None, 180.0, "http")]
+    assert calls == [("retry", payload, None, 180.0, None)]
 
     text_payload = ResponsesRequest.model_validate(
         {
@@ -4965,7 +4965,7 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monke
     ]
 
     assert disabled_bridge_output == ["data: retry\n\n"]
-    assert calls == [("retry", payload, None, 180.0, "http")]
+    assert calls == [("retry", payload, None, 180.0, None)]
 
 
 @pytest.mark.asyncio
@@ -5140,7 +5140,9 @@ async def test_native_image_bypass_emits_capacity_keepalive_before_upstream_star
 
 
 @pytest.mark.asyncio
-async def test_stream_http_bridge_or_retry_forces_http_for_input_image_when_bridge_disabled(monkeypatch):
+async def test_stream_http_bridge_or_retry_keeps_unpinned_transport_for_small_input_image_when_bridge_disabled(
+    monkeypatch,
+):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings()
@@ -5165,6 +5167,79 @@ async def test_stream_http_bridge_or_retry_forces_http_for_input_image_when_brid
             "model": "gpt-5.5",
             "instructions": "hi",
             "input": [{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    captured: dict[str, str | None] = {}
+
+    async def fake_stream_with_retry(payload, headers, **kwargs):
+        del payload, headers
+        captured["override"] = kwargs.get("upstream_stream_transport_override")
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        raise AssertionError("disabled bridge must not be used")
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: retry\n\n"]
+    # Regression for #2363: this is the population where the pin fired with no
+    # log and no counter, because the bridge was already disabled.
+    assert captured["override"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "image_url",
+    [
+        pytest.param("data:image/png;base64," + ("A" * (1024 * 1024 + 1)), id="over_frame_budget"),
+        pytest.param("https://example.com/shot.png", id="external_url"),
+    ],
+)
+async def test_stream_http_bridge_or_retry_forces_http_for_websocket_hostile_input_image(monkeypatch, image_url):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.http_responses_stream_request_budget_seconds = 180.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    # Shrink the frame budget to 1 MiB so a 1 MiB + 1 inline image crosses it.
+    monkeypatch.setattr(proxy_module, "MAX_SSE_EVENT_BYTES", 3 * 1024 * 1024)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=False,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [{"type": "input_image", "image_url": image_url}],
         }
     )
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
@@ -6889,6 +6964,7 @@ async def _capture_stream_retry_transport(
     resolved_base_transport: str = "websocket",
     payload: ResponsesRequest | None = None,
     headers: dict[str, str] | None = None,
+    resolve_kwargs: dict[str, Any] | None = None,
 ) -> str:
     dashboard_settings = _make_proxy_settings()
     dashboard_settings.http_downstream_transport_policy = dashboard_policy
@@ -6909,13 +6985,13 @@ async def _capture_stream_retry_transport(
     )
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
     monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        streaming_retry_module,
-        "_resolve_stream_transport",
-        lambda **kwargs: (
-            kwargs["transport"] if kwargs.get("transport") in ("http", "websocket") else resolved_base_transport
-        ),
-    )
+
+    def fake_resolve_stream_transport(**kwargs: Any) -> str:
+        if resolve_kwargs is not None:
+            resolve_kwargs.update(kwargs)
+        return kwargs["transport"] if kwargs.get("transport") in ("http", "websocket") else resolved_base_transport
+
+    monkeypatch.setattr(streaming_retry_module, "_resolve_stream_transport", fake_resolve_stream_transport)
 
     async def fake_stream(
         payload,
@@ -7131,9 +7207,11 @@ async def test_http_downstream_oversized_payload_bypass_still_forces_http_under_
 
 
 @pytest.mark.asyncio
-async def test_http_downstream_input_image_bypass_still_forces_http_under_always_websocket(
+async def test_http_downstream_small_input_image_follows_policy_under_always_websocket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Regression for #2363: a small inline image is no longer a transport pin,
+    # so the always_websocket policy keeps the base "auto" transport mode.
     transport = await _capture_stream_retry_transport(
         monkeypatch,
         dashboard_policy="always_websocket",
@@ -7142,7 +7220,55 @@ async def test_http_downstream_input_image_bypass_still_forces_http_under_always
         ),
     )
 
+    assert transport == "auto"
+
+
+@pytest.mark.asyncio
+async def test_http_downstream_external_image_url_still_forces_http_under_always_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = await _capture_stream_retry_transport(
+        monkeypatch,
+        dashboard_policy="always_websocket",
+        payload=_make_transport_policy_payload(
+            input=[{"type": "input_image", "image_url": "https://example.com/shot.png"}],
+        ),
+    )
+
     assert transport == "http"
+
+
+@pytest.mark.asyncio
+async def test_stream_retry_passes_image_generation_only_to_resolve_stream_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ``has_image_generation_tool`` is the argument that pinned upstream HTTP
+    # from inside _resolve_stream_transport, where the sibling tests above cannot
+    # see it because they stub the resolver out (#2363).
+    resolve_kwargs: dict[str, Any] = {}
+    await _capture_stream_retry_transport(
+        monkeypatch,
+        payload=_make_transport_policy_payload(
+            input=[{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}],
+        ),
+        resolve_kwargs=resolve_kwargs,
+    )
+
+    assert resolve_kwargs["has_image_generation_tool"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_retry_passes_image_generation_tool_to_resolve_stream_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_kwargs: dict[str, Any] = {}
+    await _capture_stream_retry_transport(
+        monkeypatch,
+        payload=_make_transport_policy_payload(tools=[{"type": "image_generation"}]),
+        resolve_kwargs=resolve_kwargs,
+    )
+
+    assert resolve_kwargs["has_image_generation_tool"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

An `input_image` anywhere in a Responses payload pinned the request to the direct HTTP upstream. On the reporting deployment **~52% of image-bearing requests ended in error** (nearly all `server_is_overloaded`) against **2.7% for bridged requests in the same window** — and because Codex keeps earlier images in the conversation input, a single pasted screenshot moved *every later turn of that thread* onto the degraded path (#2363).

The pin was never needed for that. It came from bcd63c827 (#903), whose stated rationale is about **bridge pending slots**, not about the HTTP-vs-WebSocket upstream transport — the bridge bypass on the next line already delivers it. Inline `data:` images ride the upstream websocket unchanged: `_slim_response_create_payload_for_upstream` (the only websocket-specific mutation of image payloads) runs strictly above the size budget, and native downstream websocket clients already send inline images over the upstream websocket today with no image bypass at all.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #2363

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (image pipeline, request shape) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/narrow-input-image-upstream-transport-pin/`

## Changes

There are **two** pin sites and narrowing either one alone ships a no-op:

- `http_bridge/streaming.py` — `force_upstream_stream_transport = "http" if image_request else None` becomes the narrow predicate. The bridge bypass, its `record_http_bridge_routing(stage="bypass", reason="image")` counter and its log are left exactly as they were.
- `streaming/retry.py` — `input_image` was folded into `image_bypass` and passed as `has_image_generation_tool=`, so `_resolve_stream_transport` returned `"http"` **before** the visible `if` on the next line ever ran, inside a function where no log or counter records the decision. `has_image_generation_tool` now means exactly that, and `input_image` is pinned only by the shared predicate.
- New shared predicate `_input_image_request_requires_http_upstream` in `_service/response_create.py`, reached from both sites (via the service façade re-export and the `service_stubs` seam, matching how the existing image predicates are wired). One predicate, so the two sites cannot drift apart again — which is exactly how this reached production.

It keeps the pin for the two hazards that are real:

1. **Over the websocket frame budget** (`_ws_transport_payload_budget_bytes()`, 14 MiB), where `_prepare_websocket_response_create_payload` would replace historical inline images with `[codex-lb omitted historical inline image to fit upstream websocket budget]`. The 14 MiB frame budget is used rather than the 15 MiB `upstream_response_create_max_bytes`, because `_resolve_stream_transport` already diverts above 14 MiB — gating on 15 would add a second threshold that never fires.
2. **An external `http(s)` image URL still present** after `_inline_content_images` gave up on a failed fetch (non-https, SSRF-blocked host, non-200, over 8 MiB, or the 8 s timeout). The evidence that the upstream websocket rejects or hangs on one is a code comment at `http_bridge/request_submit.py:872-879` rather than a captured trace; that is recorded as such in the change context.

## Simplicity

- [x] New behaviour works with zero configuration
- [x] No new required setup step
- New settings: none
- [x] README / `.env.example` / dashboard nav untouched

## Test plan

```
uv run ruff check app tests                       # All checks passed!
uv run ty check app                               # All checks passed!
uv run openspec validate narrow-input-image-upstream-transport-pin --strict

uv run pytest tests/unit/test_proxy_utils.py                                    # 1400 passed
uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_websocket_transport_fallback.py \
             tests/unit/test_http_bridge_safe_continuity.py tests/unit/test_http_continuation.py \
             tests/unit/test_proxy_api_responses_contract.py                    # 1205 passed
uv run pytest tests/integration/test_proxy_responses.py \
             tests/integration/test_http_promotion_accounting.py                # 108 passed
uv run pytest tests/integration/test_http_responses_bridge.py                   # 185 passed
```

**Fails-before-the-fix proof.** With the `app/` diff reverse-applied and the tests left in place, 7 of the 15 node ids fail, including the route-level `test_historical_image_does_not_pin_later_turns_to_http` — the reported production shape, where the *first* turn carried the screenshot and a later text-only turn is still pinned.

**Mutation proof on the residual clause.** `test_oversized_image_request_still_pins_http` originally passed even with the predicate's size clause disabled, because `_resolve_stream_transport`'s own 14 MiB gate produced `"http"` anyway — it was passing for a neighbouring reason. It now runs under an explicit `upstream_stream_transport = "websocket"`, which short-circuits that gate and leaves the predicate as the only thing that can produce `"http"`; re-running the same mutation afterwards makes it fail.

## Known bounds, recorded in the change context

- The residual pin still overrides an explicit operator `upstream_stream_transport = "websocket"`, as it does today. Removing that would turn an oversized image payload into a local 400 `payload_too_large` that operators do not get now.
- Site B gates its residual clauses behind `not explicit_transport`, so a request that never reaches the bridge routing decision (a `/v1/chat/completions` request whose bridge admission declined) resolves by ordinary precedence under an explicit websocket pin. The spec text is scoped to say so rather than claiming a precedence that does not hold everywhere.
- An `input_image` nested deeper than one `content` level — inside a `function_call_output` output array, say — is invisible to both `_count_external_image_urls` and `_inline_input_image_urls`. That blind spot is identical to the existing HTTP bridge guard's, so no deployment gains a hazard the bridge path did not already have. Deliberately not widened here.
- The 52% figure is not verifiable from this repository: `request_logs` carries no image marker. Post-deploy this is verifiable as a ratio shift on `codex_lb_upstream_transport_decisions_total` with `codex_lb_http_bridge_routing_total{reason="image"}` flat.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added regression coverage at the externally failing product path.
- [x] Ran the relevant `make` / pytest subset locally.
- [x] `openspec validate --strict` passes.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6).
- [x] CHANGELOG is not edited by hand.
