### PR TITLE
chore(overflow): discover the request-log source constants in the spec-delta guard

### DIFF
--- a/tests/unit/_overflow_constants.py
+++ b/tests/unit/_overflow_constants.py
@@ -1,0 +1,63 @@
+"""Dynamic discovery of the closed string enums ``app/modules/proxy/overflow.py`` defines (#2123).
+
+``overflow.py`` is the authority for the overflow feature's closed string
+enums: the ``request_logs.source`` values an overflow dispatch writes, the
+``route`` labels of ``codex_lb_subscription_overflow_total``, and the dispatch
+kinds. Drift guards that spell those constants *by name* are a hole -- they pin
+the values that exist today and say nothing about a value added tomorrow, so a
+third ``source`` could reach the request log without any normative delta, the
+operator docs or the dashboard's ``IN`` predicate learning about it, with every
+test on both sides still green.
+
+Discovery here is by *import* plus name prefix, so one new constant grows every
+expected set at once. Requiring a ``str`` value keeps same-prefix aggregates
+(the frontend module deliberately exports a ``REQUEST_LOG_SOURCE_KINDS`` array;
+a backend tuple would be the same shape) out of the discovered enum instead of
+silently widening it.
+
+This module holds no tests, so importing it from a test module does not couple
+two test files' collection order -- the same reason
+``tests/unit/_proxy_test_helpers.py`` carries a leading underscore.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.modules.proxy import overflow
+
+BACKEND_MODULE = "app/modules/proxy/overflow.py"
+
+SOURCE_PREFIX = "REQUEST_LOG_SOURCE_"
+ROUTE_PREFIX = "ROUTE_"
+DISPATCH_KIND_PREFIX = "DISPATCH_KIND_"
+
+_SUFFIX = re.compile(r"[A-Z0-9_]+")
+
+
+def overflow_constants(prefix: str) -> dict[str, str]:
+    """Every module-level ``<prefix>*`` string constant of ``overflow.py``, by name."""
+    return {
+        name: value
+        for name, value in vars(overflow).items()
+        if name.startswith(prefix) and _SUFFIX.fullmatch(name.removeprefix(prefix)) and isinstance(value, str)
+    }
+
+
+def discovery_error(prefix: str, constants: dict[str, str]) -> str | None:
+    """The loud message when a discovered set cannot be trusted, else ``None``."""
+    if not constants:
+        return (
+            f"no {prefix}* string constants found in {BACKEND_MODULE}; every {prefix}* drift guard would pass vacuously"
+        )
+    values = list(constants.values())
+    duplicates = sorted(name for name, value in constants.items() if values.count(value) > 1)
+    if duplicates:
+        return f"{BACKEND_MODULE} gives the same {prefix}* value to more than one name: {duplicates}"
+    undeclared = sorted(set(constants) - set(overflow.__all__))
+    if undeclared:
+        return (
+            f"{BACKEND_MODULE} defines {undeclared} without listing them in __all__; "
+            f"the {prefix}* drift guards discover the enum through the public surface"
+        )
+    return None

--- a/tests/unit/test_request_log_source_parity.py
+++ b/tests/unit/test_request_log_source_parity.py
@@ -10,12 +10,13 @@ still green. This file closes that residual, the way
 ``tests/unit/test_subscription_overflow_spec_delta.py`` already does for the spec
 deltas and the operator docs.
 
-The backend is the authority and is read by *import*, not by parsing: every
-module-level ``REQUEST_LOG_SOURCE_*`` string in ``overflow.py`` is discovered
-dynamically, so adding a constant grows the expected set without anyone
-remembering to update this file. The frontend side is parsed out of the one
-module WP-G made the single closed mapping, and the assertions are exact set
-equality in both directions:
+The backend is the authority and is read by *import*, not by parsing:
+``tests/unit/_overflow_constants.py`` discovers every module-level
+``REQUEST_LOG_SOURCE_*`` string in ``overflow.py``, so adding a constant grows
+the expected set without anyone remembering to update this file (the same
+discovery feeds the spec-delta and dashboard-aggregate guards). The frontend
+side is parsed out of the one module WP-G made the single closed mapping, and
+the assertions are exact set equality in both directions:
 
 * a backend value with no frontend literal fails (the new value would render as
   an unattributed row);
@@ -25,8 +26,8 @@ equality in both directions:
   fails;
 * a kind or filter option whose label is missing from any of en/ko/zh-CN fails.
 
-``_parity_error`` is exercised directly against mutated sets below, so the guard
-itself is covered rather than merely trusted.
+``_parity_error`` and ``discovery_error`` are exercised directly against mutated
+sets below, so the guards themselves are covered rather than merely trusted.
 """
 
 from __future__ import annotations
@@ -37,7 +38,7 @@ from pathlib import Path
 
 import pytest
 
-from app.modules.proxy import overflow
+from tests.unit._overflow_constants import BACKEND_MODULE, SOURCE_PREFIX, discovery_error, overflow_constants
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _FRONTEND_SRC = REPO_ROOT / "frontend/src"
@@ -46,16 +47,12 @@ _DASHBOARD_PAGE = _FRONTEND_SRC / "features/dashboard/components/dashboard-page.
 _LOCALES = _FRONTEND_SRC / "i18n/locales"
 _LOCALE_NAMES = ("en.json", "ko.json", "zh-CN.json")
 
