### PR TITLE
fix(docker): update installed Debian runtime packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        bsdutils libblkid1 libc-bin libc6 libcap2 libmount1 libsmartcols1 libssl3t64 \
+        bsdutils gzip libblkid1 libc-bin libc6 libcap2 libmount1 libpcre2-8-0 \
+        libsmartcols1 libsqlite3-0 libssl3t64 \
         libsystemd0 libudev1 libuuid1 openssl perl-base sed util-linux \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssl-provider-legacy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /app
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
         bsdutils libblkid1 libc-bin libc6 libcap2 libmount1 libsmartcols1 libssl3t64 \
-        libsystemd0 libudev1 libuuid1 openssl sed util-linux \
+        libsystemd0 libudev1 libuuid1 openssl perl-base sed util-linux \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

The local arm64 runtime image retains four installed Debian packages with fixed CRITICAL/HIGH findings. Add `gzip`, `libpcre2-8-0`, `libsqlite3-0`, and `perl-base` to the Dockerfile's existing selective upgrade list so Debian's fixed versions are installed during the image build.

## Type of change

- [x] `fix:` — package maintenance

Closes #2406.

## OpenSpec

- [x] Not applicable — packaging maintenance within the existing image contract; no application behavior, settings, API, or schema changes.

## Changes

The existing `apt-get install --only-upgrade` command gains four package names. The Debian repositories, package authentication, subsequent installs, cleanup, and Trivy policy stay unchanged.

| Package | Observed base version | Installed fixed version |
| --- | --- | --- |
| gzip | 1.13-1 | 1.13-1+deb13u1 |
| libpcre2-8-0 | 10.46-1~deb13u1 | 10.46-1~deb13u2 |
| libsqlite3-0 | 3.46.1-7+deb13u1 | 3.46.1-7+deb13u2 |
| perl-base | 5.40.1-6 | 5.40.1-6+deb13u1 |

## Test plan

Observed on September 12, 2026 using Docker Desktop 29.7.2, Linux arm64, Trivy 0.74.0, and runtime base `python:3.14-slim@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6`:

- Live apt policy selects the fixed versions above. A focused dry run upgrades four packages with zero installations or removals. The complete existing Dockerfile command also upgrades packages already present in its list.
- A direct build from an exact archive of upstream `b5dc5ff9` fails the full CRITICAL,HIGH scan with 12 findings (3 CRITICAL and 9 HIGH) across those four packages.
- Preliminary `perl-base`-only candidate passed local `make docker`'s CRITICAL scan, but the broader scan still failed with five HIGH findings.
- The final four-package Dockerfile built successfully in an isolated context. `dpkg-query` confirmed all four fixed versions.
- The unchanged enforcement command passed with zero reported vulnerabilities:

```sh
trivy image --format table --exit-code 1 --severity CRITICAL,HIGH --ignore-unfixed codex-lb:four-package-scratch-20260912
```

The maintenance branch's local targets passed: frontend lint/typecheck/build and 1,623 tests; Python lint/type checks; Rust format, clippy, tests, release build, and audit; Linux unit tests (10,754 passed, 7 skipped, 1 known xfail); core integration (2,899 passed, 397 skipped); bridge integration (350 passed); e2e (27 passed, 1 skipped); PostgreSQL (246 passed); SQLite/PostgreSQL migration checks with no drift; packaging and wheel assets; Helm lint/template/schema validation; and both bundled and external-database Kind smoke installs/tests. Strict main-spec validation passed 65/65 OpenSpec specifications.

The frontend, lint, Rust, unit, and core-integration targets completed before the package list expanded from one to four names. That expansion changes only the Dockerfile; application and test sources are identical. The active target finished before the final Dockerfile was applied. The final maintenance checkout's own `make docker` and subsequent full CRITICAL,HIGH scan both passed, followed by the remaining targets above.

The initial source archive included a generated local GitNexus index. Parking that index outside the build tree and rerunning unchanged `make package` produced a clean source archive and wheel; the archive member list confirms the index is absent, and the index was restored afterward. Disposable test containers and the Kind cluster were removed after verification.

## Scope and evidence limits

This follows an observed local arm64 scan failure. The current GitHub Docker jobs on #2110 and #2111 passed their high-severity gate. The local/cloud difference has not been explained; this PR does not claim those feature PRs' cloud checks are blocked. Their product changes stay separate.

Debian's public fixed-version records are linked in #2406. This maintenance change makes no claim about exploitability through codex-lb.

## Checklist

- [x] Conventional Commits title and issue link.
- [x] No new setting, dependency, required setup, README section, or dashboard navigation.
- [x] `CHANGELOG.md` left to the release process.
- [x] Relevant local `make` targets completed on the maintenance branch.
- [x] Final-head local/provider review and GitHub CI complete at `188f383dd10e9df6ea9a86a284638739c3241e83`: both local reviews found no findings, Codex and CodeRabbit cleared the same head, and [CI passed](https://github.com/Soju06/codex-lb/actions/runs/34712123967), including the Docker high-severity gate.

This PR remains in draft as requested. No merge or scan-policy suppression was performed.
