### PR TITLE
Surface upstream overload to native Codex clients as a retryable named error

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -119,6 +119,32 @@ SYNTHETIC_TRANSPORT_FAILURE_MARKER = "_codex_lb_synthetic_transport_failure"
 SYNTHETIC_TRANSPORT_FAILURE_CODES = frozenset(
     {"stream_incomplete", "stream_idle_timeout", "upstream_request_timeout", "upstream_unavailable"}
 )
+# The Codex CLI treats ``server_is_overloaded``/``slow_down`` as terminal
+# (zero retries), so once codex-lb gives up retrying internally for a
+# native Codex client, the give-up path must relabel the cause as the one
+# code Codex both retries on *and* parses a delay out of.
+NATIVE_GIVEUP_RETRYABLE_CODE = "rate_limit_exceeded"
+DEFAULT_NATIVE_GIVEUP_RETRY_AFTER_SECONDS = 5
+
+
+def native_giveup_retryable_message(
+    upstream_error_code: str | None,
+    message: str | None,
+    retry_after_seconds: float | int | None,
+) -> str:
+    """Build the ``rate_limit_exceeded`` message codex-rs's reconnect parses.
+
+    codex-rs matches ``(?i)try again in\\s*(\\d+(?:\\.\\d+)?)\\s*(s|ms|seconds?)``
+    against this message to size its reconnect backoff, so the trailing
+    ``Please try again in <N>s.`` clause is load-bearing and must stay in
+    that exact shape.
+    """
+    delay = retry_after_seconds if retry_after_seconds and retry_after_seconds > 0 else None
+    seconds = delay if delay is not None else DEFAULT_NATIVE_GIVEUP_RETRY_AFTER_SECONDS
+    seconds_text = str(int(seconds)) if float(seconds).is_integer() else str(seconds)
+    original = (message or "Upstream error").strip().rstrip(".")
+    code_text = upstream_error_code or "unavailable"
+    return f"codex-lb: upstream {code_text}; {original}. Please try again in {seconds_text}s."
 
 
 def openai_error(

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -2068,6 +2068,14 @@ class _HTTPBridgeRequestSubmitMixin:
                                 "stream_incomplete",
                                 "The previous response anchor was rejected upstream; retry the request.",
                             ),