-_BACKEND_MODULE = "app/modules/proxy/overflow.py"
 _FIX_HINT = (
-    f"{_BACKEND_MODULE} is the authority for request-log `source` values; "
+    f"{BACKEND_MODULE} is the authority for request-log `source` values; "
     "update frontend/src/features/dashboard/request-log-source.ts (and the chip "
     "labels / filter options / locales that hang off it) to match"
 )
 
-# ``REQUEST_LOG_SOURCE_KINDS`` / ``_FILTER_VALUES`` share the prefix but are
-# arrays, so requiring a quoted string here keeps them out of the literal set.
-_BACKEND_NAME = re.compile(r"REQUEST_LOG_SOURCE_[A-Z0-9_]+")
 _TS_LITERAL = re.compile(r'^export const (REQUEST_LOG_SOURCE_[A-Z0-9_]+) = "([^"]*)";$', re.MULTILINE)
 _TS_KINDS = re.compile(r"^export const REQUEST_LOG_SOURCE_KINDS = \[([^\]]*)\] as const;$", re.MULTILINE)
 _TS_FILTER_VALUES = re.compile(r"^export const REQUEST_LOG_SOURCE_FILTER_VALUES[^=\n]*= \[([^\]]*)\];$", re.MULTILINE)
@@ -73,15 +70,6 @@ def _rel(path: Path) -> str:
     return path.relative_to(REPO_ROOT).as_posix()
 
 
-def _backend_literals() -> dict[str, str]:
-    """Every module-level ``REQUEST_LOG_SOURCE_*`` string constant, by name."""
-    return {
-        name: value
-        for name, value in vars(overflow).items()
-        if _BACKEND_NAME.fullmatch(name) and isinstance(value, str)
-    }
-
-
 def _frontend_literals() -> dict[str, str]:
     """Every exported ``REQUEST_LOG_SOURCE_*`` string constant, by TS name."""
     return dict(_TS_LITERAL.findall(_read(_SOURCE_MODULE)))
@@ -95,9 +83,9 @@ def _parity_error(backend: frozenset[str], frontend: frozenset[str]) -> str | No
         return None
     parts: list[str] = []
     if missing:
-        parts.append(f"defined by {_BACKEND_MODULE} but absent from {_rel(_SOURCE_MODULE)}: {missing}")
+        parts.append(f"defined by {BACKEND_MODULE} but absent from {_rel(_SOURCE_MODULE)}: {missing}")
     if unknown:
-        parts.append(f"spelled in {_rel(_SOURCE_MODULE)} but not defined by {_BACKEND_MODULE}: {unknown}")
+        parts.append(f"spelled in {_rel(_SOURCE_MODULE)} but not defined by {BACKEND_MODULE}: {unknown}")
     return f"request-log `source` literals drifted -- {'; '.join(parts)}. {_FIX_HINT}."
 
 
@@ -113,7 +101,7 @@ def _locales() -> dict[str, dict[str, str]]:
     return resources
 
 
-BACKEND_LITERALS = _backend_literals()
+BACKEND_LITERALS = overflow_constants(SOURCE_PREFIX)
 LOCALES = _locales()
 
 
@@ -124,17 +112,12 @@ def test_backend_declares_its_request_log_source_literals() -> None:
     """Sanity-check the authority before comparing against it.
 
     Discovery is by name prefix, so a new value only reaches the guard if it is
-    spelled and exported like the existing two. An empty or private set would
-    make every comparison below vacuously pass.
+    spelled and exported like the existing two. An empty, duplicated or private
+    set would make every comparison below vacuously pass.
     """
-    assert BACKEND_LITERALS, f"no REQUEST_LOG_SOURCE_* string constants found in {_BACKEND_MODULE}"
-    assert len(set(BACKEND_LITERALS.values())) == len(BACKEND_LITERALS), BACKEND_LITERALS
+    error = discovery_error(SOURCE_PREFIX, BACKEND_LITERALS)
 
-    undeclared = sorted(set(BACKEND_LITERALS) - set(overflow.__all__))
-    assert not undeclared, (
-        f"{_BACKEND_MODULE} defines {undeclared} without listing them in __all__; "
-        "the dashboard parity guard discovers the enum through the public surface"
-    )
+    assert error is None, error
 
 
 # -- backend <-> frontend literal parity, both directions --------------------------------------
@@ -208,9 +191,10 @@ def test_every_filter_option_is_labelled_in_every_locale(locale: str) -> None:
 # -- the guard itself bites in both directions -------------------------------------------------
 
 _BACKEND_SET = frozenset(BACKEND_LITERALS.values())
-# Deliberately unspellable as a real ``source`` value, so these self-tests cannot
-# collide with a value someone genuinely adds later.
+# Deliberately unspellable as a real ``source`` value / constant name, so these
+# self-tests cannot collide with a value someone genuinely adds later.
 _SYNTHETIC = "<synthetic source value>"
+_SYNTHETIC_NAME = f"{SOURCE_PREFIX}<synthetic name>"
 
 
 def test_guard_accepts_the_shipped_pair() -> None:
@@ -244,3 +228,35 @@ def test_guard_detects_a_renamed_backend_value() -> None:
     assert _SYNTHETIC in error
     assert "absent from" in error
     assert "not defined by" in error
