### PR TITLE
test(dashboard): make the clean-install overflow statement count deterministic

### DIFF
--- a/tests/integration/statement_capture.py
+++ b/tests/integration/statement_capture.py
@@ -1,0 +1,63 @@
+"""Task-scoped SQL capture for query-cost assertions.
+
+``before_cursor_execute`` on the process-wide engine sees every statement the
+process issues, not only the ones the request under test issues. Two ambient
+background loops the suite deliberately leaves running write into the same
+engine while a test is measuring:
+
+* ``CacheInvalidationPoller`` polls ``cache_invalidation`` every 0.5 s, and
+* the bridge ring membership heartbeat issues three statements every 10 s
+  (a ``bridge_ring_members`` upsert, the member list, and a
+  ``dashboard_settings`` load).
+
+Either one landing inside a capture window inflates an exact statement count
+by one (or three) and makes the assertion flake. Both run on their own asyncio
+tasks, while an ``ASGITransport`` request runs inline on the calling task, so
+dropping statements issued by another task excludes the ambient loops exactly
+without weakening what the count proves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+def normalize_sql(statement: str) -> str:
+    """Collapse whitespace and case so statements compare as shapes."""
+    return " ".join(statement.split()).lower()
+
+
+@asynccontextmanager
+async def capture_task_statements(async_engine: AsyncEngine) -> AsyncIterator[list[str]]:
+    """Collect the normalized SQL issued by the calling task inside the block."""
+    own_task = asyncio.current_task()
+    if own_task is None:  # pragma: no cover - the suite always runs inside a task
+        raise RuntimeError("capture_task_statements() must be used from inside a task")
+    statements: list[str] = []
+
+    def _capture(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        try:
+            if asyncio.current_task() is not own_task:
+                return
+        except RuntimeError:  # pragma: no cover - driver thread without a loop
+            return
+        statements.append(normalize_sql(statement))
+
+    event.listen(async_engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        yield statements
+    finally:
+        event.remove(async_engine.sync_engine, "before_cursor_execute", _capture)

--- a/tests/integration/statement_capture.py
+++ b/tests/integration/statement_capture.py
@@ -1,7 +1,7 @@
-"""Task-scoped SQL capture for query-cost assertions.
+"""Caller-scoped SQL capture for query-cost assertions.
 
 ``before_cursor_execute`` on the process-wide engine sees every statement the
-process issues, not only the ones the request under test issues. Two ambient
+process issues, not only the ones the code under test issues. Two ambient
 background loops the suite deliberately leaves running write into the same
 engine while a test is measuring:
 
@@ -11,21 +11,34 @@ engine while a test is measuring:
   ``dashboard_settings`` load).
 
 Either one landing inside a capture window inflates an exact statement count
-by one (or three) and makes the assertion flake. Both run on their own asyncio
-tasks, while an ``ASGITransport`` request runs inline on the calling task, so
-dropping statements issued by another task excludes the ambient loops exactly
-without weakening what the count proves.
+by one (or three) and makes the assertion flake.
+
+The window therefore keeps a statement when the *caller's lineage* issued it --
+the calling task, or any task spawned inside the window -- and drops it
+otherwise. Lineage is carried by a ``ContextVar``: ``asyncio.create_task``
+copies the current context, so a task the measured code spawns inherits the
+window marker, while a loop that was already running when the window opened
+cannot, its context having been copied before the marker existed.
+
+Scoping on task *identity* instead would drop the ambient loops just as
+exactly, but it would also drop a statement the measured code moved -- or
+added -- inside a child task, which is precisely the cost regression these
+counts exist to catch. Filtering on statement *shape* would not work at all
+here: the ring heartbeat's ``dashboard_settings`` load is textually identical
+to the one an overview poll issues.
 """
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from typing import Any
 
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+_CAPTURE_WINDOW: ContextVar[object | None] = ContextVar("statement_capture_window", default=None)
 
 
 def normalize_sql(statement: str) -> str:
@@ -35,10 +48,9 @@ def normalize_sql(statement: str) -> str:
 
 @asynccontextmanager
 async def capture_task_statements(async_engine: AsyncEngine) -> AsyncIterator[list[str]]:
-    """Collect the normalized SQL issued by the calling task inside the block."""
-    own_task = asyncio.current_task()
-    if own_task is None:  # pragma: no cover - the suite always runs inside a task
-        raise RuntimeError("capture_task_statements() must be used from inside a task")
+    """Collect the normalized SQL the calling task and its child tasks issue."""
+    window = object()
+    token = _CAPTURE_WINDOW.set(window)
     statements: list[str] = []
 
     def _capture(
@@ -49,10 +61,7 @@ async def capture_task_statements(async_engine: AsyncEngine) -> AsyncIterator[li
         context: Any,
         executemany: bool,
     ) -> None:
-        try:
-            if asyncio.current_task() is not own_task:
-                return
-        except RuntimeError:  # pragma: no cover - driver thread without a loop
+        if _CAPTURE_WINDOW.get() is not window:
             return
         statements.append(normalize_sql(statement))
 
@@ -61,3 +70,4 @@ async def capture_task_statements(async_engine: AsyncEngine) -> AsyncIterator[li
         yield statements
     finally:
         event.remove(async_engine.sync_engine, "before_cursor_execute", _capture)
+        _CAPTURE_WINDOW.reset(token)

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import os
 import time
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import event, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth.dashboard_users_cache import get_dashboard_users_cache
+from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus, ApiKey, ModelSourcePin, RequestLog
@@ -18,6 +21,7 @@ from app.modules.dashboard.weekly_pace import _weekly_timing
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.settings.repository import SettingsRepository
 from app.modules.usage.repository import UsageRepository
+from tests.integration.statement_capture import capture_task_statements
 
 pytestmark = pytest.mark.integration
 
@@ -1829,7 +1833,7 @@ async def test_dashboard_overview_overflow_slice_excludes_soft_deleted_rows(asyn
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_issues_no_overflow_statement_on_a_clean_install(async_client, db_setup):
+async def test_dashboard_overview_issues_no_overflow_statement_on_a_clean_install(async_client, db_setup, monkeypatch):
     """Query-count neutrality: a ship-dark poll costs exactly what it cost before the tile existed.
 
     The tile's read is three bounded statements (the windowed aggregate, the
@@ -1839,53 +1843,65 @@ async def test_dashboard_overview_issues_no_overflow_statement_on_a_clean_instal
     unrendered. The gate itself must also be free: it reads the settings row
     ``get_overview`` already loads, so the poll's ``dashboard_settings``
     lookup count may not grow either.
-    """
-    statements: list[str] = []
 
-    def capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001, ANN202
-        statements.append(statement)
+    The baseline is a control measured in this run, and the claim is the
+    *delta* between two polls of the same install: designating a source adds
+    exactly the tile's three statements and changes nothing else. Two things
+    would otherwise make the measurement depend on timing rather than on the
+    gate, and both are neutralised here instead of asserted around:
+
+    * statements another task issues into the same engine while a window is
+      open (see ``capture_task_statements``: the 0.5 s cache-invalidation
+      poll and the 10 s bridge ring heartbeat), and
+    * the two 5 s TTL caches the poll's own auth middleware reads, which
+      re-issue four statements (three ``dashboard_users`` /
+      ``dashboard_identities`` reads and one ``dashboard_settings`` load) on
+      the first poll after they expire. Held warm for the whole test, so a
+      stall between a warm-up poll and the measured poll cannot land them in
+      one window only.
+    """
+    monkeypatch.setattr(get_dashboard_users_cache(), "_ttl_seconds", 3600.0)
+    monkeypatch.setattr(get_settings_cache(), "_ttl_seconds", 3600.0)
 
     # Warm the poll once so the settings row exists and every cache is primed:
     # what is measured below is the steady state, not first-boot.
     assert (await async_client.get("/api/dashboard/overview")).status_code == 200
 
-    event.listen(engine.sync_engine, "before_cursor_execute", capture)
-    try:
+    async with capture_task_statements(engine) as clean_sql:
         clean = await async_client.get("/api/dashboard/overview")
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", capture)
 
     assert clean.status_code == 200
     assert clean.json()["summary"]["subscriptionOverflow"] is None
-    clean_sql = [statement.lower() for statement in statements]
     assert not [statement for statement in clean_sql if "model_source_pins" in statement]
     assert not [statement for statement in clean_sql if "request_logs.source in" in statement]
     # One settings lookup, as before the gate existed: the second caller in
     # ``get_overview`` is served from the session identity map.
     assert len([statement for statement in clean_sql if "from dashboard_settings" in statement]) == 1
-    clean_count = len(statements)
+    clean_statements = Counter(clean_sql)
 
     async with SessionLocal() as session:
         await _designate_overflow(session)
 
-    # Same steady state, one designation later: the delta is exactly the three
-    # statements the tile costs, which is what makes the clean count above the
-    # pre-tile baseline.
     assert (await async_client.get("/api/dashboard/overview")).status_code == 200
-    statements.clear()
-    event.listen(engine.sync_engine, "before_cursor_execute", capture)
-    try:
+    async with capture_task_statements(engine) as designated_sql:
         designated = await async_client.get("/api/dashboard/overview")
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", capture)
 
     assert designated.status_code == 200
     # Still nothing to render -- but now the poll has to *ask*, and the three
     # statements it asks with are exactly the cost the clean install above no
     # longer pays. This is the residual the gate closes, measured end to end.
     assert designated.json()["summary"]["subscriptionOverflow"] is None
-    designated_sql = [statement.lower() for statement in statements]
     assert len([statement for statement in designated_sql if "model_source_pins" in statement]) == 1
     assert len([statement for statement in designated_sql if "request_logs.source in" in statement]) == 2
     assert len([statement for statement in designated_sql if "from dashboard_settings" in statement]) == 1
-    assert len(statements) == clean_count + 3
+
+    # Same steady state, one designation later. Naming the added statements is
+    # what the bare ``+ 3`` used to imply; ``dropped`` keeps the other
+    # direction honest -- a statement the clean poll issues may not disappear
+    # to pay for the tile.
+    added = Counter(designated_sql) - clean_statements
+    dropped = clean_statements - Counter(designated_sql)
+    assert dropped == Counter(), dropped
+    assert sum(added.values()) == 3, added
+    assert len([statement for statement in added.elements() if "model_source_pins" in statement]) == 1
+    assert len([statement for statement in added.elements() if "request_logs.source in" in statement]) == 2

--- a/tests/integration/test_statement_capture.py
+++ b/tests/integration/test_statement_capture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select
+
+from app.db.models import CacheInvalidation
+from app.db.session import SessionLocal, engine
+from tests.integration.statement_capture import capture_task_statements
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_capture_task_statements_ignores_other_tasks(db_setup):
+    """Query-cost assertions must not count statements a concurrent task issues.
+
+    The suite leaves ambient background loops running against the same engine
+    (the 0.5 s cache-invalidation poll, the 10 s bridge ring heartbeat), so an
+    unscoped ``before_cursor_execute`` listener turns an exact statement count
+    into a coin flip. This pins the scoping that keeps those counts exact: a
+    statement another task issues *while the window is open* -- awaited here
+    rather than raced, so the demonstration is deterministic -- is excluded,
+    and the calling task's own statements are all kept.
+    """
+    del db_setup
+
+    async def _statement_from_another_task() -> int:
+        async with SessionLocal() as session:
+            # A shape the measured task never issues, so its exclusion below
+            # is attributable rather than a counting coincidence.
+            result = await session.execute(select(func.count()).select_from(CacheInvalidation))
+            return int(result.scalar_one())
+
+    async with capture_task_statements(engine) as statements:
+        async with SessionLocal() as session:
+            await session.execute(select(CacheInvalidation.namespace))
+            other_task_rows = await asyncio.create_task(
+                _statement_from_another_task(),
+                name="statement-capture-other-task",
+            )
+            await session.execute(select(CacheInvalidation.namespace))
+
+    # The other task really did run a statement inside the window.
+    assert other_task_rows >= 0
+    assert not [statement for statement in statements if "count(" in statement]
+    assert statements == ["select cache_invalidation.namespace from cache_invalidation"] * 2

--- a/tests/integration/test_statement_capture.py
+++ b/tests/integration/test_statement_capture.py
@@ -13,36 +13,64 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.asyncio
-async def test_capture_task_statements_ignores_other_tasks(db_setup):
-    """Query-cost assertions must not count statements a concurrent task issues.
+async def test_capture_task_statements_ignores_pre_existing_tasks(db_setup):
+    """Query-cost assertions must not count statements an ambient loop issues.
 
-    The suite leaves ambient background loops running against the same engine
-    (the 0.5 s cache-invalidation poll, the 10 s bridge ring heartbeat), so an
+    The suite leaves background loops running against the same engine (the
+    0.5 s cache-invalidation poll, the 10 s bridge ring heartbeat), so an
     unscoped ``before_cursor_execute`` listener turns an exact statement count
-    into a coin flip. This pins the scoping that keeps those counts exact: a
-    statement another task issues *while the window is open* -- awaited here
-    rather than raced, so the demonstration is deterministic -- is excluded,
-    and the calling task's own statements are all kept.
+    into a coin flip. Those loops were started before the window opened, so
+    they cannot carry its marker. The statement is awaited here rather than
+    raced, so the demonstration is deterministic.
     """
     del db_setup
 
-    async def _statement_from_another_task() -> int:
+    started = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def _ambient_loop() -> None:
+        await started.wait()
         async with SessionLocal() as session:
             # A shape the measured task never issues, so its exclusion below
             # is attributable rather than a counting coincidence.
-            result = await session.execute(select(func.count()).select_from(CacheInvalidation))
-            return int(result.scalar_one())
+            await session.execute(select(func.count()).select_from(CacheInvalidation))
+        finished.set()
 
-    async with capture_task_statements(engine) as statements:
-        async with SessionLocal() as session:
-            await session.execute(select(CacheInvalidation.namespace))
-            other_task_rows = await asyncio.create_task(
-                _statement_from_another_task(),
-                name="statement-capture-other-task",
-            )
-            await session.execute(select(CacheInvalidation.namespace))
+    # Created *before* the window: this is what an ambient loop looks like.
+    ambient = asyncio.create_task(_ambient_loop(), name="statement-capture-ambient-task")
+    try:
+        async with capture_task_statements(engine) as statements:
+            async with SessionLocal() as session:
+                await session.execute(select(CacheInvalidation.namespace))
+                started.set()
+                await finished.wait()
+                await session.execute(select(CacheInvalidation.namespace))
+    finally:
+        started.set()
+        await ambient
 
-    # The other task really did run a statement inside the window.
-    assert other_task_rows >= 0
     assert not [statement for statement in statements if "count(" in statement]
     assert statements == ["select cache_invalidation.namespace from cache_invalidation"] * 2
+
+
+@pytest.mark.asyncio
+async def test_capture_task_statements_keeps_spawned_tasks(db_setup):
+    """A read the measured code issues from a task it spawns is still its cost.
+
+    Scoping on task identity alone would drop it, so moving -- or adding -- a
+    query inside an awaited ``create_task`` would read as free. The window
+    keeps the caller's lineage, not one task, so it does not.
+    """
+    del db_setup
+
+    async def _statement_from_a_spawned_task() -> None:
+        async with SessionLocal() as session:
+            await session.execute(select(func.count()).select_from(CacheInvalidation))
+
+    async with capture_task_statements(engine) as statements:
+        await asyncio.create_task(
+            _statement_from_a_spawned_task(),
+            name="statement-capture-spawned-task",
+        )
+
+    assert statements == ["select count(*) as count_1 from cache_invalidation"]


### PR DESCRIPTION
## Summary

`tests/integration/test_dashboard_overview.py::test_dashboard_overview_issues_no_overflow_statement_on_a_clean_install` — the query-count neutrality guard WP-G (#2355, `21eedbfda`) added for the ship-dark overflow tile — is **flaky, and it reddened `main`**. Recorded in the CI run for the merge of #1997 onto `main` (`3d90273e9`): [run 34612180770, `Tests (pytest, integration-core-3)`](https://github.com/Soju06/codex-lb/actions/runs/34612180770/job/103305187394), 2026-09-11 15:06 UTC:

```
___ test_dashboard_overview_issues_no_overflow_statement_on_a_clean_install ____
E       AssertionError: assert 23 == (21 + 3)
FAILED tests/integration/test_dashboard_overview.py::test_dashboard_overview_issues_no_overflow_statement_on_a_clean_install - AssertionError: assert 23 == (21 + 3)
1 failed, 939 passed, 354 skipped
```

(The other two red jobs in that run, `Tests (pytest, integration-core)` and `CI Required`, are the shard aggregators — this one test failing is what turned `main` red.)

This PR removes the timing dependency without weakening the claim. **Test-only: zero production lines**, no migration, no spec change.

## Type of change

- [x] `test:` — test-only change

Linked issue: Part of #2123

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Change directory: n/a. The test's *claim* is unchanged — it still pins `add-subscription-overflow-model-source` task 4.x ("an install that never designated a source issues none of the tile's statements"). Nothing observable changes, no requirement is added or relaxed, and `openspec/` is untouched (`git diff --name-only -- openspec/` is empty), so there is nothing to validate that was not already validated by #2355.

## What actually broke, and why a retry could not have saved it

The count was **already an in-run delta** (clean poll vs. designated poll of the same install), so the flake was not a missing control or an absolute number drifting with unrelated commits. Two independent timing dependencies remained:

**A. Statements from other tasks.** The listener was an unscoped `before_cursor_execute` on the **process-global** engine, so it saw every statement the *process* issued while the window was open — not only the ones the request issued. The suite deliberately leaves two ambient loops running against that engine: `CacheInvalidationPoller` (every 0.5 s) and the bridge ring membership heartbeat (three statements every 10 s, one of them a `dashboard_settings` load). One landing inside a window inflates the count by one or three. That is exactly the `23 == (21 + 3)` shape. Instrumented at 60 reps with the app lifespan up, an unscoped listener saw a foreign-task statement in **2/60** windows (3.3%) — `SELECT cache_invalidation.namespace, cache_invalidation.version FROM cache_invalidation`.

**B. Two 5 s TTL caches the poll's own auth middleware reads.** `dashboard_users_cache` and `settings_cache` re-issue four statements on the first poll after they expire. A >5 s stall between the warm-up poll and a measured window therefore breaks not the total but **the neutrality claim itself**: the pre-existing "exactly one `dashboard_settings` lookup" assertion fails `assert 2 == 1`. This one is nastier than A, because a reader would read the failure as "the gate re-reads settings" — a production accusation — when nothing in production moved.

Both are now **neutralised rather than asserted around**:

- the window keeps only the SQL issued by the **caller's task lineage**, via a new `capture_task_statements()` helper. An `ASGITransport` request runs inline on the calling task while both ambient loops own tasks that predate the window, so they are excluded exactly;
- both TTLs are held warm for the whole test, which is what the docstring's "every cache is primed" already claimed but did not enforce.

Worth recording: a statement-*shape* filter could **not** have fixed B, because the ring heartbeat's `dashboard_settings` SELECT is textually identical to the handler's. Caller lineage is the only available discriminator.

### Approach, and the alternatives rejected

| Alternative | Why not |
|---|---|
| **Rerun / `flaky` marker** | Hides a green-on-retry failure whose message (`assert 23 == (21 + 3)`) carries no diagnosis. This guard exists to be believed about a 30 s-forever poll; a retried assertion is not evidence. |
| **Widen to a range (`<= clean + 3 + slack`)** | Destroys the thing being measured. The claim is "exactly the tile's three statements"; slack large enough to absorb a 3-statement heartbeat is large enough to absorb the tile. |
| **Stub the ambient loops out in this test** | Fixes A only, not B, and trades a measurement problem for a fixture problem: the loops run on purpose (other tests depend on them), and stubbing them in one test either leaks or needs a fixture that changes what "steady state" means. |
| **Filter captured SQL by table/shape** | Fixes A partially and **cannot** fix B — see above, the heartbeat's settings SELECT is byte-identical to the handler's. |
| **Scope on task *identity*** (`current_task() is own_task`) | Excludes the ambient loops just as exactly, but also excludes a statement the measured code issues from a task it *spawns* — a real cost regression reading as free. This was the PR's first shape; Codex review caught it, and it is now fixed (see below). |
| **Keep identity scoping + a second unscoped capture for the overflow assertions** | Rescues only the two substring assertions. The `dropped` / `added` comparison — the part that catches an added statement of *any* shape — stays blind, and the `dashboard_settings == 1` assertion cannot be unscoped at all. |
| **Caller-lineage scoping + pinned TTLs (chosen)** | Removes both causes at the source and leaves every assertion intact and unweakened. The excluded statements are, by construction, ones the measured code did not issue. |
| **Keep `== clean_count + 3` after scoping** | Would have sufficed for the flake, but the failure message is two integers. Naming the delta costs three lines and is strictly stronger (see M3b). |

The bare `+ 3` became a named multiset delta: `dropped == Counter()` plus `sum(added.values()) == 3` plus the per-shape counts. Algebraically this **implies** the old total (`total_designated == total_clean + added − dropped`), so nothing was dropped; it additionally catches a compensating swap the bare total is blind to, and failures now name the offending SQL.

## Changes

Three files, all under `tests/integration/`. `git diff --stat origin/main -- app/ frontend/ openspec/ scripts/` is empty.

- **`tests/integration/statement_capture.py`** (new, 73 lines, over half of it the docstring recording the two ambient loops and their periods). `capture_task_statements(engine)` is an async context manager yielding the normalized SQL issued inside the block by the caller's task lineage. Lineage is a `ContextVar` marker set when the window opens: `asyncio.create_task` copies the current context, so a task the measured code spawns inherits the marker, while a loop already running when the window opened cannot — its context was copied before the marker existed. `normalize_sql()` collapses whitespace/case so statements compare as shapes.
- **`tests/integration/test_statement_capture.py`** (new, 76 lines). Pins both directions of that scoping, each one mutation away from failing: a task created **before** the window (what an ambient loop actually is) is excluded, and a task spawned **inside** it is kept. Deterministic — the other task's statement is awaited via events, not raced against a background hammer.
- **`tests/integration/test_dashboard_overview.py`** (+38/−22, 1891 → 1907 lines). The measured windows use the helper; both 5 s TTLs are pinned for the test; the bare total becomes the multiset delta. Every pre-existing assertion is kept verbatim, and the docstring now records *why* each neutralisation is there.

## Planted-mutation evidence

Production files were temporarily edited, then restored and confirmed byte-clean (`git status --porcelain` empty, `git diff -- app/` empty) after each. Every row was re-run against the final head.

| # | Mutation | New form | Observed |
|---|---|---|---|
| **M1** | `if never_designated(settings)` → `if False` (`app/modules/settings/subscription_overflow.py:431`) — the ship-dark gate itself | **FAILS** | `AssertionError: assert not ['select count(*) as count_1 from model_source_pins where model_source_pins.kind = ? and model_source_pins.expires_at > ? and model_source_pins.purge_at > ?']` at `test_dashboard_overview.py:1875` |
| **M2** | designation-gated extra reads in `app/modules/dashboard/service.py`, covered by no named assertion | **FAILS** | `assert sum(added.values()) == 3` → `assert 5 == 3`, printing both extra statements |
| **M3** | skip `latest_additional_recorded_at()` when designated | **FAILS** | `assert dropped == Counter()` → `Counter({'select max(additional_usage_history.recorded_at) …': 1})` |
| **M3b** | **exactly compensating**: drop that read *and* add one read of a different shape, so the total is unchanged | **FAILS** | `AssertionError: Counter({'select max(additional_usage_history.recorded_at) as max_1 from additional_usage_history': 1})` at `:1904` — while **`main`'s bare `+ 3` total passes 3/3**, a false negative |
| **M4** | `ever_dispatched = False` | **FAILS** | `assert … == 2` → `assert 1 == 2`; the two sibling overflow tests fail too, as designed |
| **M5** | drop the lineage filter from the helper (the obvious "simplification" back to an unscoped listener) | **FAILS** | `test_statement_capture.py`: `assert not ['select count(*) as count_1 from cache_invalidation']` |
| **M6** | revert the helper to `current_task()` identity scoping | **FAILS** | `test_statement_capture.py`: `assert [] == ['select coun...invalidation']` — the inclusion half is not vacuous either |
| **M7** | `await asyncio.create_task(_prefetch())` ahead of the gate, `_prefetch()` running `count_live_thread_pins` in its own session — i.e. every ship-dark install pays the tile's cost on every 30 s poll, forever | **FAILS** | `assert not ['select count(*) as count_1 from model_source_pins …']` at `:1875`. Under the PR's first (identity-scoped) shape this **passed 3/3**; this is the Codex P2, now closed |
| — | capture records nothing (silently empty) | **FAILS** | `assert 0 == 1` on the `dashboard_settings` lookup — an empty capture cannot pass |

**M3b is why the rewrite is a coverage gain and not just a nicer message.** M3 alone (drop 1, add 3) nets to `clean + 2`, so `main`'s total catches it too (`assert 22 == 23`). Only the *compensating* form separates the two shapes, and it was run in both directions: `main` passes, the multiset form names the statement that disappeared.

## Test plan

`uv` is unavailable on this host (disk pressure), so gate components were invoked directly with the repo venv rather than through `uv run pre-commit`. Every gate in `make lint` / `make typecheck` is covered.

**The fix actually removes the flake (differential A/B, same host, same load).** A faithful replica of `main`'s test body and the new body, run alternately under a 2 ms concurrent `SELECT` hammer on the same engine:

```
FAILED test_main_body_under_hammer[0]  - AssertionError: assert 26 == (24 + 3)
FAILED test_main_body_under_hammer[1]  - AssertionError: assert 28 == (24 + 3)
FAILED test_main_body_under_hammer[3]  - AssertionError: assert 26 == (24 + 3)
FAILED test_main_body_with_ttl_stall   - AssertionError: assert 2 == 1
4 failed, 8 passed
```

i.e. flake source A reproduces 3/5 on `main` with the exact CI failure class and flake source B reproduces on the `dashboard_settings` neutrality assertion — while **the new body passes 5/5 and 1/1 in the same run**, and 8/8 + 1/1 when the A/B was re-run against the final lineage-scoped head. Earlier independent passes of the same A/B saw 5/5 and 5/6 failures for `main` (`assert 37 == (33 + 3)`, `assert 67 == (53 + 3)`, …) with the new body green throughout. Instrumented at 60 reps, the scoped window is 23 statements in **60/60**, zero drift.

**The lineage mechanism was verified against the real engine, not assumed.** SQLAlchemy's `_AsyncIoGreenlet` copies `gr_context` from the driver greenlet, so the marker is visible where `before_cursor_execute` fires — probed in both directions:

```
PROBE  shape='cache_invalidation.namespace' in_window=True  same_task=True    # own task
PROBE  shape='cache_invalidation.version'   in_window=True  same_task=False   # child created inside the window
PROBE2 shape='cache_invalidation.version'   in_window=False                   # task created before the window
PROBE2 shape='cache_invalidation.namespace' in_window=True
```

```
tests/integration/test_statement_capture.py            2 passed  (x6 consecutive runs)
test_dashboard_gzip.py + test_dashboard_overview.py + test_statement_capture.py
                                       39 passed, 2 skipped in ~29s  (x3 consecutive runs;
                                       the 2 skips are pre-existing "frontend build output not present")

ruff check .                           All checks passed!
ruff format --check .                  1270 files already formatted
ty check                               All checks passed!
check_proxy_architecture.py            proxy architecture checks passed
check_cancellation_safety.py           cancellation safety checks passed
check_proxy_timing_seams.py            proxy timing seam checks passed
check_settings_tiers.py                check_settings_tiers: ok
check_migration_topology.py            migration topology checks passed
pytest_shards.py --shard-count 3 --verify
                                       OK: 152 integration-core test files partitioned across 3 shards
alembic heads                          ['20260911_030000_add_local_login_policy']   (exactly 1, unchanged)
git diff --stat origin/main -- app/ frontend/ openspec/ scripts/
                                       (empty)
```

A wider repeat/order/isolation matrix was run while the branch was being built: 90/90 green over 30 + 60 in-process reps of the test body; 30/30 and 20/20 under the concurrent hammer; both file orders with the CI shard neighbours; the self-test 12/12 standalone and 6/6 under hammer; 87 and 225 passed when run together with the `dashboard_users` / settings / auth suites, to rule out leakage from the TTL monkeypatch.

Cross-test-pollution check on the TTL pin: both caches evaluate freshness at *get* time against the current attribute, so `monkeypatch` teardown is effective immediately, and `tests/conftest.py:557` `_reset_hot_path_caches` (autouse, before **and** after each test) already nulls `SettingsCache._cached_settings/_cached_at/_last_loaded_settings` and calls `DashboardUsersCache.clear()`.

Sibling-scope check: 15 other test files use `before_cursor_execute`, but every exact-count one either filters by table before counting (`test_dashboard_trailing_demand_cache.py`, `test_proxy_sticky_sessions.py`, `test_request_logs_api.py`) or runs without the app lifespan (`test_automations_history_queries.py`), so none carries this flake and none needed migrating.

## Known limitations

Residual P3s from adversarial verification, disclosed rather than fixed. (The P2 that verification also surfaced — the identity-scoping blind spot, independently found by Codex review on this PR — is **fixed** in `f3a5b4aa3`, row M7 above.)

1. **The TTL pin reaches into a private attribute** (`test_dashboard_overview.py:1863-1864`: `monkeypatch.setattr(get_dashboard_users_cache(), "_ttl_seconds", 3600.0)`). There is no public TTL setter on `DashboardUsersCache` / `SettingsCache`, so this is the only lever; it is consistent with `conftest.py`'s own `_COUNT_CACHE_TTL_SECONDS`-style patches, and a rename fails loudly (`AttributeError` from `monkeypatch`) rather than silently no-opping. Maintenance coupling only.
2. **The self-tests assert exact list equality** (`test_statement_capture.py:52,76`), which would break if SQLAlchemy ever emitted an extra lineage statement at pool checkout (pre-ping, `PRAGMA`). Not currently flaky (2 passed on six consecutive runs, and 12/12 standalone plus 6/6 under hammer for the earlier shape); noted as brittleness a pool-config change could surface.
3. **Symmetric growth stays invisible** — a statement added *unconditionally* to `get_overview` appears in both windows, so no in-run delta can see it. Identical to `main`, and out of scope: this test pins the ship-dark gate, not the poll's absolute cost. Also disclosed in the commit message.
4. **Pinned/draining installs are unpinned.** A read gated on `live_pins > 0` is invisible to this test — but also to `main` (3/3 pass with it planted), to all 7 overflow integration tests and to 257 overflow unit tests. It is outside the ship-dark claim (`model_source_pins` rows are only written by the overflow dispatch path, which requires a designation, so a pin-gated read is genuinely free on a never-designated install). The pre-existing gap it exposes — nothing pins the tile's statement cost for a *pinned* install — is worth a follow-up test, not a change here.

## Screenshots / output

N/A — no user-visible surface. The diff is three files, all under `tests/integration/`; `git diff --stat origin/main -- app/ frontend/` is empty, so there is no dashboard, API or proxy behaviour to show. The CI failure output this PR removes, and the A/B that proves it removed, are quoted above in place of a screenshot.

## Checklist

- [x] Title is in Conventional Commits format (`test(dashboard): make the clean-install overflow statement count deterministic`).
- [x] Linked the related issue above (Part of #2123; the flake record is the CI run linked in the summary).
- [x] Added or updated tests covering the change — this PR *is* the test change, plus `tests/integration/test_statement_capture.py` pinning the new helper's scoping in both directions.
- [x] Ran the relevant gates locally — every component of `make lint` (`check_proxy_architecture` + `ruff check` + `ruff format`) and `make typecheck` (`ty`), plus the four other guard scripts, the shard verifier and `alembic heads`. Invoked directly with the repo venv rather than via `uv run pre-commit`, which is unavailable on this host.
- [x] If touching specs: n/a — `openspec/` untouched.
- [x] Simplicity gates reviewed — no setting, no README section, no dashboard nav item, no default changed, so the Simplicity section is deleted per the template.
- [x] CHANGELOG is **not** edited by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