+                            # Fail-closed rewrite: preserve the upstream cause
+                            # just recorded above instead of dropping it. The
+                            # native give-up path (api.py
+                            # ``_stream_response_error_events``) reads
+                            # ``upstream_error_code``/``retry_after_seconds``
+                            # off this exception to name the real cause in the
+                            # retryable error it surfaces to Codex clients.
+                            upstream_error_code="previous_response_not_found",
                         )
                     if (
                         request_state.verified_stale_anchor_replay

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -42,6 +42,7 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.clock import Scheduler
 from app.core.errors import (
+    NATIVE_GIVEUP_RETRYABLE_CODE,
     PREVIOUS_RESPONSE_MALFORMED_PARAM_REASON,
     PREVIOUS_RESPONSE_NOT_FOUND_CODE,
     PREVIOUS_RESPONSE_NOT_FOUND_MESSAGE,
@@ -49,6 +50,7 @@ from app.core.errors import (
     OpenAIErrorEnvelope,
     OpenAIErrorParam,
     coerce_error_param,
+    native_giveup_retryable_message,
     normalize_public_error_param,
     openai_error,
     previous_response_stream_incomplete_error,
@@ -1758,6 +1760,22 @@ def _sanitize_websocket_terminal_error_fields(
             error_param_state if error_param_state.present else None,
         )
     normalized_code = _normalize_error_code(error_code, error_type)
+    if normalized_code in {"server_is_overloaded", "slow_down"}:
+        # These two codes are the only ones the native Codex CLI treats as
+        # terminal (zero reconnect attempts) rather than retryable, and
+        # overflow.py's own contract already forbids sending them to Codex
+        # over this transport. Unlike ``stream_incomplete`` et al. (used
+        # broadly here for ordinary connection drops, not just capacity
+        # give-up), these two codes are unambiguous capacity signals
+        # wherever they appear on a terminal frame, so relabel them the same
+        # way the HTTP give-up path does.
+        request_state.websocket_terminal_error_fields_sanitized = True
+        return (
+            NATIVE_GIVEUP_RETRYABLE_CODE,
+            native_giveup_retryable_message(normalized_code, error_message, None),
+            "server_error",
+            error_param_state if error_param_state.present else None,
+        )
     recoverable = _facade()._is_previous_response_not_found_error(
         code=normalized_code,
         param=error_param_state,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -87,11 +87,13 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
     HTTP_BRIDGE_EVENTLESS_TIMEOUT_CODE,
+    NATIVE_GIVEUP_RETRYABLE_CODE,
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     SYNTHETIC_TRANSPORT_FAILURE_MARKER,
     OpenAIErrorEnvelope,
     OpenAIErrorParam,
     is_previous_response_not_found_public_shape,
+    native_giveup_retryable_message,
     normalize_public_error_param,
     openai_error,
     response_failed_event,
@@ -8398,13 +8400,6 @@ async def _stream_response_error_events(
     except ProxyResponseError as exc:
         error_code = exc.payload.get("error", {}).get("code") if isinstance(exc.payload, dict) else None
         await release_owned_reservation()
-        if preserve_native_failure_lifecycle and error_code in {
-            "stream_incomplete",
-            "stream_idle_timeout",
-            "upstream_request_timeout",
-            "upstream_unavailable",
-        }:
-            raise
         response_id = None
         if isinstance(exc.payload, dict):
             response_id = _response_id_from_event_payload(cast(dict[str, JsonValue], exc.payload))
@@ -8416,6 +8411,35 @@ async def _stream_response_error_events(
             default_status=exc.status_code,
         )
         error = envelope.error
+        if preserve_native_failure_lifecycle and error_code in {
+            "stream_incomplete",
+            "stream_idle_timeout",
+            "upstream_request_timeout",
+            "upstream_unavailable",
+        }:
+            # codex-lb has already given up (internal retries/replays are
+            # exhausted). Starlette already sent the 200, so the only way to
+            # tell a native Codex client anything is a terminal SSE event on
+            # the open stream — a bare re-raise here used to close the
+            # stream with zero bytes, which the client reported as "Stream
+            # disconnected before completion" and retried blind. Emit a
+            # named, retryable error instead: Codex's own reconnect logic
+            # only retries on ``rate_limit_exceeded`` (overload codes are
+            # terminal to it) and only that code's message is scanned for a
+            # "try again in Ns" delay.
+            retryable_message = native_giveup_retryable_message(
+                exc.upstream_error_code or error_code,
+                error.message if error and error.message else None,
+                exc.retry_after_seconds,
+            )
+            giveup_event = response_failed_event(
+                NATIVE_GIVEUP_RETRYABLE_CODE,
+                retryable_message,
+                "server_error",
+                response_id=response_id,
+            )
+            yield format_sse_event(giveup_event)
+            return
         retry_hint = ""
         if exc.retry_after_seconds is not None and exc.retry_after_seconds > 0:
             # Preserve the HTTP Retry-After signal when a streaming response
@@ -9294,11 +9318,32 @@ async def _normalize_public_responses_stream(
             payload = dict(payload)
             payload.pop(SYNTHETIC_TRANSPORT_FAILURE_MARKER, None)
             if preserve_native_failure_lifecycle:
-                raise ProxyResponseError(
-                    502,
-                    openai_error("stream_incomplete", "Native upstream transport ended before a terminal event"),
-                    failure_phase="upstream",
+                # Second give-up gate: codex-lb marked this event as a
+                # synthetic transport failure upstream of us (the account
+                # path's own retry/replay is exhausted) instead of raising
+                # ``ProxyResponseError`` directly. Raising here would still
+                # close the stream with no bytes sent to a native Codex
+                # client (the 200 is already on the wire), so emit the same
+                # terminal, retryable ``response.failed`` this module's other
+                # give-up gate emits and end the stream.
+                response_obj = payload.get("response")
+                nested_error = response_obj.get("error") if is_json_mapping(response_obj) else None
+                upstream_code = nested_error.get("code") if is_json_mapping(nested_error) else None
+                upstream_message = nested_error.get("message") if is_json_mapping(nested_error) else None
+                response_id = _response_id_from_event_payload(payload)
+                retryable_message = native_giveup_retryable_message(
+                    upstream_code if isinstance(upstream_code, str) else "stream_incomplete",
+                    upstream_message if isinstance(upstream_message, str) else None,
+                    None,
                 )
+                giveup_event = response_failed_event(
+                    NATIVE_GIVEUP_RETRYABLE_CODE,
+                    retryable_message,
+                    "server_error",
+                    response_id=response_id,
+                )
+                yield format_sse_event(giveup_event)
+                return
         raw_event_type = payload.get("type")
         if (
             enforce_openai_sdk_contract

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -7125,6 +7125,17 @@ MUST still execute reservation, request-log, account-health, and owned-resource
 cleanup before propagating the termination. Non-native and OpenAI-compatible
 clients MUST retain the existing stable terminal-error shaping.
 
+When codex-lb has exhausted its own internal retries/replays for one of these
+transport failures (`stream_incomplete`, `stream_idle_timeout`,
+`upstream_request_timeout`, `upstream_unavailable`) or an upstream capacity
+rejection, this "no synthetic terminal event" rule is superseded: the proxy
+MUST instead emit exactly one terminal `response.failed` with
+`error.code = "rate_limit_exceeded"` and a message naming the upstream cause
+and a "try again in `<N>`s" delay, then end the stream. Overload codes
+(`server_is_overloaded`, `slow_down`) themselves MUST NOT reach the client,
+since the native Codex CLI treats them as non-retryable; `rate_limit_exceeded`
+is the one code Codex both retries on and parses a reconnect delay from.
+
 #### Scenario: Native Codex sees a truncated SSE lifecycle
 
 - **GIVEN** a native Codex HTTP request has received a non-terminal SSE event

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -479,6 +479,10 @@ async def test_submit_rejects_a_denied_proxy_anchor_before_upstream_dispatch(
 
     assert exc_info.value.status_code == 502
     assert exc_info.value.payload["error"]["code"] == "stream_incomplete"
+    # Fail-closed rewrite: the raised exception must carry the upstream
+    # cause forward (rather than dropping it) so the native give-up path in
+    # api.py can name it in the retryable error it surfaces to Codex.
+    assert exc_info.value.upstream_error_code == "previous_response_not_found"
     send_text.assert_not_awaited()
     assert not session.pending_requests
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6,6 +6,7 @@ import gc
 import hashlib
 import json
 import logging
+import re
 import socket
 import ssl
 import sys
@@ -9815,15 +9816,28 @@ async def test_native_codex_stream_suppresses_marked_synthetic_transport_termina
         )
         yield "data: [DONE]\n\n"
 
-    with pytest.raises(proxy_module.ProxyResponseError):
-        _ = [
-            event_block
-            async for event_block in proxy_api._normalize_public_responses_stream(
-                synthetic_failure_stream(),
-                enforce_openai_sdk_contract=False,
-                preserve_native_failure_lifecycle=True,
-            )
-        ]
+    events = [
+        event_block
+        async for event_block in proxy_api._normalize_public_responses_stream(
+            synthetic_failure_stream(),
+            enforce_openai_sdk_contract=False,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
+
+    # codex-lb has already given up: rather than re-raising (which would
+    # close the already-200'd stream with zero bytes), it must emit exactly
+    # one terminal ``response.failed`` naming a retryable code, then end the
+    # stream (the ``data: [DONE]`` upstream sent after the marked event is
+    # never reached/forwarded).
+    assert len(events) == 1
+    payload = parse_sse_data_json(events[0])
+    assert payload is not None
+    assert payload["type"] == "response.failed"
+    error = payload["response"]["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    assert re.search(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)", error["message"])
+    assert "upstream_request_timeout" in error["message"]
 
 
 @pytest.mark.asyncio
@@ -9836,15 +9850,23 @@ async def test_native_codex_stream_suppresses_marked_incomplete_terminal_as_eof(
         )
         yield "data: [DONE]\n\n"
 
-    with pytest.raises(proxy_module.ProxyResponseError):
-        _ = [
-            event_block
-            async for event_block in proxy_api._normalize_public_responses_stream(
-                synthetic_failure_stream(),
-                enforce_openai_sdk_contract=False,
-                preserve_native_failure_lifecycle=True,
-            )
-        ]
+    events = [
+        event_block
+        async for event_block in proxy_api._normalize_public_responses_stream(
+            synthetic_failure_stream(),
+            enforce_openai_sdk_contract=False,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
+
+    assert len(events) == 1
+    payload = parse_sse_data_json(events[0])
+    assert payload is not None
+    assert payload["type"] == "response.failed"
+    error = payload["response"]["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    assert re.search(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)", error["message"])
+    assert "stream_incomplete" in error["message"]
 
 
 @pytest.mark.asyncio
@@ -9870,26 +9892,101 @@ async def test_non_native_stream_emits_synthetic_transport_terminal_without_inte
 
 
 @pytest.mark.asyncio
-async def test_native_codex_stream_reraises_transport_failure_without_terminal_event() -> None:
+async def test_native_codex_stream_emits_retryable_terminal_event_instead_of_reraising() -> None:
     async def failed_stream() -> AsyncIterator[str]:
         raise proxy_module.ProxyResponseError(
             502,
             openai_error("upstream_request_timeout", "timed out"),
+            retry_after_seconds=7,
         )
         yield ""  # pragma: no cover
 
-    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
-        _ = [
-            event
-            async for event in proxy_api._stream_response_error_events(
-                failed_stream(),
-                owns_reservation=False,
-                reservation=None,
-                preserve_native_failure_lifecycle=True,
-            )
-        ]
+    events = [
+        event
+        async for event in proxy_api._stream_response_error_events(
+            failed_stream(),
+            owns_reservation=False,
+            reservation=None,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
 
-    assert _proxy_error_code(exc_info.value) == "upstream_request_timeout"
+    # Starlette has already sent the 200 by the time codex-lb gives up here,
+    # so a bare re-raise used to close the stream with zero bytes (the
+    # "Stream disconnected before completion" symptom). It must instead
+    # surface exactly one named, retryable terminal event.
+    assert len(events) == 1
+    payload = parse_sse_data_json(events[0])
+    assert payload is not None
+    assert payload["type"] == "response.failed"
+    error = payload["response"]["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    assert "upstream_request_timeout" in error["message"]
+    assert "timed out" in error["message"]
+    match = re.search(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)", error["message"])
+    assert match is not None
+    assert match.group(1) == "7"
+
+
+@pytest.mark.asyncio
+async def test_native_codex_stream_error_events_default_retry_delay_when_unknown() -> None:
+    async def failed_stream() -> AsyncIterator[str]:
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("stream_idle_timeout", "idle too long"),
+        )
+        yield ""  # pragma: no cover
+
+    events = [
+        event
+        async for event in proxy_api._stream_response_error_events(
+            failed_stream(),
+            owns_reservation=False,
+            reservation=None,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
+
+    assert len(events) == 1
+    payload = parse_sse_data_json(events[0])
+    assert payload is not None
+    error = payload["response"]["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    match = re.search(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)", error["message"])
+    assert match is not None
+    assert match.group(1) == "5"
+
+
+@pytest.mark.asyncio
+async def test_native_codex_stream_error_events_unaffected_for_non_giveup_codes() -> None:
+    """Errors outside the overload/transport-failure set are untouched by
+    this patch: they keep going through the pre-existing terminal-event path
+    with their own code (not relabeled to rate_limit_exceeded, and not
+    re-raised -- only the four give-up codes are special-cased for native
+    clients)."""
+
+    async def failed_stream() -> AsyncIterator[str]:
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("bridge_continuity_persistence_failed", "retry the request"),
+        )
+        yield ""  # pragma: no cover
+
+    events = [
+        event
+        async for event in proxy_api._stream_response_error_events(
+            failed_stream(),
+            owns_reservation=False,
+            reservation=None,
+            preserve_native_failure_lifecycle=True,
+        )
+    ]
+
+    assert len(events) == 1
+    payload = parse_sse_data_json(events[0])
+    assert payload is not None
+    error = payload["response"]["error"]
+    assert error["code"] == "bridge_continuity_persistence_failed"
 
 
 def test_stream_startup_error_response_preserves_exact_retry_after_header() -> None:
@@ -39506,6 +39603,36 @@ def test_sanitize_websocket_terminal_stale_error_marks_missing_anchor_source_unk
     assert request_state.failure_detail_override is not None
     assert "previous_response_source=unknown" in request_state.failure_detail_override
     assert "previous_response_source=none" not in request_state.failure_detail_override
+
+
+@pytest.mark.parametrize("overload_code", ["server_is_overloaded", "slow_down"])
+def test_sanitize_websocket_terminal_error_relabels_overload_codes_as_retryable(overload_code: str):
+    """Codex treats server_is_overloaded/slow_down as terminal (see
+    app/modules/proxy/_service/websocket/overflow.py's own contract), so the
+    WS give-up frame must relabel them to the one code Codex retries on and
+    parses a delay from."""
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_overload_giveup",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    error_code, error_message, error_type, error_param = proxy_service._sanitize_websocket_terminal_error_fields(
+        request_state=request_state,
+        error_code=overload_code,
+        error_message="Upstream capacity exhausted after retries",
+        error_type="server_error",
+        error_param=None,
+    )
+
+    assert error_code == "rate_limit_exceeded"
+    assert error_type == "server_error"
+    assert error_param is None
+    assert overload_code in error_message
+    assert re.search(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)", error_message)
 
 
 def test_sanitize_websocket_connect_failure_rewrites_invalid_request_previous_response_not_found():


### PR DESCRIPTION
## Summary

Native Codex clients hit a give-up path where codex-lb re-raised an upstream capacity/overload error *after* the 200 had already been sent, closing the SSE/WS stream with zero bytes ("stream closed before response.completed"). Codex retried blind. The cause was also dropped at the denied-anchor fail-closed rewrite, so it never reached the give-up path in the first place.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/specs/responses-api-compat/spec.md` ("Native Codex preserves upstream failure lifecycle")

## Changes

- Emit one terminal `response.failed` (`error.code = rate_limit_exceeded`, message "Please try again in `<N>`s.") at both native-client give-up gates in `app/modules/proxy/api.py` (`_stream_response_error_events` / `_normalize_public_responses_stream`), instead of re-raising after the stream opened.
- Relabel `server_is_overloaded` / `slow_down` WS terminal frames the same way in `app/modules/proxy/_service/websocket/helpers.py` (`_sanitize_websocket_terminal_error_fields`).
- `app/modules/proxy/_service/http_bridge/request_submit.py` now preserves the upstream cause on the denied-anchor fail-closed raise instead of dropping it.
- `rate_limit_exceeded` (not `server_is_overloaded`/`slow_down`) because codex-rs treats the overload codes as terminal with zero retries and only parses a retry delay from `rate_limit_exceeded` messages (`codex-rs/codex-api/src/sse/responses.rs`).
- Non-native/OpenAI-compatible clients are unaffected.

## Simplicity

- [x] No new required setup step
- No new settings added.

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py -q
uv run pytest tests/unit/test_proxy_http_bridge.py -q
```

New/updated tests:
- `test_native_codex_stream_emits_retryable_terminal_event_instead_of_reraising`
- `test_native_codex_stream_error_events_default_retry_delay_when_unknown`
- `test_native_codex_stream_error_events_unaffected_for_non_giveup_codes`
- `test_sanitize_websocket_terminal_error_relabels_overload_codes_as_retryable`
- `test_submit_rejects_a_denied_proxy_anchor_before_upstream_dispatch` (extended to assert the preserved `upstream_error_code`)

Full suite: 2461 unit tests green. `ruff check` / `ty` clean.

## Side effect

Denied-anchor failures in `request_submit.py` now record `upstream_error_code=previous_response_not_found` in RequestLog telemetry (previously `stream_incomplete`).

https://claude.ai/code/session_01EAT21bAfhFwxeYHbK5Wr6M
