### PR TITLE
fix(proxy): retire a continuity owner that cannot return in time

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2089,6 +2089,7 @@ class _HTTPBridgeStreamingMixin:
         fresh_replay_excluded_account_ids: set[str] = set()
         model_transition_owner_conflict_fork_attempted = False
         unanchored_fork_spill_attempted = False
+        owner_retirement_attempted = False
         verified_stale_anchor_generation_captured = False
         verified_stale_anchor_circuit_key: _HTTPBridgeSessionKey | None = None
         verified_stale_anchor_generation: tuple[int, float, int, float, int, float, float] | None = None
@@ -2242,6 +2243,80 @@ class _HTTPBridgeStreamingMixin:
             if reused_parent_turn_state:
                 request_state.session_id = None
                 downstream_turn_state = None
+            return True
+
+        async def retire_unavailable_continuity_owner(exc: ProxyResponseError) -> bool:
+            """Retire an owner that cannot return in time, so this turn can rebind.
+
+            The scheduled sweep frees a thread six hours after its last turn.
+            That is right for a dormant thread but not for the one a user is
+            waiting on, so ask the narrower question here: can this owner come
+            back before this request's own budget runs out? ``reset_at``
+            answers it for a rate or quota limit; paused, re-auth-blocked and
+            deactivated owners carry no horizon, so the answer is always no.
+
+            Only for an anchor the proxy injected. A client that supplied its
+            own ``previous_response_id`` named upstream state that lived on
+            this account, and dropping it here would silently change what the
+            client asked for.
+            """
+            nonlocal durable_lookup
+            nonlocal effective_payload
+            nonlocal owner_retirement_attempted
+            nonlocal preferred_account_has_continuity_provenance
+            nonlocal request_state
+            nonlocal text_data
+
+            if owner_retirement_attempted:
+                return False
+            if not _http_bridge_is_previous_response_owner_unavailable(exc):
+                return False
+            if payload.previous_response_id is not None or rewritten_file_account_id is not None:
+                return False
+            retiring_account_id = request_state.preferred_account_id
+            if durable_lookup is None or retiring_account_id is None:
+                # Nothing durable to retire: the owner came from the
+                # request-log index or the in-process registry, which is the
+                # ``no_durable_lookup`` shape tracked separately.
+                return False
+            if durable_lookup.account_id != retiring_account_id:
+                return False
+            owner_retirement_attempted = True
+            retired = await self._durable_bridge.retire_continuity_owner_if_unavailable(
+                session_id=durable_lookup.session_id,
+                expected_account_id=retiring_account_id,
+                # ``request_deadline`` is monotonic and ``reset_at`` is wall
+                # clock, so project the remaining budget onto the epoch the
+                # account row uses rather than comparing the two directly.
+                recovery_deadline_epoch=int(
+                    clock.time() + max(0.0, request_deadline - clock.monotonic()),
+                ),
+            )
+            if not retired:
+                return False
+            _log_http_bridge_event(
+                "owner_retired_on_request",
+                bridge_session_key,
+                account_id=retiring_account_id,
+                model=payload.model,
+                detail="outcome=rebind_without_anchor",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(payload.model) if payload.model else None,
+                owner_check_applied=True,
+            )
+            # Send the body the client actually sent, minus the anchor only the
+            # retired owner could resolve. ``untrimmed_effective_payload`` is
+            # the pre-trim copy the other anchor-free retries already use.
+            effective_payload = _http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)
+            request_state, text_data = prepare_bridge_request(effective_payload)
+            request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
+            request_state.affinity_policy = affinity
+            request_state.transport = _REQUEST_TRANSPORT_HTTP
+            request_state.preferred_account_id = None
+            if downstream_turn_state is not None:
+                request_state.session_id = _normalize_session_id(downstream_turn_state)
+            preferred_account_has_continuity_provenance = False
+            durable_lookup = None
             return True
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
@@ -2470,6 +2545,8 @@ class _HTTPBridgeStreamingMixin:
                 if switch_model_transition_to_account_neutral_fork(exc):
                     continue
                 if not owner_unavailable_allows_account_neutral_replay(exc):
+                    if await retire_unavailable_continuity_owner(exc):
+                        continue
                     exc_code, _exc_message = _proxy_error_code_message(exc)
                     if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(
                         error_code=exc_code,

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -1032,6 +1032,21 @@ class DurableBridgeSessionCoordinator:
                 request_fingerprint=request_fingerprint,
             )
 
+    async def retire_continuity_owner_if_unavailable(
+        self,
+        *,
+        session_id: str,
+        expected_account_id: str,
+        recovery_deadline_epoch: int,
+    ) -> bool:
+        """Retire a row's owner now when it cannot return before the deadline."""
+        async with self._session() as session:
+            return await DurableBridgeRepository(session).retire_continuity_owner_if_unavailable(
+                session_id,
+                expected_account_id=expected_account_id,
+                recovery_deadline_epoch=recovery_deadline_epoch,
+            )
+
     async def mark_instance_draining(self, *, instance_id: str) -> int:
         async with self._session() as session:
             return await DurableBridgeRepository(session).mark_owner_draining(instance_id=instance_id)

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -65,6 +65,9 @@ DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS = 3600.0
 _RETRY_CIRCUIT_ABANDONED_TOMBSTONE_DETAIL = "anchor_abandoned"
 DURABLE_BRIDGE_OPERATION_SPOOL_PURGE_BATCH_SIZE = 50
 _PURGE_CLOSED_BATCH_SIZE = 500
