### PR TITLE
fix(db): converge the forked thread-cache and bridge-retirement Alembic heads

### DIFF
--- a/app/db/alembic/versions/20260912_000000_merge_thread_cache_and_bridge_retirement_heads.py
+++ b/app/db/alembic/versions/20260912_000000_merge_thread_cache_and_bridge_retirement_heads.py
@@ -1,0 +1,22 @@
+"""Merge the thread-cache identity and bridge owner-retirement histories.
+
+Both revisions chained onto ``20260911_030000_add_local_login_policy`` and
+merged within minutes of each other, forking the graph. Neither is wrong on
+its own, so converge them rather than re-chaining either.
+"""
+
+revision = "20260912_000000_merge_thread_cache_and_bridge_retirement_heads"
+down_revision = (
+    "20260911_040000_add_thread_cache_identity_mode",
+    "20260911_060000_add_bridge_session_continuity_abandonment",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

`main` has two Alembic heads, so `alembic upgrade head` raises `MultipleHeads` in every job that migrates. This adds the empty merge revision that converges them.

| Head | Introduced by | Parent |
|---|---|---|
| `20260911_040000_add_thread_cache_identity_mode` | #2376 | `20260911_030000_add_local_login_policy` |
| `20260911_060000_add_bridge_session_continuity_abandonment` | #2390 | `20260911_030000_add_local_login_policy` |

Both landed within minutes of each other on the same parent. Neither is wrong on its own, so they are converged rather than re-chained.

## Blast radius this fixes

`main`'s own CI run is red (run 34686903171): Lint (ruff), both Migration checks, unit, PostgreSQL, integration-core, Playwright and Helm. Because `pull_request` checks run against `main` merged into the head, **every open PR in the repository is red for this reason** — including ones whose own content is clean.

## Change

One revision file, `upgrade()`/`downgrade()` both `pass`. No schema change, no data movement, no behavior change.

```
revision      = "20260912_000000_merge_thread_cache_and_bridge_retirement_heads"
down_revision = ("20260911_040000_add_thread_cache_identity_mode",
                 "20260911_060000_add_bridge_session_continuity_abandonment")
```

## Verification

- `scripts/check_migration_topology.py` → `migration topology checks passed` (258 revisions, single head, ratchet `20260911_000000`, `--base-ref origin/main` clean)
- `ScriptDirectory.get_heads()` → `['20260912_000000_merge_thread_cache_and_bridge_retirement_heads']` (was 2)
- `ruff check` / `ruff format --check` clean

## OpenSpec

Not applicable — graph hygiene only, no requirement, contract or schema changes.

## Screenshots

N/A — no dashboard-visible change.

## Known limitations

None. The recurrence guard already exists (`check_migration_topology.py` fails on a forked graph); it cannot prevent two PRs that are each green in isolation from forking the graph when both merge, which is what happened here. The operational rule remains: land migration PRs one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)