+
+
+# -- the shared discovery refuses to hand out an untrustworthy set -----------------------------
+
+
+def test_discovery_error_accepts_the_shipped_enum() -> None:
+    assert discovery_error(SOURCE_PREFIX, BACKEND_LITERALS) is None
+
+
+def test_discovery_error_detects_a_prefix_that_discovers_nothing() -> None:
+    """A renamed prefix must fail loudly instead of making every comparison vacuous."""
+    error = discovery_error(SOURCE_PREFIX, {})
+
+    assert error is not None
+    assert "vacuously" in error
+
+
+def test_discovery_error_detects_a_constant_kept_out_of_dunder_all() -> None:
+    error = discovery_error(SOURCE_PREFIX, {**BACKEND_LITERALS, _SYNTHETIC_NAME: _SYNTHETIC})
+
+    assert error is not None
+    assert _SYNTHETIC_NAME in error
+    assert "__all__" in error
+
+
+def test_discovery_error_detects_two_names_for_one_value() -> None:
+    """A copy-pasted constant would otherwise shrink the expected set silently."""
+    error = discovery_error(SOURCE_PREFIX, {**BACKEND_LITERALS, _SYNTHETIC_NAME: sorted(_BACKEND_SET)[0]})
+
+    assert error is not None
+    assert _SYNTHETIC_NAME in error
+    assert "more than one name" in error

--- a/tests/unit/test_subscription_overflow_dashboard_summary.py
+++ b/tests/unit/test_subscription_overflow_dashboard_summary.py
@@ -10,27 +10,46 @@ the ``IN`` predicate is pinned against the prefix ``LIKE`` the design text
 originally suggested (a prefix ``LIKE`` cannot use the plain btree
 ``idx_logs_source_requested_at`` under a non-C PostgreSQL collation, which would
 put a sequential scan over ``request_logs`` into the 30 s dashboard poll).
+
+The tuple is pinned against the whole enum ``tests/unit/_overflow_constants.py``
+discovers, not against the two constant names that exist today. The ``IN``
+predicate is closed, so a third ``source`` value absent from the tuple is spend
+the overflow tile under-counts -- and installations the tile's existence probe
+cannot see -- with nothing else on either side failing.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
 
-from app.modules.proxy import overflow
 from app.modules.settings.subscription_overflow import (
     OVERFLOW_REQUEST_LOG_SOURCES,
     overflow_existence_statement,
     overflow_window_statement,
 )
+from tests.unit._overflow_constants import BACKEND_MODULE, SOURCE_PREFIX, discovery_error, overflow_constants
 
 _SINCE = datetime(2026, 9, 1, 0, 0, 0)
 _UNTIL = datetime(2026, 9, 8, 0, 0, 0)
 
+_SOURCE_LITERALS = overflow_constants(SOURCE_PREFIX)
 
