### PR TITLE
fix(proxy): deliver the denied-anchor refusal to native clients

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -590,6 +590,7 @@ class ProxyResponseError(Exception):
         retry_after_seconds: int | None = None,
         retry_after_header: str | None = None,
         reservation_released: bool = False,
+        local_pre_dispatch_refusal: bool = False,
     ) -> None:
         super().__init__(f"Proxy response error ({status_code})")
         self.status_code = status_code
@@ -604,6 +605,14 @@ class ProxyResponseError(Exception):
         self.retry_after_seconds = retry_after_seconds
         self.retry_after_header = retry_after_header
         self.reservation_released = reservation_released
+        # True when the proxy refused the request itself before any upstream
+        # frame was sent, so the failure is not an observed upstream transport
+        # failure: the native Codex transport-failure lifecycle, which ends the
+        # body without a terminal event, must not be applied to it (issue
+        # #2364, where such a refusal reached the client as an empty 200). The
+        # refusing instance may be another replica: an internal bridge forward
+        # carries the provenance back so the origin reaches the same verdict.
+        self.local_pre_dispatch_refusal = local_pre_dispatch_refusal
 
 
 def _safe_retry_after_header(headers: Mapping[str, object] | None) -> str | None:

--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -185,6 +185,7 @@ class _OwnerForwardRequestError(ProxyResponseError):
             upstream_status_code=source.upstream_status_code,
             upstream_error_code=source.upstream_error_code,
             failed_session=source.failed_session,
+            local_pre_dispatch_refusal=source.local_pre_dispatch_refusal,
         )
         self.outcome = outcome
 

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2062,12 +2062,20 @@ class _HTTPBridgeRequestSubmitMixin:
                             session_id=request_state.session_id,
                             upstream_error_code="previous_response_not_found",
                         )