+# Marks a retirement taken on the request path rather than by the sweep.
+# The sweep writes the global timestamp form instead; both read as retired.
+_REQUEST_PATH_ABANDONMENT_SCOPE = "request_path"
 # Claim retry budget: insert races and epoch-CAS losses re-read and retry;
 # each round has a winner, so a small budget converges under any realistic
 # same-row claim contention.
@@ -3565,6 +3568,73 @@ class DurableBridgeRepository:
                 await self._session.commit()
             deleted_count += len(deleted.scalars().all())
 
+    async def retire_continuity_owner_if_unavailable(
+        self,
+        session_id: str,
+        *,
+        expected_account_id: str,
+        recovery_deadline_epoch: int,
+    ) -> bool:
+        """Retire one row's owner now, when it cannot return before the deadline.
+
+        The scheduled sweep frees a thread six hours after its last turn. This
+        is the request-path counterpart, and it asks a narrower question: can
+        this owner come back before the request that is waiting on it gives up?
+        ``reset_at`` is the answer for a rate or quota limit; ``paused``,
+        ``reauth_required`` and ``deactivated`` carry no horizon at all, so the
+        answer for them is always no.
+
+        Mirrors ``StickySessionsRepository.abandon_legacy_session_header_owner_if_unavailable``,
+        including why the account row is locked first: PostgreSQL evaluates the
+        status subquery from the UPDATE's snapshot, so without the lock a
+        concurrent recovery can commit while this statement waits on the
+        session row and the stale snapshot would still authorize a retirement.
+        The status predicate stays inside the UPDATE as a second, database-level
+        invariant so a later refactor cannot turn a prior observation into an
+        unconditional write.
+
+        Writes the scope marker alone and leaves the timestamp NULL, so a
+        replica running the previous build keeps treating ``account_id`` as
+        hard ownership for the rest of a rolling deploy.
+        """
+        if not session_id or not expected_account_id:
+            return False
+        owner_status_lock = (
+            select(Account.status, Account.reset_at).where(Account.id == expected_account_id).with_for_update()
+        )
+        unavailable_owner = select(Account.id).where(
+            Account.id == expected_account_id,
+            Account.status.in_(HARD_OWNER_UNAVAILABLE_STATUSES),
+            or_(Account.reset_at.is_(None), Account.reset_at >= recovery_deadline_epoch),
+        )
+        statement = (
+            update(HttpBridgeSessionRecord)
+            .where(
+                HttpBridgeSessionRecord.id == session_id,
+                HttpBridgeSessionRecord.account_id == expected_account_id,
+                HttpBridgeSessionRecord.continuity_abandoned_at.is_(None),
+                HttpBridgeSessionRecord.continuity_abandonment_scope.is_(None),
+                HttpBridgeSessionRecord.account_id.in_(unavailable_owner),
+            )
+            .values(continuity_abandonment_scope=_REQUEST_PATH_ABANDONMENT_SCOPE)
+            .returning(HttpBridgeSessionRecord.id)
+        )
+        async with sqlite_writer_section():
+            locked = (await self._session.execute(owner_status_lock)).one_or_none()
+            if locked is None or locked[0] not in HARD_OWNER_UNAVAILABLE_STATUSES:
+                await self._session.commit()
+                return False
+            owner_reset_at = locked[1]
+            if owner_reset_at is not None and owner_reset_at < recovery_deadline_epoch:
+                # The owner is expected back inside the window the caller is
+                # willing to wait, so waiting keeps the upstream prompt cache
+                # instead of forcing a full resend onto another account.
+                await self._session.commit()
+                return False
+            result = await self._session.execute(statement)
+            await self._session.commit()
+        return result.scalar_one_or_none() is not None
+
     async def retire_stale_unavailable_bridge_owners(self, cutoff: datetime, *, now: datetime) -> int:
         """Retire continuity owners that have been unroutable since ``cutoff``.
 
@@ -3599,11 +3669,22 @@ class DurableBridgeRepository:
         tombstone_stmt = (
             update(HttpBridgeSessionRecord)
             .where(
-                HttpBridgeSessionRecord.account_id.is_not(None),
                 HttpBridgeSessionRecord.continuity_abandoned_at.is_(None),
-                HttpBridgeSessionRecord.continuity_abandonment_scope.is_(None),
                 HttpBridgeSessionRecord.last_seen_at < cutoff_naive,
-                HttpBridgeSessionRecord.account_id.in_(unavailable_account_ids),
+                or_(
+                    # A request-path retirement wrote the scope marker alone.
+                    # Promote it once the row goes stale, exactly as the sticky
+                    # sweep promotes its own younger scoped marker: without
+                    # this, such a row satisfies neither phase — phase 1 wants
+                    # both columns NULL and phase 2 wants a timestamp — and
+                    # would sit in the table forever.
+                    HttpBridgeSessionRecord.continuity_abandonment_scope.is_not(None),
+                    and_(
+                        HttpBridgeSessionRecord.continuity_abandonment_scope.is_(None),
+                        HttpBridgeSessionRecord.account_id.is_not(None),
+                        HttpBridgeSessionRecord.account_id.in_(unavailable_account_ids),
+                    ),
+                ),
             )
             # Timestamp with NULL scope is the global form: this sweep has no
             # per-source question to answer, and a replica that predates the

--- a/openspec/changes/retire-continuity-owner-on-the-request-path/.openspec.yaml
+++ b/openspec/changes/retire-continuity-owner-on-the-request-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-12

--- a/openspec/changes/retire-continuity-owner-on-the-request-path/context.md
+++ b/openspec/changes/retire-continuity-owner-on-the-request-path/context.md
@@ -1,0 +1,93 @@
+# Context
+
+## Purpose and scope
+
+Close the latency gap left by the scheduled retirement sweep: a thread whose owner just became
+unroutable should be served now, not in six hours. In scope: one extra question asked at the
+connect failure, the CAS that answers it, and the in-request rebind. Out of scope: owners pinned
+without a durable row, and bodies that cannot leave their account.
+
+## Decisions
+
+**Why the request's own budget is the deadline.** The plan's rule was "wait if there is evidence
+the owner returns in time, otherwise release", and the request budget is the only deadline that
+is already agreed by both sides: the client is waiting that long anyway, and
+`_http_bridge_request_budget_seconds` is an existing dashboard-managed value. Inventing a second
+window would mean another setting to tune and another thing to get wrong.
+
+**Why `reset_at` is the evidence.** It is the horizon the upstream itself gave us for a rate or
+quota limit, already stored and already used by the sweep's predicate. `paused`,
+`reauth_required` and `deactivated` have no horizon, which is exactly why they are the statuses
+that produced permanent 502s in production: nothing about them says "later".
+
+**Why a separate scope value.** `request_path` versus the sweep's global timestamp form costs
+nothing and makes the two writers distinguishable in the row itself, which matters when reading
+a production table to ask "did the sweep free this, or did a request?". Both read as retired
+through the same predicate.
+
+**Why the lock, not just the CAS.** Copied deliberately from
+`sticky_repository.abandon_legacy_session_header_owner_if_unavailable`, including its comment:
+PostgreSQL evaluates the status subquery from the UPDATE's snapshot, so without locking the
+account row first, a concurrent recovery can commit while the statement waits on the session row
+and the stale snapshot still authorizes a retirement. The in-UPDATE status predicate is the
+second, database-level invariant that keeps a future refactor from turning a prior observation
+into an unconditional write.
+
+**Why only a proxy-injected anchor.** When the proxy injected the anchor, the client's own body
+is still the full turn, so re-sending it without the anchor is exactly what the client asked for.
+When the client supplied the anchor, it named upstream state on that account; dropping it would
+silently change the request. Every production trace of this bug carries
+`previous_response_id=None`, so the covered shape is the one that actually occurs.
+
+## Constraints
+
+- No schema change: uses the two columns the previous change added.
+- No new setting: the deadline is the request's existing budget.
+- `request_deadline` is monotonic and `accounts.reset_at` is a wall-clock epoch, so the
+  projection is explicit rather than a direct comparison.
+- No ceiling-guarded proxy file grows; the helper lives in the uncapped
+  `_service/http_bridge/streaming.py` beside the other connect-failure closures.
+
+## Failure modes
+
+- **Retiring an owner that just recovered.** The lock plus the in-UPDATE status predicate make
+  the write lose that race; `test_request_path_never_retires_a_healthy_owner` pins it.
+- **Retiring after a concurrent rebind.** The CAS requires the row to still name the observed
+  owner, so a rebind wins; `test_request_path_retirement_requires_the_expected_owner` pins it.
+- **Retrying forever.** The attempt is one-shot per request
+  (`owner_retirement_attempted`), so a failure after retirement falls through to the existing
+  handling rather than looping.
+- **A leaked marker.** The request path writes the scope marker alone, which satisfies neither
+  sweep phase: phase 1 wanted both columns NULL, phase 2 wants a timestamp. In the normal case
+  the same request re-claims the row and clears it, but a rebind that never lands would have left
+  the row in the table forever. Phase 1 now promotes a scope-only marker to its own form once the
+  row is stale — the same promotion the sticky sweep performs — and does so without requiring the
+  owner to still be unavailable, since an owner that recovered without the thread rebinding would
+  otherwise make the marker permanent.
+- **A test that proves nothing.** The end-to-end test for the previous change ran over a soft
+  prompt-cache key, which falls back to a healthy account by itself — it would have passed
+  without the fix. Both end-to-end tests now use a hard `thread_header` key, verified by removing
+  the `continuity_abandoned` exemption and watching the sweep test fail.
+
+## Example
+
+An operator pauses an account while a thread is mid-conversation. Before:
+
+```text
+Proxy preferred account unavailable error_code=continuity_owner_unavailable
+proxy_error_response status=502 code="previous_response_owner_unavailable"
+# ... repeated on every resume for up to six hours
+```
+
+After:
+
+```text
+owner_unavailable_replay_rejected  detail=reason=payload_not_full_resend  key_strength=hard
+owner_retired_on_request           detail=outcome=rebind_without_anchor
+http_bridge_event event=create     account_id=<healthy>
+"POST /backend-api/codex/responses HTTP/1.1" 200 OK
+```
+
+The thread loses its upstream conversation state and re-sends its history once. The first line
+is the attribution added by the tracing change, which is what showed that this shape — a
+proxy-injected anchor on a hard thread key — is the one worth handling.

--- a/openspec/changes/retire-continuity-owner-on-the-request-path/proposal.md
+++ b/openspec/changes/retire-continuity-owner-on-the-request-path/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The scheduled sweep added by `retire-unroutable-bridge-continuity-owners` frees a thread six
+hours after its last turn. That is the right window for a dormant thread, and the wrong one for
+the turn a user is waiting on: when an operator pauses an account, every thread it owns keeps
+returning 502 `previous_response_owner_unavailable` until the sweep catches up.
+
+The owner's own state usually answers the question directly. A rate or quota limit carries
+`accounts.reset_at`, a horizon saying when the owner comes back. `paused`, `reauth_required` and
+`deactivated` carry no horizon at all — for those, waiting can never help. So the request can
+decide for itself rather than waiting out a fixed window.
+
+## What Changes
+
+- **One narrower question, asked at the failure.** `DurableBridgeRepository.retire_continuity_owner_if_unavailable`
+  retires a single row's owner when it cannot return before **this request's own budget** runs
+  out. `reset_at` before the deadline means wait — that preserves the upstream prompt cache
+  instead of forcing a full resend. `reset_at` after it, or absent, means retire.
+- **Rebind inside the same request.** The HTTP bridge connect-failure path calls it once per
+  request and, on success, re-enters its existing retry loop with the owner dropped. The turn is
+  re-sent as `_http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)` —
+  the same anchor-free body shape the context-overflow and stale-anchor recoveries already use.
+  The user sees a served turn, not a 502 followed by a retry.
+- **Only a proxy-injected anchor.** A client that supplied its own `previous_response_id` named
+  upstream state that lived on that account; dropping it here would silently change what the
+  client asked for, so that shape keeps failing closed. A file-pinned request is likewise
+  excluded. Every production trace of this bug carries `previous_response_id=None`, which is the
+  shape this covers.
+- **Same serialization as the sticky writer.** The CAS locks the account row with
+  `SELECT ... FOR UPDATE` before the update, because PostgreSQL evaluates the status subquery
+  from the UPDATE's snapshot: without the lock, a concurrent recovery can commit while the
+  statement waits on the session row and the stale snapshot would still authorize a retirement.
+  The status predicate stays inside the UPDATE as a second, database-level invariant.
+- **A distinct marker, the same meaning.** The request path writes
+  `continuity_abandonment_scope="request_path"` and leaves the timestamp NULL; the sweep writes
+  the global timestamp form. Both read as retired, and a replica on a build without the columns
+  keeps treating `account_id` as hard ownership through a rolling deploy.
+
+No schema change — this uses the columns the previous change added. No new `CODEX_LB_*` setting:
+the deadline is the request's existing budget. No ceiling-guarded proxy file grows.
+
+## Not in this change
+
+- **Owners resolved without a durable row.** When the pin came from the request-log index or the
+  in-process registry there is no row to mark, so the turn still fails closed. That is the
+  `no_durable_lookup` reason the attribution change reports, and it is its own fix.
+- **Moving a turn whose body cannot leave its account.** Retirement stops the re-welding; it does
+  not make encrypted reasoning or an uploaded file portable.
+
+## Impact
+
+- Affected specs: `sticky-session-operations` (ADDED — request-path retirement and its horizon
+  rule).
+- Affected code: `app/modules/proxy/durable_bridge_repository.py`,
+  `app/modules/proxy/durable_bridge_coordinator.py`,
+  `app/modules/proxy/_service/http_bridge/streaming.py`.
+- Tests: `tests/unit/test_durable_bridge_owner_retirement.py` (seven cases covering the horizon
+  rule, owner mismatch, idempotence and reversibility) and
+  `tests/integration/test_http_responses_bridge.py` (a hard `thread_header` resume served on a
+  healthy account with no sweep and no grace).
+- Partial fix for #1707.

--- a/openspec/changes/retire-continuity-owner-on-the-request-path/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/retire-continuity-owner-on-the-request-path/specs/sticky-session-operations/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: A continuity owner that cannot return in time is retired for the waiting turn
+
+When a bridge turn fails because its continuity owner is unavailable, the proxy MUST decide
+whether that owner can return before the turn's own request budget expires, and retire it when
+it cannot. An owner whose reset horizon falls before the deadline MUST be waited for, preserving
+the upstream conversation state. An owner whose reset horizon falls after the deadline, or which
+carries no horizon at all, MUST be retired. The decision MUST be taken at most once per request,
+MUST be serialized against a concurrent recovery of the same account, and MUST re-check the
+owner's status inside the write so a prior observation alone can never authorize it.
+
+#### Scenario: Owner with no recovery horizon
+
+- **GIVEN** a bridged thread whose owner account is paused, re-authentication-blocked, or
+  deactivated
+- **WHEN** the turn fails because that owner is unavailable
+- **THEN** the owner is retired and the turn is served on a healthy account within the same
+  request
+- **AND** no grace window has to elapse and no scheduled sweep has to run
+
+#### Scenario: Owner returning inside the budget
+
+- **GIVEN** a bridged thread whose owner is rate limited with a reset horizon before the
+  request's deadline
+- **WHEN** the turn fails because that owner is unavailable
+- **THEN** the owner is not retired
+- **AND** the thread keeps its owner so the upstream conversation state is preserved
+
+#### Scenario: Owner returning after the budget
+
+- **GIVEN** the same thread, but with a reset horizon after the request's deadline
+- **THEN** the owner is retired rather than waited for
+
+#### Scenario: A healthy owner is never retired
+
+- **WHEN** the owner's status is not one of the unavailable statuses at the moment of the write
+- **THEN** no retirement is recorded, whatever the failure was
+
+#### Scenario: A concurrent rebind is not overwritten
+
+- **GIVEN** the session's owner changed between the failure and the write
+- **WHEN** the retirement is attempted for the previously observed owner
+- **THEN** nothing is retired and the current owner is left intact
+
+### Requirement: Request-path retirement rebinds only an anchor the proxy injected
+
+Retiring an owner mid-request MUST re-send the turn without the response anchor, using the body
+the client supplied rather than a trimmed one. It MUST NOT be attempted when the client supplied
+its own `previous_response_id`, nor when the request is pinned to an account by an uploaded
+file: in both cases the request names account-scoped state the proxy may not silently discard,
+and the turn MUST keep failing closed. Retirement MUST remain reversible — a later successful
+claim clears it, as for any other retirement.
+
+#### Scenario: Proxy-injected anchor
+
+- **GIVEN** a resume whose anchor the proxy injected from the durable row
+- **WHEN** its owner is retired mid-request
+- **THEN** the turn is re-sent without the anchor and carries the client's full body
+- **AND** the durable row ends up owned by the replacement account with no retirement marker left
+
+#### Scenario: Client-supplied anchor
+
+- **WHEN** the client sent its own `previous_response_id` and the owner is unavailable
+- **THEN** no retirement is attempted and the turn fails closed as before
+
+#### Scenario: File-pinned request
+
+- **WHEN** the request is pinned to an account by an uploaded input file
+- **THEN** no retirement is attempted
+
+### Requirement: An unclaimed request-path retirement is collected
+
+A retirement recorded on the request path MUST remain collectable by the scheduled sweep. Once
+the session has had no successful activity for the grace window, the sweep MUST convert that
+marker into the same form it writes itself, so the existing deletion phase can reclaim the row.
+That conversion MUST NOT require the owner account to still be unavailable, because an owner
+that recovered without the thread ever rebinding would otherwise leave the marker permanent.
+
+#### Scenario: The rebind never lands
+
+- **GIVEN** a session whose owner was retired on the request path and which was never claimed
+  afterwards
+- **WHEN** it has had no successful activity for the grace window and the sweep runs
+- **THEN** the marker is converted to the sweep's own form
+- **AND** a later sweep deletes the row once that marker is itself past the window
+
+#### Scenario: The owner recovered meanwhile
+
+- **GIVEN** the same session, whose retired owner has since returned to a routable status
+- **WHEN** the sweep runs after the grace window
+- **THEN** the marker is still converted, so the row cannot outlive every sweep

--- a/openspec/changes/retire-continuity-owner-on-the-request-path/tasks.md
+++ b/openspec/changes/retire-continuity-owner-on-the-request-path/tasks.md
@@ -1,0 +1,47 @@
+## 1. Implementation
+
+- [x] 1.1 `DurableBridgeRepository.retire_continuity_owner_if_unavailable(session_id, *,
+  expected_account_id, recovery_deadline_epoch)` mirroring
+  `abandon_legacy_session_header_owner_if_unavailable`: lock the account row with
+  `SELECT ... FOR UPDATE`, refuse when the status has recovered or the reset horizon falls before
+  the deadline, then CAS on row id + expected owner + both markers NULL + status still
+  unavailable. Writes `continuity_abandonment_scope="request_path"` only.
+- [x] 1.2 `DurableBridgeSessionCoordinator.retire_continuity_owner_if_unavailable` wrapper.
+- [x] 1.3 `retire_unavailable_continuity_owner(exc)` in `_stream_via_http_bridge_impl`: one
+  attempt per request, gated on an owner-unavailable failure, a proxy-injected anchor
+  (`payload.previous_response_id is None`), no file pin, and a durable lookup naming the account
+  being retired. On success re-prepare the turn from
+  `_http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)`, drop the
+  owner and the durable lookup, log `owner_retired_on_request`, and `continue` the connect loop.
+- [x] 1.4 Project the monotonic request deadline onto the wall clock `reset_at` uses, rather than
+  comparing the two clock domains.
+
+## 2. Regression coverage
+
+- [x] 2.1 `tests/unit/test_durable_bridge_owner_retirement.py`: no horizon retires; a horizon
+  inside the budget waits; a horizon after it retires; a healthy owner is never retired; an owner
+  mismatch is refused; idempotent; cleared by a fresh claim.
+- [x] 2.2 `tests/integration/test_http_responses_bridge.py`: a hard `thread_header` resume whose
+  owner is paused is served **200** on a healthy account inside the same request, with exactly one
+  `owner_retired_on_request` event, no sweep and no grace; the durable row ends owned by the
+  replacement with no marker left.
+- [x] 2.3 Strengthen the sweep's end-to-end test from the previous change to use the same hard
+  `thread_header` key. It previously ran over a soft prompt-cache key, which falls back to a
+  healthy account on its own and so proved nothing; verified by removing the
+  `continuity_abandoned` exemption and watching it fail.
+
+- [x] 2.4 `retire_stale_unavailable_bridge_owners` phase 1 promotes a scope-only marker to its
+  own global form once the row is stale, mirroring the sticky sweep's promotion. Without it a
+  request-path retirement satisfies neither phase and leaks. Promotion deliberately does not
+  require the owner to still be unavailable. Covered by
+  `test_an_unclaimed_request_path_marker_is_collected` and
+  `test_promotion_does_not_need_the_owner_to_be_unavailable`.
+
+## 3. Validation
+
+- [ ] 3.1 `make lint`, `make typecheck`.
+- [ ] 3.2 `make test-unit`, `make test-integration-bridge`, `make test-integration-core-1..3`,
+  `tests/e2e`.
+- [ ] 3.3 `openspec validate retire-continuity-owner-on-the-request-path --strict`,
+  `openspec validate --specs`.
+- [ ] 3.4 `codex review --base origin/main`.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8828,6 +8828,140 @@ async def test_v1_responses_http_bridge_resumes_a_thread_whose_owner_was_retired
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_rebinds_immediately_when_the_owner_cannot_return(
+    async_client,
+    app_instance,
+    monkeypatch,
+    caplog,
+):
+    """#1707 without the wait: the first resume after the owner dies must serve.
+
+    The scheduled sweep frees a dormant thread six hours after its last turn.
+    That is too late for the turn a user is actually waiting on, so the connect
+    failure retires the owner in place and rebinds within the same request.
+    """
+    _install_bridge_settings(monkeypatch, enabled=True)
+    owner_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_instant_retire",
+        "http-bridge-instant-retire@example.com",
+    )
+    healthy_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_instant_replacement",
+        "http-bridge-instant-replacement@example.com",
+    )
+    owner_account = await _get_account(owner_account_id)
+    healthy_account = await _get_account(healthy_account_id)
+    upstream = _ClosingBridgeUpstreamWebSocket()
+    served_account_ids: list[str] = []
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        preferred_account_id = cast(str | None, kwargs.get("preferred_account_id"))
+        if preferred_account_id == owner_account.id:
+            return AccountSelection(
+                account=None,
+                error_message="No available accounts",
+                error_code=CONTINUITY_OWNER_UNAVAILABLE,
+            )
+        account = owner_account if not served_account_ids else healthy_account
+        served_account_ids.append(account.id)
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    thread_headers = {"session_id": "session-instant-retire", "thread-id": "thread-instant-retire"}
+    first = await asyncio.wait_for(
+        async_client.post(
+            "/backend-api/codex/responses",
+            headers=thread_headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "hello",
+                "prompt_cache_key": "http-bridge-instant-retire",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+    assert first.status_code == 200
+
+    service = get_proxy_service_for_app(app_instance)
+    deadline = time.monotonic() + _TEST_SYNC_TIMEOUT_SECONDS
+    owned: list[HttpBridgeSessionRecord] = []
+    while time.monotonic() < deadline:
+        async with SessionLocal() as session:
+            owned = list(
+                (
+                    await session.execute(
+                        select(HttpBridgeSessionRecord).where(HttpBridgeSessionRecord.account_id == owner_account.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        if owned:
+            break
+        await asyncio.sleep(0.05)
+    assert owned, "the first turn did not persist a durable bridge row"
+    async with service._http_bridge_lock:
+        service._http_bridge_sessions.clear()
+
+    # The owner is paused. No grace elapses and no sweep runs.
+    async with SessionLocal() as session:
+        await session.execute(update(Account).where(Account.id == owner_account.id).values(status=AccountStatus.PAUSED))
+        await session.commit()
+
+    caplog.set_level(logging.INFO, logger="app.modules.proxy.service")
+    second = await asyncio.wait_for(
+        async_client.post(
+            "/backend-api/codex/responses",
+            headers=thread_headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "continue",
+                "prompt_cache_key": "http-bridge-instant-retire",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    assert second.status_code == 200
+    assert served_account_ids[-1] == healthy_account.id
+    retired = [record.getMessage() for record in caplog.records if "owner_retired_on_request" in record.getMessage()]
+    assert len(retired) == 1
+    assert "outcome=rebind_without_anchor" in retired[0]
+
+    async with SessionLocal() as session:
+        rows = list((await session.execute(select(HttpBridgeSessionRecord))).scalars().all())
+    # The rebind claimed the row for the replacement, and that claim clears the
+    # marker the retirement wrote — retirement is a step, not a resting state.
+    assert [row.account_id for row in rows if row.account_id == owner_account.id] == []
+    assert any(row.account_id == healthy_account.id for row in rows)
+    assert all(row.continuity_abandoned_at is None for row in rows)
+    assert all(row.continuity_abandonment_scope is None for row in rows)
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_soft_prompt_cache_follow_up_uses_durable_owner_over_stale_local_lane(
     async_client,
     app_instance,

--- a/tests/unit/test_durable_bridge_owner_retirement.py
+++ b/tests/unit/test_durable_bridge_owner_retirement.py
@@ -499,6 +499,246 @@ async def test_a_retired_row_still_refuses_a_client_supplied_anchor(
     assert by_anchor.latest_response_id is None
 
 
+async def _retire_now(
+    factory: Callable[[], AsyncSession],
+    *,
+    session_id: str,
+    account_id: str,
+    deadline_epoch: int,
+) -> bool:
+    async with factory() as session:
+        return await DurableBridgeRepository(session).retire_continuity_owner_if_unavailable(
+            session_id,
+            expected_account_id=account_id,
+            recovery_deadline_epoch=deadline_epoch,
+        )
+
+
+def _epoch_in(seconds: float) -> int:
+    return naive_utc_to_epoch(to_utc_naive(utcnow() + timedelta(seconds=seconds)))
+
+
+async def test_request_path_retires_an_owner_with_no_recovery_horizon(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """A paused owner carries no horizon, so waiting can never help."""
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.continuity_abandoned is True
+    assert lookup.account_id is None
+    # No grace elapsed and no sweep ran: the row was freed for the waiting turn.
+    assert lookup.retired_account_id == "acc-paused"
+
+
+async def test_request_path_waits_for_an_owner_returning_inside_the_budget(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """A reset inside the budget is evidence the owner returns, so keep the cache."""
+    await _add_account(
+        async_session_factory,
+        "acc-limited",
+        AccountStatus.RATE_LIMITED,
+        reset_at=_epoch_in(60),
+    )
+    session_id = await _claim(coordinator, account_id="acc-limited")
+
+    assert not await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-limited",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.account_id == "acc-limited"
+
+
+async def test_request_path_retires_an_owner_returning_after_the_budget(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """A five-hour limit with hours left is not worth waiting out."""
+    await _add_account(
+        async_session_factory,
+        "acc-limited",
+        AccountStatus.RATE_LIMITED,
+        reset_at=_epoch_in(4 * 3600),
+    )
+    session_id = await _claim(coordinator, account_id="acc-limited")
+
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-limited",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+
+async def test_request_path_never_retires_a_healthy_owner(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-active", AccountStatus.ACTIVE)
+    session_id = await _claim(coordinator, account_id="acc-active")
+
+    assert not await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-active",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+
+async def test_request_path_retirement_requires_the_expected_owner(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """A concurrent rebind must lose the race, not have its new owner retired."""
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _add_account(async_session_factory, "acc-other", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+
+    assert not await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-other",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.account_id == "acc-paused"
+
+
+async def test_request_path_retirement_is_idempotent(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+    assert not await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+
+async def test_request_path_retirement_is_cleared_by_a_fresh_claim(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """The scope-only marker is as reversible as the sweep's timestamp form."""
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    await _add_account(async_session_factory, "acc-healthy", AccountStatus.ACTIVE)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+
+    await _claim(coordinator, account_id="acc-healthy", latest_response_id=None)
+
+    lookup = await _lookup(coordinator)
+    assert lookup is not None
+    assert lookup.continuity_abandoned is False
+    assert lookup.account_id == "acc-healthy"
+
+
+async def test_an_unclaimed_request_path_marker_is_collected(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """A request-path retirement must not leak when the rebind never lands.
+
+    It writes the scope marker alone, which satisfies neither sweep phase on
+    its own — phase 1 wants both columns NULL, phase 2 wants a timestamp — so
+    the sweep promotes it to the global form once the row goes stale, and the
+    next sweep collects it.
+    """
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+    async with async_session_factory() as session:
+        row = (await session.execute(select(HttpBridgeSessionRecord))).scalar_one()
+        assert row.continuity_abandonment_scope == "request_path"
+        assert row.continuity_abandoned_at is None
+
+    # Still fresh: nothing to collect yet.
+    assert await _retire(async_session_factory) == 0
+
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+    assert await _retire(async_session_factory) == 1
+    async with async_session_factory() as session:
+        row = (await session.execute(select(HttpBridgeSessionRecord))).scalar_one()
+        assert row.continuity_abandonment_scope is None
+        assert row.continuity_abandoned_at is not None
+
+    # Aged past a second window, the promoted tombstone is deleted.
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord).values(
+                continuity_abandoned_at=to_utc_naive(utcnow() - _GRACE - timedelta(minutes=1))
+            )
+        )
+        await session.commit()
+    assert await _retire(async_session_factory) == 1
+    async with async_session_factory() as session:
+        assert (await session.execute(select(HttpBridgeSessionRecord))).scalars().all() == []
+
+
+async def test_promotion_does_not_need_the_owner_to_be_unavailable(
+    async_session_factory: Callable[[], AsyncSession],
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    """An already-retired row is collected even if its old owner recovered.
+
+    Otherwise a marker written while the account was paused would outlive every
+    sweep once the operator resumed it.
+    """
+    await _add_account(async_session_factory, "acc-paused", AccountStatus.PAUSED)
+    session_id = await _claim(coordinator, account_id="acc-paused")
+    assert await _retire_now(
+        async_session_factory,
+        session_id=session_id,
+        account_id="acc-paused",
+        deadline_epoch=_epoch_in(7200),
+    )
+    async with async_session_factory() as session:
+        await session.execute(update(Account).values(status=AccountStatus.ACTIVE))
+        await session.commit()
+    await _age_row(async_session_factory, seconds=_GRACE.total_seconds() + 60)
+
+    assert await _retire(async_session_factory) == 1
+
+
 def test_unavailable_status_set_covers_every_non_serving_status() -> None:
     assert HARD_OWNER_UNAVAILABLE_STATUSES == {
         AccountStatus.PAUSED,


### PR DESCRIPTION
> Stacked on #2390 → #2384. Review the top commit; the bases merge first.

## Why

The sweep added by #2390 frees a thread six hours after its last turn. That is the right window for a dormant thread and the wrong one for **the turn a user is waiting on**: pause an account and every thread it owns keeps returning 502 `previous_response_owner_unavailable` until the sweep catches up.

The owner's own state usually answers the question directly. A rate or quota limit carries `accounts.reset_at` — a horizon saying when the owner comes back. `paused`, `reauth_required` and `deactivated` carry **no horizon at all**, which is precisely why those are the statuses that produced permanent 502s in production. So the request can decide for itself instead of waiting out a fixed window.

## What changes

- **One narrower question, asked at the failure.** `retire_continuity_owner_if_unavailable` retires a single row's owner when it cannot return before **this request's own budget** expires. A reset horizon inside the budget means wait — that keeps the upstream conversation state instead of forcing a full resend. Outside it, or absent, means retire.

- **Rebind inside the same request.** The connect-failure path calls it once per request and, on success, re-enters the existing retry loop with the owner dropped. The turn is re-sent as `_http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)` — the same anchor-free body shape the context-overflow and stale-anchor recoveries already use. **The user sees a served turn, not a 502.**

- **Only a proxy-injected anchor.** A client that supplied its own `previous_response_id` named upstream state that lived on that account; dropping it here would silently change what the client asked for, so that shape keeps failing closed. File-pinned requests likewise. Every production trace of this bug carries `previous_response_id=None` — that is the shape this covers.

- **Same serialization as the sticky writer it mirrors.** The CAS locks the account row with `SELECT … FOR UPDATE` before the update, because PostgreSQL evaluates the status subquery from the UPDATE's snapshot: without the lock a concurrent recovery can commit while the statement waits on the session row, and the stale snapshot would still authorize a retirement. The status predicate stays inside the UPDATE as a second, database-level invariant.

- **A distinct marker, the same meaning.** The request path writes `continuity_abandonment_scope="request_path"` and leaves the timestamp NULL; the sweep writes the global timestamp form. Both read as retired, and a replica on a build without the columns keeps treating `account_id` as hard ownership through a rolling deploy.

- **The sweep now promotes that marker.** A scope-only marker satisfied *neither* cleanup phase — phase 1 wanted both columns NULL, phase 2 wants a timestamp — so a rebind that never landed would have left the row in the table forever. Phase 1 promotes it once the row is stale, exactly as the sticky sweep promotes its own younger scoped marker, and deliberately without requiring the owner to still be unavailable (an owner that recovered without the thread rebinding would otherwise make the marker permanent). Caught by `codex review`; see below.

No schema change — this uses the columns #2390 adds. No new `CODEX_LB_*` setting: the deadline is the request's existing budget. No ceiling-guarded proxy file grows.

## It also fixes #2390's test, which was proving nothing

Self-review caught that #2390's end-to-end test ran over `/v1/responses` with only a `prompt_cache_key`, producing a **soft** `prompt_cache` bridge key. A soft key falls back to a healthy account on its own, so the test would have passed without any of that change. Both end-to-end tests now go through `/backend-api/codex/responses` with a thread identity, producing a hard `thread_header` key — the shape that actually welds a thread to its owner.

Verified load-bearing: removing the `durable_lookup.continuity_abandoned` exemption makes #2390's test fail and restoring it makes it pass. (That fix is on #2390's branch, so it is already in that PR.)

## Not in this change

- **Owners resolved without a durable row.** When the pin came from the request-log index or the in-process registry there is no row to mark, so the turn still fails closed. That is the `no_durable_lookup` reason #2384 reports, and it is its own fix.
- **Moving a turn whose body cannot leave its account.** Retirement stops the re-welding; it does not make encrypted reasoning or an uploaded file portable.

## Local codex review

- **Fixed** — *"Reclaim request-path tombstones during cleanup."* Correct and mine: the scope-only marker fell through both phases and could grow the session table without bound. Phase 1 now promotes it (see above). Regressions: `test_an_unclaimed_request_path_marker_is_collected`, `test_promotion_does_not_need_the_owner_to_be_unavailable`.

## Test plan

| Gate | Result |
|---|---|
| `make lint` / `make typecheck` | pass |
| `make migration-check` | `migration_policy=ok`, `schema_drift=none` |
| `make test-unit` | **10,058 passed**, 6 skipped, 1 xfailed |
| `make test-integration-bridge` | **343 passed** |
| `make test-integration-core-1` / `-2` / `-3` | **869** / **910** / **1,036 passed** |
| `uv run pytest tests/e2e` | **27 passed**, 1 skipped |
| `openspec validate retire-continuity-owner-on-the-request-path --strict` | valid |
| `openspec validate --specs` | 65 passed, 0 failed |
| `codex review --base origin/main` | 1 finding, fixed |

The core shards above were started before the leak fix landed, so they cover the tree without it. After the fix I re-ran lint, typecheck and every directly affected suite — `test_durable_bridge_sessions`, `test_durable_bridge_owner_retirement`, `test_sticky_session_cleanup_scheduler`, `test_repositories`: 162 passed — and CI runs the full matrix against the final tree.

New coverage:
- `tests/unit/test_durable_bridge_owner_retirement.py` — no horizon retires; a horizon inside the budget waits; one after it retires; a healthy owner never retires; an owner mismatch is refused (a concurrent rebind wins); idempotent; cleared by a fresh claim; the unclaimed marker is collected, with and without the owner recovering.
- `tests/integration/test_http_responses_bridge.py` — a hard `thread_header` resume whose owner is paused is served **200 on a healthy account inside the same request**, with exactly one `owner_retired_on_request` event, no sweep and no grace, and the durable row ends owned by the replacement with no marker left.

Partial fix for #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)