### PR TITLE
fix(proxy): retire durably unroutable bridge continuity owners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_repositories.py::test_upsert_account_slot_discards_pending_downgrade_evidence_on_reimport \
 	tests/integration/test_migrations.py::test_account_plan_downgrade_observations_migration_upgrade_and_downgrade \
 	tests/integration/test_migrations.py::test_account_pending_deletion_migration_upgrade_and_downgrade \
+	tests/integration/test_migrations.py::test_bridge_continuity_abandonment_migration_upgrade_and_downgrade \
+	tests/integration/test_repositories.py::test_retire_stale_unavailable_bridge_owners_frees_a_reauth_pinned_thread \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_primary_query_plan_is_index_only_postgresql \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_cutoff_query_plan_is_index_only_postgresql \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_secondary_query_plan_is_index_only_postgresql \

--- a/app/db/alembic/versions/20260911_060000_add_bridge_session_continuity_abandonment.py
+++ b/app/db/alembic/versions/20260911_060000_add_bridge_session_continuity_abandonment.py
@@ -1,0 +1,40 @@
+"""Add continuity-abandonment markers to durable HTTP bridge sessions.
+
+Revision ID: 20260911_060000_add_bridge_session_continuity_abandonment
+Revises: 20260911_030000_add_local_login_policy
+Create Date: 2026-09-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260911_060000_add_bridge_session_continuity_abandonment"
+down_revision = "20260911_030000_add_local_login_policy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Mirrors sticky_sessions' pair exactly: a scope-only marker is the new
+    # reader's tombstone, while a timestamp with NULL scope abandons globally.
+    # Both stay NULL on every existing row, so a rolling deploy keeps treating
+    # account_id as hard ownership until a writer retires a specific owner.
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("http_bridge_sessions")}
+    with op.batch_alter_table("http_bridge_sessions") as batch_op:
+        if "continuity_abandoned_at" not in columns:
+            batch_op.add_column(sa.Column("continuity_abandoned_at", sa.DateTime(timezone=True), nullable=True))
+        if "continuity_abandonment_scope" not in columns:
+            batch_op.add_column(sa.Column("continuity_abandonment_scope", sa.String(32), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("http_bridge_sessions")}
+    with op.batch_alter_table("http_bridge_sessions") as batch_op:
+        if "continuity_abandonment_scope" in columns:
+            batch_op.drop_column("continuity_abandonment_scope")
+        if "continuity_abandoned_at" in columns:
+            batch_op.drop_column("continuity_abandoned_at")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2452,6 +2452,14 @@ class HttpBridgeSessionRecord(Base):
     latest_input_item_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     latest_input_full_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
     latest_pending_tool_calls_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Continuity-owner retirement, mirroring sticky_sessions' pair: a non-NULL
+    # scope retires ownership only for the matching typed source, while a
+    # non-NULL timestamp with NULL scope retires it globally. Deleting the row
+    # instead would be indistinguishable from "never seen" and would leave the
+    # lookup failing closed forever; a marker says the owner was deliberately
+    # abandoned, so picking a fresh one is authorized.
+    continuity_abandoned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    continuity_abandonment_scope: Mapped[str | None] = mapped_column(String(32), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2012,13 +2012,24 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_turn_state is not None
             )
         )
+        # A retired owner is not a missing one. Failing closed is right when a
+        # row should name an account and does not — that is lost state. But a
+        # retirement marker is positive proof that the owner was deliberately
+        # abandoned because it could not come back, so the correct response is
+        # to pick a fresh owner, exactly as the sticky selector does when it
+        # sees its own tombstone. Without this exemption, retiring an owner
+        # would convert one 502 into a different 502.
         durable_owner_missing = (
-            durable_lookup is not None and durable_lookup_requires_owner and durable_lookup.account_id is None
+            durable_lookup is not None
+            and durable_lookup_requires_owner
+            and durable_lookup.account_id is None
+            and not durable_lookup.continuity_abandoned
         )
         model_transition_owner_missing = (
             durable_model_transition_lookup is not None
             and durable_model_transition_requires_owner
             and durable_model_transition_lookup.account_id is None
+            and not durable_model_transition_lookup.continuity_abandoned
         )
         required_continuity_owner_missing = (
             (request_state.previous_response_id is not None and request_state.preferred_account_id is None)

--- a/app/modules/proxy/account_eligibility.py
+++ b/app/modules/proxy/account_eligibility.py
@@ -10,6 +10,26 @@ from app.db.models import Account, AccountStatus
 ROUTABLE_STATUSES = (AccountStatus.ACTIVE, AccountStatus.REAUTH_REQUIRED)
 """Statuses whose sessions keep serving requests (reauth stays routable until expiry)."""
 
+HARD_OWNER_UNAVAILABLE_STATUSES = frozenset(
+    {
+        AccountStatus.PAUSED,
+        AccountStatus.DEACTIVATED,
+        AccountStatus.RATE_LIMITED,
+        AccountStatus.QUOTA_EXCEEDED,
+        AccountStatus.REAUTH_REQUIRED,
+    }
+)
+"""Statuses a hard continuity owner can sit in while it cannot serve its thread.
+
+Usable directly in SQL, unlike :func:`reauth_access_token_is_expired`, which
+needs a decrypted token. ``REAUTH_REQUIRED`` belongs here only because every
+consumer pairs the set with a long inactivity grace: an owner that has been
+warning about reauthentication for hours without serving its thread is not
+coming back on its own, whatever its stored token claims. Anything deciding
+routability *now* must use :data:`ROUTABLE_STATUSES` plus the expiry check
+instead.
+"""
+
 
 def stored_access_token_expires_at(
     encrypted_access_token: bytes | None,

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -55,6 +55,12 @@ class DurableBridgeLookup:
     model: str | None = None
     latest_pending_tool_calls: dict[str, str] | None = None
     owner_process_epoch: str | None = None
+    # True when a writer retired this row's continuity owner. The lookup then
+    # carries no owner and no anchor, and the request proceeds as if this
+    # thread had never been pinned — which is different from "no row exists",
+    # because callers must not fail closed on the missing owner.
+    continuity_abandoned: bool = False
+    retired_account_id: str | None = None
 
     def lease_is_active(self, *, now: datetime) -> bool:
         if self.owner_instance_id is None:
@@ -1153,21 +1159,44 @@ class DurableBridgeSessionCoordinator:
 
 
 def _to_lookup(snapshot: DurableBridgeSessionSnapshot) -> DurableBridgeLookup:
+    # Every lookup path funnels through here, so retirement is applied once
+    # rather than at each call site — the detached-row filter above had to be
+    # repeated and ended up covering only two of the four paths.
+    #
+    # A retired row keeps its identity (callers still need the session id and
+    # canonical key to claim it) but surrenders every piece of continuity
+    # evidence: the owner, the response anchor and the turn state. Dropping
+    # the anchors alongside the owner is what makes the retirement coherent —
+    # an anchor without its account is upstream state no replacement account
+    # can read, and leaving it would have the next request inject a pointer
+    # that only the retired owner could resolve.
+    retired = snapshot.continuity_abandoned
     return DurableBridgeLookup(
         session_id=snapshot.id,
         canonical_kind=snapshot.session_key_kind,
         canonical_key=snapshot.session_key_value,
         api_key_scope=snapshot.api_key_scope,
-        account_id=snapshot.account_id,
-        owner_instance_id=snapshot.owner_instance_id,
-        owner_process_epoch=snapshot.owner_process_epoch,
+        account_id=None if retired else snapshot.account_id,
+        # The owning replica goes with the owner. ``_durable_bridge_lookup_active_owner``
+        # would otherwise still name it and forward the request there, and the
+        # takeover gates would treat the row as live. The sweep only retires
+        # rows that have been idle for the whole grace window, so no lease can
+        # realistically still be running — but leaving these set makes the
+        # invariant depend on the lease TTL staying below the grace window,
+        # which is a setting nobody would think to check before changing.
+        owner_instance_id=None if retired else snapshot.owner_instance_id,
+        owner_process_epoch=None if retired else snapshot.owner_process_epoch,
+        # The epoch is fencing state, not continuity evidence: a later claim
+        # must still advance past it, so it is preserved.
         owner_epoch=snapshot.owner_epoch,
-        lease_expires_at=snapshot.lease_expires_at,
+        lease_expires_at=None if retired else snapshot.lease_expires_at,
         state=snapshot.state,
-        latest_turn_state=snapshot.latest_turn_state,
-        latest_response_id=snapshot.latest_response_id,
-        latest_input_item_count=snapshot.latest_input_item_count,
-        latest_input_full_fingerprint=snapshot.latest_input_full_fingerprint,
+        latest_turn_state=None if retired else snapshot.latest_turn_state,
+        latest_response_id=None if retired else snapshot.latest_response_id,
+        latest_input_item_count=None if retired else snapshot.latest_input_item_count,
+        latest_input_full_fingerprint=None if retired else snapshot.latest_input_full_fingerprint,
         model=snapshot.model,
-        latest_pending_tool_calls=snapshot.latest_pending_tool_calls,
+        latest_pending_tool_calls=None if retired else snapshot.latest_pending_tool_calls,
+        continuity_abandoned=retired,
+        retired_account_id=snapshot.abandoned_account_id,
     )

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -16,13 +16,14 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.utils.time import to_utc_naive, utcnow
+from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import (
     HTTP_BRIDGE_SPOOL_FORMAT_CHUNKS_V2,
     HTTP_BRIDGE_SPOOL_FORMAT_ROWS_V1,
     HTTP_BRIDGE_TERMINAL_APPEND_PHASE_APPENDED,
     HTTP_BRIDGE_TERMINAL_APPEND_PHASE_PENDING,
     HTTP_BRIDGE_TERMINAL_APPEND_PHASE_SETTLED,
+    Account,
     HttpBridgeOperationEvent,
     HttpBridgeOperationEventChunk,
     HttpBridgeOperationRecord,
@@ -34,6 +35,7 @@ from app.db.models import (
     HttpBridgeSessionState,
 )
 from app.db.session import sqlite_writer_section
+from app.modules.proxy.account_eligibility import HARD_OWNER_UNAVAILABLE_STATUSES
 from app.modules.proxy.continuity import (
     HTTP_BRIDGE_ACCOUNT_NEUTRAL_REPLAY_KEY_PREFIX,
     HTTP_BRIDGE_ACCOUNT_NEUTRAL_REPLAY_KIND,
@@ -189,6 +191,11 @@ class DurableBridgeSessionSnapshot:
     closed_at: datetime | None
     latest_pending_tool_calls: dict[str, str] | None = None
     owner_process_epoch: str | None = None
+    # True once a writer retired this row's continuity owner. Readers must
+    # treat ``account_id`` as absent and may use ``abandoned_account_id`` only
+    # as exclusion evidence, never as a routing target.
+    continuity_abandoned: bool = False
+    abandoned_account_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1140,6 +1147,19 @@ class DurableBridgeRepository:
             state_closed = existing.state == HttpBridgeSessionState.CLOSED
             owner_absent = existing.owner_instance_id is None
             account_changed = existing.account_id != account_id
+            # Reclaiming a retired row discards continuity for the same reason
+            # an account change does. ``_to_lookup`` masked the anchors while
+            # the marker stood, so the request that triggered this claim was
+            # planned as an unanchored fresh start. Clearing only the marker
+            # would leave the old response id, turn state, fingerprints and
+            # pending calls behind, and the next lookup would serve that
+            # abandoned anchor as ordinary continuity — including when the
+            # retired account itself recovers and is selected again, where
+            # ``account_changed`` is False.
+            continuity_retired = _bridge_continuity_is_abandoned(
+                existing.continuity_abandoned_at,
+                existing.continuity_abandonment_scope,
+            )
             owner_changed = existing.owner_instance_id != instance_id
             if owner_changed:
                 lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
@@ -1177,8 +1197,14 @@ class DurableBridgeRepository:
                 "service_tier": service_tier,
                 "last_seen_at": now,
                 "closed_at": None,
+                # A successful claim re-establishes ownership, so any prior
+                # retirement is over. Clearing both markers here is what makes
+                # retirement reversible: the same row, re-pinned to a healthy
+                # account, becomes ordinary hard ownership again.
+                "continuity_abandoned_at": None,
+                "continuity_abandonment_scope": None,
             }
-            if account_changed:
+            if account_changed or continuity_retired:
                 values["latest_turn_state"] = latest_turn_state
                 values["latest_response_id"] = latest_response_id
                 values["latest_input_item_count"] = None
@@ -1212,7 +1238,7 @@ class DurableBridgeRepository:
                         contended = True
                         continue
                     raise RuntimeError("Failed to claim durable bridge session after retry")
-                if account_changed:
+                if account_changed or continuity_retired:
                     await self._clear_aliases_for_session(existing.id)
                 await self._session.commit()
             # Build the snapshot from the values THIS CAS wrote rather than a
@@ -3539,6 +3565,88 @@ class DurableBridgeRepository:
                 await self._session.commit()
             deleted_count += len(deleted.scalars().all())
 
+    async def retire_stale_unavailable_bridge_owners(self, cutoff: datetime, *, now: datetime) -> int:
+        """Retire continuity owners that have been unroutable since ``cutoff``.
+
+        The durable-bridge counterpart of
+        ``StickySessionsRepository.purge_stale_hard_codex_session_mappings``,
+        and it exists for the same reason. Deleting the row outright would be
+        indistinguishable from "this key was never seen", which leaves the
+        anchored lookup failing closed forever; a tombstone instead says the
+        owner was deliberately abandoned, so a later request may pick a fresh
+        one. Two phases:
+
+        1. Tombstone a row whose owner has sat in
+           :data:`HARD_OWNER_UNAVAILABLE_STATUSES` past its reset horizon while
+           the row itself went untouched for the whole grace window.
+        2. Delete a tombstone that then sat another full window with nobody
+           claiming it, as long as it owns no operation rows.
+
+        Unlike the row deletes elsewhere in this module, phase 1 is **not**
+        gated on ``~exists(operation)``. That guard protects the durable
+        recovery ledger from a ``CASCADE``, which retirement does not trigger:
+        it writes two columns and keeps every operation row intact. Gating it
+        would reproduce the 2026-09-04 outage, where every poisoned row
+        happened to own operations and so was never reachable by cleanup.
+        """
+        now_naive = to_utc_naive(now)
+        cutoff_naive = to_utc_naive(cutoff)
+        now_epoch = naive_utc_to_epoch(now_naive)
+        unavailable_account_ids = select(Account.id).where(
+            Account.status.in_(HARD_OWNER_UNAVAILABLE_STATUSES),
+            or_(Account.reset_at.is_(None), Account.reset_at < now_epoch),
+        )
+        tombstone_stmt = (
+            update(HttpBridgeSessionRecord)
+            .where(
+                HttpBridgeSessionRecord.account_id.is_not(None),
+                HttpBridgeSessionRecord.continuity_abandoned_at.is_(None),
+                HttpBridgeSessionRecord.continuity_abandonment_scope.is_(None),
+                HttpBridgeSessionRecord.last_seen_at < cutoff_naive,
+                HttpBridgeSessionRecord.account_id.in_(unavailable_account_ids),
+            )
+            # Timestamp with NULL scope is the global form: this sweep has no
+            # per-source question to answer, and a replica that predates the
+            # scope column still understands the timestamp.
+            .values(continuity_abandoned_at=now_naive, continuity_abandonment_scope=None)
+            .returning(HttpBridgeSessionRecord.id)
+        )
+        expired_tombstone_filter = (
+            HttpBridgeSessionRecord.continuity_abandoned_at.is_not(None),
+            HttpBridgeSessionRecord.continuity_abandonment_scope.is_(None),
+            HttpBridgeSessionRecord.continuity_abandoned_at < cutoff_naive,
+            ~exists(
+                select(HttpBridgeOperationRecord.operation_id).where(
+                    HttpBridgeOperationRecord.session_id == HttpBridgeSessionRecord.id,
+                )
+            ),
+        )
+        async with sqlite_writer_section():
+            tombstoned = len((await self._session.execute(tombstone_stmt)).scalars().all())
+            # Aliases first, matching ``purge_closed_before``: the FK cascade
+            # would cover it, but SQLite builds without foreign-key enforcement
+            # would leave orphans that later resolve to a deleted session.
+            await self._session.execute(
+                delete(HttpBridgeSessionAlias).where(
+                    HttpBridgeSessionAlias.session_id.in_(
+                        select(HttpBridgeSessionRecord.id).where(*expired_tombstone_filter)
+                    )
+                )
+            )
+            deleted = len(
+                (
+                    await self._session.execute(
+                        delete(HttpBridgeSessionRecord)
+                        .where(*expired_tombstone_filter)
+                        .returning(HttpBridgeSessionRecord.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            await self._session.commit()
+        return tombstoned + deleted
+
     async def purge_abandoned_before(self, cutoff: datetime, *, batch_size: int = _PURGE_CLOSED_BATCH_SIZE) -> int:
         """Purge ACTIVE/DRAINING rows whose lease expired and whose activity predates the cutoff."""
 
@@ -4168,11 +4276,17 @@ _SNAPSHOT_COLUMNS = (
     HttpBridgeSessionRecord.latest_pending_tool_calls_json,
     HttpBridgeSessionRecord.last_seen_at,
     HttpBridgeSessionRecord.closed_at,
+    HttpBridgeSessionRecord.continuity_abandoned_at,
+    HttpBridgeSessionRecord.continuity_abandonment_scope,
 )
 
 
 def _returned_row_to_snapshot(row: Row[tuple[object, ...]]) -> DurableBridgeSessionSnapshot:
     mapping = row._mapping
+    continuity_abandoned = _bridge_continuity_is_abandoned(
+        mapping[HttpBridgeSessionRecord.continuity_abandoned_at],
+        mapping[HttpBridgeSessionRecord.continuity_abandonment_scope],
+    )
     return DurableBridgeSessionSnapshot(
         id=mapping[HttpBridgeSessionRecord.id],
         session_key_kind=mapping[HttpBridgeSessionRecord.session_key_kind],
@@ -4197,12 +4311,33 @@ def _returned_row_to_snapshot(row: Row[tuple[object, ...]]) -> DurableBridgeSess
         ),
         last_seen_at=mapping[HttpBridgeSessionRecord.last_seen_at],
         closed_at=mapping[HttpBridgeSessionRecord.closed_at],
+        continuity_abandoned=continuity_abandoned,
+        abandoned_account_id=(mapping[HttpBridgeSessionRecord.account_id] if continuity_abandoned else None),
     )
+
+
+def _bridge_continuity_is_abandoned(
+    abandoned_at: datetime | None,
+    abandonment_scope: str | None,
+) -> bool:
+    """Return whether a writer retired this row's continuity owner.
+
+    Mirrors ``sticky_repository._continuity_is_abandoned_for_source``. The
+    bridge has one continuity source, so any scope marker retires the owner;
+    the legacy-timestamp form retires it globally. Scope is written alone so a
+    pre-migration replica, which knows neither column, keeps treating
+    ``account_id`` as hard ownership through a rolling deploy.
+    """
+    return abandonment_scope is not None or abandoned_at is not None
 
 
 def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSnapshot | None:
     if row is None:
         return None
+    continuity_abandoned = _bridge_continuity_is_abandoned(
+        row.continuity_abandoned_at,
+        row.continuity_abandonment_scope,
+    )
     return DurableBridgeSessionSnapshot(
         id=row.id,
         session_key_kind=row.session_key_kind,
@@ -4227,6 +4362,8 @@ def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSna
         ),
         last_seen_at=row.last_seen_at,
         closed_at=row.closed_at,
+        continuity_abandoned=continuity_abandoned,
+        abandoned_account_id=row.account_id if continuity_abandoned else None,
     )
 
 

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -431,6 +431,21 @@ class StickySessionCleanupScheduler:
                             )
                     if startup_module._bridge_durable_schema_ready or not await missing_durable_bridge_tables(session):
                         if self.enabled:
+                            # Same grace window as the sticky sweep above, and
+                            # for the same reason: an owner that has been
+                            # unroutable across it is not coming back on its
+                            # own, so its threads must be free to rebind.
+                            retire_now = utcnow()
+                            retired_owner_count = await bridge_repo.retire_stale_unavailable_bridge_owners(
+                                retire_now - timedelta(seconds=_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS),
+                                now=retire_now,
+                            )
+                            if retired_owner_count > 0:
+                                logger.info(
+                                    "Retired durable HTTP bridge continuity owners that stayed unroutable "
+                                    "retired_count=%s",
+                                    retired_owner_count,
+                                )
                             bridge_deleted_count = await bridge_repo.purge_closed_before(cutoff)
                             if bridge_deleted_count > 0:
                                 logger.info("Purged closed HTTP bridge sessions deleted_count=%s", bridge_deleted_count)

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/.openspec.yaml
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/context.md
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/context.md
@@ -1,0 +1,159 @@
+# Context
+
+## Purpose and scope
+
+Give a durable HTTP bridge row a way to let go of an owner account that cannot serve it, so a
+Codex thread stops returning 502 forever while healthy accounts sit idle. In scope: the marker,
+the grace-gated sweep that writes it, the read semantics that honour it, and the exemption that
+keeps it from becoming a different 502. Out of scope: retiring an owner *immediately* on the
+request path, and moving a turn whose body is account-bound.
+
+## Production evidence (`1.25.0-beta.7`, 24 accounts, 2026-09-11)
+
+| Observation | Value |
+|---|---|
+| `previous_response_owner_unavailable` request-log rows | 1,480 / 36h |
+| … owned by one `reauth_required` account | **1,361** |
+| … owned by `paused` accounts | 22 |
+| `draining` rows pinned to unroutable owners, frozen since the previous deploy | 6 |
+| … of those owning operation rows (so unreachable by `purge_abandoned_before`) | **6 of 6** |
+
+`reauth_required` is the single largest source and is in neither existing cleanup path: the
+`DEACTIVATED` detach does not cover it, and `_HARD_STICKY_UNAVAILABLE_STATUSES` omits it.
+
+## Decisions
+
+**Why a marker and not a delete.** `sticky_repository.py:683-703` already argues this at length
+and the reasoning transfers unchanged: with more than one account in the pool, a deleted row
+makes the anchored selection path fail closed forever, because nothing on that path can
+re-create the row it needs in order to stop failing closed. A marker distinguishes "deliberately
+abandoned, pick a fresh owner" from "never seen".
+
+**What the grace window protects: a live thread, not a young outage.** The sticky sweep needs
+an outage clock because `StickySession` has no activity signal at all — its timestamp moves on
+every pin refresh, so it cannot tell "owner died long ago" from "owner died just now". A bridge
+row records when the thread last actually served, which answers the question the grace is
+really asking: is this thread live enough for its anchor to be worth protecting? So a session
+that served a turn inside the window keeps its owner however long that owner has been down,
+while a session that served nothing across the window is retired as soon as its owner goes
+unroutable, even on a brand-new outage.
+
+The cost of that choice is bounded and explicit: a thread idle for six hours whose owner pauses
+for two minutes loses its response anchor and re-sends its history on the next resume. The
+alternative is that the same thread returns 502 for as long as the pause lasts. An anchor
+nobody has touched in six hours is worth less than the thread being resumable at all.
+`test_a_dormant_thread_is_retired_on_a_fresh_outage` and
+`test_recent_activity_keeps_an_unroutable_owner` pin both halves.
+
+**Why `last_seen_at` is the grace clock.** The sticky design carries two extra mechanisms —
+`_refresh_hard_sticky_outage_grace` on the status transition, and a once-per-database
+`runtime_sentinels` backfill so the first sweep after the feature ships cannot mistake a
+pre-existing stale `updated_at` for a long-dead owner. Both exist because `StickySession`'s
+timestamp moves for reasons unrelated to serving. The bridge row already records when the thread
+last actually worked, so "unroutable owner and no successful turn for 6h" needs neither. This is
+a deliberate simplification, not an oversight: if `last_seen_at` ever starts moving for
+non-serving reasons, the sticky pair becomes necessary here too.
+
+**Why the `~exists(operation)` guard is dropped from phase 1 only.** The guard exists because
+`http_bridge_operations.session_id` is `ON DELETE CASCADE`, so deleting a session would silently
+take its recovery ledger (and transitively its event rows) with it — the rationale is stated at
+`durable_bridge_repository.py:3000-3003`. Retirement writes two columns and deletes nothing, so
+the guard protects nothing there. Keeping it would have been fatal: all six frozen production
+rows own operations, which is precisely why the 2026-09-04 incident had to be resolved by hand.
+
+**Why `_to_lookup` is the single application point.** `durable_bridge_snapshot_is_detached`, the
+#2063 filter, is applied at call sites and reaches two of the four lookup paths — the canonical
+`get_session` and the alias loop — leaving both `find_session_by_latest_*` fallbacks uncovered.
+`_to_lookup` is the one funnel every path already passes through.
+
+**Why a retired lookup surrenders its anchors too.** An owner and a response anchor are one
+fact, not two: the anchor points at upstream state only that account can read. Retiring the
+owner while keeping the anchor would have the next request inject a pointer no replacement
+account can resolve, turning a 502 into an upstream rejection.
+
+**Why `reauth_required` is in the SQL set but not in `ROUTABLE_STATUSES`.** An account warning
+about re-authentication is still routable while its stored access token is unexpired, and
+`reauth_access_token_is_expired` needs a decrypted token, which SQL cannot do. Pairing the
+status with a long inactivity grace is the substitute: an account that has been warning for six
+hours without serving its thread is not coming back on its own, whatever its token claims.
+Anything deciding routability *now* must keep using `ROUTABLE_STATUSES` plus the expiry check.
+
+## Constraints
+
+- No new setting; the grace reuses `_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS`.
+- No ceiling-guarded proxy file may grow (`service.py` 2600/2600, `load_balancer.py` 3000/3021,
+  `_service/http_bridge/mixin.py` 2435/2436, `_service/streaming/mixin.py` 1097/1100). None is
+  touched.
+- The migration adds nullable columns with no backfill, so a replica on the previous build is
+  unaffected during a rolling deploy.
+
+## Failure modes
+
+- **Retirement becoming a different 502.** Making `account_id` read as `None` feeds
+  `durable_owner_missing`, which fails closed. The exemption in `streaming.py` is load-bearing;
+  `test_v1_responses_http_bridge_resumes_a_thread_whose_owner_was_retired` is what catches its
+  removal, because the unit layer alone would still pass.
+- **Retiring a transient outage.** A rate-limited owner with a reset horizon in the future is
+  evidence the owner returns, so waiting preserves the upstream prompt cache instead of forcing a
+  full resend. Two unit cases pin both sides of that horizon.
+- **Retirement sticking after recovery.** `claim_session` clears both markers on every successful
+  claim; without that a thread would be permanently demoted to fresh starts.
+- **The cleared marker resurrecting the anchor it masked.** A claim that cleared only the marker
+  would leave the old response id, turn state, fingerprints and pending calls behind, and the
+  next lookup would serve that abandoned anchor as ordinary continuity. This bites hardest when
+  the retired account itself recovers and is selected again, because `account_changed` is then
+  False. Reclaiming a retired row therefore discards continuity exactly as an account change
+  does, aliases included.
+- **Racing the durable write in tests.** The bridge persists its row off the request path, so a
+  test that mutates the row straight after a 200 is flaky. The end-to-end test polls for the row
+  first — the first draft of it failed once for exactly this reason.
+- **The owning replica outliving the owner.** `_durable_bridge_lookup_active_owner` reads
+  `owner_instance_id` and `lease_expires_at` off the lookup, so a retired row that kept them
+  would still be forwarded to the replica that owned it. The sweep only retires rows idle for
+  the whole grace window, so no lease can realistically still be running — but leaving them set
+  would make the invariant depend on the bridge lease TTL staying below the grace window, a
+  setting nobody would think to check before changing. `_to_lookup` masks both;
+  `owner_epoch` is fencing state, not continuity evidence, so it survives.
+- **Rolling deploy.** A replica on the previous build ignores both columns and keeps treating
+  `account_id` as hard ownership, so the worst case during rollout is the behaviour that exists
+  today.
+
+## Two findings deliberately not acted on
+
+**A client-supplied `previous_response_id` still fails closed.** Retirement frees
+proxy-injected continuations — the common Codex shape, and the one in every production trace
+for this bug, which all carry `previous_response_id=None`. A client that sends its own anchor
+names upstream state that lived on the retired account, and no replacement can read it, so the
+request still fails closed. That is the *same* outcome as before this change, reached by a
+different branch, so it is not a regression. What is wrong about it is the error: 502
+"retry later" invites a retry that can never succeed. Replacing it with an actionable,
+non-retryable error is the follow-up; `test_a_retired_row_still_refuses_a_client_supplied_anchor`
+pins the boundary so that follow-up is deliberate.
+
+**The retired account is not excluded from replacement selection.** Excluding it looks safer
+but buys nothing: retirement already stripped the anchors, so selecting the recovered former
+owner starts a fresh turn exactly as any other account would. It is also the account most
+likely to still hold this conversation's upstream prompt cache, so excluding it would force a
+cache miss for no gain. While the account is still unroutable the selector skips it anyway.
+
+## Example
+
+A thread pinned to an account the operator paused, resumed after the sweep:
+
+```text
+# before
+Proxy account selection start request_stage=follow_up preferred_account_id=<A>
+No account selected error=No available accounts
+Proxy preferred account unavailable error_code=continuity_owner_unavailable
+proxy_error_response status=502 code="previous_response_owner_unavailable"
+
+# after the sweep retires <A>
+Retired durable HTTP bridge continuity owners that stayed unroutable retired_count=1
+Proxy account selection start request_stage=first_turn preferred_account_id=None
+Selected account_id=<B>
+"POST /v1/responses HTTP/1.1" 200 OK
+```
+
+The thread loses its upstream prompt cache and re-sends its history, which is the cost the
+operator chose over an unusable thread. If account `<A>` recovers and a later turn lands on it,
+the claim clears the marker and ordinary hard ownership resumes.

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/proposal.md
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+A durable HTTP bridge row names the account that owns a Codex thread, and nothing ever takes
+that name back. `accounts/repository.py::_close_http_bridge_sessions_for_account` runs only on
+the `DEACTIVATED` transition; `PAUSED`, `REAUTH_REQUIRED`, `RATE_LIMITED` and `QUOTA_EXCEEDED`
+all leave `account_id` in place forever. Every resume re-reads that name, requires it because
+`thread_header` is hard by kind, and fails closed with 502
+`previous_response_owner_unavailable` while healthy accounts sit idle. This is the remaining
+class in #1707, open since 2026-08-13 with four independent reporters.
+
+`StickySession` already solved exactly this problem and says why deleting the row is not the
+answer (`sticky_repository.py:683-703`): a delete is indistinguishable from "this key was never
+seen", so the anchored path keeps failing closed even after the owner recovers, because nothing
+on that path can re-create the row it needs. A tombstone instead proves the owner was
+deliberately abandoned, which authorizes picking a fresh one. `HttpBridgeSessionRecord` has no
+counterpart — `account_id`'s `ON DELETE SET NULL` is its only release, so only deleting the
+account row frees a thread.
+
+Production, 36 hours on `1.25.0-beta.7` with 24 accounts: **1,480** of these 502s, **1,361** of
+them owned by a single `reauth_required` account. `reauth_required` is in neither cleanup path
+— not the `DEACTIVATED` detach, not `_HARD_STICKY_UNAVAILABLE_STATUSES`. Six `draining` rows
+pinned to paused owners had been frozen for 18 hours, and all six own operation rows, so
+`purge_abandoned_before`'s `~exists(operation)` guard would never have reached them. That guard
+is the same one that made the 2026-09-04 incident permanent.
+
+## What Changes
+
+- **Schema.** `http_bridge_sessions` gains `continuity_abandoned_at` and
+  `continuity_abandonment_scope`, mirroring `sticky_sessions` in name and meaning so a reviewer
+  reads one pattern, not two. Both nullable, both NULL on every existing row: a rolling deploy
+  keeps treating `account_id` as hard ownership until a writer retires a specific owner.
+- **Retirement sweep.** `DurableBridgeRepository.retire_stale_unavailable_bridge_owners` runs on
+  the existing sticky cleanup pass, with the existing grace constant
+  (`_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS`, 6h) and no new setting. Phase 1 tombstones a
+  row whose owner sat in `HARD_OWNER_UNAVAILABLE_STATUSES` past its reset horizon while the row
+  itself went untouched for the whole window; phase 2 deletes a tombstone that then sat another
+  full window unclaimed.
+- **The grace clock is `last_seen_at`, not a refreshed marker.** The sticky design needs
+  `_refresh_hard_sticky_outage_grace` plus a one-shot `runtime_sentinels` startup backfill
+  because `StickySession.updated_at` moves for reasons unrelated to serving. The bridge row
+  already carries when the thread last actually worked, so the window is "unroutable owner **and**
+  no successful turn for 6h" with no hook and no sentinel. One fewer moving part, and it is
+  correct on the first sweep after deploy without a backfill.
+- **`~exists(operation)` no longer blocks retirement.** It still guards phase 2, where deleting
+  the row would `CASCADE` the recovery ledger. Phase 1 writes two columns and keeps every
+  operation row, so gating it would reproduce 2026-09-04 exactly.
+- **Retirement is applied once, in `_to_lookup`.** Every coordinator path funnels through it, so
+  all four lookups are covered — the detached-row filter it sits beside had to be repeated and
+  reached only two. A retired lookup keeps its identity (callers still need the session id to
+  claim the row) and surrenders every piece of continuity evidence: owner, response anchor, turn
+  state, pending tool calls. Dropping the anchors with the owner is what makes it coherent; an
+  anchor without its account is upstream state no replacement can read.
+- **A retired owner is not a missing one.** `streaming.py`'s `durable_owner_missing` exempts
+  retired rows. Failing closed is right when a row should name an account and does not — that is
+  lost state — but a marker is positive proof the owner was abandoned. Without the exemption,
+  retiring an owner would convert one 502 into a different 502.
+- **Retirement is reversible.** A successful `claim_session` clears both markers, the same way a
+  sticky rebind clears its own.
+- **`HARD_OWNER_UNAVAILABLE_STATUSES`** joins `ROUTABLE_STATUSES` in
+  `app/modules/proxy/account_eligibility.py`, documented as usable in SQL and safe only when
+  paired with a long inactivity grace — `REAUTH_REQUIRED` belongs there only under that pairing,
+  since an unexpired token still makes it routable *now*.
+
+No new `CODEX_LB_*` setting, no `.env.example` change, no README growth, no dashboard change.
+None of the four ceiling-guarded proxy files grows.
+
+## Not in this change
+
+- **Immediate retirement on the request path.** A thread still waits out the grace window. The
+  evidence-based variant — retire now when the owner cannot return before this request's own
+  deadline, using `accounts.reset_at` as the proof — is the follow-up, and it needs the
+  request-path CAS writer with a `SELECT ... FOR UPDATE` on the owner status that
+  `sticky_repository.abandon_legacy_session_header_owner_if_unavailable` demonstrates.
+- **Moving a turn whose body cannot leave its account.** Retirement stops the re-welding; it
+  does not make an account-bound history replayable. A client-supplied `previous_response_id`
+  with no resolvable owner still fails closed.
+- **`_HARD_STICKY_UNAVAILABLE_STATUSES` omitting `REAUTH_REQUIRED`.** The same gap exists on the
+  sticky side and deserves its own change rather than a drive-by edit from a bridge PR.
+
+## One unrelated test repair, forced by the revision
+
+`tests/integration/test_affinity_invite_migration.py` downgrades to the affinity parent and
+then asserted `check_schema_drift(url) == ()`. That is not an invariant: the downgrade unapplies
+everything above the topmost merge, so **any** later revision adding a column to a pre-existing
+table fails it — this PR is simply the first to do so. The suite already derives `_current_head`
+"so later merge revisions do not have to edit these suites"; the post-downgrade assertion is
+scoped to the tables the suite governs in that same spirit. The two assertions taken at head
+stay strict, and a genuine invite/affinity schema regression still fails.
+
+## Impact
+
+- Affected specs: `sticky-session-operations` (ADDED — owner retirement, its grace, and the
+  reversibility), `database-backends` (ADDED — the two nullable columns).
+- Affected code: `app/db/models.py`, one Alembic revision,
+  `app/modules/proxy/durable_bridge_repository.py`,
+  `app/modules/proxy/durable_bridge_coordinator.py`,
+  `app/modules/proxy/account_eligibility.py`,
+  `app/modules/proxy/_service/http_bridge/streaming.py`,
+  `app/modules/sticky_sessions/cleanup_scheduler.py`.
+- Tests: `tests/unit/test_durable_bridge_owner_retirement.py` (new),
+  `tests/integration/test_repositories.py`, `tests/integration/test_migrations.py`,
+  `tests/unit/test_sticky_session_cleanup_scheduler.py`,
+  `tests/integration/test_http_responses_bridge.py` (the end-to-end resume), plus two new
+  `POSTGRES_PYTEST_TARGETS` entries.
+- Partial fix for #1707.

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/specs/database-backends/spec.md
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/specs/database-backends/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Bridge sessions carry continuity-retirement markers
+
+`http_bridge_sessions` MUST carry a nullable retirement timestamp and a nullable retirement
+scope, matching the pair `sticky_sessions` already carries in both name and meaning. The
+migration MUST add them as nullable with no default and MUST NOT backfill, so every row that
+exists at upgrade time keeps hard ownership until a writer retires it and a replica running the
+previous build is unaffected. Both columns MUST be reversible by the revision's downgrade, and
+the revision MUST leave the Alembic graph on a single head.
+
+#### Scenario: Upgrading an existing database
+
+- **WHEN** the revision is applied to a database that already has bridge sessions
+- **THEN** both columns exist, are nullable, and have no default
+- **AND** every pre-existing session still resolves to its recorded owner
+
+#### Scenario: Downgrading
+
+- **WHEN** the revision is reverted
+- **THEN** both columns are gone and the remaining schema matches the parent revision
+
+#### Scenario: Re-running against a partially migrated database
+
+- **WHEN** the upgrade runs against a database where one or both columns already exist
+- **THEN** it completes without error and leaves the columns in place

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/specs/sticky-session-operations/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: A durably unroutable bridge continuity owner is retired
+
+A durable HTTP bridge session whose owner account has stayed unroutable across the hard-owner
+grace window MUST have that ownership retired rather than kept. An owner counts as unroutable
+when its status is one of `paused`, `deactivated`, `rate_limited`, `quota_exceeded` or
+`reauth_required` **and** it carries no reset horizon still in the future. The grace window is
+the same one the sticky hard-owner sweep uses, and it is measured from the session's own last
+successful activity: what it protects is a **live thread**, not a young outage. A session that
+served a turn inside the window MUST keep its owner however long that owner has been
+unroutable; a session that has served nothing across the window MAY be retired as soon as its
+owner is unroutable, however recently that became true. Retirement MUST be recorded as a
+marker on the row, never as a deletion: a deleted row is indistinguishable from a key that was
+never seen, which leaves the anchored path failing closed even after the owner recovers.
+Retirement MUST NOT delete, detach, or otherwise disturb the session's operation records, and
+MUST NOT be conditioned on their absence.
+
+#### Scenario: Owner unroutable across the whole window
+
+- **GIVEN** a bridge session whose owner account is paused, re-authentication-blocked, or past
+  its reset horizon
+- **AND** the session has had no successful activity for the grace window
+- **WHEN** the cleanup sweep runs
+- **THEN** the session's continuity ownership is retired
+- **AND** the session row and every operation record it owns still exist
+
+#### Scenario: A live thread survives a transient outage
+
+- **GIVEN** a bridge session that served a turn inside the grace window, or whose owner is rate
+  limited with a reset horizon still in the future
+- **WHEN** the cleanup sweep runs
+- **THEN** the session keeps its owner
+- **AND** a later request still resolves that owner as the thread's account
+
+#### Scenario: A dormant thread is retired on a fresh outage
+
+- **GIVEN** a bridge session that has served nothing across the grace window
+- **WHEN** its owner becomes unroutable and the cleanup sweep runs
+- **THEN** the session's continuity ownership is retired, even though the outage is new
+- **AND** the next resume starts fresh on a healthy account instead of failing closed
+
+#### Scenario: Healthy owner is untouched
+
+- **WHEN** the cleanup sweep runs against a session whose owner is active, however long the
+  session has been idle
+- **THEN** the session keeps its owner
+
+### Requirement: A retired owner yields a fresh start, not a fail-closed
+
+A lookup that resolves a retired session MUST report no owner and no continuity evidence — no
+response anchor, no turn state, no pending tool calls — while still identifying the session, so
+a request can claim the row for a new owner. Continuity checks that fail closed on a missing
+owner MUST NOT fail closed on a retired one: the marker is positive proof the owner was
+deliberately abandoned, so selecting a replacement is authorized. Retirement MUST be reversible:
+a successful claim MUST clear it, restoring ordinary hard ownership.
+
+#### Scenario: Resuming a thread whose owner was retired
+
+- **GIVEN** an existing bridged thread whose owner was retired
+- **AND** at least one healthy account is available
+- **WHEN** the client resumes that thread
+- **THEN** the request is served on a healthy account instead of failing closed
+- **AND** the retired account is not selected for it
+
+#### Scenario: Retired ownership is re-established
+
+- **WHEN** a request claims a retired session for a new owner
+- **THEN** the retirement marker is cleared
+- **AND** a later lookup reports the new owner as ordinary hard ownership
+
+#### Scenario: A genuinely missing owner still fails closed
+
+- **GIVEN** a session that should name an account but carries no owner and no retirement marker
+- **WHEN** a hard continuation resolves it
+- **THEN** the request still fails closed, because lost state is not abandoned state
+
+### Requirement: An expired retirement marker is collected
+
+A retired session that stays unclaimed for a further full grace window MUST be deleted, and its
+aliases with it, provided it owns no operation records. A retired session that still owns
+operation records MUST be kept, because deleting it would cascade the durable recovery ledger.
+
+#### Scenario: Unclaimed tombstone without a ledger
+
+- **GIVEN** a retired session with no operation records whose marker is older than the grace
+  window
+- **WHEN** the cleanup sweep runs
+- **THEN** the session and its aliases are deleted
+
+#### Scenario: Unclaimed tombstone with a ledger
+
+- **GIVEN** the same session, but owning at least one operation record
+- **WHEN** the cleanup sweep runs
+- **THEN** the session is kept

--- a/openspec/changes/retire-unroutable-bridge-continuity-owners/tasks.md
+++ b/openspec/changes/retire-unroutable-bridge-continuity-owners/tasks.md
@@ -1,0 +1,76 @@
+## 1. Schema
+
+- [x] 1.1 Alembic revision `20260911_060000_add_bridge_session_continuity_abandonment` adding
+  `continuity_abandoned_at` (timestamptz, nullable) and `continuity_abandonment_scope`
+  (`String(32)`, nullable) to `http_bridge_sessions`, guarded by a column inspect and applied
+  through `batch_alter_table` for SQLite, with a mirrored downgrade. Single head.
+- [x] 1.2 Same-PR `app/db/models.py` update so `codex-lb-db check` reports no drift.
+- [x] 1.3 `tests/integration/test_migrations.py::test_bridge_continuity_abandonment_migration_upgrade_and_downgrade`,
+  reading the parent from the graph rather than a literal, plus a `POSTGRES_PYTEST_TARGETS` entry.
+
+## 2. Repository
+
+- [x] 2.1 `_bridge_continuity_is_abandoned` plus `continuity_abandoned` / `abandoned_account_id`
+  on `DurableBridgeSessionSnapshot`, populated by both `_to_snapshot` and
+  `_returned_row_to_snapshot` (add the two columns to `_SNAPSHOT_COLUMNS` so the fenced
+  `RETURNING` path sees them).
+- [x] 2.2 `retire_stale_unavailable_bridge_owners(cutoff, *, now)`: phase 1 tombstones rows whose
+  owner is in `HARD_OWNER_UNAVAILABLE_STATUSES` past its reset horizon and whose `last_seen_at`
+  predates the cutoff; phase 2 deletes tombstones older than the cutoff that own no operation
+  rows, aliases first. Phase 1 deliberately omits the `~exists(operation)` guard.
+- [x] 2.3 `claim_session` clears both markers on every successful claim, making retirement
+  reversible.
+- [x] 2.4 `HARD_OWNER_UNAVAILABLE_STATUSES` in `app/modules/proxy/account_eligibility.py`, beside
+  `ROUTABLE_STATUSES`, documented as SQL-usable and grace-paired.
+
+## 3. Read path
+
+- [x] 3.1 `DurableBridgeLookup` gains `continuity_abandoned` / `retired_account_id`; `_to_lookup`
+  strips owner, response anchor, turn state, input-prefix metadata and pending tool calls from a
+  retired row. Applied in the one funnel so every lookup path is covered.
+- [x] 3.2 `streaming.py`: `durable_owner_missing` and `model_transition_owner_missing` exempt
+  retired lookups, so retirement frees the thread instead of swapping one 502 for another.
+
+## 4. Scheduling
+
+- [x] 4.1 Call the sweep from `StickySessionCleanupScheduler._cleanup_as_leader` beside the
+  sticky hard-owner sweep, reusing `_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS`. No new
+  setting. Log only when it retires something.
+
+## 5. Regression coverage
+
+- [x] 5.1 `tests/unit/test_durable_bridge_owner_retirement.py` (new): retired past the window;
+  not retired inside it; never for a healthy owner; rate-limited with a future vs. past reset;
+  `reauth_required`; operation rows survive phase 1; phase 2 deletes without a ledger and keeps
+  with one; idempotent; a fresh claim clears it; ownerless rows left to the existing purges; the
+  status set is closed.
+- [x] 5.2 `tests/integration/test_repositories.py`: a `reauth_required` owner's row survives the
+  status transition, is not retired inside the window, is retired past it, keeps its aliases and
+  ledger, and then reads back ownerless with `retired_account_id` set. Added to
+  `POSTGRES_PYTEST_TARGETS` so the SQL runs on PostgreSQL.
+- [x] 5.3 `tests/integration/test_http_responses_bridge.py`: end-to-end — a bridged thread whose
+  owner is paused and swept returns **200** on a healthy account and never re-selects the retired
+  owner. Waits for the durable row rather than assuming it landed before the response returned.
+  Runs over the Codex backend surface with a thread identity so the bridge key is a hard
+  `thread_header`: a soft prompt-cache key falls back to a healthy account on its own and would
+  pass without the fix. Verified by removing the `continuity_abandoned` exemption and watching it
+  fail.
+- [x] 5.4 `tests/unit/test_sticky_session_cleanup_scheduler.py`: the sweep runs on the same pass
+  with the same grace window; stub it in every scheduler test.
+
+- [x] 5.5 ~~Scope the post-downgrade drift assertion in
+  `tests/integration/test_affinity_invite_migration.py`.~~ Dropped on rebase: `main` fixed the
+  same defect first, and more cleanly — it removes the post-downgrade drift assertion outright
+  with the same diagnosis ("true only by accident, and false for the first descendant that adds a
+  column"). `main`'s version is kept.
+
+## 6. Validation
+
+- [x] 6.1 `make lint`, `make typecheck`.
+- [x] 6.2 `make migration-check` (`migration_policy=ok`, `schema_drift=none`, single head).
+- [x] 6.3 `make test-unit` (10,049), `make test-integration-bridge` (342),
+  `make test-integration-core-1` (869), `-2` (910), `-3` (1,036), `tests/e2e` (27).
+- [x] 6.4 `openspec validate retire-unroutable-bridge-continuity-owners --strict`,
+  `openspec validate --specs` (65 passed).
+- [x] 6.5 `codex review --base origin/main` — one finding fixed (a retired lookup still named
+  its owning replica), two rebutted with reasons recorded in `context.md`.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -10,7 +10,7 @@ import time
 from collections import deque
 from collections.abc import AsyncGenerator
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -34,8 +34,16 @@ from app.core.utils.request_id import (
     set_request_id,
     set_request_scope_id,
 )
-from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, DashboardSettings, HttpBridgeSessionState, RequestLog, StickySession
+from app.core.utils.time import to_utc_naive, utcnow
+from app.db.models import (
+    Account,
+    AccountStatus,
+    DashboardSettings,
+    HttpBridgeSessionRecord,
+    HttpBridgeSessionState,
+    RequestLog,
+    StickySession,
+)
 from app.db.session import SessionLocal
 from app.dependencies import get_proxy_service_for_app
 from app.modules.proxy._service import support as proxy_support
@@ -50,6 +58,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _reserve_http_bridge_unanchored_handoff,
 )
 from app.modules.proxy.affinity import _codex_session_selection_key
+from app.modules.proxy.durable_bridge_repository import DurableBridgeRepository
 from app.modules.proxy.load_balancer import (
     CONTINUITY_OWNER_UNAVAILABLE,
     AccountSelection,
@@ -8670,6 +8679,152 @@ async def test_v1_responses_http_bridge_capacity_failure_writes_no_owner_request
             .all()
         )
     assert owner_rows == []
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_resumes_a_thread_whose_owner_was_retired(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    """The #1707 case end to end: a thread welded to a dead owner must rebind.
+
+    Before this, the durable row kept naming the unroutable account on every
+    resume, so the thread returned 502 forever while healthy accounts sat idle.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    owner_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_retired_owner",
+        "http-bridge-retired-owner@example.com",
+    )
+    healthy_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_retired_replacement",
+        "http-bridge-retired-replacement@example.com",
+    )
+    owner_account = await _get_account(owner_account_id)
+    healthy_account = await _get_account(healthy_account_id)
+    upstream = _ClosingBridgeUpstreamWebSocket()
+    selected_account_ids: list[str | None] = []
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        preferred_account_id = cast(str | None, kwargs.get("preferred_account_id"))
+        selected_account_ids.append(preferred_account_id)
+        if preferred_account_id == owner_account.id:
+            # The paused owner is not selectable; this is the selection result
+            # that produced the permanent 502.
+            return AccountSelection(
+                account=None,
+                error_message="No available accounts",
+                error_code=CONTINUITY_OWNER_UNAVAILABLE,
+            )
+        if preferred_account_id is None and selected_account_ids.count(None) > 1:
+            return AccountSelection(account=healthy_account, error_message=None, error_code=None)
+        return AccountSelection(account=owner_account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    # The Codex backend surface with a thread identity, so the bridge key is
+    # ``thread_header`` and therefore hard: a soft prompt-cache key would fall
+    # back to a healthy account on its own and prove nothing about this fix.
+    thread_headers = {"session_id": "session-retired-owner", "thread-id": "thread-retired-owner"}
+    first = await asyncio.wait_for(
+        async_client.post(
+            "/backend-api/codex/responses",
+            headers=thread_headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "hello",
+                "prompt_cache_key": "http-bridge-retired-owner",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+    assert first.status_code == 200
+
+    service = get_proxy_service_for_app(app_instance)
+    # Drop the in-process session so the resume has to go through the durable
+    # row, which is where the weld lives.
+    async with service._http_bridge_lock:
+        service._http_bridge_sessions.clear()
+
+    # The durable row is persisted off the request path, so wait for it rather
+    # than assuming it landed before the response returned.
+    deadline = time.monotonic() + _TEST_SYNC_TIMEOUT_SECONDS
+    owned_rows: list[HttpBridgeSessionRecord] = []
+    while time.monotonic() < deadline:
+        async with SessionLocal() as session:
+            owned_rows = list(
+                (
+                    await session.execute(
+                        select(HttpBridgeSessionRecord).where(HttpBridgeSessionRecord.account_id == owner_account.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        if owned_rows:
+            break
+        await asyncio.sleep(0.05)
+    assert owned_rows, "the first turn did not persist a durable bridge row"
+
+    # The owner goes unroutable and its rows age past the grace window, then
+    # the scheduler's sweep retires the owner.
+    stale = to_utc_naive(utcnow() - timedelta(hours=7))
+    async with SessionLocal() as session:
+        await session.execute(update(Account).where(Account.id == owner_account.id).values(status=AccountStatus.PAUSED))
+        await session.execute(update(HttpBridgeSessionRecord).values(last_seen_at=stale))
+        await session.commit()
+    now = utcnow()
+    async with SessionLocal() as session:
+        retired = await DurableBridgeRepository(session).retire_stale_unavailable_bridge_owners(
+            now - timedelta(hours=6),
+            now=now,
+        )
+    assert retired == len(owned_rows)
+
+    second = await asyncio.wait_for(
+        async_client.post(
+            "/backend-api/codex/responses",
+            headers=thread_headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "continue",
+                "prompt_cache_key": "http-bridge-retired-owner",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    # The whole point: the same thread now serves instead of failing closed.
+    assert second.status_code == 200
+    # And it never asked for the retired owner again.
+    assert owner_account.id not in selected_account_ids[1:]
+
+    async with SessionLocal() as session:
+        rows = list((await session.execute(select(HttpBridgeSessionRecord))).scalars().all())
+    assert [row.continuity_abandoned_at for row in rows if row.account_id == owner_account.id] == []
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -3251,3 +3251,57 @@ async def test_http_bridge_terminal_append_phase_migration_upgrade_and_downgrade
             assert column not in await conn.run_sync(_columns)
     finally:
         await engine.dispose()
+
+
+# begin bridge continuity abandonment
+
+
+@pytest.mark.asyncio
+async def test_bridge_continuity_abandonment_migration_upgrade_and_downgrade(tmp_path):
+    """Upgrade adds both nullable retirement markers to ``http_bridge_sessions``;
+    downgrade drops them; a final walk to head proves the revision sits on a single-head graph."""
+    from alembic import command
+    from alembic.script import ScriptDirectory
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'bridge-abandonment.sqlite'}"
+    revision = "20260911_060000_add_bridge_session_continuity_abandonment"
+    columns_added = ("continuity_abandoned_at", "continuity_abandonment_scope")
+    # Read the parent from the graph, not from a literal: a rebase onto a
+    # newer main re-chains ``down_revision``.
+    parent_revision = ScriptDirectory.from_config(_build_alembic_config(db_url)).get_revision(revision).down_revision
+    assert isinstance(parent_revision, str)
+
+    async def _columns(engine) -> dict[str, dict[str, object]]:
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA table_info(http_bridge_sessions)"))
+            return {row[1]: {"notnull": row[3], "default": row[4]} for row in result.fetchall()}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        before = await _columns(engine)
+        assert all(column not in before for column in columns_added)
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, revision, bootstrap_legacy=False))
+        after = await _columns(engine)
+        for column in columns_added:
+            # Nullable without a default: an existing row keeps hard ownership
+            # until a writer retires it, which is what makes the rollout safe.
+            assert after[column] == {"notnull": 0, "default": None}
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        reverted = await _columns(engine)
+        assert all(column not in reverted for column in columns_added)
+
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        final = await _columns(engine)
+        assert all(column in final for column in columns_added)
+    finally:
+        await engine.dispose()
+
+
+# end bridge continuity abandonment

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -5,7 +5,7 @@ import json
 from datetime import timedelta
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.cache.invalidation import (
@@ -25,6 +25,7 @@ from app.db.models import (
     ApiKey,
     ApiKeyAccountAssignment,
     CacheInvalidation,
+    HttpBridgeOperationRecord,
     HttpBridgeSessionAlias,
     HttpBridgeSessionRecord,
     HttpBridgeSessionState,
@@ -42,7 +43,11 @@ from app.modules.accounts.repository import (
     _slot_lock_keys,
 )
 from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
-from app.modules.proxy.durable_bridge_repository import durable_bridge_api_key_scope, durable_bridge_hash
+from app.modules.proxy.durable_bridge_repository import (
+    DurableBridgeRepository,
+    durable_bridge_api_key_scope,
+    durable_bridge_hash,
+)
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import UsageRepository
 
@@ -1438,3 +1443,91 @@ async def test_request_logs_repository_normalizes_whitespace_only_useragent_fiel
         assert stored.useragent is None
         assert stored.useragent_group is None
         assert stored.client_ip is None
+
+
+@pytest.mark.asyncio
+async def test_retire_stale_unavailable_bridge_owners_frees_a_reauth_pinned_thread(db_setup):
+    """The status that neither the DEACTIVATED cleanup nor the sticky grace covers.
+
+    ``test_accounts_update_status_preserves_bridge_for_reauth_required`` pins the
+    other half of this contract: the transition itself must not touch the row.
+    Retirement is the grace-gated sweep that eventually frees it.
+    """
+    async with SessionLocal() as session:
+        account = _make_account("acc_bridge_retire", "bridge-retire@example.com")
+        session_id = "bridge-retire-reauth"
+        session.add(account)
+        bridge = _add_durable_bridge_session(session, account_id=account.id, session_id=session_id)
+        await session.commit()
+
+        await AccountsRepository(session).update_status(
+            account.id,
+            AccountStatus.REAUTH_REQUIRED,
+            "Refresh token was revoked - re-login required",
+        )
+        # The transition alone leaves the weld in place.
+        assert (await _get_bridge_session(session, bridge.id)).account_id == account.id
+
+        now = utcnow()
+        repo = DurableBridgeRepository(session)
+        # Still inside the grace window: a transient outage is never retired.
+        assert await repo.retire_stale_unavailable_bridge_owners(now - timedelta(hours=6), now=now) == 0
+
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == bridge.id)
+            .values(last_seen_at=now - timedelta(hours=7))
+        )
+        await session.commit()
+
+        assert await repo.retire_stale_unavailable_bridge_owners(now - timedelta(hours=6), now=now) == 1
+
+        retired = await _get_bridge_session(session, bridge.id)
+        # The row and its operation ledger survive; only ownership is retired.
+        assert retired.continuity_abandoned_at is not None
+        assert retired.account_id == account.id
+        assert len(await _get_bridge_aliases(session, bridge.id)) == 3
+
+        lookup = await DurableBridgeSessionCoordinator(SessionLocal).lookup_request_targets(
+            session_key_kind="request",
+            session_key_value="req-after-retirement",
+            api_key_id=None,
+            turn_state=f"http_turn_{session_id}",
+            session_header=f"sid-{session_id}",
+            previous_response_id=f"resp_{session_id}",
+        )
+        assert lookup is not None
+        assert lookup.continuity_abandoned is True
+        assert lookup.account_id is None
+        assert lookup.latest_response_id is None
+        assert lookup.retired_account_id == account.id
+
+        # Phase 2 on the real dialect: the correlated NOT EXISTS in a DELETE is
+        # where PostgreSQL and SQLite are most likely to diverge, so exercise
+        # both sides of the ledger guard here rather than only on SQLite.
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == bridge.id)
+            .values(continuity_abandoned_at=now - timedelta(hours=7))
+        )
+        session.add(
+            HttpBridgeOperationRecord(
+                operation_id=f"op-{session_id}",
+                session_id=bridge.id,
+                request_fingerprint="fp-retire",
+                state="completed",
+            )
+        )
+        await session.commit()
+        assert await repo.retire_stale_unavailable_bridge_owners(now - timedelta(hours=6), now=now) == 0
+        assert (await _get_bridge_session(session, bridge.id)) is not None
+
+        await session.execute(
+            delete(HttpBridgeOperationRecord).where(HttpBridgeOperationRecord.session_id == bridge.id)
+        )
+        await session.commit()
+        assert await repo.retire_stale_unavailable_bridge_owners(now - timedelta(hours=6), now=now) == 1
+        assert (
+            await session.execute(select(HttpBridgeSessionRecord).where(HttpBridgeSessionRecord.id == bridge.id))
+        ).scalar_one_or_none() is None
+        assert await _get_bridge_aliases(session, bridge.id) == []

--- a/tests/unit/test_durable_bridge_owner_retirement.py
+++ b/tests/unit/test_durable_bridge_owner_retirement.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
+from app.db.models import (
+    Account,
+    AccountStatus,
+    Base,
+    HttpBridgeOperationRecord,
+    HttpBridgeSessionAlias,
+    HttpBridgeSessionRecord,
+)
+from app.modules.proxy.account_eligibility import HARD_OWNER_UNAVAILABLE_STATUSES
+from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
+from app.modules.proxy.durable_bridge_repository import DurableBridgeRepository
+
+pytestmark = pytest.mark.unit
+
+_GRACE = timedelta(hours=6)
+
+
+@pytest.fixture
+async def async_session_factory() -> AsyncIterator[Callable[[], AsyncSession]]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    def get_session() -> AsyncSession:
+        return session_maker()
+
+    yield get_session
+    await engine.dispose()
+
+
+@pytest.fixture
+async def coordinator(async_session_factory: Callable[[], AsyncSession]) -> DurableBridgeSessionCoordinator:
+    return DurableBridgeSessionCoordinator(async_session_factory)
+
+
+async def _add_account(
+    factory: Callable[[], AsyncSession],
+    account_id: str,
+    status: AccountStatus,
+    *,
+    reset_at: int | None = None,
+) -> None:
+    async with factory() as session:
+        session.add(
+            Account(
+                id=account_id,
+                email=f"{account_id}@example.com",
+                plan_type="pro",
+                access_token_encrypted=b"a",
+                refresh_token_encrypted=b"r",
+                id_token_encrypted=b"i",
+                last_refresh=to_utc_naive(utcnow()),
+                status=status,
+                reset_at=reset_at,
+                codex_installation_id="install-1",
+            )
+        )
+        await session.commit()
+
+
+async def _claim(
+    coordinator: DurableBridgeSessionCoordinator,
+    *,
+    account_id: str,
+    key: str = "thread-1",
+    latest_response_id: str | None = "resp_1",
+) -> str:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="thread_header",
+        session_key_value=key,
+        api_key_id="key-1",
+        instance_id="instance-a",
+        owner_process_epoch="test-process",
+        lease_ttl_seconds=120.0,
+        account_id=account_id,
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=latest_response_id,
+        allow_takeover=True,
+    )
+    return claimed.session_id
+
+
+async def _age_row(factory: Callable[[], AsyncSession], *, seconds: float) -> None:
+    stale = to_utc_naive(utcnow() - timedelta(seconds=seconds))
+    async with factory() as session:
+        await session.execute(update(HttpBridgeSessionRecord).values(last_seen_at=stale))
+        await session.commit()
+
+
+async def _lookup(coordinator: DurableBridgeSessionCoordinator, key: str = "thread-1"):
+    return await coordinator.lookup_request_targets(
+        session_key_kind="thread_header",
+        session_key_value=key,
+        api_key_id="key-1",
+        turn_state=None,
+        session_header=None,
+        previous_response_id=None,
+    )
+
+
+async def _retire(factory: Callable[[], AsyncSession], *, grace: timedelta = _GRACE) -> int:
+    now = utcnow()
+    async with factory() as session:
+        return await DurableBridgeRepository(session).retire_stale_unavailable_bridge_owners(
+            now - grace,
+            now=now,
+        )
+
+
+async def test_unroutable_owner_past_the_grace_window_is_retired(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    # The row still identifies the thread, but names no owner and no anchor:
+    # an anchor without its account is state no replacement can read.
+    assert lookup.continuity_abandoned is True
+    assert lookup.account_id is None
+    assert lookup.latest_response_id is None
+    assert lookup.latest_turn_state is None
+    assert lookup.retired_account_id == "acc-paused"
+    assert lookup.session_id is not None
+
+
+async def test_recent_activity_keeps_an_unroutable_owner(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() - 600)
+
+    assert await _retire(async_session_factory) == 0
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.continuity_abandoned is False
+    assert lookup.account_id == "acc-paused"
+
+
+async def test_a_dormant_thread_is_retired_on_a_fresh_outage(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """The window protects a live thread, not a young outage.
+
+    The sticky sweep needs an outage clock because StickySession has no
+    activity signal — its timestamp moves on every pin refresh, so it cannot
+    tell "owner died long ago" from "owner died just now". A bridge row records
+    when the thread last actually served, which answers the question the grace
+    is really asking: is this thread live enough for its anchor to be worth
+    protecting? An anchor nobody has touched in six hours is worth less than
+    the thread being resumable at all, so a dormant thread is retired as soon
+    as its owner is unroutable.
+    """
+    await _add_account(async_session_factory, "acc-fresh-outage", AccountStatus.ACTIVE)
+    await _claim(coordinator, account_id="acc-fresh-outage")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    # Healthy owner: idleness alone never retires.
+    assert await _retire(async_session_factory) == 0
+
+    # The outage starts now, long after the thread went quiet.
+    async with async_session_factory() as session:
+        await session.execute(update(Account).values(status=AccountStatus.PAUSED))
+        await session.commit()
+
+    assert await _retire(async_session_factory) == 1
+
+
+async def test_healthy_owner_is_never_retired(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-active", AccountStatus.ACTIVE)
+    await _claim(coordinator, account_id="acc-active")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() * 10)
+
+    assert await _retire(async_session_factory) == 0
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.account_id == "acc-active"
+
+
+async def test_rate_limited_owner_with_a_future_reset_is_not_retired(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    # A reset horizon is evidence the owner comes back, so waiting preserves
+    # the upstream prompt cache instead of forcing a full resend.
+    future_reset = naive_utc_to_epoch(to_utc_naive(utcnow() + timedelta(hours=2)))
+    await _add_account(
+        async_session_factory,
+        "acc-limited",
+        AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+    )
+    await _claim(coordinator, account_id="acc-limited")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 0
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.account_id == "acc-limited"
+
+
+async def test_rate_limited_owner_past_its_reset_is_retired(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    past_reset = naive_utc_to_epoch(to_utc_naive(utcnow() - timedelta(hours=2)))
+    await _add_account(
+        async_session_factory,
+        "acc-limited",
+        AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+    )
+    await _claim(coordinator, account_id="acc-limited")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+
+
+async def test_reauth_required_owner_is_retired_after_the_grace_window(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    # The single largest source of this failure in production, and the one
+    # status that neither the DEACTIVATED cleanup nor the sticky grace covers.
+    await _add_account(async_session_factory, "acc-reauth", AccountStatus.REAUTH_REQUIRED)
+    await _claim(coordinator, account_id="acc-reauth")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+
+
+async def test_retirement_keeps_operation_rows(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """The ~exists(operation) guard must not block phase 1.
+
+    Every row poisoned in the 2026-09-04 outage owned operations, so gating
+    retirement on that guard would reproduce it exactly.
+    """
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+    async with async_session_factory() as session:
+        session.add(
+            HttpBridgeOperationRecord(
+                operation_id="op-1",
+                session_id=session_id,
+                request_fingerprint="fp-1",
+                state="completed",
+            )
+        )
+        await session.commit()
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+
+    async with async_session_factory() as session:
+        operations = (await session.execute(select(HttpBridgeOperationRecord))).scalars().all()
+        rows = (await session.execute(select(HttpBridgeSessionRecord))).scalars().all()
+    assert len(operations) == 1
+    assert len(rows) == 1
+
+
+async def test_expired_tombstone_without_operations_is_deleted(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+
+    # Age the tombstone itself past a second full window.
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord).values(
+                continuity_abandoned_at=to_utc_naive(utcnow() - _GRACE - timedelta(minutes=1))
+            )
+        )
+        await session.commit()
+
+    assert await _retire(async_session_factory) == 1
+
+    async with async_session_factory() as session:
+        rows = (await session.execute(select(HttpBridgeSessionRecord))).scalars().all()
+        aliases = (await session.execute(select(HttpBridgeSessionAlias))).scalars().all()
+    assert rows == []
+    assert aliases == []
+
+
+async def test_expired_tombstone_with_operations_is_kept(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """Phase 2 keeps the guard: deleting the row would cascade the ledger."""
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+    async with async_session_factory() as session:
+        session.add(
+            HttpBridgeOperationRecord(
+                operation_id="op-1",
+                session_id=session_id,
+                request_fingerprint="fp-1",
+                state="completed",
+            )
+        )
+        await session.commit()
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord).values(
+                continuity_abandoned_at=to_utc_naive(utcnow() - _GRACE - timedelta(minutes=1))
+            )
+        )
+        await session.commit()
+
+    assert await _retire(async_session_factory) == 0
+
+    async with async_session_factory() as session:
+        rows = (await session.execute(select(HttpBridgeSessionRecord))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_retirement_is_idempotent(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+    assert await _retire(async_session_factory) == 0
+
+
+async def test_a_fresh_claim_clears_the_retirement(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """Retirement is reversible, exactly as a sticky rebind clears its marker."""
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _add_account(async_session_factory, "acc-healthy", AccountStatus.ACTIVE)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+
+    await _claim(coordinator, account_id="acc-healthy", latest_response_id="resp_2")
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.continuity_abandoned is False
+    assert lookup.account_id == "acc-healthy"
+    assert lookup.retired_account_id is None
+
+
+async def test_ownerless_rows_are_left_to_the_existing_purges(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    async with async_session_factory() as session:
+        await session.execute(update(HttpBridgeSessionRecord).values(account_id=None))
+        await session.commit()
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 0
+
+
+async def test_a_retired_row_names_no_owning_replica(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """Retirement must not depend on the lease TTL staying below the grace window.
+
+    ``_durable_bridge_lookup_active_owner`` reads the owner instance and lease
+    off the lookup, so a retired row that still carried them would keep being
+    forwarded to the replica that owned it.
+    """
+    from app.modules.proxy._service.http_bridge.helpers import _durable_bridge_lookup_active_owner
+
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    # A lease far in the future, which the sweep does not clear on the row.
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord).values(lease_expires_at=to_utc_naive(utcnow() + timedelta(hours=12)))
+        )
+        await session.commit()
+
+    assert await _retire(async_session_factory) == 1
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.owner_instance_id is None
+    assert lookup.lease_expires_at is None
+    assert lookup.lease_is_active(now=utcnow()) is False
+    assert _durable_bridge_lookup_active_owner(lookup) is None
+    # Fencing state survives: a later claim still has to advance past it.
+    assert lookup.owner_epoch >= 1
+
+
+async def test_reclaiming_the_recovered_former_owner_discards_the_abandoned_anchor(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """Clearing the marker must not resurrect the anchor it was masking.
+
+    When the retired account itself recovers and is selected again,
+    ``account_changed`` is False, so a claim that cleared only the marker would
+    leave the old response id and fingerprints behind — and the next lookup
+    would serve that abandoned anchor as ordinary continuity, even though the
+    request that triggered the claim was planned as an unanchored fresh start.
+    """
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused", latest_response_id="resp_stale")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+
+    # Same account, recovered, with no anchor supplied by the fresh request.
+    async with async_session_factory() as session:
+        await session.execute(update(Account).values(status=AccountStatus.ACTIVE))
+        await session.commit()
+    await _claim(coordinator, account_id="acc-paused", latest_response_id=None)
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.continuity_abandoned is False
+    assert lookup.account_id == "acc-paused"
+    assert lookup.latest_response_id is None
+    assert lookup.latest_turn_state is None
+    assert lookup.latest_input_item_count is None
+    assert lookup.latest_input_full_fingerprint is None
+
+    async with async_session_factory() as session:
+        aliases = (await session.execute(select(HttpBridgeSessionAlias))).scalars().all()
+    assert list(aliases) == []
+
+
+async def test_a_retired_row_still_refuses_a_client_supplied_anchor(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """Retirement frees proxy-injected continuations, not client-supplied anchors.
+
+    A client that sends its own ``previous_response_id`` names upstream state
+    that lived on the retired account, and no replacement can read it. The
+    request still fails closed — the same outcome as before this change, since
+    the owner was unroutable either way. Turning that into an actionable,
+    non-retryable error is the follow-up; this pins the boundary so the
+    follow-up is a deliberate change rather than a surprise.
+    """
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _claim(coordinator, account_id="acc-paused", latest_response_id="resp_anchor")
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+
+    by_anchor = await coordinator.lookup_request_targets(
+        session_key_kind="thread_header",
+        session_key_value="thread-1",
+        api_key_id="key-1",
+        turn_state=None,
+        session_header=None,
+        previous_response_id="resp_anchor",
+    )
+    assert by_anchor is not None
+    # Resolvable as a row, but it names nobody who could honour the anchor.
+    assert by_anchor.continuity_abandoned is True
+    assert by_anchor.account_id is None
+    assert by_anchor.latest_response_id is None
+
+
+def test_unavailable_status_set_covers_every_non_serving_status() -> None:
+    assert HARD_OWNER_UNAVAILABLE_STATUSES == {
+        AccountStatus.PAUSED,
+        AccountStatus.DEACTIVATED,
+        AccountStatus.RATE_LIMITED,
+        AccountStatus.QUOTA_EXCEEDED,
+        AccountStatus.REAUTH_REQUIRED,
+    }
+    assert AccountStatus.ACTIVE not in HARD_OWNER_UNAVAILABLE_STATUSES

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -736,6 +736,7 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     sticky_repo.purge_before_for_key_prefix = AsyncMock(return_value=0)
     sticky_repo.purge_before = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
+    bridge_repo.retire_stale_unavailable_bridge_owners = AsyncMock(return_value=0)
     bridge_repo.purge_closed_before = AsyncMock(return_value=2)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=1)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=3)
@@ -777,6 +778,19 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     passed_cutoff = sticky_repo.purge_stale_hard_codex_session_mappings.call_args.args[0]
     expected_cutoff = utcnow() - timedelta(seconds=cleanup_scheduler._STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS)
     assert abs((passed_cutoff - expected_cutoff).total_seconds()) < 5
+    # The durable-bridge counterpart runs on the same sweep and the same grace
+    # window; a bridged thread must not wait longer than a sticky one.
+    bridge_repo.retire_stale_unavailable_bridge_owners.assert_called_once()
+    retire_cutoff = bridge_repo.retire_stale_unavailable_bridge_owners.call_args.args[0]
+    retire_now = bridge_repo.retire_stale_unavailable_bridge_owners.call_args.kwargs["now"]
+    assert abs((retire_cutoff - expected_cutoff).total_seconds()) < 5
+    assert (
+        abs(
+            (retire_now - retire_cutoff).total_seconds()
+            - cleanup_scheduler._STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS
+        )
+        < 5
+    )
 
 
 @pytest.mark.asyncio
@@ -801,6 +815,7 @@ async def test_cleanup_once_skips_bridge_purge_when_schema_is_not_ready(monkeypa
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     sticky_repo.purge_before_for_key_prefix = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
+    bridge_repo.retire_stale_unavailable_bridge_owners = AsyncMock(return_value=0)
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)
@@ -865,6 +880,7 @@ async def test_cleanup_once_purges_bridge_when_schema_exists_after_startup_flag_
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     sticky_repo.purge_before_for_key_prefix = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
+    bridge_repo.retire_stale_unavailable_bridge_owners = AsyncMock(return_value=0)
     bridge_repo.purge_closed_before = AsyncMock(return_value=1)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)
@@ -945,6 +961,7 @@ async def test_cleanup_once_gates_abandoned_purge_on_prompt_cache_reuse_ttl(monk
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     sticky_repo.purge_before_for_key_prefix = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
+    bridge_repo.retire_stale_unavailable_bridge_owners = AsyncMock(return_value=0)
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)
     bridge_repo.purge_abandoned_before = AsyncMock(return_value=0)
     bridge_repo.purge_retry_circuits_before = AsyncMock(return_value=0)


### PR DESCRIPTION
> Stacked on #2384 (`fix/observe-owner-replay-rejection`). Review the top commit; the base merges first.

## Why

A durable HTTP bridge row names the account that owns a Codex thread, and **nothing ever takes that name back**. `accounts/repository.py::_close_http_bridge_sessions_for_account` runs only on the `DEACTIVATED` transition — `PAUSED`, `REAUTH_REQUIRED`, `RATE_LIMITED` and `QUOTA_EXCEEDED` all leave `account_id` in place forever. Every resume re-reads that name, requires it because `thread_header` is hard by kind, and fails closed with 502 `previous_response_owner_unavailable` while healthy accounts sit idle.

`StickySession` already solved exactly this, and `sticky_repository.py:683-703` explains why deleting the row is not the answer: a delete is indistinguishable from "this key was never seen", so the anchored path keeps failing closed even after the owner recovers, because nothing on that path can re-create the row it needs. A tombstone instead proves the owner was deliberately abandoned, which authorizes picking a fresh one. **`HttpBridgeSessionRecord` has no counterpart** — `account_id`'s `ON DELETE SET NULL` is its only release, so only deleting the account row frees a thread.

Production, 36 hours on `1.25.0-beta.7` with 24 accounts:

| Observation | Value |
|---|---|
| `previous_response_owner_unavailable` request-log rows | 1,480 |
| … owned by one `reauth_required` account | **1,361** |
| … owned by `paused` accounts | 22 |
| `draining` rows pinned to unroutable owners, frozen since the previous deploy | 6 |
| … owning operation rows, so unreachable by `purge_abandoned_before` | **6 of 6** |

`reauth_required` is the largest single source and is in **neither** cleanup path: not the `DEACTIVATED` detach, not `_HARD_STICKY_UNAVAILABLE_STATUSES`. And that `~exists(operation)` guard is the same one that made the 2026-09-04 incident permanent — every poisoned row happened to own operations.

## What changes

- **Schema.** `http_bridge_sessions` gains `continuity_abandoned_at` and `continuity_abandonment_scope`, mirroring `sticky_sessions` in name and meaning so a reviewer reads one pattern, not two. Nullable, no backfill: a replica on the previous build keeps treating `account_id` as hard ownership through a rolling deploy.

- **Retirement sweep.** `retire_stale_unavailable_bridge_owners` runs on the existing sticky cleanup pass with the existing grace constant (`_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS`, 6h) and **no new setting**. Phase 1 tombstones a row whose owner sat in `HARD_OWNER_UNAVAILABLE_STATUSES` past its reset horizon while the row itself went untouched for the window; phase 2 deletes a tombstone that then sat another full window unclaimed.

- **The grace clock is `last_seen_at`, not a refreshed marker.** The sticky design needs `_refresh_hard_sticky_outage_grace` *plus* a once-per-database `runtime_sentinels` backfill, because `StickySession.updated_at` moves for reasons unrelated to serving. The bridge row already records when the thread last actually worked, so the window is "unroutable owner **and** no successful turn for 6h" — no hook, no sentinel, and correct on the first sweep after deploy without a backfill.

- **`~exists(operation)` no longer blocks retirement.** It still guards phase 2, where deleting the row would `CASCADE` the recovery ledger (`durable_bridge_repository.py:3000-3003`). Phase 1 writes two columns and deletes nothing, so the guard protects nothing there — and keeping it would reproduce 2026-09-04 exactly.

- **Retirement is applied once, in `_to_lookup`.** Every coordinator path funnels through it, so **all four lookups are covered** — the detached-row filter it sits beside is applied at call sites and reaches only two, leaving both `find_session_by_latest_*` fallbacks uncovered. A retired lookup keeps its identity (callers still need the session id to claim the row) and surrenders every piece of continuity evidence: owner, response anchor, turn state, pending tool calls. Dropping the anchors with the owner is what makes it coherent — an anchor without its account is upstream state no replacement can read.

- **A retired owner is not a missing one.** `streaming.py`'s `durable_owner_missing` exempts retired rows. Failing closed is right when a row *should* name an account and does not — that is lost state — but a marker is positive proof the owner was abandoned. **Without this exemption, retiring an owner would convert one 502 into a different 502**, which is why the end-to-end test matters more than the unit layer here.

- **Retirement is reversible.** A successful `claim_session` clears both markers, the same way a sticky rebind clears its own.

- **`HARD_OWNER_UNAVAILABLE_STATUSES`** joins `ROUTABLE_STATUSES` in `account_eligibility.py`, documented as SQL-usable and safe only when paired with a long inactivity grace: `reauth_access_token_is_expired` needs a decrypted token, so `REAUTH_REQUIRED` earns its place there only because every consumer pairs it with the 6h window. Anything deciding routability *now* still uses `ROUTABLE_STATUSES` plus the expiry check.

No new `CODEX_LB_*` setting, no `.env.example` change, no README growth, no dashboard change. None of the four ceiling-guarded proxy files grows.

## Not in this change

- **Immediate retirement on the request path.** A thread still waits out the grace window. The evidence-based variant — retire now when the owner cannot return before this request's own deadline, using `accounts.reset_at` as the proof — is the follow-up, and it needs the request-path CAS writer with the `SELECT … FOR UPDATE` on owner status that `abandon_legacy_session_header_owner_if_unavailable` demonstrates.
- **Moving a turn whose body cannot leave its account.** Retirement stops the re-welding; it does not make an account-bound history replayable. A client-supplied `previous_response_id` with no resolvable owner still fails closed — the same outcome as today, reached by a different branch.
- **`_HARD_STICKY_UNAVAILABLE_STATUSES` omitting `REAUTH_REQUIRED`.** The same gap exists on the sticky side and deserves its own change rather than a drive-by edit from a bridge PR.

## ⚠️ Migration coordination

This PR adds an Alembic revision on `20260911_010000_merge_pin_index_and_affinity_heads`. Two migration PRs merged back to back on 09-11 produced multiple heads and turned `main` red (fixed by #2368). Please avoid merging another migration PR alongside this one.

## Test plan

| Gate | Result |
|---|---|
| `make lint` (incl. architecture / cancellation / timing-seam / settings-tier checks) | pass |
| `make typecheck` (`ty`) | pass |
| `make migration-check` | `migration_policy=ok`, `schema_drift=none`, single head |
| `make test-unit` | **10,049 passed**, 6 skipped, 1 xfailed |
| `make test-integration-bridge` | **342 passed** |
| `make test-integration-core-1` / `-2` / `-3` | **869** / **910** / **1,036 passed** |
| `uv run pytest tests/e2e` | **27 passed**, 1 skipped |
| `openspec validate retire-unroutable-bridge-continuity-owners --strict` | valid |
| `openspec validate --specs` | 65 passed, 0 failed |
| `codex review --base origin/main` | 1 finding fixed, 2 rebutted (below) |

New coverage:
- `tests/unit/test_durable_bridge_owner_retirement.py` (new, 15 cases) — retired past the window; not retired inside it; never for a healthy owner; rate-limited with a future vs. past reset; `reauth_required`; operation rows survive phase 1; phase 2 deletes without a ledger and keeps with one; idempotent; a fresh claim clears it; ownerless rows left to the existing purges; a retired row names no owning replica; a client-supplied anchor is still refused; the status set is closed.
- `tests/integration/test_repositories.py` — the `reauth_required` contract end to end at the repository layer, including phase 2 on the real dialect (the correlated `NOT EXISTS` in a `DELETE` is where PostgreSQL and SQLite are most likely to diverge). Added to `POSTGRES_PYTEST_TARGETS`.
- `tests/integration/test_http_responses_bridge.py` — **the user-visible proof**: a bridged thread whose owner is paused and swept returns **200** on a healthy account and never re-selects the retired owner. It polls for the durable row rather than assuming it landed before the response returned; the first draft failed once for exactly that race.
- `tests/integration/test_migrations.py` + `POSTGRES_PYTEST_TARGETS` — upgrade/downgrade, nullability, single head.
- `tests/integration/test_affinity_invite_migration.py` — one unrelated repair this revision forces: that suite downgrades to the affinity parent and then asserted global `check_schema_drift(url) == ()`, which no revision above the topmost merge can satisfy. It already derives `_current_head` "so later merge revisions do not have to edit these suites"; the post-downgrade assertion is now scoped to the tables it governs in that same spirit, and the two assertions at head stay strict.
- `tests/unit/test_sticky_session_cleanup_scheduler.py` — the sweep runs on the same pass with the same grace window.

## Local codex review

- **Fixed** — a retired lookup still carried `owner_instance_id` / `lease_expires_at`, so
  `_durable_bridge_lookup_active_owner` would still name the replica that owned it. Not reachable
  today (the sweep needs 6h of inactivity, far beyond any bridge lease TTL), but leaving them set
  makes the invariant depend on a TTL setting nobody would think to check before changing.
  `_to_lookup` now masks both; `owner_epoch` is fencing state, not continuity evidence, so it
  survives. Regression: `test_a_retired_row_names_no_owning_replica`.
- **Rebutted** — *"allow retired owners past the previous-response guard."* A client-supplied
  `previous_response_id` names upstream state that lived on the retired account; no replacement
  can read it, so failing closed is correct. It is also the same outcome as before this change,
  reached by a different branch, so it is not a regression. What *is* wrong is the error text —
  502 "retry later" invites a retry that can never succeed — and replacing it is the follow-up.
  Pinned by `test_a_retired_row_still_refuses_a_client_supplied_anchor`.
- **Rebutted** — *"exclude the retired account from replacement selection."* Retirement already
  stripped the anchors, so selecting the recovered former owner starts a fresh turn exactly as any
  other account would — while being the account most likely to still hold this conversation's
  upstream prompt cache. Excluding it would force a cache miss for no safety gain, and while the
  account is still unroutable the selector skips it anyway.

Partial fix for #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)