+                        # The fence sits above the pending-request enqueue and
+                        # the upstream send, so this refusal is proven to be
+                        # ours rather than an upstream transport failure. Say
+                        # so on the exception: without the flag the native
+                        # Codex lifecycle aborts the committed body with no
+                        # terminal event and the client sees an empty 200
+                        # (issue #2364).
                         raise ProxyResponseError(
                             502,
                             openai_error(
                                 "stream_incomplete",
                                 "The previous response anchor was rejected upstream; retry the request.",
                             ),
+                            local_pre_dispatch_refusal=True,
                         )
                     if (
                         request_state.verified_stale_anchor_replay

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -278,7 +278,10 @@ from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.capability_routing import required_capability_metadata_values
 from app.modules.proxy.downstream_delivery import DeliveryTracedStreamingResponse
 from app.modules.proxy.helpers import _openai_error_param, _parse_openai_error, _rate_limit_details
-from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
+from app.modules.proxy.http_bridge_forwarding import (
+    HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER,
+    parse_forwarded_request,
+)
 from app.modules.proxy.images_observability import (
     IMAGE_ROUTE_MODEL_STATE,
     IMAGE_ROUTE_STARTED_AT_STATE,
@@ -6812,6 +6815,11 @@ async def _stream_responses(
             and isinstance(startup_error, ProxyResponseError)
             and startup_error_code
             in {"stream_incomplete", "stream_idle_timeout", "upstream_request_timeout", "upstream_unavailable"}
+            # A refusal the proxy raised itself before any upstream frame left
+            # the process is not a transport failure, so it keeps the ordinary
+            # error response instead of being replayed into the committed body
+            # as a terminated stream (issue #2364).
+            and not startup_error.local_pre_dispatch_refusal
         )
         if native_transport_startup_failure:
             assert isinstance(startup_error, ProxyResponseError)
@@ -6834,7 +6842,10 @@ async def _stream_responses(
             return _stream_startup_error_response(
                 request,
                 startup_error,
-                headers=rate_limit_headers,
+                headers={
+                    **rate_limit_headers,
+                    **_owner_forward_local_refusal_headers(startup_error, forwarded_request=forwarded_request),
+                },
             )
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(
@@ -6893,6 +6904,29 @@ async def _stream_responses(
 
 def _strip_internal_bridge_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {key: value for key, value in headers.items() if not key.lower().startswith("x-codex-bridge-")}
+
+
+def _owner_forward_local_refusal_headers(
+    error: ProxyResponseError | OpenAIErrorEnvelopeModel,
+    *,
+    forwarded_request: bool,
+) -> dict[str, str]:
+    """Mark an owner instance's error response as a local pre-dispatch refusal.
+
+    The origin instance rebuilds the error from the status and the body, and
+    the body cannot express the difference between a refusal the owner raised
+    before any upstream frame was sent and a transport failure it observed —
+    both are `stream_incomplete`. Without this marker the origin's own native
+    Codex transport-failure lifecycle aborts the committed body, which is
+    issue #2364 one hop further out. Only forwarded requests carry it: the
+    header belongs to the internal bridge contract, not to the public API.
+    """
+
+    if not forwarded_request or not isinstance(error, ProxyResponseError):
+        return {}
+    if not error.local_pre_dispatch_refusal:
+        return {}
+    return {HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER: "1"}
 
 
 async def _http_bridge_active_for_request(
@@ -8390,13 +8424,23 @@ async def _stream_response_error_events(
             yield line
     except ProxyResponseError as exc:
         error_code = exc.payload.get("error", {}).get("code") if isinstance(exc.payload, dict) else None
+        # A refusal the proxy raised before any upstream frame was sent shares
+        # its public code with the upstream transport failures below, but it is
+        # not one: it keeps the terminal event so a native Codex client is not
+        # left with a committed body that ends without one (issue #2364).
+        local_refusal = exc.local_pre_dispatch_refusal
         await release_owned_reservation()
-        if preserve_native_failure_lifecycle and error_code in {
-            "stream_incomplete",
-            "stream_idle_timeout",
-            "upstream_request_timeout",
-            "upstream_unavailable",
-        }:
+        if (
+            preserve_native_failure_lifecycle
+            and not local_refusal
+            and error_code
+            in {
+                "stream_incomplete",
+                "stream_idle_timeout",
+                "upstream_request_timeout",
+                "upstream_unavailable",
+            }
+        ):
             raise
         response_id = None
         if isinstance(exc.payload, dict):
@@ -8424,12 +8468,15 @@ async def _stream_response_error_events(
             response_id=response_id,
             error_param=error.param_state if error else None,
         )
-        if error_code in {
+        if not local_refusal and error_code in {
             "stream_incomplete",
             "stream_idle_timeout",
             "upstream_request_timeout",
             "upstream_unavailable",
         }:
+            # Marking a local refusal as a synthetic transport failure would
+            # only move the abort one layer out: the native normalizer converts
+            # a marked terminal straight back into a terminated stream.
             failed_event = synthetic_transport_failure_event(failed_event)
         yield retry_hint + format_sse_event(failed_event)
 

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -74,6 +74,15 @@ HTTP_BRIDGE_SIGNATURE_HEADER = "x-codex-bridge-signature"
 # ``parse_forwarded_request``.
 HTTP_BRIDGE_SIGNATURE_V2_HEADER = "x-codex-bridge-signature-v2"
 _HTTP_BRIDGE_SIGNATURE_VERSION_V2 = "2"
+# Response header (owner -> origin) carrying ``ProxyResponseError``
+# provenance back across the forward hop. The owner's error body is an
+# ordinary OpenAI envelope, so a refusal the owner raised before it sent any
+# upstream frame is indistinguishable by code from a transport failure it
+# observed: both end as ``stream_incomplete``. Without this marker the origin
+# rebuilds the error without the provenance and its own native Codex
+# transport-failure lifecycle aborts the committed body, moving issue #2364's
+# empty 200 from the owner onto the origin.
+HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER = "x-codex-bridge-local-pre-dispatch-refusal"
 
 
 @dataclass(frozen=True, slots=True)
@@ -216,6 +225,15 @@ class HTTPBridgeOwnerClient:
                             failure_phase="owner_forward_status",
                             failure_detail="owner_forward_non_200",
                             upstream_status_code=response.status,
+                            # Rebuilding the error from the owner's body alone
+                            # would drop the provenance the owner attached, so
+                            # carry it over the hop: a non-200 by itself does
+                            # not prove the owner sent no upstream frame, and
+                            # only the owner knows which of its failures was a
+                            # local pre-dispatch refusal (issue #2364).
+                            local_pre_dispatch_refusal=_bool_header(
+                                response.headers.get(HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER)
+                            ),
                         )
                     if on_response_ready is not None:
                         on_response_ready()

--- a/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/.openspec.yaml
+++ b/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/proposal.md
+++ b/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/proposal.md
@@ -1,0 +1,93 @@
+## Why
+
+The HTTP bridge fails a request closed when it is about to dispatch a
+`previous_response_id` the proxy injected and upstream has already denied. The
+refusal is raised from inside the SSE body generator as a 502 carrying the
+spec-mandated public code `stream_incomplete`.
+
+For a native Codex client that code is also how an observed upstream transport
+failure ends, and the native lifecycle answers a transport failure by ending the
+downstream stream with no terminal event. The proxy therefore classified its own
+pre-dispatch refusal as an upstream transport failure and aborted the committed
+body: the client received HTTP `200` with zero bytes, no terminal event, and
+never saw the "retry the request" message, while the ASGI layer logged an
+unhandled exception and the delivery trace recorded
+`outcome=exception_before_terminal chunks=0 bytes=0` (issue #2364). Non-native
+clients were unaffected — they already receive the 502 JSON envelope.
+
+## What Changes
+
+- Carry provenance on `ProxyResponseError` (`local_pre_dispatch_refusal`) so the
+  API layer can tell a refusal the proxy raised before any upstream frame was
+  sent from a transport failure it observed, without changing the public error
+  code. Re-coding the refusal was rejected: the bridge's explicit
+  previous-response-rejection predicates would then turn a deliberate
+  fail-closed into a local recovery/replay attempt.
+- Flag the denied-anchor before-dispatch fence with it. The status, the code,
+  the message, and the `continuity_fail_closed` record are unchanged.
+- Exclude flagged errors from the native transport-failure lifecycle on both
+  paths: the startup-probe branch returns the ordinary HTTP error response, and
+  the already-committed branch yields a terminal `response.failed` that is not
+  stamped as a synthetic transport failure.
+- Propagate the flag through `_OwnerForwardRequestError`, which rebuilds a
+  `ProxyResponseError` from a fixed field list.
+- Carry the flag across the internal bridge owner forward. In a ring deployment
+  the session, its denial tombstone, and the fence live on the owner replica, so
+  a continuation reaches the fence only through `/internal/bridge/responses`.
+  The origin rebuilds the owner's failure from the status and the body alone,
+  and that body cannot express the difference between a refusal the owner raised
+  before dispatch and a transport failure it observed. The owner therefore marks
+  its error response with `x-codex-bridge-local-pre-dispatch-refusal` and the
+  relay reads it back onto the rebuilt error. Without it the fix would simply
+  move the empty 200 from the owner onto the origin. A non-200 alone is not
+  taken as proof: it does not establish that the owner sent no upstream frame.
+
+## Capabilities
+
+### Modified Capabilities
+
+- responses-api-compat: the native transport-failure lifecycle applies only to
+  failures observed on the upstream leg, and the denied-anchor before-dispatch
+  fail-closed must reach the client.
+
+## Impact
+
+`app/core/clients/proxy.py`, `app/modules/proxy/api.py`,
+`app/modules/proxy/_service/http_bridge/request_submit.py`,
+`app/modules/proxy/_service/http_bridge/owner_forwarding.py`, and
+`app/modules/proxy/http_bridge_forwarding.py`, plus bridge-route, owner-forward,
+and stream-shaping regression coverage.
+
+Native Codex clients now see a real error where they previously saw a truncated
+stream, which may change their retry behaviour. That is already the precedent on
+the same route: a pre-response 429 reaches a native client as a real HTTP status
+with `Retry-After`, and every error code outside the four-code transport set
+already reaches native clients as a JSON error.
+
+Scope is the single raise site. The sibling local refusals in
+`_service/http_bridge/` that also use codes from the transport set keep today's
+behaviour — some of them are not provably pre-dispatch, so a blanket sweep would
+be wrong; the new field is the seam a follow-up uses for the safe subset. The
+spec text is scoped to refusals the proxy records as such for the same reason,
+so it does not promise delivery the code does not implement. The nearest
+unrecorded neighbours are the bridge retry-circuit suppressions
+(`request_submit.py` `_http_bridge_precreated_retry_block` and the stale-anchor
+replay generation check), which raise `upstream_request_timeout` and still reach
+a native client as a terminated stream when the turn carries a continuation
+anchor.
+
+Multi-replica deployments have a rolling-upgrade window. An upgraded owner
+answers the internal forward with a real 502 where it used to abort a committed
+200, and an origin that predates this change ignores the marker and applies its
+own native transport lifecycle, so a forwarded denied-anchor refusal reaches the
+client as an empty 200 until every replica is upgraded. Today the same case ends
+as a `bridge_owner_unreachable` 503, because the origin sees the owner's
+truncated body as a transport failure. Single-instance deployments — the default
+— never take that path, and the window closes as soon as the origins are on this
+build.
+
+The anchor-poisoning loop itself is untouched. When the durable clear returns a
+clean no-match the tombstone persists and the durable row re-injects the same
+id, so every retry is refused again, exactly as the retirement requirement
+mandates. After this change the user sees repeated visible errors instead of
+repeated silent truncations.

--- a/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/specs/responses-api-compat/spec.md
+++ b/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/specs/responses-api-compat/spec.md
@@ -1,0 +1,256 @@
+## MODIFIED Requirements
+
+### Requirement: Native Codex preserves upstream failure lifecycle
+
+For a native Codex HTTP/SSE Responses request, an upstream transport timeout or
+stream EOF without a terminal Responses event MUST terminate the downstream
+stream without synthesizing `response.failed`, `error`, or `[DONE]`. The proxy
+MUST still execute reservation, request-log, account-health, and owned-resource
+cleanup before propagating the termination. Non-native and OpenAI-compatible
+clients MUST retain the existing stable terminal-error shaping.
+
+This rule applies only to failures the proxy observed on the upstream leg. A
+failure the proxy manufactured itself before any upstream frame was sent for the
+request, and which it records as a local pre-dispatch refusal, MUST NOT be
+delivered as a silent transport termination to a native Codex client. When the
+downstream response has not committed, such a refusal MUST be returned as its
+HTTP status with the error envelope in the body. When the downstream response
+has already committed, it MUST be delivered as a terminal `response.failed`
+event carrying the same error code, followed by `[DONE]`, and that terminal MUST
+NOT be marked as a synthetic transport failure. A native Codex client MUST NOT
+receive a committed `200` with zero bytes and no terminal event for a recorded
+local pre-dispatch refusal.
+
+The proxy MUST record that provenance at least on the HTTP bridge's
+denied-anchor before-dispatch fence, and MUST carry it across an internal bridge
+owner forward so the origin instance reaches the same verdict as the owner. The
+other local refusals that reuse the transport error codes are not recorded as
+such yet and keep the transport lifecycle until they are; that bound is
+deliberate, because not all of them are provably pre-dispatch.
+
+#### Scenario: Native Codex sees a truncated SSE lifecycle
+
+- **GIVEN** a native Codex HTTP request has received a non-terminal SSE event
+- **WHEN** upstream closes without a terminal event
+- **THEN** downstream closes without a synthetic terminal event or `[DONE]`
+- **AND** proxy cleanup and failure accounting still complete
+
+#### Scenario: Non-native client keeps the terminal umbrella
+
+- **GIVEN** an OpenAI SDK or other non-native client receives the same upstream
+  truncation
+- **WHEN** codex-lb normalizes the stream
+- **THEN** the client receives the existing terminal `response.failed` shape
+
+#### Scenario: Native Codex sees a local pre-dispatch refusal before commit
+
+- **GIVEN** a native Codex HTTP Responses request
+- **WHEN** the proxy refuses it before sending any upstream frame and the
+  downstream response has not committed
+- **THEN** the client receives the refusal's HTTP status and error envelope
+- **AND** the body is not an empty event stream
+
+#### Scenario: Native Codex sees a local pre-dispatch refusal after commit
+
+- **GIVEN** a native Codex HTTP Responses request
+- **WHEN** the proxy refuses it before sending any upstream frame and the
+  downstream response has already committed
+- **THEN** the client receives a terminal `response.failed` with the same error
+  code
+- **AND** `[DONE]`
+- **AND** the terminal is not marked as a synthetic transport failure
+
+### Requirement: Explicit upstream previous-response denials retire proxy-injected anchors
+
+When upstream answers an HTTP bridge request with a `previous_response_not_found` terminal frame, and the `previous_response_id` on that request was injected by the proxy onto a full-resend-shaped payload, the proxy MUST retire that anchor on the first denial rather than waiting for the eventless-failure poison threshold. Retirement MUST clear the durable anchor only when the denied id is still the durable latest response and the session owner fence still matches; the write MUST clear the four anchor-bound fields and delete only the matching response-id alias, preserving turn-state and sibling response aliases. The proxy MUST clear the in-memory session carrier even if durable cleanup or alias unregistering fails.
+
+Before awaiting durable cleanup, the proxy MUST publish the denied id to the live session. Publication MUST be serialized with the submitter's final tombstone check and upstream send so either an already-started send finishes first or publication wins and fences that send. Immediately before dispatch, any already-prepared request carrying that id as a proxy-injected anchor MUST fail closed without sending another upstream frame. This revalidation MUST close the retirement/dispatch race; it MUST NOT reject a client-supplied anchor merely because the same id is tombstoned for proxy injection.
+
+The proxy MUST also retain the denied-id generation in a bounded process-local ledger independent of the canonical live-session registry. A request that captured the durable anchor before a live session existed MUST fail closed when that generation advances during owner lookup or successor session creation. Active requests MUST pin their ledger entries until finalization so pruning cannot remove a fence that is still needed.
+
+When a request captures a proxy-injected anchor after this process has already recorded a denial for that id, the request MUST retain that denial observation and fail closed before dispatch even when the captured generation equals the current denial generation. Owner-forward recovery that injects a durable anchor MUST perform the same capture and denial observation; it MUST NOT rely on provenance copied from an initially unanchored request.
+
+The proxy MUST NOT retire the anchor when:
+
+- the anchor was supplied by the client, because removing it changes the meaning of the client's own request;
+- the anchor was injected onto a payload that is not full-resend shaped, because a delta-only request has no other way to convey prior context once its anchor is gone;
+- the session's current anchor is no longer the denied id, because a concurrent request may have completed and advanced it.
+
+When a durable clear raises, the proxy MUST NOT report the anchor as retired, MUST still clear the in-memory anchor, and MUST retain the bounded cleanup retry so a transient failure is not lost. When the durable clear returns no matching row, the proxy MUST treat that no-match as a terminal fenced outcome for this cleanup attempt and MUST NOT spend the retry budget on it; it MUST preserve the local alias and denial fence because the durable owner or latest anchor may have advanced. A durable record that still carries the denied id can then be retired by the matching owner rather than by a stale epoch.
+
+Retirement is bookkeeping and MUST NOT change how the denial is delivered downstream. A failure while retiring MUST NOT propagate into terminal-event handling.
+
+A denial that settles several requests sharing one anchor MUST retire that anchor once, on the same terms.
+
+The downstream error contract is unchanged: the denial is still reported to the client as `stream_incomplete`, so the client retains its own anchor and is not driven into a full-history resend.
+
+The before-dispatch fail-closed MUST reach the client. It MUST be surfaced as the `stream_incomplete` error with its HTTP status when the downstream response has not committed, and as an unmarked terminal `response.failed` carrying `stream_incomplete` when it has, including for native Codex clients. When the fail-closed happens on an internal bridge forward target, that instance MUST identify its error response as a local pre-dispatch refusal, and the origin instance MUST honour that identification when it rebuilds the failure, so a forwarded turn reaches the same delivery as a local one.
+
+#### Scenario: A denied proxy-injected anchor is retired immediately
+
+- **GIVEN** an HTTP bridge session whose stored anchor was injected by the proxy
+- **WHEN** upstream answers the anchored request with `previous_response_not_found`
+- **THEN** the proxy clears the durable continuity record under the session's owner epoch
+- **AND** clears the in-memory session anchor and its stored input count and prefix fingerprint
+- **AND** the next turn on that session dispatches without a `previous_response_id`
+
+#### Scenario: The following turn is not trimmed against a denied anchor
+
+- **GIVEN** a proxy-injected anchor was denied by upstream on the previous turn
+- **WHEN** the client sends a full resend of the conversation on the next turn
+- **THEN** the request MUST NOT be trimmed against the denied anchor's stored prefix
+- **AND** upstream receives the resent conversation rather than a suffix of it
+
+#### Scenario: A concurrent completion protects the current anchor
+
+- **GIVEN** a proxy-injected anchor is denied by upstream
+- **AND** another request on the same session completed first and advanced the session anchor to a different response id
+- **WHEN** the denial is handled
+- **THEN** the proxy MUST NOT clear the session anchor
+- **AND** it MUST still tombstone the denied id so an already-prepared proxy-injected request cannot dispatch it
+
+#### Scenario: Client-supplied anchors are left alone
+
+- **GIVEN** an HTTP bridge request carries a `previous_response_id` the client supplied
+- **WHEN** upstream answers it with `previous_response_not_found`
+- **THEN** the proxy MUST NOT retire the anchor on the client's behalf
+
+#### Scenario: A delta-only payload keeps its injected anchor
+
+- **GIVEN** the proxy injected an anchor onto a payload that is not full-resend shaped
+- **WHEN** upstream answers that request with `previous_response_not_found`
+- **THEN** the proxy MUST NOT clear the anchor
+- **AND** the request keeps the only reference it has to its prior context
+
+#### Scenario: A fan-out denial retires the shared anchor once
+
+- **GIVEN** several pending requests on one session share a proxy-injected anchor
+- **WHEN** upstream answers with a single `previous_response_not_found` that settles all of them together
+- **THEN** the proxy retires that anchor before the grouped settlement completes
+
+#### Scenario: A prepared denied anchor is rejected before dispatch
+
+- **GIVEN** a request was prepared with a proxy-injected anchor
+- **AND** another request receives `previous_response_not_found` for that anchor before the prepared request reaches the upstream send
+- **WHEN** the prepared request reaches its final dispatch check
+- **THEN** the proxy fails it closed as `stream_incomplete`
+- **AND** the proxy MUST NOT send that denied anchor upstream again
+
+#### Scenario: Denial publication wins against a prepared dispatch
+
+- **GIVEN** a request is prepared with a proxy-injected anchor while another request receives `previous_response_not_found` for that anchor
+- **WHEN** denial publication acquires session lifecycle ownership before the prepared request's final send section
+- **THEN** the denied id is tombstoned before the prepared request revalidates
+- **AND** the prepared request fails closed without sending an upstream frame
+
+#### Scenario: A detached predecessor fences an absent-session capture
+
+- **GIVEN** a request captures a proxy-injected durable anchor before a canonical live session exists
+- **AND** a detached predecessor receives `previous_response_not_found` for that anchor while the request is resolving ownership
+- **WHEN** successor session creation completes and the request reaches final dispatch
+- **THEN** the process-local denial generation MUST fail the request closed as `stream_incomplete`
+- **AND** the successor MUST NOT send the denied anchor upstream
+
+#### Scenario: A stale durable recapture remains fenced after cleanup failure
+
+- **GIVEN** a detached predecessor records a denial for a proxy-injected anchor
+- **AND** durable anchor cleanup fails, leaving the durable row unchanged
+- **WHEN** a later request captures that same durable anchor after the denial was recorded
+- **THEN** the request MUST retain the existing denial observation
+- **AND** it MUST fail closed as `stream_incomplete` before dispatch
+
+#### Scenario: Owner-forward recovery observes an existing denial
+
+- **GIVEN** owner-forward recovery injects a durable proxy anchor into a successor request
+- **AND** this process has already recorded a denial for that anchor
+- **WHEN** the recovery retry request state is prepared
+- **THEN** the retry MUST retain the denial observation
+- **AND** it MUST fail closed before sending the denied anchor upstream
+
+#### Scenario: Sibling response aliases survive retirement
+
+- **GIVEN** a session has a denied response alias and another valid response alias
+- **WHEN** the denied anchor is retired
+- **THEN** only the denied response alias is removed
+- **AND** the valid response alias and turn-state aliases remain routable
+
+#### Scenario: An unconfirmed durable clear still drops the in-memory anchor
+
+- **GIVEN** a denied proxy-injected anchor whose durable clear is fenced or fails
+- **WHEN** the denial is handled
+- **THEN** the proxy MUST clear the in-memory session anchor
+- **AND** MUST NOT report the anchor as retired
+
+If alias unregistering raises after the durable clear, the same in-memory cleanup MUST still occur.
+
+The process-local denial fence MUST retain its positive generation while any
+request still pins the denied id, even after durable cleanup succeeds. Such a
+prepared request MUST remain fenced until its final pin is released; the fence
+may then be removed. Fence state MUST be bounded to one current denial slot per
+active durable or local owner plus active request pins, and a session close or
+durable-owner epoch change MUST retire the old owner's unpinned slot without
+clearing a successor epoch's slot. A close MAY retain an otherwise unpinned
+durable denial slot while that session still records an unresolved durable
+cleanup, so a stale row cannot be recaptured; the slot MUST be retired when
+cleanup succeeds or the durable row is confirmed absent.
+
+When several late predecessor denials arrive for one durable owner, only the
+newest unpinned predecessor slot MUST be retained while its durable cleanup is
+unresolved. Older predecessor slots MUST remain fenced while request pins are
+active, then MUST be retired when those pins release or when a newer owner
+confirms durable cleanup. This keeps predecessor churn bounded without
+allowing an already-prepared request to redispatch a denied anchor.
+
+#### Scenario: Late predecessor churn remains bounded
+
+- **GIVEN** one durable owner advances through more than the process-local
+  denial-ledger bound
+- **AND** each successor denial is followed by a late predecessor denial
+- **WHEN** no predecessor request retains an active ledger pin
+- **THEN** the ledger retains the current denial and at most the newest
+  unresolved predecessor denial for that owner
+- **AND** a current-owner durable clear retires the unresolved predecessor
+  slot
+
+#### Scenario: Pinned predecessor survives bounded churn until release
+
+- **GIVEN** a late predecessor denial still has an active prepared-request pin
+- **WHEN** a newer predecessor denial is recorded for the same durable owner
+- **THEN** the pinned predecessor remains fenced until its request finalizes
+- **AND** releasing the final pin removes that superseded predecessor slot
+
+#### Scenario: A retirement failure cannot change the denial delivered downstream
+
+- **GIVEN** the bookkeeping performed while retiring a denied anchor raises
+- **WHEN** the denial is handled
+- **THEN** the error MUST NOT propagate into terminal-event handling
+
+#### Scenario: Durable cleanup preserves a prepared request's denial fence
+
+- **GIVEN** a request has pinned a proxy-injected anchor while another request receives `previous_response_not_found`
+- **WHEN** the durable clear succeeds
+- **THEN** the denied fence keeps its positive generation until the prepared request releases its pin
+- **AND** the prepared request remains fenced during that interval
+- **AND** the fence is removed after the final pin is released
+
+#### Scenario: A successor epoch survives predecessor fence cleanup
+
+- **GIVEN** a successor owns the same durable session id at a newer epoch
+- **WHEN** the predecessor closes or its durable clear completes
+- **THEN** cleanup removes only the predecessor's unpinned fence state
+- **AND** the successor's current denial slot remains active
+
+#### Scenario: A native client sees the before-dispatch refusal
+
+- **GIVEN** a native Codex HTTP bridge request prepared with a proxy-injected anchor another request had denied
+- **WHEN** it reaches its final dispatch check
+- **THEN** the proxy fails it closed as `stream_incomplete`
+- **AND** the client receives that error rather than a committed empty stream
+- **AND** `codex_lb_continuity_fail_closed_total{surface="http_bridge",reason="denied_proxy_anchor_before_dispatch"}` is still incremented
+
+#### Scenario: A forwarded before-dispatch refusal reaches the origin's client
+
+- **GIVEN** a native Codex HTTP bridge turn whose session is owned by another instance in the ring
+- **WHEN** the owner instance fails it closed at its before-dispatch check
+- **THEN** the owner's error response identifies the failure as a local pre-dispatch refusal
+- **AND** the origin instance delivers that `stream_incomplete` error to the client rather than a committed empty stream

--- a/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/tasks.md
+++ b/openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/tasks.md
@@ -1,0 +1,40 @@
+## 1. Distinguish a local refusal from an upstream transport failure
+
+- [x] 1.1 Reproduce the empty `200` on an unchanged tree: a native Codex bridge
+      turn whose proxy-injected anchor upstream denies, whose recovery retry the
+      before-dispatch fence refuses, delivers zero bytes and no terminal event.
+- [x] 1.2 Add `local_pre_dispatch_refusal` to `ProxyResponseError` and set it on
+      the denied-anchor fence, leaving the status, code, message, and
+      `continuity_fail_closed` record unchanged.
+- [x] 1.3 Copy the flag through `_OwnerForwardRequestError`'s field rebuild.
+- [x] 1.4 Carry the flag across the internal bridge owner forward: the owner
+      marks its error response, the relay reads the marker back onto the error
+      it rebuilds from the owner's status and body, and a bare non-200 is not
+      taken as proof of a local refusal.
+
+## 2. Deliver the refusal on both downstream phases
+
+- [x] 2.1 Return the ordinary HTTP error response when the startup probe catches
+      a flagged refusal before the downstream response commits.
+- [x] 2.2 Yield an unmarked terminal `response.failed` when the response has
+      already committed, so the native normalizer does not convert the terminal
+      back into an abort.
+
+## 3. Coverage
+
+- [x] 3.1 Bridge-route regression for the pre-commit phase (HTTP 502 with the
+      `stream_incomplete` envelope), the post-commit phase (terminal
+      `response.failed` plus `[DONE]`, unmarked, no escaped exception), and the
+      unchanged non-native 502 JSON contract. Each asserts the
+      `continuity_fail_closed reason=denied_proxy_anchor_before_dispatch`
+      record, so a scenario that drifted onto the plain upstream denial fails.
+- [x] 3.2 Stream-shaping unit coverage that the flagged error yields one unmarked
+      terminal and the same error without the flag still ends the native stream
+      without one.
+- [x] 3.3 Owner-forward regression on both halves of the hop: the forwarded
+      route's 502 carries the marker, and a native turn whose owner answers with
+      a marked 502 receives that envelope on the origin instead of a zero-byte
+      committed 200. Relay-level coverage that an unmarked non-200 stays
+      unflagged.
+- [x] 3.4 Pass the bridge, owner-forwarding, proxy-utils, and transient-retry
+      suites, the static checks, and strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -16876,6 +16876,9 @@ async def test_native_codex_http_bridge_denied_anchor_refusal_returns_502_before
     _assert_denied_anchor_fence_refused_before_dispatch(caplog)
     assert second.status_code == 502, f"native client received {second.status_code} with body {second.text!r}"
     assert second.json()["error"]["code"] == "stream_incomplete"
+    # The retry instruction is the actionable half: a terminal that kept the
+    # code and dropped the message leaves the client where #2364 left it.
+    assert second.json()["error"]["message"] == "The previous response anchor was rejected upstream; retry the request."
     assert len(_anchored_bridge_frames(upstream)) == 1, "the denied anchor was sent upstream a second time"
 
 
@@ -16940,6 +16943,10 @@ async def test_native_codex_http_bridge_denied_anchor_refusal_emits_terminal_aft
     failed = [event for event in events if event.get("type") == "response.failed"]
     assert len(failed) == 1, f"expected one terminal failure, got {[event.get('type') for event in events]}"
     assert failed[0]["response"]["error"]["code"] == "stream_incomplete"
+    assert (
+        failed[0]["response"]["error"]["message"]
+        == "The previous response anchor was rejected upstream; retry the request."
+    )
     assert "_codex_lb_synthetic_transport_failure" not in second.text
     assert second.text.rstrip().endswith("data: [DONE]")
     assert not [

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -16723,6 +16723,524 @@ async def test_v1_responses_http_bridge_stops_reinjecting_an_anchor_upstream_den
     )
 
 
+# --- Reproduction for #2364: the denied-anchor refusal must reach native Codex clients ---
+
+
+def _install_denied_anchor_bridge_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    account: Account,
+    upstream: _DeniesAnchoredTurnUpstreamWebSocket,
+) -> None:
+    """Pin selection, token refresh, and the upstream connect to one fake that
+    denies every anchored turn."""
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del self, deadline, request_id, kind, request_stage, sticky_key, sticky_kind
+        del reallocate_sticky, sticky_max_age_seconds, prefer_earlier_reset_accounts
+        del routing_strategy, model, exclude_account_ids, additional_limit_name
+        del api_key, preferred_account_id
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+
+@contextlib.asynccontextmanager
+async def _client_reporting_committed_stream_failures(app_instance) -> AsyncGenerator[AsyncClient, None]:
+    """Yield a client that sees what a real ASGI server hands a real client.
+
+    ``ASGITransport`` re-raises an exception that escapes the application, which
+    hides the shape issue #2364 is about: uvicorn logs the escaped
+    ``ProxyResponseError`` and closes the socket, so the client is left holding
+    the already-committed ``200`` with an empty body rather than an exception.
+    """
+    async with AsyncClient(
+        transport=ASGITransport(app=app_instance, raise_app_exceptions=False),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+def _assert_denied_anchor_fence_refused_before_dispatch(caplog) -> None:
+    """The before-dispatch fence, not the plain upstream denial, must be what
+    failed the turn.
+
+    Both paths end in a ``stream_incomplete`` 502 for a non-native client, so a
+    scenario that drifted onto the upstream denial would otherwise pass while
+    testing nothing about issue #2364.
+    """
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "continuity_fail_closed surface=http_bridge reason=denied_proxy_anchor_before_dispatch"
+        in record.getMessage()
+    ], "the before-dispatch denied-anchor fence never fired; the turn failed somewhere else"
+
+
+def _anchored_bridge_frames(upstream: _FakeBridgeUpstreamWebSocket) -> list[dict[str, Any]]:
+    frames = [json.loads(text) for text in upstream.sent_text]
+    return [frame for frame in frames if frame.get("previous_response_id") is not None]
+
+
+def _denied_anchor_turn_inputs() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    def _user_item(text: str) -> dict[str, Any]:
+        return {"role": "user", "content": [{"type": "input_text", "text": text}]}
+
+    turn_one_input = [_user_item("turn one")]
+    return turn_one_input, [*turn_one_input, _user_item("turn two")]
+
+
+@pytest.mark.asyncio
+async def test_native_codex_http_bridge_denied_anchor_refusal_returns_502_before_commit(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """A native Codex client must receive the before-dispatch refusal itself.
+
+    Regression for issue #2364: the fence raises its ``stream_incomplete`` 502
+    from inside the SSE body generator, and the native transport-failure
+    lifecycle replayed even a probe-caught, pre-commit refusal back into the
+    committed response. The client saw ``200`` with zero bytes and no terminal
+    event, and the ASGI layer logged an unhandled exception.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_native_denied_anchor_precommit",
+        "native-denied-anchor-precommit@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _DeniesAnchoredTurnUpstreamWebSocket()
+    _install_denied_anchor_bridge_fakes(monkeypatch, account=account, upstream=upstream)
+
+    headers = {
+        "session_id": "native-denied-anchor-precommit-session",
+        "user-agent": "codex_exec/0.153.4",
+    }
+    turn_one_input, turn_two_input = _denied_anchor_turn_inputs()
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+
+    async with _client_reporting_committed_stream_failures(app_instance) as client:
+        first = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_one_input},
+            headers=headers,
+        )
+        assert first.status_code == 200
+
+        # Upstream denies the injected anchor, local recovery rebinds the same
+        # now-denied id, and the fence refuses the retry before dispatch.
+        second = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_two_input},
+            headers=headers,
+        )
+
+    _assert_denied_anchor_fence_refused_before_dispatch(caplog)
+    assert second.status_code == 502, f"native client received {second.status_code} with body {second.text!r}"
+    assert second.json()["error"]["code"] == "stream_incomplete"
+    assert len(_anchored_bridge_frames(upstream)) == 1, "the denied anchor was sent upstream a second time"
+
+
+@pytest.mark.asyncio
+async def test_native_codex_http_bridge_denied_anchor_refusal_emits_terminal_after_commit(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """Once the response has committed, the refusal must arrive as a terminal.
+
+    Same scenario as the pre-commit case with the startup probe disabled, so the
+    refusal lands after the ``200`` is on the wire. The stream must end with a
+    ``response.failed`` the client can read instead of stopping at zero bytes,
+    and that terminal must not be marked as a synthetic transport failure — the
+    native normalizer turns a marked terminal straight back into an abort.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    from app.modules.proxy import api as proxy_api_module
+
+    monkeypatch.setattr(proxy_api_module, "_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS", 0.0)
+    account_id = await _import_account(
+        async_client,
+        "acc_native_denied_anchor_postcommit",
+        "native-denied-anchor-postcommit@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _DeniesAnchoredTurnUpstreamWebSocket()
+    _install_denied_anchor_bridge_fakes(monkeypatch, account=account, upstream=upstream)
+
+    headers = {
+        "session_id": "native-denied-anchor-postcommit-session",
+        "user-agent": "codex_exec/0.153.4",
+    }
+    turn_one_input, turn_two_input = _denied_anchor_turn_inputs()
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.downstream_delivery")
+
+    async with _client_reporting_committed_stream_failures(app_instance) as client:
+        first = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_one_input},
+            headers=headers,
+        )
+        assert first.status_code == 200
+
+        second = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_two_input},
+            headers=headers,
+        )
+
+    _assert_denied_anchor_fence_refused_before_dispatch(caplog)
+    assert second.status_code == 200
+    assert second.text, "the committed response ended with an empty body"
+    events = [
+        json.loads(block.split("data: ", 1)[1])
+        for block in second.text.split("\n\n")
+        if "data: " in block and "data: [DONE]" not in block
+    ]
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1, f"expected one terminal failure, got {[event.get('type') for event in events]}"
+    assert failed[0]["response"]["error"]["code"] == "stream_incomplete"
+    assert "_codex_lb_synthetic_transport_failure" not in second.text
+    assert second.text.rstrip().endswith("data: [DONE]")
+    assert not [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "app.modules.proxy.downstream_delivery"
+        and "outcome=exception_before_terminal" in record.getMessage()
+    ], "the refusal still escaped the committed body instead of ending it with a terminal"
+    assert len(_anchored_bridge_frames(upstream)) == 1, "the denied anchor was sent upstream a second time"
+
+
+@pytest.mark.asyncio
+async def test_non_native_http_bridge_denied_anchor_refusal_still_returns_502_json(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """A non-native client keeps the 502 JSON envelope it already receives.
+
+    The native fix suppresses the synthetic-transport-failure marker for this
+    refusal; the marker is stripped before a non-native client ever sees it, so
+    this contract must be byte-identical afterwards.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_non_native_denied_anchor",
+        "non-native-denied-anchor@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _DeniesAnchoredTurnUpstreamWebSocket()
+    _install_denied_anchor_bridge_fakes(monkeypatch, account=account, upstream=upstream)
+
+    headers = {
+        "session_id": "non-native-denied-anchor-session",
+        "user-agent": "OpenAI/Python 1.0.0",
+    }
+    turn_one_input, turn_two_input = _denied_anchor_turn_inputs()
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+
+    async with _client_reporting_committed_stream_failures(app_instance) as client:
+        first = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_one_input},
+            headers=headers,
+        )
+        assert first.status_code == 200
+
+        second = await client.post(
+            "/backend-api/codex/responses",
+            json={"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_two_input},
+            headers=headers,
+        )
+
+    _assert_denied_anchor_fence_refused_before_dispatch(caplog)
+    assert second.status_code == 502
+    assert second.json()["error"]["code"] == "stream_incomplete"
+
+
+def _denied_anchor_owner_forward_headers(
+    payload_dict: dict[str, Any],
+    *,
+    session_key: str,
+) -> tuple[proxy_module.ResponsesRequest, dict[str, str]]:
+    """Sign a native Codex turn the way an origin instance forwards it.
+
+    ``original_request_unanchored`` mirrors what the origin computes for these
+    turns: the affinity is the session header, the client sent no turn-state
+    token, and the client payload carries no ``previous_response_id`` — the
+    anchor for turn two is the one the owner injects itself.
+    """
+    from app.modules.proxy.http_bridge_forwarding import HTTPBridgeForwardContext, build_owner_forward_headers
+
+    payload = proxy_module.ResponsesRequest.model_validate(payload_dict)
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-b",
+        target_instance="instance-a",
+        codex_session_affinity=True,
+        downstream_turn_state=None,
+        original_request_unanchored=True,
+        original_affinity_kind="session_header",
+        original_affinity_key=session_key,
+    )
+    headers = build_owner_forward_headers(
+        headers={"session_id": session_key, "user-agent": "codex_exec/0.153.4"},
+        payload=payload,
+        context=context,
+    )
+    return payload, headers
+
+
+@pytest.mark.asyncio
+async def test_forwarded_denied_anchor_refusal_marks_the_owner_error_as_a_local_refusal(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """The owner half of a ring deployment must say the refusal was its own.
+
+    The origin instance rebuilds the failure from the owner's status and body,
+    and that body cannot express the difference between a refusal the owner
+    raised before dispatch and a transport failure it observed: both are
+    `stream_incomplete`. The owner therefore marks the response, and
+    ``test_native_codex_owner_forward_denied_anchor_refusal_returns_502_before_commit``
+    covers what the origin does with the mark (issue #2364).
+    """
+    from app.modules.proxy import api as proxy_api_module
+    from app.modules.proxy.http_bridge_forwarding import HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER
+
+    _install_bridge_settings(monkeypatch, enabled=True)
+    owner_settings = proxy_module.get_settings()
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: owner_settings)
+    account_id = await _import_account(
+        async_client,
+        "acc_forwarded_denied_anchor_owner",
+        "forwarded-denied-anchor-owner@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _DeniesAnchoredTurnUpstreamWebSocket()
+    _install_denied_anchor_bridge_fakes(monkeypatch, account=account, upstream=upstream)
+
+    session_key = "forwarded-denied-anchor-owner-session"
+    turn_one_input, turn_two_input = _denied_anchor_turn_inputs()
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+
+    async with _client_reporting_committed_stream_failures(app_instance) as client:
+        payload_one, headers_one = _denied_anchor_owner_forward_headers(
+            {"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_one_input},
+            session_key=session_key,
+        )
+        first = await client.post(
+            "/internal/bridge/responses",
+            json=payload_one.model_dump_for_forwarding(),
+            headers=headers_one,
+        )
+        assert first.status_code == 200, first.text
+
+        payload_two, headers_two = _denied_anchor_owner_forward_headers(
+            {"model": "gpt-5.1", "instructions": "Return exactly OK.", "input": turn_two_input},
+            session_key=session_key,
+        )
+        second = await client.post(
+            "/internal/bridge/responses",
+            json=payload_two.model_dump_for_forwarding(),
+            headers=headers_two,
+        )
+
+    _assert_denied_anchor_fence_refused_before_dispatch(caplog)
+    assert second.status_code == 502, second.text
+    assert second.json()["error"]["code"] == "stream_incomplete"
+    assert second.headers.get(HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER) == "1"
+
+
+@pytest.mark.asyncio
+async def test_native_codex_owner_forward_denied_anchor_refusal_returns_502_before_commit(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    """The origin half must deliver the owner's refusal, not abort its own body.
+
+    In a ring deployment the bridge session, its denial tombstone, and the
+    before-dispatch fence all live on the owner replica, so a continuation
+    reaches the fence only through the internal forward. The origin rebuilds
+    the owner's failure into a fresh error; without the owner's marker that
+    rebuild loses the provenance and the origin's own native transport-failure
+    lifecycle aborts the committed body, putting issue #2364's zero-byte 200 on
+    the origin instead of the owner.
+    """
+    from app.modules.proxy.http_bridge_forwarding import HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER
+
+    _install_bridge_settings_with_limits(
+        monkeypatch,
+        enabled=True,
+        instance_id="instance-b",
+        instance_ring=["instance-a", "instance-b"],
+    )
+    account_id = await _import_account(
+        async_client,
+        "acc_native_owner_forward_denied_anchor",
+        "native-owner-forward-denied-anchor@example.com",
+    )
+    service = get_proxy_service_for_app(app_instance)
+    prompt_cache_key = "native-owner-forward-denied-anchor-cache"
+    turn_state = "http_turn_native_owner_forward_denied_anchor"
+    response_id = "resp_native_owner_forward_denied_anchor"
+    durable_lookup = await service._durable_bridge.claim_live_session(
+        session_key_kind="prompt_cache",
+        session_key_value=prompt_cache_key,
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="remote-process",
+        lease_ttl_seconds=60.0,
+        account_id=account_id,
+        model="gpt-5.1",
+        service_tier=None,
+        latest_turn_state=turn_state,
+        latest_response_id=response_id,
+        allow_takeover=True,
+    )
+    await service._durable_bridge.register_turn_state(
+        session_id=durable_lookup.session_id,
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_epoch=durable_lookup.owner_epoch,
+        turn_state=turn_state,
+        lease_ttl_seconds=60.0,
+    )
+    await service._durable_bridge.register_previous_response_id(
+        session_id=durable_lookup.session_id,
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_epoch=durable_lookup.owner_epoch,
+        response_id=response_id,
+        lease_ttl_seconds=60.0,
+    )
+
+    class Ring:
+        async def list_active(self, *, require_endpoint: bool = False) -> list[str]:
+            assert require_endpoint is True
+            return ["instance-a", "instance-b"]
+
+        async def resolve_endpoint(self, instance_id: str) -> str:
+            assert instance_id == "instance-a"
+            return "http://instance-a"
+
+    # The owner answers exactly as the route above does: the fence's 502
+    # envelope plus the marker that says the owner, not upstream, refused.
+    owner_refusal_body = json.dumps(
+        {
+            "error": {
+                "message": "The previous response anchor was rejected upstream; retry the request.",
+                "type": "server_error",
+                "code": "stream_incomplete",
+            }
+        }
+    )
+
+    class FakeOwnerResponse:
+        status = 502
+        headers = {HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER: "1"}
+
+        async def __aenter__(self) -> "FakeOwnerResponse":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def text(self) -> str:
+            return owner_refusal_body
+
+    class FakeOwnerSession:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        async def __aenter__(self) -> "FakeOwnerSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, **_kwargs: object) -> FakeOwnerResponse:
+            assert url == "http://instance-a/internal/bridge/responses"
+            return FakeOwnerResponse()
+
+    monkeypatch.setattr(
+        "app.modules.proxy.http_bridge_forwarding.aiohttp.ClientSession",
+        FakeOwnerSession,
+    )
+
+    original_ring = service._ring_membership
+    service._ring_membership = cast(Any, Ring())
+    try:
+        async with _client_reporting_committed_stream_failures(app_instance) as client:
+            response = await client.post(
+                "/backend-api/codex/responses",
+                json={
+                    "model": "gpt-5.1",
+                    "instructions": "Return exactly OK.",
+                    "input": "continue",
+                    "prompt_cache_key": prompt_cache_key,
+                    "previous_response_id": response_id,
+                    "stream": True,
+                },
+                headers={
+                    "x-codex-turn-state": turn_state,
+                    "user-agent": "codex_exec/0.153.4",
+                },
+            )
+    finally:
+        service._ring_membership = original_ring
+
+    assert response.status_code == 502, f"native client received {response.status_code} with body {response.text!r}"
+    assert response.json()["error"]["code"] == "stream_incomplete"
+    # The marker belongs to the internal forward contract; the external client
+    # sees only the ordinary error envelope.
+    assert HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER not in response.headers
+
+
 # --- Reproduction for #1384 takeover (narrowed scope): accepted, output-free capacity failure ---
 
 

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -10,6 +10,7 @@ import aiohttp
 import pytest
 from aiohttp.client_reqrep import ConnectionKey
 
+from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import get_settings
 from app.core.openai.requests import ResponsesRequest
 from app.modules.api_keys.service import ApiKeyUsageReservationData
@@ -21,6 +22,7 @@ from app.modules.proxy.http_bridge_forwarding import (
     HTTP_BRIDGE_CODEX_AFFINITY_HEADER,
     HTTP_BRIDGE_FILE_OWNER_HEADER,
     HTTP_BRIDGE_FORWARDED_HEADER,
+    HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER,
     HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER,
     HTTP_BRIDGE_ORIGINAL_UNANCHORED_HEADER,
     HTTP_BRIDGE_RESERVATION_ID_HEADER,
@@ -1406,6 +1408,85 @@ async def test_owner_forward_non_200_body_read_failure_keeps_rejected(
         await collect()
     assert rejected["called"] is True
     assert dispatched["called"] is False
+
+
+@pytest.mark.parametrize(
+    ("owner_headers", "expected_local_refusal"),
+    [
+        ({HTTP_BRIDGE_LOCAL_PRE_DISPATCH_REFUSAL_HEADER: "1"}, True),
+        ({}, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_owner_forward_non_200_carries_local_refusal_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    owner_headers: dict[str, str],
+    expected_local_refusal: bool,
+) -> None:
+    """The rebuilt error must keep what only the owner could know.
+
+    A non-200 owner response is rebuilt into a fresh ``ProxyResponseError`` from
+    the status and the body, and the body cannot express whether the owner
+    refused before dispatch or observed a transport failure — both are
+    ``stream_incomplete``. The owner's marker is the only carrier, and a non-200
+    on its own must not be read as one (issue #2364).
+    """
+
+    class FakeResponse:
+        status = 502
+        headers = owner_headers
+
+        async def __aenter__(self) -> "FakeResponse":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def text(self) -> str:
+            return (
+                '{"error":{"message":"The previous response anchor was rejected upstream; '
+                'retry the request.","type":"server_error","code":"stream_incomplete"}}'
+            )
+
+    class FakeSession:
+        def __init__(self, *, timeout: aiohttp.ClientTimeout, trust_env: bool) -> None:
+            del timeout, trust_env
+
+        async def __aenter__(self) -> "FakeSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> FakeResponse:
+            del url, kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.aiohttp.ClientSession", FakeSession)
+
+    async def collect() -> None:
+        client = HTTPBridgeOwnerClient()
+        async for _event in client.stream_responses(
+            owner_endpoint="http://instance-b:2455",
+            payload=_payload(),
+            headers={"Authorization": "Bearer proxy-key"},
+            context=HTTPBridgeForwardContext(
+                origin_instance="instance-a",
+                target_instance="instance-b",
+                codex_session_affinity=False,
+                downstream_turn_state=None,
+            ),
+            request_started_at=10.0,
+            clock=VirtualClock(monotonic_value=10.0),
+        ):
+            return
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await collect()
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "stream_incomplete"
+    assert exc_info.value.local_pre_dispatch_refusal is expected_local_refusal
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9892,6 +9892,67 @@ async def test_native_codex_stream_reraises_transport_failure_without_terminal_e
     assert _proxy_error_code(exc_info.value) == "upstream_request_timeout"
 
 
+@pytest.mark.asyncio
+async def test_native_codex_stream_surfaces_local_pre_dispatch_refusal_as_unmarked_terminal() -> None:
+    """A refusal the proxy raised before dispatch keeps its terminal event.
+
+    Regression for issue #2364: the denied-anchor fence reports the public code
+    ``stream_incomplete``, which is also how an upstream transport failure ends,
+    so without the provenance flag the native lifecycle aborted the committed
+    body and the client received nothing at all. The terminal must also stay
+    unmarked — ``_normalize_public_responses_stream`` turns a terminal marked as
+    a synthetic transport failure back into an abort for native clients.
+    """
+
+    def _refusal(*, local_pre_dispatch_refusal: bool) -> proxy_module.ProxyResponseError:
+        return proxy_module.ProxyResponseError(
+            502,
+            openai_error("stream_incomplete", "The previous response anchor was rejected upstream; retry the request."),
+            local_pre_dispatch_refusal=local_pre_dispatch_refusal,
+        )
+
+    async def refused_stream() -> AsyncIterator[str]:
+        raise _refusal(local_pre_dispatch_refusal=True)
+        yield ""  # pragma: no cover
+
+    events = [
+        parse_sse_data_json(event_block)
+        async for event_block in proxy_api._stream_response_error_events(
+            refused_stream(),
+            owns_reservation=False,
+            reservation=None,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
+
+    assert len(events) == 1
+    assert events[0] is not None
+    assert events[0]["type"] == "response.failed"
+    response = cast(dict[str, JsonValue], events[0]["response"])
+    error = cast(dict[str, JsonValue], response["error"])
+    assert error["code"] == "stream_incomplete"
+    assert "_codex_lb_synthetic_transport_failure" not in events[0]
+
+    async def unflagged_stream() -> AsyncIterator[str]:
+        raise _refusal(local_pre_dispatch_refusal=False)
+        yield ""  # pragma: no cover
+
+    # The same error without the provenance flag still ends the native stream
+    # without a terminal: the flag is the whole of the new behaviour.
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        _ = [
+            event
+            async for event in proxy_api._stream_response_error_events(
+                unflagged_stream(),
+                owns_reservation=False,
+                reservation=None,
+                preserve_native_failure_lifecycle=True,
+            )
+        ]
+
+    assert _proxy_error_code(exc_info.value) == "stream_incomplete"
+
+
 def test_stream_startup_error_response_preserves_exact_retry_after_header() -> None:
     request = Request({"type": "http", "method": "POST", "path": "/backend-api/codex/responses", "headers": []})
     error = proxy_module.ProxyResponseError(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9931,6 +9931,10 @@ async def test_native_codex_stream_surfaces_local_pre_dispatch_refusal_as_unmark
     response = cast(dict[str, JsonValue], events[0]["response"])
     error = cast(dict[str, JsonValue], response["error"])
     assert error["code"] == "stream_incomplete"
+    # The actionable half of the fix is the message, not the code: a regression
+    # that kept the terminal but dropped the retry instruction would leave the
+    # client with the same dead end #2364 reported.
+    assert error["message"] == "The previous response anchor was rejected upstream; retry the request."
     assert "_codex_lb_synthetic_transport_failure" not in events[0]
 
     async def unflagged_stream() -> AsyncIterator[str]:


### PR DESCRIPTION
## Summary

When upstream rejects a **proxy-injected** `previous_response_id`, the HTTP bridge refuses the next request on that session before dispatch (`denied_proxy_anchor_before_dispatch`) with `ProxyResponseError(502, stream_incomplete, "The previous response anchor was rejected upstream; retry the request.")`. A native Codex client received **HTTP 200 and a zero-byte stream with no terminal event**: `stream disconnected before completion: stream closed before response.completed`. The retry message never arrived and the ASGI layer logged an unhandled traceback (#2364).

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` / `refactor:` / `docs:` / `chore:` / `test:`
- [ ] **Breaking change**

Linked issue: Fixes #2364

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (SSE framing, error envelopes) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/deliver-http-bridge-denied-anchor-refusal-to-native-clients/`

## Root cause

This is not "the response happened to have started already" — the api layer classifies the failure **purely by error code**. `_stream_responses` computes

```python
native_transport_startup_failure = (
    preserve_native_failure_lifecycle
    and startup_error_code in {"stream_incomplete", "stream_idle_timeout",
                               "upstream_request_timeout", "upstream_unavailable"}
)
```

and, when true, deliberately re-raises an **already probe-caught** error back into the committed body instead of returning an error response; `_stream_response_error_events` applies the identical set post-commit. `preserve_native_failure_lifecycle` is native-Codex-only, and native clients also skip heartbeat and keepalive injection while the bridge suppresses its own pre-`response.created` keepalive — so the body is literally 0 bytes. Non-native clients were unaffected: they got a JSON 502 or a terminal `response.failed`.

So shortening the window could never have fixed it. Nor could re-coding the refusal to `previous_response_not_found`: that flips `explicit_previous_response_rejection` / `should_attempt_previous_response_recovery`, turning a deliberate fail-closed into a local recovery attempt, against the spec.

## Changes

The public contract is unchanged — still `502`, still `stream_incomplete`, same message, as the spec mandates. What changes is that the exception now carries **provenance**, so the api layer stops mistaking a proxy-side pre-dispatch refusal for an observed upstream transport failure.

- `ProxyResponseError` gains `local_pre_dispatch_refusal`. The denied-anchor fence sets it — provably pre-dispatch, since the raise sits above both the pending-request enqueue and the upstream send.
- `_stream_responses` excludes a flagged error from `native_transport_startup_failure`, so it returns a real HTTP 502 JSON body in the common fast-failure case (inside the 2 s startup probe window).
- `_stream_response_error_events` excludes it from **both** the re-raise gate and the `synthetic_transport_failure_event` marker gate, so the probe-overrun case yields an *unmarked* terminal `response.failed`. Both gates are load-bearing: changing only the first leaves the marker to convert the terminal straight back into a silent abort.
- `_OwnerForwardRequestError` propagates the flag, since that wrapper rebuilds the exception from a fixed field list.

### Cross-hop fix found during review

The in-process fix alone is not enough on a multi-instance ring. Adversarial review built a two-instance reproduction (durable session owned by instance-a, real owner-forward client, faked transport) and got **`STATUS 200 BODY ''` one hop out**: the origin rebuilds the error from the owner's status and body, and the body cannot express the difference between "the owner refused before sending anything" and "the owner observed a transport failure" — both are `stream_incomplete`.

So the provenance travels: the owner stamps `x-codex-bridge-local-pre-dispatch-refusal` on its error response (only for forwarded requests — the header belongs to the internal bridge contract and is asserted never to reach an external client), and `HTTPBridgeOwnerClient` reads it back into the rebuilt `ProxyResponseError`.

## Test plan

```
uv run ruff check app tests                       # All checks passed!
uv run ty check app                               # All checks passed!
uv run openspec validate deliver-http-bridge-denied-anchor-refusal-to-native-clients --strict
uv run openspec validate --specs                  # 65 passed, 0 failed

uv run pytest tests/unit                                              # 9968 passed, 4 skipped
uv run pytest tests/integration/test_http_responses_bridge.py \
             tests/unit/test_http_bridge_forwarding.py                # 244 passed
uv run pytest tests/integration/{test_multi_instance_bridge,test_proxy_responses,test_codex_client_compat,\
             test_native_sse_egress,test_native_routed_egress,test_proxy_affinity_local_recovery,\
             test_proxy_api_extended}.py                              # 216 passed, 320 skipped
uv run pytest tests/integration/{test_proxy_websocket_responses,test_proxy_sticky_sessions,test_proxy_compact,\
             test_routed_stream_release,test_startup_bridge_cleanup,test_proxy_websocket_overflow,\
             test_proxy_chat_completions}.py                          # 284 passed
```

Regression coverage sits at the product path on **both halves of the hop**, and every test asserts the `continuity_fail_closed reason=denied_proxy_anchor_before_dispatch` record so a mis-orchestrated test fails loudly instead of silently exercising the ordinary upstream-denial path (which returns a visible 502 and would pass in both the buggy and the fixed world).

**Fails-before-fix proof**, patch reverse-applied:
- owner half — `AssertionError: assert None == '1' where None = get('x-codex-bridge-local-pre-dispatch-refusal')`
- origin half — `AssertionError: native client received 200 with body ''`

## Known bounds, recorded in the proposal

- **Scope is one raise site.** The ~20 sibling local refusals in `_service/http_bridge/` that also use codes from the native-abort set are enumerated by name in `proposal.md` but deliberately untouched — some of them are *not* safely pre-dispatch, so a blanket sweep would be wrong. Follow-up issue below.
- **Rolling-upgrade window for ring deployments.** An upgraded owner answers the internal forward with a real 502 where it previously aborted a committed 200; an origin that predates this change ignores the marker and applies its own native lifecycle, so a forwarded refusal reaches the client as an empty 200 until every replica is on this build. Single-instance deployments — the default — never take that path.
- **The anchor-poisoning loop is untouched.** When the durable clear returns a clean no-match the tombstone persists and the durable row re-injects the same id, so the user now sees repeated *visible* 502s rather than repeated silent truncations. Fixing the loop itself is a separate change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added regression coverage at the externally failing product path.
- [x] Ran the relevant pytest subsets locally.
- [x] `openspec validate --strict` passes.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6) — no new setting, no new nav, defaults unchanged.
- [x] CHANGELOG is not edited by hand.