-def test_dashboard_sources_are_exactly_the_two_dispatch_labels() -> None:
-    assert OVERFLOW_REQUEST_LOG_SOURCES == (
-        overflow.REQUEST_LOG_SOURCE_FRESH,
-        overflow.REQUEST_LOG_SOURCE_PINNED,
+
+def test_dashboard_sources_are_exactly_the_dispatch_labels() -> None:
+    """A ``source`` value absent from the closed ``IN`` tuple is spend the tile never sees."""
+    error = discovery_error(SOURCE_PREFIX, _SOURCE_LITERALS)
+    assert error is None, error
+
+    dashboard = set(OVERFLOW_REQUEST_LOG_SOURCES)
+    expected = set(_SOURCE_LITERALS.values())
+
+    assert dashboard == expected, {
+        "in_dashboard_only": sorted(dashboard - expected),
+        "in_overflow_only": sorted(expected - dashboard),
+    }
+    assert len(dashboard) == len(OVERFLOW_REQUEST_LOG_SOURCES), (
+        f"OVERFLOW_REQUEST_LOG_SOURCES repeats a value: {OVERFLOW_REQUEST_LOG_SOURCES}; "
+        f"{BACKEND_MODULE} gives each dispatch kind its own `source`"
     )
 
 

--- a/tests/unit/test_subscription_overflow_spec_delta.py
+++ b/tests/unit/test_subscription_overflow_spec_delta.py
@@ -10,7 +10,10 @@ The closed enums -- the request-log ``source`` values, the metric ``route``
 labels and the dispatch kinds -- are discovered from ``overflow.py`` by import
 (``tests/unit/_overflow_constants.py``) rather than spelled here, so a value
 added to the authority grows the expected set instead of slipping past guards
-that only knew the values which existed when they were written.
+that only knew the values which existed when they were written. The removal
+direction is covered by comparing the delta's own prose enumerations of the
+closed ``route`` and dispatch-``kind`` sets against the discovered enum, so a
+retired label cannot stay advertised by the normative spec either.
 """
 
 from __future__ import annotations
@@ -49,6 +52,14 @@ _BACKTICKED = re.compile(r"`([^`\n]+)`")
 # observability delta may not quote any such token that the enum lacks.
 _OUTCOME_SHAPE = re.compile(r"^(dispatched|bounced|declined|pinned|pin_commit|decision)_[a-z_]+$")
 
+# ``route`` labels and dispatch kinds are ordinary words, so they have no shape
+# the outcome regex above could match on. The delta enumerates them in prose
+# instead -- "closed `route` set `a`, `b`, `c`", "`kind` `a`, `b` or `c`" -- and
+# each such run is compared to the discovered enum in both directions.
+_ENUMERATED_RUN = re.compile(r"`[a-z0-9_]+`(?:(?:, | or |, or )`[a-z0-9_]+`)*")
+_ROUTE_ENUMERATION = re.compile(r"`route`(?: set| in) (?=`)")
+_KIND_ENUMERATION = re.compile(r"(?:for direct source routing and |`kind` (?=`))")
+
 # The closed enums the deltas and the docs must keep naming, read off the authority.
 SOURCE_LITERALS = overflow_constants(SOURCE_PREFIX)
 ROUTE_LABELS = overflow_constants(ROUTE_PREFIX)
@@ -65,6 +76,16 @@ def _rel(path: Path) -> str:
 
 def _backticked(path: Path) -> set[str]:
     return set(_BACKTICKED.findall(_read(path)))
+
+
+def _enumerations(text: str, anchor: re.Pattern[str]) -> list[set[str]]:
+    """Every backticked run the delta enumerates right after ``anchor``."""
+    runs: list[set[str]] = []
+    for match in anchor.finditer(text):
+        run = _ENUMERATED_RUN.match(text, match.end())
+        assert run is not None, text[match.start() : match.end() + 80]
+        runs.append(set(_BACKTICKED.findall(run.group(0))))
+    return runs
 
 
 @pytest.mark.parametrize("prefix", [SOURCE_PREFIX, ROUTE_PREFIX, DISPATCH_KIND_PREFIX])
@@ -115,6 +136,34 @@ def test_observability_delta_names_the_routes_and_metrics() -> None:
     # counter; naming it would also trip the model-source metric drift guard's
     # successor regex once it covers the overflow prefix.
     assert "codex_lb_subscription_overflow_source_result_total" not in text
+
+
+def test_observability_delta_enumerates_exactly_the_closed_route_and_kind_sets() -> None:
+    """The other direction: the delta may not advertise a label the runtime cannot emit.
+
+    Discovery grows the expected set when a label is *added*. A retired
+    ``ROUTE_*`` / ``DISPATCH_KIND_*`` constant would just shrink the loops above,
+    leaving the normative delta enumerating a value the metric can no longer
+    carry -- so each prose enumeration is compared to the enum as a set.
+    """
+    text = _read(_OBSERVABILITY_DELTA)
+
+    for family, anchor, expected in (
+        ("`route`", _ROUTE_ENUMERATION, set(ROUTE_LABELS.values())),
+        ("dispatch `kind`", _KIND_ENUMERATION, set(DISPATCH_KINDS.values())),
+    ):
+        runs = _enumerations(text, anchor)
+
+        assert runs, (
+            f"{_rel(_OBSERVABILITY_DELTA)} no longer enumerates the closed {family} set in a shape "
+            f"this guard can read; the reverse check would pass vacuously"
+        )
+        for run in runs:
+            assert run == expected, {
+                "family": family,
+                "in_spec_only": sorted(run - expected),
+                "in_code_only": sorted(expected - run),
+            }
 
 
 def test_request_log_source_values_are_quoted_in_every_normative_surface() -> None:

--- a/tests/unit/test_subscription_overflow_spec_delta.py
+++ b/tests/unit/test_subscription_overflow_spec_delta.py
@@ -5,6 +5,12 @@ deltas quote the closed enums, error codes, hint texts and request-log labels
 that ``app/modules/proxy/overflow.py`` defines; these tests fail when either
 side drifts, the way ``tests/unit/test_metrics.py`` does for the
 ``codex_lb_model_source_*`` metric names.
+
+The closed enums -- the request-log ``source`` values, the metric ``route``
+labels and the dispatch kinds -- are discovered from ``overflow.py`` by import
+(``tests/unit/_overflow_constants.py``) rather than spelled here, so a value
+added to the authority grows the expected set instead of slipping past guards
+that only knew the values which existed when they were written.
 """
 
 from __future__ import annotations
@@ -17,6 +23,14 @@ from typing import get_args
 import pytest
 
 from app.modules.proxy import overflow
+from tests.unit._overflow_constants import (
+    BACKEND_MODULE,
+    DISPATCH_KIND_PREFIX,
+    ROUTE_PREFIX,
+    SOURCE_PREFIX,
+    discovery_error,
+    overflow_constants,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _CHANGE = REPO_ROOT / "openspec/changes/add-subscription-overflow-model-source"
@@ -35,13 +49,35 @@ _BACKTICKED = re.compile(r"`([^`\n]+)`")
 # observability delta may not quote any such token that the enum lacks.
 _OUTCOME_SHAPE = re.compile(r"^(dispatched|bounced|declined|pinned|pin_commit|decision)_[a-z_]+$")
 
+# The closed enums the deltas and the docs must keep naming, read off the authority.
+SOURCE_LITERALS = overflow_constants(SOURCE_PREFIX)
+ROUTE_LABELS = overflow_constants(ROUTE_PREFIX)
+DISPATCH_KINDS = overflow_constants(DISPATCH_KIND_PREFIX)
+
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
 def _backticked(path: Path) -> set[str]:
     return set(_BACKTICKED.findall(_read(path)))
+
+
+@pytest.mark.parametrize("prefix", [SOURCE_PREFIX, ROUTE_PREFIX, DISPATCH_KIND_PREFIX])
+def test_discovered_enums_are_trustworthy(prefix: str) -> None:
+    """Sanity-check the authority before comparing the deltas against it.
+
+    Every enum expectation below is discovered by name prefix, so an empty,
+    duplicated or unexported set would make those comparisons pass vacuously
+    instead of failing.
+    """
+    error = discovery_error(prefix, overflow_constants(prefix))
+
+    assert error is None, error
 
 
 def test_observability_delta_names_exactly_the_closed_outcome_enum() -> None:
@@ -69,24 +105,29 @@ def test_observability_delta_names_the_routes_and_metrics() -> None:
     quoted = _backticked(_OBSERVABILITY_DELTA)
     text = _read(_OBSERVABILITY_DELTA)
 
-    for route in (
-        overflow.ROUTE_CODEX_RESPONSES,
-        overflow.ROUTE_V1_RESPONSES,
-        overflow.ROUTE_WEBSOCKET_HANDSHAKE,
-        overflow.ROUTE_WEBSOCKET,
-        overflow.ROUTE_COMPACT,
-    ):
+    for route in sorted(ROUTE_LABELS.values()):
         assert route in quoted, route
     assert overflow.OVERFLOW_TOTAL_METRIC in text
     assert overflow.BREAKER_STATE_METRIC in text
-    for kind in (overflow.DISPATCH_KIND_FRESH, overflow.DISPATCH_KIND_PINNED, overflow.DISPATCH_KIND_ANCHOR):
+    for kind in sorted(DISPATCH_KINDS.values()):
         assert kind in quoted, kind
-    assert overflow.REQUEST_LOG_SOURCE_FRESH in quoted
-    assert overflow.REQUEST_LOG_SOURCE_PINNED in quoted
     # The design's separate overflow result counter was folded into the dispatch
     # counter; naming it would also trip the model-source metric drift guard's
     # successor regex once it covers the overflow prefix.
     assert "codex_lb_subscription_overflow_source_result_total" not in text
+
+
+def test_request_log_source_values_are_quoted_in_every_normative_surface() -> None:
+    """Both normative deltas and the operator docs name every attributable ``source`` value."""
+    for path in (_ROUTING_DELTA, _OBSERVABILITY_DELTA, _ROUTING_DOC):
+        quoted = _backticked(path)
+        missing = sorted(value for value in SOURCE_LITERALS.values() if value not in quoted)
+
+        assert missing == [], (
+            f"{_rel(path)} does not quote the request-log `source` value(s) {missing} that "
+            f"{BACKEND_MODULE} defines; every attributable source value must be named in the "
+            f"normative deltas and the operator docs"
+        )
 
 
 @pytest.mark.parametrize(
@@ -105,7 +146,7 @@ def test_compat_delta_quotes_every_overflow_error_code(code: str) -> None:
     assert code in _backticked(_COMPAT_DELTA), code
 
 
-def test_routing_delta_quotes_the_row_and_pin_failure_codes() -> None:
+def test_routing_delta_quotes_the_pin_failure_codes_and_the_job_headers() -> None:
     quoted = _backticked(_ROUTING_DELTA)
 
     for token in (
@@ -115,8 +156,6 @@ def test_routing_delta_quotes_the_row_and_pin_failure_codes() -> None:
         overflow.UNSUPPORTED_INPUT_CODE,
         overflow.MODEL_SOURCE_UNAVAILABLE_CODE,
         overflow.MODEL_SOURCE_BUSY_CODE,
-        overflow.REQUEST_LOG_SOURCE_FRESH,
-        overflow.REQUEST_LOG_SOURCE_PINNED,
         overflow.SUBAGENT_HEADER,
         overflow.MEMGEN_HEADER,
         *sorted(overflow.BACKGROUND_ALLOWLIST),

--- a/tests/unit/test_subscription_overflow_spec_delta.py
+++ b/tests/unit/test_subscription_overflow_spec_delta.py
@@ -56,7 +56,12 @@ _OUTCOME_SHAPE = re.compile(r"^(dispatched|bounced|declined|pinned|pin_commit|de
 # the outcome regex above could match on. The delta enumerates them in prose
 # instead -- "closed `route` set `a`, `b`, `c`", "`kind` `a`, `b` or `c`" -- and
 # each such run is compared to the discovered enum in both directions.
-_ENUMERATED_RUN = re.compile(r"`[a-z0-9_]+`(?:(?:, | or |, or )`[a-z0-9_]+`)*")
+# The connectors are comma-anchored on purpose. A bare ``and`` before a backticked
+# token starts a new clause in this delta ("... `compact` and `outcome` in the closed
+# set"), so absorbing it would misread the live spec; a run cut short by an
+# unrecognised connector still fails the comparison whenever the dropped token is a
+# live label.
+_ENUMERATED_RUN = re.compile(r"`[a-z0-9_]+`(?:(?:, |, and |, or | or )`[a-z0-9_]+`)*")
 _ROUTE_ENUMERATION = re.compile(r"`route`(?: set| in) (?=`)")
 _KIND_ENUMERATION = re.compile(r"(?:for direct source routing and |`kind` (?=`))")
 
@@ -164,6 +169,20 @@ def test_observability_delta_enumerates_exactly_the_closed_route_and_kind_sets()
                 "in_spec_only": sorted(run - expected),
                 "in_code_only": sorted(expected - run),
             }
+
+
+def test_enumeration_parser_reads_the_connectors_the_delta_uses() -> None:
+    """The run must not stop early on a comma connector, nor swallow the next clause."""
+    oxford = _enumerations(
+        "the closed `route` set `a`, `b`, and `retired` and the closed `outcome` set", _ROUTE_ENUMERATION
+    )
+
+    assert oxford == [{"a", "b", "retired"}], oxford
+    # The delta's second enumeration really ends this way; a bare ``and`` before a
+    # backticked token starts a new clause and must not join the run.
+    clause = _enumerations("with `route` in `a`, `b` and `outcome` in the closed set", _ROUTE_ENUMERATION)
+
+    assert clause == [{"a", "b"}], clause
 
 
 def test_request_log_source_values_are_quoted_in_every_normative_surface() -> None:


### PR DESCRIPTION
## Summary

Test-only. #2380 closed the *frontend* half of the by-name hole in the overflow drift guards: it made `tests/unit/test_request_log_source_parity.py` discover every `REQUEST_LOG_SOURCE_*` constant in `app/modules/proxy/overflow.py` **by import**, so a third `source` value grows the expected set on its own. Its three siblings kept spelling the same enum **by name** — the OpenSpec routing delta, the observability delta, `docs/routing.md`, and the dashboard's closed `IN` predicate. Planting `REQUEST_LOG_SOURCE_TRIAL = "subscription_overflow_trial"` on `main` fails **exactly one** test: #2380's frontend guard. Everything else stays green.

That residual is recorded on #2123 in the merge note for #2380 (2026-09-11 — "closes the last WP-G residual") and in merge commit [`065842e55`](https://github.com/Soju06/codex-lb/commit/065842e556e4df8d87cd4b48a66fe6c51c3d9493): both describe the by-name → discovery conversion as done, but it was done for the dashboard literals only. This PR converts the remaining surfaces to the same discovery and extends it to the `ROUTE_*` and `DISPATCH_KIND_*` families, which had **no** coverage of new members at all — a sixth route label or a fourth dispatch kind was silent on `main`.

Part of #2123. No production line changes: 4 files, all under `tests/unit/`, +260 / −55 at head `4a89bca26`.

> **Review follow-ups (2 commits on top of `c2fde55fe`)** — `247b8dcee` adds the *reverse* check codex asked for (the observability delta may not enumerate a `route` label or dispatch `kind` the runtime can no longer emit; this closes Known limitation 2). `4a89bca26` teaches that parser the Oxford comma after CodeRabbit found `` `a`, `b`, and `retired` `` parsed as `{a, b}`, and refutes the stricter "reject any later backticked token" variant with a measurement showing it fails on the delta's live text. Both threads are resolved.

## Type of change

- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging

The PR title (what the squash records) is `chore(overflow)`; the two commits are typed `test(overflow)` because the diff is 100% test code. Either type is release-neutral.

Linked issue: Part of #2123

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Change directory: n/a — **no delta was edited.** All three normative surfaces this guard now enforces (`openspec/changes/add-subscription-overflow-model-source/specs/model-source-routing/spec.md`, `.../specs/proxy-runtime-observability/spec.md`, `docs/routing.md`) already quote both shipped `source` values, all five `route` labels and all three dispatch kinds, so the conversion required no text change — the same precedent as #2380. `openspec validate add-subscription-overflow-model-source --strict` re-run and still valid; `tasks.md` untouched.

## Changes

**`tests/unit/_overflow_constants.py` (new, 63 lines, test-only).** Leading underscore so pytest never collects it and it cannot couple two test modules' collection order — the same reason `tests/unit/_proxy_test_helpers.py` has one.

- `overflow_constants(prefix)` — every module-level `<prefix>*` **string** constant of `overflow.py`, by import.
- `discovery_error(prefix, constants)` — the shared non-vacuity check, and the reason this is one helper rather than three copies. It refuses an empty set (a renamed prefix would otherwise make every comparison pass vacuously), two names for one value (a copy-pasted constant would silently *shrink* the expected set), and a constant kept out of `__all__` (discovery reads the public surface).

**`test_request_log_source_parity.py`** — WP-G's private `_backend_literals()` and its inline sanity asserts move onto the shared helper. No parity assertion changed. Four self-tests for `discovery_error` are added beside the existing `_parity_error` ones, so the new guard is covered rather than trusted.

**`test_subscription_overflow_spec_delta.py`**

- `test_request_log_source_values_are_quoted_in_every_normative_surface` (new) owns source-value coverage across the routing delta, the observability delta **and** `docs/routing.md`, and names the file that is missing a value. The two by-name asserts it replaces were split across two tests, hence the rename `test_routing_delta_quotes_the_row_and_pin_failure_codes` → `test_routing_delta_quotes_the_pin_failure_codes_and_the_job_headers` ("the row" referred to the source values that moved out). `docs/routing.md` was never checked for source values before.
- The five `ROUTE_*` and three `DISPATCH_KIND_*` tuples in `test_observability_delta_names_the_routes_and_metrics` become discovered sets.
- `test_discovered_enums_are_trustworthy[prefix]` runs the non-vacuity check for all three families.

**`test_subscription_overflow_dashboard_summary.py`** — `OVERFLOW_REQUEST_LOG_SOURCES` is compared to the discovered enum as a **set** (plus an explicit no-duplicates assert) instead of a two-element tuple spelled by name. This is the one consequence here that is **not** documentation: `overflow_window_statement` / `overflow_existence_statement` build a closed `IN`, so a `source` value missing from that tuple is spend the dashboard overflow tile under-counts, and installations its existence probe cannot see. The `tuple[str, str]` annotation forced an edit at that line but never forced the value *set* to agree. Ordering is dropped deliberately (semantically irrelevant to an `IN` predicate; arity is still pinned by the annotation at `app/modules/settings/subscription_overflow.py:91`); the four `LIKE` / window / existence / soft-delete assertions are byte-identical.

### Approach, and the alternatives I rejected

| Option | Verdict |
|---|---|
| **Discovery by import + name prefix, in one shared test-only helper** | **Chosen.** Already the house style #2380 established; one new constant grows every expected set at once, and the non-vacuity logic exists once. |
| A registry/decorator or `Literal` alias in `app/**` that tests enumerate | Rejected — a production edit for a test-only concern, and a module *outside* the proxy package importing `overflow` is exactly what the positive ratchet in `test_subscription_overflow_inert.py` exists to prevent. That is why the helper lives under `tests/`. |
| Copy the discovery into each of the three files | Rejected — three copies of the non-vacuity check; the copy that goes stale is the one nobody notices. |
| Parse `overflow.py` as text | Rejected — the values are already live objects; a regex adds a way to silently stop matching. |
| Convert the constants to an `enum`/`Literal` union | Rejected — real production diff surface (metric label values and DB column values are plain `str` at every call site) for no extra guard strength. |

Requiring `isinstance(value, str)` keeps same-prefix **aggregates** out of the discovered enum instead of silently widening it: the frontend deliberately exports a `REQUEST_LOG_SOURCE_KINDS` array, and a backend tuple of that shape would be the same collision.

## Planted-mutation evidence

Each mutation was added to `app/modules/proxy/overflow.py`, measured against the same three test files on both sides, then reverted (`git status` clean after each). Baseline: **36 passed** on `main`, **44 passed** here.

| Planted in `overflow.py` | On `main` | With this PR | What fails here |
|---|---|---|---|
| `REQUEST_LOG_SOURCE_TRIAL = "subscription_overflow_trial"` + `__all__` | **1 failed** / 35 passed | **3 failed** / 41 passed | `parity::test_frontend_declares_exactly_the_backend_source_literals` (#2380, the only one `main` had), `spec_delta::test_request_log_source_values_are_quoted_in_every_normative_surface`, `dashboard_summary::test_dashboard_sources_are_exactly_the_dispatch_labels` |
| same, **without** the `__all__` entry | **2 failed** / 34 passed | **6 failed** / 38 passed | the three above, plus `parity::test_backend_declares_its_request_log_source_literals`, `parity::test_discovery_error_accepts_the_shipped_enum`, `spec_delta::test_discovered_enums_are_trustworthy[REQUEST_LOG_SOURCE_]` |
| `ROUTE_TRIAL = "trial_probe"` + `__all__` | **0 failed** / 36 passed — *silent* | **1 failed** / 43 passed | `spec_delta::test_observability_delta_names_the_routes_and_metrics` — `AssertionError: trial_probe` |
| `DISPATCH_KIND_TRIAL = "trial"` + `__all__` | **0 failed** / 36 passed — *silent* | **1 failed** / 43 passed | same guard — `AssertionError: trial` |
| retire `ROUTE_COMPACT` (constant + `__all__`) | 36 passed — *silent* | **1 failed** | `spec_delta::test_observability_delta_enumerates_exactly_the_closed_route_and_kind_sets` (added in `247b8dcee`) — `in_spec_only: ['compact']` |
| retire `DISPATCH_KIND_ANCHOR` (constant + `__all__`) | 36 passed — *silent* | **1 failed** | same guard — `in_spec_only: ['anchor']` |

Two independent adversarial verification passes ran further mutations on top of these, all reproducing:

- **renamed value** (`subscription_overflow_pinned` → `..._pin`): 3 fail (parity, dashboard, spec-delta).
- **duplicate value under a second name**: 5 fail; **`overflow_constants()` stubbed to return `{}`**: 10 fail, including all three `test_discovered_enums_are_trustworthy` params — the vacuity trap is itself trapped.
- **renamed constant *name*, value unchanged** (`REQUEST_LOG_SOURCE_FRESH` → `_INITIAL`, `__all__` updated): 44 pass. Correct — nothing drifted; `main` would have raised `AttributeError` for no real reason, so this is a strengthening.
- Widened to `tests/unit -k "overflow or source or metrics"` (894 tests) with the third source value planted: exactly the 3 expected failures, 881 pass — the two new guards are genuinely new coverage, not restatements of an existing one.

## Test plan

All commands run against head `c2fde55fe` with the repo venv (never `uv` — the root disk on this host is at 99%).

```
pytest tests/unit/test_request_log_source_parity.py \
       tests/unit/test_subscription_overflow_spec_delta.py \
       tests/unit/test_subscription_overflow_dashboard_summary.py \
       tests/unit/test_subscription_overflow_inert.py \
       tests/unit/test_metrics.py                          76 passed in 2.35s
pytest --collect-only tests/                               13789 tests collected, no errors
                                                           (_overflow_constants.py contributes 0 node ids)

ruff check .                                               All checks passed!
ruff format --check .                                      1269 files already formatted
ty check                                                   All checks passed!
scripts/check_proxy_architecture.py                        proxy architecture checks passed
scripts/check_cancellation_safety.py                       cancellation safety checks passed
scripts/check_proxy_timing_seams.py                        proxy timing seam checks passed
scripts/check_settings_tiers.py                            check_settings_tiers: ok
scripts/check_migration_topology.py                        migration topology checks passed
openspec validate add-subscription-overflow-model-source --strict
                                                           Change '...' is valid
openspec validate --specs                                  65 passed, 0 failed
```

Nearest ratchets checked on purpose:

- `tests/unit/test_subscription_overflow_inert.py` — the positive ratchet walks `app/` only (AST + regex), so a `tests/` helper importing `overflow` cannot trip it; still green. Both files that gained the helper import already imported `overflow` on `main`, so `sys.modules` state during the unit run is unchanged.
- **Alembic:** no migration is added or touched. `check_migration_topology.py` (check #1: exactly one head, one base, no fork) passes and reports `+0 revision(s) on this checkout` versus `origin/main`, head `20260911_030000_add_local_login_policy`. Note for the record: `python -m alembic -c alembic.ini heads` is **not runnable in this repo** — there is no `alembic.ini`, only `app/db/alembic/`; the topology script is the gate that enforces the single-head invariant, and it runs in `make lint`.
- No `frontend/**` change, so no `node_modules` install and no bun suite is implicated; `frontend/src/features/dashboard/request-log-source.ts` and its vitest are byte-identical.

## Screenshots / output

**N/A — no user-visible surface.** The diff is entirely under `tests/unit/`; no `app/**` or `frontend/**` file is touched, the `source` literals, chip, filter options and locale strings are byte-identical, and every addition here is a build-time assertion with no runtime path.

## Known limitations

Residual P3s from adversarial verification, recorded rather than fixed (none changes behaviour; all are inside the new tests):

1. **`test_subscription_overflow_spec_delta.py:78` — the non-vacuity guard re-derives its own set.** `test_discovered_enums_are_trustworthy` calls `discovery_error(prefix, overflow_constants(prefix))` instead of asserting on the module-level bindings at `:53-55` (`SOURCE_LITERALS` / `ROUTE_LABELS` / `DISPATCH_KINDS`) that the consuming tests actually read. Planting a plausible copy-paste at `:54` (`ROUTE_LABELS = overflow_constants(SOURCE_PREFIX)`) leaves all 44 tests green while `test_observability_delta_names_the_routes_and_metrics` silently stops checking any `route` label — the exact vacuous-pass class this change set out to close, surviving inside the new guard. Both sibling files got this right (`test_request_log_source_parity.py:118` validates the consumed `BACKEND_LITERALS`; `test_subscription_overflow_dashboard_summary.py:40` validates the consumed `_SOURCE_LITERALS`). One-line fix: parametrize over `(prefix, constants)` pairs built from the module-level bindings.
2. ~~**The removal-direction tripwire is weaker than `main`'s.**~~ **Fixed in `247b8dcee`** after codex raised the same point as a P2 ([thread](https://github.com/Soju06/codex-lb/pull/2395#discussion_r3994483541)). Discovery only closed the *addition* direction; `main`'s by-name tuples closed removals by accident (`AttributeError`), which the discovered loops lose. `test_observability_delta_enumerates_exactly_the_closed_route_and_kind_sets` now reads the delta's own prose enumerations of the closed `route` and dispatch-`kind` sets and compares each to the discovered enum in both directions, so the delta cannot keep advertising a label the runtime can no longer emit. Retiring `ROUTE_COMPACT` or `DISPATCH_KIND_ANCHOR` goes from *22 passed, silent* to a named failure; rewording the delta so no enumeration is parseable fails loudly rather than vacuously. Residual: if one of the two matching occurrences is reworded out of the anchor's reach, that one occurrence stops being checked while the other keeps the guard honest.
3. **`_overflow_constants.py:43` — `overflow_constants`'s own filters are untested.** `discovery_error` has four self-tests, but `_SUFFIX.fullmatch` and `isinstance(value, str)` have none, and `overflow.py` contains no non-`str` same-prefix constant to exercise them. So the docstring claim about keeping aggregates out is asserted but not proven: a future `REQUEST_LOG_SOURCE_KINDS: tuple[str, ...]` carrying a new source value would be dropped from the discovered enum with every guard still green.
4. **`_overflow_constants.py:32` — `ROUTE_` is a broad prefix.** A future `ROUTE_*` string constant in `overflow.py` that is *not* a `codex_lb_subscription_overflow_total` route label (a route template, a header name, a route-scoped message) would be forced into the observability delta's required tokens, with no exclusion mechanism analogous to the deliberate `isinstance(str)` carve-out. This is a loud false positive rather than a silent pass, and cheap to fix if it ever fires.
5. **`test_subscription_overflow_dashboard_summary.py:3,8` — stale docstring prose.** The opening paragraph still says "the two `request_logs.source` values" and "this file is where the two spellings are pinned together", which the paragraph added at `:14-18` now contradicts. Documentation only.

Non-defects worth recording from the same passes: `discovery_error` checks `constants ⊆ __all__` but not the reverse — an `__all__` entry whose constant was deleted is caught independently by ruff `F822`, which this repo selects. And `spec_delta:122-130` asserts inside the per-file loop, so only the first missing normative surface is named per run.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change (the change *is* tests; the new guard has its own self-tests and a planted-mutation matrix).
- [x] Ran the relevant gate subset locally — `make lint`'s full contents (ruff check, ruff format --check, and all five `scripts/check_*.py`) plus `ty check` and the touched suites, invoked directly with the repo venv instead of `uv run` because the root disk on this host is at 99%.
- [x] If touching specs: no spec text changed; `openspec validate add-subscription-overflow-model-source --strict` and `openspec validate --specs` re-run and clean.
- [x] Simplicity gates reviewed (PRINCIPLES.md P1-P6): no new setting, no README section, no dashboard nav item, no default changed, no production line.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
